### PR TITLE
spanlogger: Take an interface implementation for extracting tenant IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 * [CHANGE] Added CHANGELOG.md and Pull Request template to reference the changelog
 * [CHANGE] Remove `cortex_` prefix for metrics registered in the ring. #46
 * [CHANGE] Rename `kv/kvtls` to `crypto/tls`. #39
+* [CHANGE] spanlogger: Take interface implementation for extracting tenant ID. #59
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41
 * [ENHANCEMENT] Add grpcclient, grpcencoding and grpcutil packages. #39
 * [ENHANCEMENT] Replace go-kit/kit/log with go-kit/log. #52
 * [ENHANCEMENT] Add spanlogger package. #42
+* [BUGFIX] spanlogger: Support multiple tenant IDs. #59


### PR DESCRIPTION
**What this PR does**:
Change `spanlogger` into taking an interface implementation for extracting tenant IDs, and also fix a bug by supporting multiple tenant IDs in the context.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
