### PR TITLE
Chore: Replace all usages of ioutil

### DIFF
--- a/crypto/tls/tls.go
+++ b/crypto/tls/tls.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -44,7 +44,7 @@ func (cfg *ClientConfig) GetTLSConfig() (*tls.Config, error) {
 	// read ca certificates
 	if cfg.CAPath != "" {
 		var caCertPool *x509.CertPool
-		caCert, err := ioutil.ReadFile(cfg.CAPath)
+		caCert, err := os.ReadFile(cfg.CAPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error loading ca cert: %s", cfg.CAPath)
 		}

--- a/grpcencoding/snappy/snappy_test.go
+++ b/grpcencoding/snappy/snappy_test.go
@@ -3,7 +3,6 @@ package snappy
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestSnappy(t *testing.T) {
 			// Decompress
 			r, err := c.Decompress(&buf)
 			require.NoError(t, err)
-			out, err := ioutil.ReadAll(r)
+			out, err := io.ReadAll(r)
 			require.NoError(t, err)
 			assert.Equal(t, test.input, string(out))
 		})
@@ -49,7 +48,7 @@ func BenchmarkSnappyCompress(b *testing.B) {
 	c := newCompressor()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		w, _ := c.Compress(ioutil.Discard)
+		w, _ := c.Compress(io.Discard)
 		_, _ = w.Write(data)
 		_ = w.Close()
 	}
@@ -65,7 +64,7 @@ func BenchmarkSnappyDecompress(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r, _ := c.Decompress(reader)
-		_, _ = ioutil.ReadAll(r)
+		_, _ = io.ReadAll(r)
 		_, _ = reader.Seek(0, io.SeekStart)
 	}
 }

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"sync"
 	"time"
@@ -277,7 +276,7 @@ func (t *TCPTransport) handleConnection(conn net.Conn) {
 		}
 
 		// read the rest to buffer -- this is the "packet" itself
