### PR TITLE
ring.Lifecycler: Handle when previous ring state is leaving and the number of tokens has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,4 @@
 * [BUGFIX] Ring status page: fixed the owned tokens percentage value displayed. #282
 * [BUGFIX] Ring: prevent iterating the whole ring when using `ExcludedZones`. #285
 * [BUGFIX] grpcclient: fix missing `.` in flag name for initial connection window size flag. #314
+* [BUGFIX] ring.Lifecycler: Handle when previous ring state is leaving and the number of tokens has changed. #79

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -616,7 +616,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			return ringDesc, true, nil
 		}
 
-		level.Info(i.logger).Log("msg", "existing entry found in ring", "state", i.GetState(), "tokens", len(instanceDesc.Tokens), "ring", i.RingName)
+		level.Info(i.logger).Log("msg", "existing entry found in ring", "state", instanceDesc.State, "tokens", len(instanceDesc.Tokens), "ring", i.RingName)
 
 		// If the ingester failed to clean its ring entry up it can leave its state in LEAVING
 		// OR unregister_on_shutdown=false
@@ -651,7 +651,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			instanceDesc.State = i.state
 			instanceDesc.Tokens = tokens
 		} else {
-			// We exist in the ring and not in leaving state, so assume the ring is right and copy out tokens & state out of there.
+			// We exist in the ring and not in leaving state, so assume the ring is right and copy tokens & state out of there.
 			i.setState(instanceDesc.State)
 			i.setTokens(instanceDesc.Tokens)
 		}

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -754,7 +754,6 @@ func (i *Lifecycler) autoJoin(ctx context.Context, targetState InstanceState) er
 		// At this point, we should not have any tokens, and we should be in PENDING state.
 		myTokens, takenTokens := ringDesc.TokensFor(i.ID)
 		if len(myTokens) > 0 {
-			// TODO: Should we log this case as an error, as we don't treat it as one?
 			level.Error(i.logger).Log("msg", "tokens already exist for this instance - wasn't expecting any!", "num_tokens", len(myTokens), "ring", i.RingName)
 		}
 

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -636,9 +636,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				// We have too many tokens
 				level.Debug(i.logger).Log("msg", "existing instance has too many tokens, removing difference",
 					"num_tokens", len(tokens), "need", i.cfg.NumTokens)
-				// Originally suggested by Andrea Gardiman, make sure we don't pick the N smallest tokens,
-				// since that would increase the chance of the instance receiving only smaller hashes
-				// https://github.com/grafana/dskit/pull/79#discussion_r1056205242
+				// Make sure we don't pick the N smallest tokens, since that would increase the chance of the instance receiving only smaller hashes.
 				rand.Shuffle(len(tokens), func(i, j int) {
 					tokens[i], tokens[j] = tokens[j], tokens[i]
 				})

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -642,17 +642,13 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				sort.Sort(tokens)
 			}
 
-			level.Debug(i.logger).Log("msg", "switching state from LEAVING to ACTIVE")
-			i.setState(ACTIVE)
-
-			i.setTokens(tokens)
-			instanceDesc.State = i.GetState()
+			instanceDesc.State = ACTIVE
 			instanceDesc.Tokens = tokens
-		} else {
-			// We exist in the ring and not in leaving state, so assume the ring is right and copy tokens & state out of there.
-			i.setState(instanceDesc.State)
-			i.setTokens(tokens)
 		}
+
+		// Set the local state based on the updated instance.
+		i.setState(instanceDesc.State)
+		i.setTokens(tokens)
 
 		// We're taking over this entry, update instanceDesc with our values
 		instanceDesc.Addr = i.Addr

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -644,11 +644,11 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				level.Debug(i.logger).Log("msg", "switching state to active")
 				i.setState(ACTIVE)
 			} else {
-				level.Debug(i.logger).Log("msg", "not switching state to active", "state", i.state)
+				level.Debug(i.logger).Log("msg", "not switching state to active", "state", i.GetState())
 			}
 
 			i.setTokens(tokens)
