### PR TITLE
Add faillint paths to reject global prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ lint: .tools/bin/misspell .tools/bin/faillint .tools/bin/golangci-lint
 	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
 		sync/atomic=go.uber.org/atomic,\
-		github.com/prometheus/client_golang/prometheus.{MultiError}=github.com/prometheus/prometheus/tsdb/errors.{NewMulti}" ./...
+        github.com/prometheus/client_golang/prometheus.{NewCounter,NewCounterVec,NewCounterVec,NewGauge,NewGaugeVec,NewGaugeFunc,\
+        NewHistorgram,NewHistogramVec,NewSummary,NewSummaryVec}=github.com/prometheus/client_golang/prometheus/promauto.With.{NewCounter,\
+        NewCounterVec,NewCounterVec,NewGauge,NewGaugeVec,NewGaugeFunc,NewHistorgram,NewHistogramVec,NewSummary,NewSummaryVec}" ./...
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This covers metrics registered with `prometheus.{NewCounter,NewCounterVec,NewCounterVec,NewGauge,NewGaugeVec,NewGaugeFunc,\
        NewHistorgram,NewHistogramVec,NewSummary,NewSummaryVec}` and will suggest to use `promauto.With()` to register metrics to prevent registering of global metrics.

Signed-off-by: Tyler Reid <tyler.reid@grafana.com>