-		buf, err := ioutil.ReadAll(conn)
+		buf, err := io.ReadAll(conn)
 		if err != nil {
 			t.receivedPacketsErrors.Inc()
 			level.Error(t.logger).Log("msg", "TCPTransport: error while reading packet data:", "err", err)

--- a/ring/basic_lifecycler_delegates_test.go
+++ b/ring/basic_lifecycler_delegates_test.go
@@ -2,7 +2,6 @@ package ring
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -41,7 +40,7 @@ func TestLeaveOnStoppingDelegate(t *testing.T) {
 
 func TestTokensPersistencyDelegate_ShouldSkipTokensLoadingIfFileDoesNotExist(t *testing.T) {
 	// Create a temporary file and immediately delete it.
-	tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+	tokensFile, err := os.CreateTemp("", "tokens-*")
 	require.NoError(t, err)
 	require.NoError(t, os.Remove(tokensFile.Name()))
 
@@ -79,7 +78,7 @@ func TestTokensPersistencyDelegate_ShouldSkipTokensLoadingIfFileDoesNotExist(t *
 }
 
 func TestTokensPersistencyDelegate_ShouldLoadTokensFromFileIfFileExist(t *testing.T) {
-	tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+	tokensFile, err := os.CreateTemp("", "tokens-*")
 	require.NoError(t, err)
 	defer os.Remove(tokensFile.Name()) //nolint:errcheck
 
@@ -146,7 +145,7 @@ func TestTokensPersistencyDelegate_ShouldHandleTheCaseTheInstanceIsAlreadyInTheR
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+			tokensFile, err := os.CreateTemp("", "tokens-*")
 			require.NoError(t, err)
 			defer os.Remove(tokensFile.Name()) //nolint:errcheck
 
@@ -191,7 +190,7 @@ func TestDelegatesChain(t *testing.T) {
 	onStoppingCalled := false
 
 	// Create a temporary file and immediately delete it.
-	tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+	tokensFile, err := os.CreateTemp("", "tokens-*")
 	require.NoError(t, err)
 	require.NoError(t, os.Remove(tokensFile.Name()))
 

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -3,7 +3,6 @@ package ring
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"testing"
@@ -596,7 +595,7 @@ func TestTokensOnDisk(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	tokenDir, err := ioutil.TempDir(os.TempDir(), "tokens_on_disk")
+	tokenDir, err := os.MkdirTemp("", "tokens_on_disk")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.RemoveAll(tokenDir))

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -3,7 +3,6 @@ package ring
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -595,11 +594,7 @@ func TestTokensOnDisk(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	tokenDir, err := os.MkdirTemp("", "tokens_on_disk")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tokenDir))
-	}()
+	tokenDir := t.TempDir()
 
 	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
 	lifecyclerConfig.NumTokens = 512

--- a/ring/tokens.go
+++ b/ring/tokens.go
@@ -3,7 +3,6 @@ package ring
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"sort"
 )
@@ -72,7 +71,7 @@ func (t Tokens) StoreToFile(tokenFilePath string) error {
 
 // LoadTokensFromFile loads tokens from given file path.
 func LoadTokensFromFile(tokenFilePath string) (Tokens, error) {
-	b, err := ioutil.ReadFile(tokenFilePath)
+	b, err := os.ReadFile(tokenFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/ring/tokens_test.go
+++ b/ring/tokens_test.go
@@ -2,7 +2,6 @@ package ring
 
 import (
 	"math/rand"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,11 +58,7 @@ func TestTokens_Equals(t *testing.T) {
 }
 
 func TestLoadTokensFromFile_ShouldGuaranteeSortedTokens(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-tokens")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
+	tmpDir := t.TempDir()
 
 	// Store tokens to file.
 	orig := Tokens{1, 5, 3}

--- a/ring/tokens_test.go
+++ b/ring/tokens_test.go
@@ -1,7 +1,6 @@
 package ring
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -60,7 +59,7 @@ func TestTokens_Equals(t *testing.T) {
 }
 
 func TestLoadTokensFromFile_ShouldGuaranteeSortedTokens(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test-tokens")
+	tmpDir, err := os.MkdirTemp("", "test-tokens")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -145,7 +145,7 @@ func (om *Manager) loop(ctx context.Context) error {
 // loadConfig loads configuration using the loader function, and if successful,
 // stores it as current configuration and notifies listeners.
 func (om *Manager) loadConfig() error {
-	buf, err := ioutil.ReadFile(om.cfg.LoadPath)
+	buf, err := os.ReadFile(om.cfg.LoadPath)
 	if err != nil {
 		om.configLoadSuccess.Set(0)
 		return errors.Wrap(err, "read file")

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -58,7 +57,7 @@ func newTestOverridesManagerConfig(t *testing.T, i int32) (*atomic.Int32, Config
 	var config = atomic.NewInt32(i)
 
 	// create empty file
-	tempFile, err := ioutil.TempFile("", "test-validation")
+	tempFile, err := os.CreateTemp("", "test-validation")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -78,7 +77,7 @@ func newTestOverridesManagerConfig(t *testing.T, i int32) (*atomic.Int32, Config
 }
 
 func TestNewOverridesManager(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "test-validation")
+	tempFile, err := os.CreateTemp("", "test-validation")
 	require.NoError(t, err)
 
 	defer func() {
@@ -113,7 +112,7 @@ func TestNewOverridesManager(t *testing.T) {
 }
 
 func TestManager_ListenerWithDefaultLimits(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "test-validation")
+	tempFile, err := os.CreateTemp("", "test-validation")
 	require.NoError(t, err)
 	require.NoError(t, tempFile.Close())
 
@@ -125,7 +124,7 @@ func TestManager_ListenerWithDefaultLimits(t *testing.T) {
 	config := []byte(`overrides:
   user1:
     limit2: 150`)
-	err = ioutil.WriteFile(tempFile.Name(), config, 0600)
+	err = os.WriteFile(tempFile.Name(), config, 0600)
 	require.NoError(t, err)
 
 	defaultTestLimits = &TestLimits{Limit1: 100}
@@ -160,7 +159,7 @@ func TestManager_ListenerWithDefaultLimits(t *testing.T) {
 	config = []byte(`overrides:
   user2:
     limit2: 200`)
-	err = ioutil.WriteFile(tempFile.Name(), config, 0600)
+	err = os.WriteFile(tempFile.Name(), config, 0600)
 	require.NoError(t, err)
 
 	// reload
@@ -258,7 +257,7 @@ func TestManager_StopClosesListenerChannels(t *testing.T) {
 
 func TestManager_ShouldFastFailOnInvalidConfigAtStartup(t *testing.T) {
 	// Create an invalid runtime config file.
-	tempFile, err := ioutil.TempFile("", "invalid-config")
+	tempFile, err := os.CreateTemp("", "invalid-config")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, os.Remove(tempFile.Name()))


### PR DESCRIPTION
**What this PR does**:
Since ioutil is [deprecated](https://golang.org/doc/go1.16#ioutil) since Go 1.16, replace all usages of it with preferred equivalents. Nothing important, but might as well clean up :)

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
