### PR TITLE
Add sync.pool to contain our token map in conflictingTokensExist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * [ENHANCEMENT] Replace go-kit/kit/log with go-kit/log. #52
 * [ENHANCEMENT] Add spanlogger package. #42
 * [ENHANCEMENT] Add runutil.CloseWithLogOnErr function. #58
-* [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77
+* [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77 #84
 * [ENHANCEMENT] Memberlist: prepare the data to send on the write before starting counting the elapsed time for `-memberlist.packet-write-timeout`, in order to reduce chances we hit the timeout when sending a packet to other node. #89
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/ring/model.go
+++ b/ring/model.go
@@ -303,7 +303,7 @@ func normalizeIngestersMap(inputRing *Desc) {
 	}
 }
 
-var tokenMapPool = sync.Pool{New: func() interface{}{return make(map[uint32]bool)}}
+var tokenMapPool = sync.Pool{New: func() interface{} { return make(map[uint32]bool) }}
 
 func conflictingTokensExist(normalizedIngesters map[string]InstanceDesc) bool {
 	count := 0
@@ -312,6 +312,9 @@ func conflictingTokensExist(normalizedIngesters map[string]InstanceDesc) bool {
 	}
 	tokensMap := tokenMapPool.Get().(map[uint32]bool)
 	defer func() {
+		for k := range tokensMap {
+			delete(tokensMap, k)
+		}
 		tokenMapPool.Put(tokensMap)
 	}()
 	for _, ing := range normalizedIngesters {

--- a/ring/model.go
+++ b/ring/model.go
@@ -306,10 +306,6 @@ func normalizeIngestersMap(inputRing *Desc) {
 var tokenMapPool = sync.Pool{New: func() interface{} { return make(map[uint32]bool) }}
 
 func conflictingTokensExist(normalizedIngesters map[string]InstanceDesc) bool {
-	count := 0
-	for _, ing := range normalizedIngesters {
-		count += len(ing.Tokens)
-	}
 	tokensMap := tokenMapPool.Get().(map[uint32]bool)
 	defer func() {
 		for k := range tokensMap {

--- a/ring/model.go
+++ b/ring/model.go
@@ -303,10 +303,10 @@ func normalizeIngestersMap(inputRing *Desc) {
 	}
 }
 
-var tokenMapPool = sync.Pool{New: func() interface{} { return make(map[uint32]bool) }}
+var tokenMapPool = sync.Pool{New: func() interface{} { return make(map[uint32]struct{}) }}
 
 func conflictingTokensExist(normalizedIngesters map[string]InstanceDesc) bool {
-	tokensMap := tokenMapPool.Get().(map[uint32]bool)
+	tokensMap := tokenMapPool.Get().(map[uint32]struct{})
 	defer func() {
 		for k := range tokensMap {
 			delete(tokensMap, k)
@@ -315,10 +315,10 @@ func conflictingTokensExist(normalizedIngesters map[string]InstanceDesc) bool {
 	}()
 	for _, ing := range normalizedIngesters {
 		for _, t := range ing.Tokens {
-			if tokensMap[t] {
+			if _, contains := tokensMap[t]; contains {
 				return true
 			}
-			tokensMap[t] = true
+			tokensMap[t] = struct{}{}
 		}
 	}
 	return false

--- a/ring/model.go
+++ b/ring/model.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -302,13 +303,17 @@ func normalizeIngestersMap(inputRing *Desc) {
 	}
 }
 
+var tokenMapPool = sync.Pool{New: func() interface{}{return make(map[uint32]bool)}}
+
 func conflictingTokensExist(normalizedIngesters map[string]InstanceDesc) bool {
 	count := 0
 	for _, ing := range normalizedIngesters {
 		count += len(ing.Tokens)
 	}
-
-	tokensMap := make(map[uint32]bool, count)
+	tokensMap := tokenMapPool.Get().(map[uint32]bool)
+	defer func() {
+		tokenMapPool.Put(tokensMap)
+	}()
 	for _, ing := range normalizedIngesters {
 		for _, t := range ing.Tokens {
 			if tokensMap[t] {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: This PR _should_ use a memory pool instead of allocating a map for every time we call conflictingTokensExists to allow us to gc that memory easily and prevent long lived maps.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
