### PR TITLE
Move backoff from util/backoff to dskit/backoff. Rename backoff config to config for clarity

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -15,8 +15,8 @@ type Config struct {
 	MaxRetries int           `yaml:"max_retries"` // give up after this many; zero means infinite retries
 }
 
-// RegisterFlags for Config.
-func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {
+// RegisterFlagsWithPrefix for Config.
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.MinBackoff, prefix+".backoff-min-period", 100*time.Millisecond, "Minimum delay when backing off.")
 	f.DurationVar(&cfg.MaxBackoff, prefix+".backoff-max-period", 10*time.Second, "Maximum delay when backing off.")
 	f.IntVar(&cfg.MaxRetries, prefix+".backoff-retries", 10, "Number of times to backoff and retry before failing.")

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -15,7 +15,7 @@ type Config struct {
 	MaxRetries int           `yaml:"max_retries"` // give up after this many; zero means infinite retries
 }
 
-// RegisterFlags for BackoffConfig.
+// RegisterFlags for Config.
 func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.MinBackoff, prefix+".backoff-min-period", 100*time.Millisecond, "Minimum delay when backing off.")
 	f.DurationVar(&cfg.MaxBackoff, prefix+".backoff-max-period", 10*time.Second, "Maximum delay when backing off.")
@@ -31,8 +31,8 @@ type Backoff struct {
 	nextDelayMax time.Duration
 }
 
-// NewBackoff creates a Backoff object. Pass a Context that can also terminate the operation.
-func NewBackoff(ctx context.Context, cfg Config) *Backoff {
+// New creates a Backoff object. Pass a Context that can also terminate the operation.
+func New(ctx context.Context, cfg Config) *Backoff {
 	return &Backoff{
 		cfg:          cfg,
 		ctx:          ctx,

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,4 +1,4 @@
-package util
+package backoff
 
 import (
 	"context"
@@ -8,15 +8,15 @@ import (
 	"time"
 )
 
-// BackoffConfig configures a Backoff
-type BackoffConfig struct {
+// Config configures a Backoff
+type Config struct {
 	MinBackoff time.Duration `yaml:"min_period"`  // start backoff at this level
 	MaxBackoff time.Duration `yaml:"max_period"`  // increase exponentially to this level
 	MaxRetries int           `yaml:"max_retries"` // give up after this many; zero means infinite retries
 }
 
 // RegisterFlags for BackoffConfig.
-func (cfg *BackoffConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
+func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.MinBackoff, prefix+".backoff-min-period", 100*time.Millisecond, "Minimum delay when backing off.")
 	f.DurationVar(&cfg.MaxBackoff, prefix+".backoff-max-period", 10*time.Second, "Maximum delay when backing off.")
 	f.IntVar(&cfg.MaxRetries, prefix+".backoff-retries", 10, "Number of times to backoff and retry before failing.")
@@ -24,7 +24,7 @@ func (cfg *BackoffConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
 
 // Backoff implements exponential backoff with randomized wait times
 type Backoff struct {
-	cfg          BackoffConfig
+	cfg          Config
 	ctx          context.Context
 	numRetries   int
 	nextDelayMin time.Duration
@@ -32,7 +32,7 @@ type Backoff struct {
 }
 
 // NewBackoff creates a Backoff object. Pass a Context that can also terminate the operation.
-func NewBackoff(ctx context.Context, cfg BackoffConfig) *Backoff {
+func NewBackoff(ctx context.Context, cfg Config) *Backoff {
 	return &Backoff{
 		cfg:          cfg,
 		ctx:          ctx,

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -1,4 +1,4 @@
-package util
+package backoff
 
 import (
 	"context"
@@ -85,7 +85,7 @@ func TestBackoff_NextDelay(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			b := NewBackoff(context.Background(), BackoffConfig{
+			b := NewBackoff(context.Background(), Config{
 				MinBackoff: testData.minBackoff,
 				MaxBackoff: testData.maxBackoff,
 				MaxRetries: len(testData.expectedRanges),

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -85,7 +85,7 @@ func TestBackoff_NextDelay(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			b := NewBackoff(context.Background(), Config{
+			b := New(context.Background(), Config{
 				MinBackoff: testData.minBackoff,
 				MaxBackoff: testData.maxBackoff,
 				MaxRetries: len(testData.expectedRanges),


### PR DESCRIPTION

Signed-off-by: Tyler Reid <tyler.reid@grafana.com>