### PR TITLE
Add a channel to close the go routine for updating ring metrics

### DIFF
--- a/ring/ring.go
+++ b/ring/ring.go
@@ -198,7 +198,6 @@ type Ring struct {
 	totalTokensGauge        prometheus.Gauge
 	numTokensGaugeVec       *prometheus.GaugeVec
 	oldestTimestampGaugeVec *prometheus.GaugeVec
-	metricsUpdateTicker     *time.Ticker
 	metricsUpdateCloser     chan struct{}
 
 	logger log.Logger
@@ -285,14 +284,16 @@ func (r *Ring) starting(ctx context.Context) error {
 	r.updateRingState(value.(*Desc))
 	r.updateRingMetrics()
 
-	// Start metrics update ticker, and give it a function to update the ring metrics.
-	r.metricsUpdateTicker = time.NewTicker(10 * time.Second)
 	// Use this channel to close the go routine to prevent leaks.
 	r.metricsUpdateCloser = make(chan struct{})
 	go func() {
+		// Start metrics update ticker to update the ring metrics.
+		ticker := time.NewTimer(10 * time.Second)
+		defer ticker.Stop()
+
 		for {
 			select {
-			case <-r.metricsUpdateTicker.C:
+			case <-ticker.C:
 				r.updateRingMetrics()
 			case <-r.metricsUpdateCloser:
 				return
@@ -317,8 +318,7 @@ func (r *Ring) loop(ctx context.Context) error {
 
 func (r *Ring) stopping(_ error) error {
 	// Stop Metrics ticker.
-	if r.metricsUpdateTicker != nil {
-		r.metricsUpdateTicker.Stop()
+	if r.metricsUpdateCloser != nil {
 		close(r.metricsUpdateCloser)
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: While hunting down a leak in cortex unit tests with ring migration I found that we don't close the ticker channel and that can leave the go routine open. With the closer channel added to the ring when we call stopping we will signal that channel and return the go routine we use to collect metrics.



**Checklist**
- [-] Tests updated
- [-] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
