### PR TITLE
Clean up golang ci lint issues for services and kv package

### DIFF
--- a/kv/memberlist/kv_init_service.go
+++ b/kv/memberlist/kv_init_service.go
@@ -19,7 +19,7 @@ import (
 	"github.com/grafana/dskit/services"
 )
 
-// This service initialized memberlist.KV on first call to GetMemberlistKV, and starts it. On stop,
+// KVInitService initializes a memberlist.KV on first call to GetMemberlistKV, and starts it. On stop,
 // KV is stopped too. If KV fails, error is reported from the service.
 type KVInitService struct {
 	services.Service
@@ -47,7 +47,7 @@ func NewKVInitService(cfg *KVConfig, logger log.Logger) *KVInitService {
 	return kvinit
 }
 
-// This method will initialize Memberlist.KV on first call, and add it to service failure watcher.
+// GetMemberlistKV will initialize Memberlist.KV on first call, and add it to service failure watcher.
 func (kvs *KVInitService) GetMemberlistKV() (*KV, error) {
 	kvs.init.Do(func() {
 		kv := NewKV(*kvs.cfg, kvs.logger)

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -164,7 +164,7 @@ type KVConfig struct {
 	Codecs []codec.Codec `yaml:"-"`
 }
 
-// RegisterFlags registers flags.
+// RegisterFlagsWithPrefix registers flags.
 func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	mlDefaults := defaultMemberlistConfig()
 

--- a/services/basic_service.go
+++ b/services/basic_service.go
@@ -77,7 +77,7 @@ func invalidServiceStateWithFailureError(state, expected State, failure error) e
 	return fmt.Errorf("invalid service state: %v, expected: %v, failure: %w", state, expected, failure)
 }
 
-// Returns service built from three functions (using BasicService).
+// NewBasicService returns service built from three functions (using BasicService).
 func NewBasicService(start StartingFn, run RunningFn, stop StoppingFn) *BasicService {
 	return &BasicService{
 		startFn:             start,
@@ -246,7 +246,7 @@ func (b *BasicService) StopAsync() {
 	}
 }
 
-// Returns context that this service uses internally for controlling its lifecycle. It is the same context that
+// ServiceContext returns context that this service uses internally for controlling its lifecycle. It is the same context that
 // is passed to Starting and Running functions, and is based on context passed to the service via StartAsync.
 //
 // Before service enters Starting state, there is no context. This context is stopped when service enters Stopping state.

--- a/services/failure_watcher.go
+++ b/services/failure_watcher.go
@@ -13,7 +13,7 @@ func NewFailureWatcher() *FailureWatcher {
 	return &FailureWatcher{ch: make(chan error)}
 }
 
-// Returns channel for this watcher. If watcher is nil, returns nil channel.
+// Chan returns channel for this watcher. If watcher is nil, returns nil channel.
 // Errors returned on the channel include failure case and service description.
 func (w *FailureWatcher) Chan() <-chan error {
 	if w == nil {

--- a/services/manager.go
+++ b/services/manager.go
@@ -17,18 +17,18 @@ const (
 
 // ManagerListener listens for events from Manager.
 type ManagerListener interface {
-	// Called when Manager reaches Healthy state (all services Running)
+	// Healthy is alled when Manager reaches Healthy state (all services Running)
 	Healthy()
 
-	// Called when Manager reaches Stopped state (all services are either Terminated or Failed)
+	// Stopped is called when Manager reaches Stopped state (all services are either Terminated or Failed)
 	Stopped()
 
-	// Called when service fails.
+	// Failure is called when service fails.
 	Failure(service Service)
 }
 
-// Service Manager is initialized with a collection of services. They all must be in New state.
-// Service manager can start them, and observe their state as a group.
+// Manager is initialized with a collection of services. They all must be in New state.
+// Manager can start them, and observe their state as a group.
 // Once all services are running, Manager is said to be Healthy. It is possible for manager to never reach the Healthy state, if some services fail to start.
 // When all services are stopped (Terminated or Failed), manager is Stopped.
 type Manager struct {
@@ -72,7 +72,7 @@ func NewManager(services ...Service) (*Manager, error) {
 	return m, nil
 }
 
-// Initiates service startup on all the services being managed.
+// StartAsync initiates service startup on all the services being managed.
 // It is only valid to call this method if all of the services are New.
 func (m *Manager) StartAsync(ctx context.Context) error {
 	for _, s := range m.services {
@@ -84,7 +84,7 @@ func (m *Manager) StartAsync(ctx context.Context) error {
 	return nil
 }
 
-// Initiates service shutdown if necessary on all the services being managed.
+// StopAsync initiates service shutdown if necessary on all the services being managed.
 func (m *Manager) StopAsync() {
 	if m == nil {
 		return
@@ -95,7 +95,7 @@ func (m *Manager) StopAsync() {
 	}
 }
 
-// Returns true if all services are currently in the Running state.
+// IsHealthy returns true if all services are currently in the Running state.
 func (m *Manager) IsHealthy() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -103,7 +103,7 @@ func (m *Manager) IsHealthy() bool {
 	return m.state == healthy
 }
 
-// Waits for the ServiceManager to become healthy. Returns nil, if manager is healthy, error otherwise (eg. manager
+// AwaitHealthy waits for the ServiceManager to become healthy. Returns nil, if manager is healthy, error otherwise (eg. manager
 // is in a state in which it cannot get healthy anymore).
 func (m *Manager) AwaitHealthy(ctx context.Context) error {
 	select {
@@ -132,7 +132,7 @@ func (m *Manager) AwaitHealthy(ctx context.Context) error {
 	return nil
 }
 
-// Returns true if all services are in terminal state (Terminated or Failed)
+// IsStopped returns true if all services are in terminal state (Terminated or Failed)
 func (m *Manager) IsStopped() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -140,7 +140,7 @@ func (m *Manager) IsStopped() bool {
 	return m.state == stopped
 }
 
-// Waits for the ServiceManager to become stopped. Returns nil, if manager is stopped, error when context finishes earlier.
+// AwaitStopped waits for the ServiceManager to become stopped. Returns nil, if manager is stopped, error when context finishes earlier.
 func (m *Manager) AwaitStopped(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
@@ -150,7 +150,7 @@ func (m *Manager) AwaitStopped(ctx context.Context) error {
 	}
 }
 
-// Provides a snapshot of the current state of all the services under management.
+// ServicesByState provides a snapshot of the current state of all the services under management.
 func (m *Manager) ServicesByState() map[State][]Service {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -219,7 +219,7 @@ func (m *Manager) serviceStateChanged(s Service, from State, to State) {
 	}
 }
 
-// Registers a ManagerListener to be run when this Manager changes state.
+// AddListener registers a ManagerListener to be run when this Manager changes state.
 // The listener will not have previous state changes replayed, so it is suggested that listeners are added before any of the managed services are started.
 //
 // AddListener guarantees execution ordering across calls to a given listener but not across calls to multiple listeners.

--- a/services/manager.go
+++ b/services/manager.go
@@ -17,7 +17,7 @@ const (
 
 // ManagerListener listens for events from Manager.
 type ManagerListener interface {
-	// Healthy is alled when Manager reaches Healthy state (all services Running)
+	// Healthy is called when Manager reaches Healthy state (all services Running)
 	Healthy()
 
 	// Stopped is called when Manager reaches Stopped state (all services are either Terminated or Failed)

--- a/services/service.go
+++ b/services/service.go
@@ -8,13 +8,14 @@ import (
 // State of the service. See Service interface for full state diagram.
 type State int
 
+// Possible states to represent the service State.
 const (
-	New        State = iota // Service is new, not running yet. Initial state.
-	Starting                // Service is starting. If starting succeeds, service enters Running state.
-	Running                 // Service is fully running now. When service stops running, it enters Stopping state.
-	Stopping                // Service is shutting down
-	Terminated              // Service has stopped successfully. Terminal state.
-	Failed                  // Service has failed in Starting, Running or Stopping state. Terminal state.
+	New        State = iota // New: Service is new, not running yet. Initial State.
+	Starting                // Starting: Service is starting. If starting succeeds, service enters Running state.
+	Running                 // Running: Service is fully running now. When service stops running, it enters Stopping state.
+	Stopping                // Stopping: Service is shutting down
+	Terminated              // Terminated: Service has stopped successfully. Terminal state.
+	Failed                  // Failed: Service has failed in Starting, Running or Stopping state. Terminal state.
 )
 
 func (s State) String() string {
@@ -104,18 +105,18 @@ type NamedService interface {
 
 // Listener receives notifications about Service state changes.
 type Listener interface {
-	// Called when the service transitions from NEW to STARTING.
+	// Starting is called when the service transitions from NEW to STARTING.
 	Starting()
 
-	// Called when the service transitions from STARTING to RUNNING.
+	// Running is called when the service transitions from STARTING to RUNNING.
 	Running()
 
-	// Called when the service transitions to the STOPPING state.
+	// Stopping ic called when the service transitions to the STOPPING state.
 	Stopping(from State)
 
-	// Called when the service transitions to the TERMINATED state.
+	// Terminated is called when the service transitions to the TERMINATED state.
 	Terminated(from State)
 
-	// Called when the service transitions to the FAILED state.
+	// Failed is called when the service transitions to the FAILED state.
 	Failed(from State, failure error)
 }

--- a/services/service.go
+++ b/services/service.go
@@ -111,7 +111,7 @@ type Listener interface {
 	// Running is called when the service transitions from STARTING to RUNNING.
 	Running()
 
-	// Stopping ic called when the service transitions to the STOPPING state.
+	// Stopping is called when the service transitions to the STOPPING state.
 	Stopping(from State)
 
 	// Terminated is called when the service transitions to the TERMINATED state.

--- a/services/services.go
+++ b/services/services.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Initializes basic service as an "idle" service -- it doesn't do anything in its Running state,
+// NewIdleService initializes basic service as an "idle" service -- it doesn't do anything in its Running state,
 // but still supports all state transitions.
 func NewIdleService(up StartingFn, down StoppingFn) *BasicService {
 	run := func(ctx context.Context) error {
@@ -17,11 +17,11 @@ func NewIdleService(up StartingFn, down StoppingFn) *BasicService {
 	return NewBasicService(up, run, down)
 }
 
-// One iteration of the timer service. Called repeatedly until service is stopped, or this function returns error
+// OneIteration is one iteration of the timer service. Called repeatedly until service is stopped, or this function returns error
 // in which case, service will fail.
 type OneIteration func(ctx context.Context) error
 
-// Runs iteration function on every interval tick. When iteration returns error, service fails.
+// NewTimerService runs iteration function on every interval tick. When iteration returns error, service fails.
 func NewTimerService(interval time.Duration, start StartingFn, iter OneIteration, stop StoppingFn) *BasicService {
 	run := func(ctx context.Context) error {
 		t := time.NewTicker(interval)


### PR DESCRIPTION
While adding the linting for global metrics I found a lot of comments that were failing `golangci-lint run` step of `make lint`, this PR fixes the currently existing issues. 

Signed-off-by: Tyler Reid <tyler.reid@grafana.com>