### PR TITLE
Add vendor/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.tools/
+vendor


### PR DESCRIPTION
I would like to add vendor/ to .gitignore, since in this repo we're not committing it.