### PR TITLE
Collect ring metrics on ring start

### DIFF
--- a/ring/ring.go
+++ b/ring/ring.go
@@ -282,6 +282,7 @@ func (r *Ring) starting(ctx context.Context) error {
 	}
 
 	r.updateRingState(value.(*Desc))
+	r.updateRingMetrics()
 
 	// Start metrics update ticker, and give it a function to update the ring metrics.
 	r.metricsUpdateTicker = time.NewTicker(10 * time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: This will collect and register metrics for the ring before the first tick at 10 seconds. 

**Which issue(s) this PR fixes**:

**Checklist**
- [-] Tests updated
- [-] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
