### PR TITLE
Memberlist: Avoid checking for conflicting tokens if no tokens changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * [ENHANCEMENT] Replace go-kit/kit/log with go-kit/log. #52
 * [ENHANCEMENT] Add spanlogger package. #42
 * [ENHANCEMENT] Add runutil.CloseWithLogOnErr function. #58
-* [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77 #84
+* [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77 #84 #91
 * [ENHANCEMENT] Memberlist: prepare the data to send on the write before starting counting the elapsed time for `-memberlist.packet-write-timeout`, in order to reduce chances we hit the timeout when sending a packet to other node. #89
 * [ENHANCEMENT] flagext: for cases such as `DeprecatedFlag()` that need a logger, add RegisterFlagsWithLogger. #80
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

If we can assume that the current ring state does not have conflicting tokens, then we only need to check for conflicting tokens if the tokens for any ingester actually changed. This will be the case for systems not currently scaling up or down, as only heartbeats will be sent.

Having both ingester maps normalized means we can use a simple slice equality to check for equivalence.

```
name                             old time/op    new time/op    delta
MemberlistReceiveWithRingDesc-6    4.17ms ±14%    0.40ms ± 6%  -90.41%  (p=0.000 n=10+9)

name                             old alloc/op   new alloc/op   delta
MemberlistReceiveWithRingDesc-6    50.3kB ±16%    22.7kB ± 0%  -54.89%  (p=0.000 n=9+8)

name                             old allocs/op  new allocs/op  delta
MemberlistReceiveWithRingDesc-6       679 ± 1%       655 ± 0%   -3.53%  (p=0.000 n=9+10)
```

**Which issue(s) this PR fixes**:

Fixes n/a

**Checklist**
- n/a Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
