### PR TITLE
Fix linting issues after enabling CI

### DIFF
--- a/services/basic_service.go
+++ b/services/basic_service.go
@@ -151,7 +151,7 @@ func (b *BasicService) mustSwitchState(from, to State, stateFn func()) {
 // Service is in Starting state when this method runs.
 // Entire lifecycle of the service happens here.
 func (b *BasicService) main() {
-	var err error = nil
+	var err error
 
 	if b.startFn != nil {
 		err = b.startFn(b.serviceContext)

--- a/services/failure_watch_test.go
+++ b/services/failure_watch_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNilServiceFailureWatcher(t *testing.T) {
-	var w *FailureWatcher = nil
+	var w *FailureWatcher
 
 	// prove it doesn't fail, but returns nil channel.
 	require.Nil(t, w.Chan())


### PR DESCRIPTION
This is failing now in main, as it went in before CI was around.

(https://github.com/mgechev/revive relplaced golint in golangci-lint)