-			instanceDesc.State = i.state
+			instanceDesc.State = i.GetState()
 			instanceDesc.Tokens = tokens
 		} else {
 			// We exist in the ring and not in leaving state, so assume the ring is right and copy tokens & state out of there.

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -630,13 +630,18 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 					level.Debug(i.logger).Log("msg", "adding tokens from file", "tokens", len(tokensFromFile))
 					isActive = len(tokensFromFile) >= i.cfg.NumTokens
 					tokens = tokensFromFile
-				} else {
-					level.Debug(i.logger).Log("msg", "no tokens in file, generating new ones")
-					takenTokens := ringDesc.GetTokens()
+				} else if i.cfg.NumTokens == len(instanceDesc.Tokens) {
+					level.Debug(i.logger).Log("msg", "no tokens in file, adopting those of existing instance")
+					tokens = instanceDesc.Tokens
+				} else if i.cfg.NumTokens > len(instanceDesc.Tokens) {
 					needTokens := i.cfg.NumTokens - len(instanceDesc.Tokens)
-					newTokens := GenerateTokens(needTokens, takenTokens)
+					level.Debug(i.logger).Log("msg", "no tokens in file, generating new ones in addition to those of existing instance", "newTokens", needTokens)
+					newTokens := GenerateTokens(needTokens, ringDesc.GetTokens())
 					tokens = append(instanceDesc.Tokens, newTokens...)
 					sort.Sort(tokens)
+				} else {
+					level.Debug(i.logger).Log("msg", "no tokens in file, adopting a subset of existing instance's tokens", "numTokens", i.cfg.NumTokens)
+					tokens = instanceDesc.Tokens[0:i.cfg.NumTokens]
 				}
 			}
 

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -618,7 +618,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 		}
 
 		tokens := Tokens(instanceDesc.Tokens)
