### PR TITLE
Remove the closer package since it's trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Closer: remove the closer package since it's trivial to just copy/paste. #70
 * [CHANGE] Memberlist: allow specifying address and port advertised to the memberlist cluster members by setting the following configuration: #37
   * `-memberlist.advertise_addr`
   * `-memberlist.advertise_port`

--- a/closer/closer.go
+++ b/closer/closer.go
@@ -1,9 +1,0 @@
-package closer
-
-// Func is like http.HandlerFunc but for io.Closers.
-type Func func() error
-
-// Close implements io.Closer.
-func (f Func) Close() error {
-	return f()
-}

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -59,7 +59,7 @@ type kv interface {
 	Put(p *consul.KVPair, q *consul.WriteOptions) (*consul.WriteMeta, error)
 }
 
-// Client is a KV.Client for Consul.
+// Client is a kv.Client for Consul.
 type Client struct {
 	kv
 	codec         codec.Codec

--- a/kv/etcd/etcd.go
+++ b/kv/etcd/etcd.go
@@ -38,7 +38,7 @@ type Clientv3Facade interface {
 	clientv3.Watcher
 }
 
-// Client implements ring.KVClient for etcd.
+// Client implements kv.Client for etcd.
 type Client struct {
 	cfg    Config
 	codec  codec.Codec


### PR DESCRIPTION
The only uses found were the Consul mock kv client. Even in
Cortex/Loki/Tempo the only uses were the vendored version of
the same Consul mock kv client.

Fixes #51

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
