### PR TITLE
Relax memberlist probe interval and timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [CHANGE] Rename `kv/kvtls` to `crypto/tls`. #39
 * [CHANGE] spanlogger: Take interface implementation for extracting tenant ID. #59
 * [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #68
+* [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #90
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -400,6 +400,13 @@ func (m *KV) buildMemberlistConfig() (*memberlist.Config, error) {
 	// Memberlist uses UDPBufferSize to figure out how many messages it can put into single "packet".
 	// As we don't use UDP for sending packets, we can use higher value here.
 	mlCfg.UDPBufferSize = 10 * 1024 * 1024
+
+	// For our use cases, we don't need a very fast detection of dead nodes. Since we use a TCP transport
+	// and we open a new TCP connection for each packet, we prefer to reduce the probe frequency and increase
+	// the timeout compared to defaults.
+	mlCfg.ProbeInterval = 5 * time.Second // Probe a random node every this interval. This setting is also the total timeout for the direct + indirect probes.
+	mlCfg.ProbeTimeout = 2 * time.Second  // Timeout for the direct probe.
+
 	return mlCfg, nil
 }
 


### PR DESCRIPTION
**What this PR does**:
The memberlist client probes a random node every `ProbeInterval` (defaults to 1s). If it fails to get probe ack response within `ProbeTimeout` (defaults to 500ms) it both initiates an indirect probe (via 3 other nodes) and a direct probe via TCP (opening a stream this time, not packet). The timeout for this 2nd attempt via indirect+TCP stream is `ProbeInterval-ProbeTimeout` (so other 500ms with default config).

I've noticed an high volume of logs like this:
```
level=warn msg="Was able to connect to ingester-REDACTED but other probes failed, network may be misconfigured"
```

This log happens is both direct + indirect pings timeout but the TCP stream one succeed. I think the main reason of having TCP stream only succeeding is that, due to how our `TCPTransport` works, TCP stream requires only opening 1 TCP connection while other methods requires 2 TCP connections (1 to send the PING from node A->B and then B needs to open another TCP connection to send the response back from node B->A). The 2 TCP connections introduce further overhead.

In this PR I propose to relax `ProbeInterval` and `ProbeTimeout` to hopefully get the 1st direct ping to succeed, without having to fallback at all.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
