### PR TITLE
Handle -memberlist.packet-write-timeout as an idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@
 * [ENHANCEMENT] Add spanlogger package. #42
 * [ENHANCEMENT] Add runutil.CloseWithLogOnErr function. #58
 * [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77
+* [EHHANCEMENT] Memberlist: `-memberlist.packet-write-timeout` config option is now handled as an idle timeout for individual write operations instead of the max time the whole packet transferring can take. #87
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/kv/memberlist/util.go
+++ b/kv/memberlist/util.go
@@ -1,0 +1,38 @@
+package memberlist
+
+import (
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type connectionWithTimeout struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func newConnectionWithTimeout(conn net.Conn, timeout time.Duration) net.Conn {
+	return &connectionWithTimeout{
+		Conn:    conn,
+		timeout: timeout,
+	}
+}
+
+// Read implements net.Conn.
+func (c *connectionWithTimeout) Read(b []byte) (n int, err error) {
+	if err := c.Conn.SetDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, errors.Wrap(err, "set deadline")
+	}
+
+	return c.Conn.Read(b)
+}
+
+// Write implements net.Conn.
+func (c *connectionWithTimeout) Write(b []byte) (n int, err error) {
+	if err := c.Conn.SetDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, errors.Wrap(err, "set deadline")
+	}
+
+	return c.Conn.Write(b)
+}


### PR DESCRIPTION
**What this PR does**:
I'm investigating the following errors that we see sometime on the **receiving** side:
```
msg="TCPTransport: packet digest mismatch" expected=6af0ad4fbb98e34497fa5933b735793b received=40ff8e998d061a0872696e6744657363
```

I've noticed that when we have these errors, on the sender side we also have this log:
```
msg="TCPTransport: WriteTo failed" addr=REDACTED:7946 err="digest: write tcp REDACTED:34320->REDACTED:7946: i/o timeout"
```

It makes sense. It on the writing side we hit the configured `-memberlist.packet-write-timeout`, then the TCP connection is closed before we send the digest too.

When investigating this, I've noticed `-memberlist.packet-write-timeout` is the total time the whole packet send can take and not an idle timeout on each write operation. In this PR I propose to change it to be an idle timeout instead.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