-		level.Info(i.logger).Log("msg", "existing instance found in ring", "state", i.GetState(), "tokens",
+		level.Info(i.logger).Log("msg", "existing instance found in ring", "state", instanceDesc.State, "tokens",
 			len(tokens), "ring", i.RingName)
 
 		// If the ingester fails to clean its ring entry up or unregister_on_shutdown=false, it can leave behind its

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -627,8 +627,8 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			delta := i.cfg.NumTokens - len(tokens)
 			if delta > 0 {
 				// We need more tokens
-				level.Debug(i.logger).Log("msg", "existing instance has too few tokens, adding difference",
-					"num_tokens", len(tokens), "need", i.cfg.NumTokens)
+				level.Info(i.logger).Log("msg", "existing instance has too few tokens, adding difference",
+					"current_tokens", len(tokens), "desired_tokens", i.cfg.NumTokens)
 				newTokens := GenerateTokens(delta, ringDesc.GetTokens())
 				tokens = append(tokens, newTokens...)
 				sort.Sort(tokens)

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -637,9 +637,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				level.Info(i.logger).Log("msg", "existing instance has too many tokens, removing difference",
 					"current_tokens", len(tokens), "desired_tokens", i.cfg.NumTokens)
 				// Make sure we don't pick the N smallest tokens, since that would increase the chance of the instance receiving only smaller hashes.
-				rand.Shuffle(len(tokens), func(i, j int) {
-					tokens[i], tokens[j] = tokens[j], tokens[i]
-				})
+				rand.Shuffle(len(tokens), tokens.Swap)
 				tokens = tokens[0:i.cfg.NumTokens]
 				sort.Sort(tokens)
 			}

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -620,23 +620,23 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 		// OR unregister_on_shutdown=false
 		// Move it into ACTIVE to ensure the ingester joins the ring.
 		if instanceDesc.State == LEAVING {
-			var tokens Tokens = instanceDesc.Tokens // way of forcing tokens to be of type Tokens instead of []uint32.
+			tokens := Tokens(instanceDesc.Tokens)
 			setIsActive := true
-			if len(instanceDesc.Tokens) != i.cfg.NumTokens {
-				level.Debug(i.logger).Log("msg", "existing entry has different number of tokens", "existingTokens", len(instanceDesc.Tokens), "newTokens", i.cfg.NumTokens)
+			if len(tokens) != i.cfg.NumTokens {
+				level.Debug(i.logger).Log("msg", "existing entry has different number of tokens", "existingTokens", len(tokens), "newTokens", i.cfg.NumTokens)
 				if len(tokensFromFile) > 0 {
 					level.Debug(i.logger).Log("msg", "adding tokens from file", "tokens", len(tokensFromFile))
 					setIsActive = len(tokensFromFile) >= i.cfg.NumTokens
 					tokens = tokensFromFile
-				} else if i.cfg.NumTokens > len(instanceDesc.Tokens) {
-					needTokens := i.cfg.NumTokens - len(instanceDesc.Tokens)
+				} else if i.cfg.NumTokens > len(tokens) {
+					needTokens := i.cfg.NumTokens - len(tokens)
 					level.Debug(i.logger).Log("msg", "no tokens in file, generating new ones in addition to those of existing instance", "newTokens", needTokens)
 					newTokens := GenerateTokens(needTokens, ringDesc.GetTokens())
-					tokens = append(instanceDesc.Tokens, newTokens...)
+					tokens = append(tokens, newTokens...)
 					sort.Sort(tokens)
 				} else {
 					level.Debug(i.logger).Log("msg", "no tokens in file, adopting a subset of existing instance's tokens", "numTokens", i.cfg.NumTokens)
-					tokens = instanceDesc.Tokens[0:i.cfg.NumTokens]
+					tokens = tokens[0:i.cfg.NumTokens]
 				}
 			} else {
 				level.Debug(i.logger).Log("msg", "adopting tokens of existing instance")

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -635,7 +636,14 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				// We have too many tokens
 				level.Debug(i.logger).Log("msg", "existing instance has too many tokens, removing difference",
 					"num_tokens", len(tokens), "need", i.cfg.NumTokens)
+				// Originally suggested by Andrea Gardiman, make sure we don't pick the N smallest tokens,
+				// since that would increase the chance of the instance receiving only smaller hashes
+				// https://github.com/grafana/dskit/pull/79#discussion_r1056205242
+				rand.Shuffle(len(tokens), func(i, j int) {
+					tokens[i] = tokens[j]
+				})
 				tokens = tokens[0:i.cfg.NumTokens]
+				sort.Sort(tokens)
 			} else {
 				level.Debug(i.logger).Log("msg", "existing instance has the right amount of tokens")
 			}

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -640,7 +640,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				// since that would increase the chance of the instance receiving only smaller hashes
 				// https://github.com/grafana/dskit/pull/79#discussion_r1056205242
 				rand.Shuffle(len(tokens), func(i, j int) {
-					tokens[i] = tokens[j]
+					tokens[i], tokens[j] = tokens[j], tokens[i]
 				})
 				tokens = tokens[0:i.cfg.NumTokens]
 				sort.Sort(tokens)

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -634,8 +634,8 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				sort.Sort(tokens)
 			} else if delta < 0 {
 				// We have too many tokens
-				level.Debug(i.logger).Log("msg", "existing instance has too many tokens, removing difference",
-					"num_tokens", len(tokens), "need", i.cfg.NumTokens)
+				level.Info(i.logger).Log("msg", "existing instance has too many tokens, removing difference",
+					"current_tokens", len(tokens), "desired_tokens", i.cfg.NumTokens)
 				// Make sure we don't pick the N smallest tokens, since that would increase the chance of the instance receiving only smaller hashes.
 				rand.Shuffle(len(tokens), func(i, j int) {
 					tokens[i], tokens[j] = tokens[j], tokens[i]

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -642,8 +642,6 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				})
 				tokens = tokens[0:i.cfg.NumTokens]
 				sort.Sort(tokens)
-			} else {
-				level.Debug(i.logger).Log("msg", "existing instance has the right amount of tokens")
 			}
 
 			level.Debug(i.logger).Log("msg", "switching state from LEAVING to ACTIVE")

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -516,6 +516,64 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	})
 }
 
