### PR TITLE
Move moduleService and ErrStopProcess to modules.

### DIFF
--- a/modules/module_service_wrapper.go
+++ b/modules/module_service_wrapper.go
@@ -20,7 +20,7 @@ func newModuleServiceWrapper(serviceMap map[string]services.Service, mod string,
 		return r
 	}
 
-	return services.NewModuleService(mod, logger, modServ,
+	return NewModuleService(mod, logger, modServ,
 		func(_ string) map[string]services.Service {
 			return getDeps(startDeps)
 		},

--- a/services/service.go
+++ b/services/service.go
@@ -2,12 +2,8 @@ package services
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
-
-// ErrStopProcess is the error returned by a service as a hint to stop the server entirely.
-var ErrStopProcess = errors.New("stop process")
 
 // State of the service. See Service interface for full state diagram.
 type State int


### PR DESCRIPTION
`moduleService` and `ErrStopProcess` were moved out of `services` package to `modules`.

Rationale: Idea behind `services` package is to provide clean reimplementation of Guava services, without too much cruft in it. `moduleService` is used by modules, and is not related to `services` package. Same goes for `ErrStopProcess`.
