### PR TITLE
fix panic with very low durations

### DIFF
--- a/time/time.go
+++ b/time/time.go
@@ -56,6 +56,11 @@ func DurationWithJitter(input time.Duration, variancePerc float64) time.Duration
 	}
 
 	variance := int64(float64(input) * variancePerc)
+	if variance == 0 {
+		// Values too low
+		return input
+	}
+
 	jitter := rand.Int63n(variance*2) - variance
 
 	return input + time.Duration(jitter)
@@ -69,6 +74,11 @@ func DurationWithPositiveJitter(input time.Duration, variancePerc float64) time.
 	}
 
 	variance := int64(float64(input) * variancePerc)
+	if variance == 0 {
+		// Values too low
+		return input
+	}
+
 	jitter := rand.Int63n(variance)
 
 	return input + time.Duration(jitter)

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTimeFromMillis(t *testing.T) {
-	var testExpr = []struct {
+	testExpr := []struct {
 		input    int64
 		expected time.Time
 	}{
@@ -40,6 +40,10 @@ func TestDurationWithJitter_ZeroInputDuration(t *testing.T) {
 	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(0), 0.5))
 }
 
+func TestDurationWithJitter_VeryLowDuration(t *testing.T) {
+	assert.Equal(t, 4*time.Nanosecond, DurationWithJitter(4*time.Nanosecond, 0.2))
+}
+
 func TestDurationWithPositiveJitter(t *testing.T) {
 	const numRuns = 1000
 
@@ -54,8 +58,12 @@ func TestDurationWithPositiveJitter_ZeroInputDuration(t *testing.T) {
 	assert.Equal(t, time.Duration(0), DurationWithPositiveJitter(time.Duration(0), 0.5))
 }
 
+func TestDurationWithPositiveJitter_VeryLowDuration(t *testing.T) {
+	assert.Equal(t, time.Nanosecond, DurationWithPositiveJitter(time.Nanosecond, 0.5))
+}
+
 func TestParseTime(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		input  string
 		fail   bool
 		result time.Time


### PR DESCRIPTION
I discovered this panic because some of our e2e test cases were actually using such low values