### PR TITLE
Memberlist/Ring: do not normalise tokens on subsequent Merge().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [ENHANCEMENT] Replace go-kit/kit/log with go-kit/log. #52
 * [ENHANCEMENT] Add spanlogger package. #42
 * [ENHANCEMENT] Add runutil.CloseWithLogOnErr function. #58
-* [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77 #84 #91
+* [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #76 #77 #84 #91 #93
 * [ENHANCEMENT] Memberlist: prepare the data to send on the write before starting counting the elapsed time for `-memberlist.packet-write-timeout`, in order to reduce chances we hit the timeout when sending a packet to other node. #89
 * [ENHANCEMENT] flagext: for cases such as `DeprecatedFlag()` that need a logger, add RegisterFlagsWithLogger. #80
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59

--- a/ring/model.go
+++ b/ring/model.go
@@ -175,6 +175,12 @@ func (i *InstanceDesc) IsReady(now time.Time, heartbeatTimeout time.Duration) er
 //
 // This method is part of memberlist.Mergeable interface, and is only used by gossiping ring.
 //
+// The Desc on which this function is called must be normalised, that is, the token lists must
+// sorted and not contain duplicates. The function guarantees that the Desc will be left in this
+// normalised state, so multiple subsequent Merge calls on the same Desc is valid.
+//
+// The Mergeable passed as the parameter does not need to be normalised.
+//
 // Note: This method modifies d and mergeable to reduce allocations and copies.
 func (d *Desc) Merge(mergeable memberlist.Mergeable, localCAS bool) (memberlist.Mergeable, error) {
 	return d.mergeWithTime(mergeable, localCAS, time.Now())
@@ -195,7 +201,6 @@ func (d *Desc) mergeWithTime(mergeable memberlist.Mergeable, localCAS bool, now 
 		return nil, nil
 	}
 
-	normalizeIngestersMap(d)
 	normalizeIngestersMap(other)
 
 	thisIngesterMap := d.Ingesters

--- a/ring/model.go
+++ b/ring/model.go
@@ -175,9 +175,9 @@ func (i *InstanceDesc) IsReady(now time.Time, heartbeatTimeout time.Duration) er
 //
 // This method is part of memberlist.Mergeable interface, and is only used by gossiping ring.
 //
-// The Desc on which this function is called must be normalised, that is, the token lists must
-// sorted and not contain duplicates. The function guarantees that the Desc will be left in this
-// normalised state, so multiple subsequent Merge calls on the same Desc is valid.
+// The receiver must be normalised, that is, the token lists must sorted and not contain
+// duplicates. The function guarantees that the receiver will be left in this normalised state,
+// so multiple subsequent Merge calls are valid usage.
 //
 // The Mergeable passed as the parameter does not need to be normalised.
 //


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Improves performance of `ring.Desc.Merge()`.

Memberlist uses the Merge() function on ring.Desc such that it is only ever
called subsequently on the result of itself. Therefore, because the Merge()
function always returns Desc in the normalised form, it does not have to
normalise again before doing another Merge().

Unit tests are fixed up and extended to reflect the precondition that the LHS
must be normalised, and the RHS does not have to be normalised.

I suspect it is also possible to remove normalisation on the incoming change
(the Desc being merged into the current Desc), but it would be safest to test
these changes incrementally. (Open to opinions as to omitting both now)

Performance difference:
```
name                             old time/op    new time/op    delta
MemberlistReceiveWithRingDesc-6     414µs ± 5%      31µs ± 7%  -92.49%  (p=0.000 n=10+10)

name                             old alloc/op   new alloc/op   delta
MemberlistReceiveWithRingDesc-6    22.7kB ± 0%     8.3kB ± 0%  -63.54%  (p=0.000 n=9+10)

name                             old allocs/op  new allocs/op  delta
MemberlistReceiveWithRingDesc-6       655 ± 0%        55 ± 0%  -91.60%  (p=0.000 n=10+10)
```


**Which issue(s) this PR fixes**:

Fixes n/a

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
