### PR TITLE
Use UTC explicitly for flagext.DayValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71
 * [CHANGE] Closer: remove the closer package since it's trivial to just copy/paste. #70
 * [CHANGE] Memberlist: allow specifying address and port advertised to the memberlist cluster members by setting the following configuration: #37
   * `-memberlist.advertise_addr`

--- a/flagext/day.go
+++ b/flagext/day.go
@@ -25,12 +25,12 @@ func NewDayValue(t model.Time) DayValue {
 
 // String implements flag.Value
 func (v DayValue) String() string {
-	return v.Time.Time().Format(time.RFC3339)
+	return v.Time.Time().UTC().Format(time.RFC3339)
 }
 
 // Set implements flag.Value
 func (v *DayValue) Set(s string) error {
-	t, err := time.Parse("2006-01-02", s)
+	t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
 	if err != nil {
 		return err
 	}
@@ -55,5 +55,5 @@ func (v *DayValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // MarshalYAML implements yaml.Marshaler.
 func (v DayValue) MarshalYAML() (interface{}, error) {
-	return v.Time.Time().Format("2006-01-02"), nil
+	return v.Time.Time().UTC().Format("2006-01-02"), nil
 }

--- a/flagext/day_test.go
+++ b/flagext/day_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestDayValueYAML(t *testing.T) {
-	// Test embedding of DayValue.
-	{
+	t.Run("embedding DayValue", func(t *testing.T) {
 		type TestStruct struct {
 			Day DayValue `yaml:"day"`
 		}
@@ -28,10 +27,9 @@ func TestDayValueYAML(t *testing.T) {
 		err = yaml.Unmarshal(expected, &actualStruct)
 		require.NoError(t, err)
 		assert.Equal(t, testStruct, actualStruct)
-	}
+	})
 
-	// Test pointers of DayValue.
-	{
+	t.Run("pointer of DayValue", func(t *testing.T) {
 		type TestStruct struct {
 			Day *DayValue `yaml:"day"`
 		}
@@ -50,5 +48,5 @@ func TestDayValueYAML(t *testing.T) {
 		err = yaml.Unmarshal(expected, &actualStruct)
 		require.NoError(t, err)
 		assert.Equal(t, testStruct, actualStruct)
-	}
+	})
 }


### PR DESCRIPTION
Fixes #23

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
