### PR TITLE
Add drone CI

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,0 +1,26 @@
+local image = 'golang:1.16.7';
+
+local pipeline = {
+  new(name):: {
+    kind: 'pipeline',
+    name: name,
+  },
+};
+
+local step = {
+  make(target):: {
+    name: 'make-%s' % target,
+    image: image,
+    commands: ['make %s' % target],
+  },
+};
+
+[
+  pipeline.new('validate-pr') {
+    steps: [
+      step.make('mod-check'),
+      step.make('lint'),
+      step.make('test'),
+    ],
+  },
+]

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -26,3 +26,8 @@
       }
    ]
 }
+---
+kind: signature
+hmac: 15993ec505ce889199b31c48337b1e44085e00d424f331c2f7b75f65eb9a695e
+
+...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,0 +1,28 @@
+---
+{
+   "kind": "pipeline",
+   "name": "validate-pr",
+   "steps": [
+      {
+         "commands": [
+            "make mod-check"
+         ],
+         "image": "golang:1.16.7",
+         "name": "make-mod-check"
+      },
+      {
+         "commands": [
+            "make lint"
+         ],
+         "image": "golang:1.16.7",
+         "name": "make-lint"
+      },
+      {
+         "commands": [
+            "make test"
+         ],
+         "image": "golang:1.16.7",
+         "name": "make-test"
+      }
+   ]
+}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,12 @@ mod-check:
 .tools/bin/golangci-lint: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1
 
+drone: .drone/drone.yml
+
 .drone/drone.yml: .drone/drone.jsonnet
 	# Drones jsonnet formatting causes issues where arrays disappear
-	drone jsonnet --source $< --target $@ --stream --format=false
-	drone lint --trusted $@
+	drone jsonnet --source $< --target $@.tmp --stream --format=false
+	drone sign --save grafana/dskit $@.tmp
+	drone lint --trusted $@.tmp
+	# When all passes move to correct destination
+	mv $@.tmp $@

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,8 @@ mod-check:
 
 .tools/bin/golangci-lint: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1
+
+.drone/drone.yml: .drone/drone.jsonnet
+	# Drones jsonnet formatting causes issues where arrays disappear
+	drone jsonnet --source $< --target $@ --stream --format=false
+	drone lint --trusted $@


### PR DESCRIPTION
This adds a simple drone configuration to run the CI checks added via #4 

(Needed multiple PRs as I had initially pushed it as branch in my own fork, rather than a branch of dskit)