+// Test Lifecycler when decreasing tokens and instance is already in the ring in leaving state.
+func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
+	ctx := context.Background()
+
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = ringStore
+	r, err := New(ringConfig, "ingester", IngesterRingKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+	})
+
+	tokenDir := t.TempDir()
+	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
+	// Make sure changes are applied instantly
+	lifecyclerConfig.HeartbeatPeriod = 0
+	lifecyclerConfig.NumTokens = 64
+	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
+
+	// Simulate ingester with 128 tokens left the ring in LEAVING state
+	err = r.KVClient.CAS(ctx, IngesterRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := NewDesc()
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil)
+		if err != nil {
+			return nil, false, err
+		}
+
+		ringDesc.AddIngester("ing1", addr, lifecyclerConfig.Zone, GenerateTokens(128, nil), LEAVING, time.Now())
+		return ringDesc, true, nil
+	})
+	require.NoError(t, err)
+
+	// Start ingester with decreased number of tokens
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", IngesterRingKey, true, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, l))
+	})
+
+	// Verify ingester joined, is active, and has 64 tokens
+	test.Poll(t, time.Second, true, func() interface{} {
+		d, err := r.KVClient.Get(ctx, IngesterRingKey)
+		require.NoError(t, err)
+
+		desc, ok := d.(*Desc)
+		require.True(t, ok)
+		ingDesc := desc.Ingesters["ing1"]
+		t.Log("Polling for new ingester to have become active with 64 tokens", "state", ingDesc.State, "tokens", len(ingDesc.Tokens))
+		return ingDesc.State == ACTIVE && len(ingDesc.Tokens) == 64
+	})
+}
+
 type MockClient struct {
 	ListFunc        func(ctx context.Context, prefix string) ([]string, error)
 	GetFunc         func(ctx context.Context, key string) (interface{}, error)

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -598,6 +598,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 		// Guard against potential bug in token shuffling
 		_, exists := seen[tok]
 		require.False(t, exists, "tokens are not unique")
+		seen[tok] = struct{}{}
 
 		found := false
 		for _, ot := range origTokens {
@@ -607,8 +608,6 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 			}
 		}
 		require.True(t, found, "old tokens were not re-used")
-
-		seen[tok] = struct{}{}
 	}
 
 	assert.True(t, sort.SliceIsSorted(ingDesc.Tokens, func(i, j int) bool {

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -3,8 +3,8 @@ package ring
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -485,7 +485,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	// Simulate ingester with 64 tokens left the ring in LEAVING state
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
-		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil)
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
 		if err != nil {
 			return nil, false, err
 		}
@@ -543,7 +543,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	// Simulate ingester with 128 tokens left the ring in LEAVING state
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
-		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil)
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
 		if err != nil {
 			return nil, false, err
 		}

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -3,6 +3,7 @@ package ring
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"os"
 	"sort"
 	"testing"
@@ -455,6 +456,64 @@ func TestLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s:%d", lifecyclerCfg.Addr, lifecyclerCfg.Port), desc.GetAddr())
 	assert.Equal(t, lifecyclerCfg.Zone, desc.Zone)
 	assert.Equal(t, prevTokens, Tokens(desc.GetTokens()))
+}
+
+// Test Lifecycler when increasing tokens and instance is already in the ring in leaving state.
+func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
+	ctx := context.Background()
+
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = ringStore
+	r, err := New(ringConfig, "ingester", IngesterRingKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+	})
+
+	tokenDir := t.TempDir()
+	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
+	// Make sure changes are applied instantly
+	lifecyclerConfig.HeartbeatPeriod = 0
+	lifecyclerConfig.NumTokens = 128
+	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
+
+	// Simulate ingester with 64 tokens left the ring in LEAVING state
+	err = r.KVClient.CAS(ctx, IngesterRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := NewDesc()
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil)
+		if err != nil {
+			return nil, false, err
+		}
+
+		ringDesc.AddIngester("ing1", addr, lifecyclerConfig.Zone, GenerateTokens(64, nil), LEAVING, time.Now())
+		return ringDesc, true, nil
+	})
+	require.NoError(t, err)
+
+	// Start ingester with increased number of tokens
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", IngesterRingKey, true, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, l))
+	})
+
+	// Verify ingester joined, is active, and has 128 tokens
+	test.Poll(t, time.Second, true, func() interface{} {
+		d, err := r.KVClient.Get(ctx, IngesterRingKey)
+		require.NoError(t, err)
+
+		desc, ok := d.(*Desc)
+		require.True(t, ok)
+		ingDesc := desc.Ingesters["ing1"]
+		t.Log("Polling for new ingester to have become active with 128 tokens", "state", ingDesc.State, "tokens", len(ingDesc.Tokens))
+		return ingDesc.State == ACTIVE && len(ingDesc.Tokens) == 128
+	})
 }
 
 type MockClient struct {

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -475,12 +474,10 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
 	})
 
