### PR TITLE
flagext: add RegisterFlagsWithLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@
 * [ENHANCEMENT] Add runutil.CloseWithLogOnErr function. #58
 * [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77 #84
 * [ENHANCEMENT] Memberlist: prepare the data to send on the write before starting counting the elapsed time for `-memberlist.packet-write-timeout`, in order to reduce chances we hit the timeout when sending a packet to other node. #89
+* [ENHANCEMENT] flagext: for cases such as `DeprecatedFlag()` that need a logger, add RegisterFlagsWithLogger. #80
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/flagext/register.go
+++ b/flagext/register.go
@@ -11,8 +11,8 @@ type Registerer interface {
 	RegisterFlags(*flag.FlagSet)
 }
 
-// Registerer2 is a thing that can RegisterFlags with a Logger
-type Registerer2 interface {
+// RegistererWithLogger is a thing that can RegisterFlags with a Logger
+type RegistererWithLogger interface {
 	RegisterFlags(*flag.FlagSet, log.Logger)
 }
 
@@ -29,10 +29,10 @@ func RegisterFlagsWithLogger(logger log.Logger, rs ...interface{}) {
 		switch r := v.(type) {
 		case Registerer:
 			r.RegisterFlags(flag.CommandLine)
-		case Registerer2:
+		case RegistererWithLogger:
 			r.RegisterFlags(flag.CommandLine, logger)
 		default:
-			panic("RegisterFlagsWithLogger must be passed a Registerer")
+			panic("RegisterFlagsWithLogger must be passed a Registerer or RegistererWithLogger")
 		}
 	}
 }
@@ -45,7 +45,7 @@ func DefaultValues(rs ...interface{}) {
 		switch r := v.(type) {
 		case Registerer:
 			r.RegisterFlags(fs)
-		case Registerer2:
+		case RegistererWithLogger:
 			r.RegisterFlags(fs, logger)
 		default:
 			panic("RegisterFlagsWithLogger must be passed a Registerer")

--- a/flagext/register.go
+++ b/flagext/register.go
@@ -1,10 +1,19 @@
 package flagext
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/go-kit/log"
+)
 
 // Registerer is a thing that can RegisterFlags
 type Registerer interface {
 	RegisterFlags(*flag.FlagSet)
+}
+
+// Registerer2 is a thing that can RegisterFlags with a Logger
+type Registerer2 interface {
+	RegisterFlags(*flag.FlagSet, log.Logger)
 }
 
 // RegisterFlags registers flags with the provided Registerers
@@ -14,11 +23,33 @@ func RegisterFlags(rs ...Registerer) {
 	}
 }
 
+// RegisterFlagsWithLogger registers flags with the provided Registerers
+func RegisterFlagsWithLogger(logger log.Logger, rs ...interface{}) {
+	for _, v := range rs {
+		switch r := v.(type) {
+		case Registerer:
+			r.RegisterFlags(flag.CommandLine)
+		case Registerer2:
+			r.RegisterFlags(flag.CommandLine, logger)
+		default:
+			panic("RegisterFlagsWithLogger must be passed a Registerer")
+		}
+	}
+}
+
 // DefaultValues initiates a set of configs (Registerers) with their defaults.
-func DefaultValues(rs ...Registerer) {
+func DefaultValues(rs ...interface{}) {
 	fs := flag.NewFlagSet("", flag.PanicOnError)
-	for _, r := range rs {
-		r.RegisterFlags(fs)
+	logger := log.NewNopLogger()
+	for _, v := range rs {
+		switch r := v.(type) {
+		case Registerer:
+			r.RegisterFlags(fs)
+		case Registerer2:
+			r.RegisterFlags(fs, logger)
+		default:
+			panic("RegisterFlagsWithLogger must be passed a Registerer")
+		}
 	}
 	_ = fs.Parse([]string{})
 }


### PR DESCRIPTION
For cases such as `DeprecatedFlag()` that need a logger, extend `RegisterFlags` to allow this while still working with existing code.


**Checklist**
- NA Tests updated
- [x] `CHANGELOG.md` updated.
