### PR TITLE
Improve gRPC error status label in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [CHANGE] Remove `cortex_` prefix for metrics registered in the ring. #46
 * [CHANGE] Rename `kv/kvtls` to `crypto/tls`. #39
 * [CHANGE] spanlogger: Take interface implementation for extracting tenant ID. #59
-* [CHANGE] The `status_code` label on metrics from client has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #68
+* [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #68
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [CHANGE] Remove `cortex_` prefix for metrics registered in the ring. #46
 * [CHANGE] Rename `kv/kvtls` to `crypto/tls`. #39
 * [CHANGE] spanlogger: Take interface implementation for extracting tenant ID. #59
+* [CHANGE] The `status_code` label on metrics from client has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #68
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/middleware/grpc_test.go
+++ b/middleware/grpc_test.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/httpgrpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestErrorCode_NoError(t *testing.T) {
+	a := errorCode(nil)
+	assert.Equal(t, a, "2xx")
+}
+
+func TestErrorCode_Any5xx(t *testing.T) {
+	err := httpgrpc.Errorf(http.StatusNotImplemented, "Fail")
+	a := errorCode(err)
+	assert.Equal(t, a, "5xx")
+}
+
+func TestErrorCode_Any4xx(t *testing.T) {
+	err := httpgrpc.Errorf(http.StatusConflict, "Fail")
+	a := errorCode(err)
+	assert.Equal(t, a, "4xx")
+}
+
+func TestErrorCode_Canceled(t *testing.T) {
+	err := status.Errorf(codes.Canceled, "Fail")
+	a := errorCode(err)
+	assert.Equal(t, a, "cancel")
+}
+
+func TestErrorCode_Unknown(t *testing.T) {
+	err := status.Errorf(codes.Unknown, "Fail")
+	a := errorCode(err)
+	assert.Equal(t, a, "error")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This is an attempt to continue a PR in cortex (https://github.com/cortexproject/cortex/pull/4519)
After a discussion(https://github.com/cortexproject/cortex/issues/4441), we noticed that client metrics sent from cortex could be improved.

**Which issue(s) this PR fixes**:
The main purpose is to separate 5xx and 4xx error types in the metrics.


**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