-	tokenDir := t.TempDir()
 	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
 	// Make sure changes are applied instantly
 	lifecyclerConfig.HeartbeatPeriod = 0
 	lifecyclerConfig.NumTokens = 128
-	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
 
 	// Simulate ingester with 64 tokens left the ring in LEAVING state
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
@@ -533,12 +530,10 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
 	})
 
-	tokenDir := t.TempDir()
 	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
 	// Make sure changes are applied instantly
 	lifecyclerConfig.HeartbeatPeriod = 0
 	lifecyclerConfig.NumTokens = 64
-	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
 
 	// Simulate ingester with 128 tokens left the ring in LEAVING state
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -468,7 +468,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
 	ringConfig.KVStore.Mock = ringStore
-	r, err := New(ringConfig, "ingester", IngesterRingKey, log.NewNopLogger(), nil)
+	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
 	t.Cleanup(func() {
@@ -483,7 +483,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
 
 	// Simulate ingester with 64 tokens left the ring in LEAVING state
-	err = r.KVClient.CAS(ctx, IngesterRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil)
 		if err != nil {
@@ -496,7 +496,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start ingester with increased number of tokens
-	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", IngesterRingKey, true, log.NewNopLogger(), nil)
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
 	t.Cleanup(func() {
@@ -505,7 +505,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 
 	// Verify ingester joined, is active, and has 128 tokens
 	test.Poll(t, time.Second, true, func() interface{} {
-		d, err := r.KVClient.Get(ctx, IngesterRingKey)
+		d, err := r.KVClient.Get(ctx, ringKey)
 		require.NoError(t, err)
 
 		desc, ok := d.(*Desc)
@@ -526,7 +526,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	var ringConfig Config
 	flagext.DefaultValues(&ringConfig)
 	ringConfig.KVStore.Mock = ringStore
-	r, err := New(ringConfig, "ingester", IngesterRingKey, log.NewNopLogger(), nil)
+	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
 	t.Cleanup(func() {
@@ -541,7 +541,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
 
 	// Simulate ingester with 128 tokens left the ring in LEAVING state
-	err = r.KVClient.CAS(ctx, IngesterRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil)
 		if err != nil {
@@ -554,7 +554,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start ingester with decreased number of tokens
-	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", IngesterRingKey, true, log.NewNopLogger(), nil)
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
 	t.Cleanup(func() {
@@ -563,7 +563,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 
 	// Verify ingester joined, is active, and has 64 tokens
 	test.Poll(t, time.Second, true, func() interface{} {
-		d, err := r.KVClient.Get(ctx, IngesterRingKey)
+		d, err := r.KVClient.Get(ctx, ringKey)
 		require.NoError(t, err)
 
 		desc, ok := d.(*Desc)


### PR DESCRIPTION
**What this PR does**:
When starting a `ring.Lifecycler`, handle when previous ingester state is found in ring, its state is leaving and the number of tokens has changed. Tests are included.

# Manual testing

I've tested manually, leaving ring member behind (in LEAVING state) on exit via `unregister_on_shutdown=false`, AFAICT it works as it should in all relevant test cases:

* Token count is unchanged
* Token count changes from 512 to 256
* Token count changes from 256 to 512

The ring member state always gets switched to ACTIVE.

**Which issue(s) this PR fixes**:

Fixes #73

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
