### PR TITLE
Add info log when entering final sleep

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -846,6 +846,7 @@ func (i *Lifecycler) processShutdown(ctx context.Context) {
 	}
 
 	// Sleep so the shutdownDuration metric can be collected.
+	level.Info(i.logger).Log("msg", "lifecycler entering final sleep before shutdown", "final_sleep", i.cfg.FinalSleep)
 	time.Sleep(i.cfg.FinalSleep)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds an info log indicating when the lifecycler is about to enter it's current sleep period.

**Which issue(s) this PR fixes**:
Since the lifecycler defaults this values to `30s`, to someone using the default who may not be aware of this behavior, it can be confusing why on shutdown the process seems to be hanging. This provides a helpful log message indicating the final sleep is beginning, and for how long it will last.
