### PR TITLE
Import module_service service wrapper with history

### DIFF
--- a/services/service.go
+++ b/services/service.go
@@ -20,6 +20,7 @@ const (
 	Terminated              // Service has stopped successfully. Terminal state.
 	Failed                  // Service has failed in Starting, Running or Stopping state. Terminal state.
 )
+
 func (s State) String() string {
 	switch s {
 	case New:

--- a/services/service.go
+++ b/services/service.go
@@ -2,8 +2,12 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
+
+// ErrStopProcess is the error returned by a service as a hint to stop the server entirely.
+var ErrStopProcess = errors.New("stop process")
 
 // State of the service. See Service interface for full state diagram.
 type State int
@@ -16,7 +20,6 @@ const (
 	Terminated              // Service has stopped successfully. Terminal state.
 	Failed                  // Service has failed in Starting, Running or Stopping state. Terminal state.
 )
-
 func (s State) String() string {
 	switch s {
 	case New:


### PR DESCRIPTION
Imports the Cortex module_service wrapper that waits for module dependencies when starting and stopping, with history.