### PR TITLE
Add netutil package

### DIFF
--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -1,0 +1,108 @@
+package netutil
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+func ipForAddr(addr net.Addr) (net.IP, bool) {
+	switch a := addr.(type) {
+	case *net.IPAddr:
+		return a.IP, true
+	case *net.IPNet:
+		return a.IP, true
+	default:
+		return net.IPv4zero, false
+	}
+}
+
+func PrivateNetworkInterfaces() []string {
+	ifaces := []string{}
+
+	all, err := net.Interfaces()
+	if err != nil {
+		return ifaces
+	}
+
+IFACES:
+	for _, iface := range all {
+		if iface.Flags&net.FlagLoopback == 0 && iface.Flags&net.FlagUp != 0 {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				continue
+			}
+			for _, addr := range addrs {
+				ip, ok := ipForAddr(addr)
+				if !ok {
+					continue
+				}
+				if !ip.IsPrivate() {
+					continue IFACES
+				}
+			}
+			ifaces = append(ifaces, iface.Name)
+		}
+	}
+	return ifaces
+}
+
+// FirstAddressOf returns the first IPv4 address of the supplied interface
+// names, omitting any 169.254.x.x automatic private IPs if possible.
+func FirstAddressOf(names []string, logger log.Logger) (string, error) {
+	var ipAddr net.IP
+	for _, name := range names {
+		inf, err := net.InterfaceByName(name)
+		if err != nil {
+			level.Warn(logger).Log("msg", "error getting interface", "inf", name, "err", err)
+			continue
+		}
+		addrs, err := inf.Addrs()
+		if err != nil {
+			level.Warn(logger).Log("msg", "error getting addresses for interface", "inf", name, "err", err)
+			continue
+		}
+		if len(addrs) <= 0 {
+			level.Warn(logger).Log("msg", "no addresses found for interface", "inf", name, "err", err)
+			continue
+		}
+		if ip := filterIPs(addrs); !ip.IsUnspecified() {
+			ipAddr = ip
+		}
+		if isAPIPA(ipAddr) || ipAddr.IsUnspecified() {
+			continue
+		}
+		return ipAddr.String(), nil
+	}
+	if ipAddr.IsUnspecified() {
+		return "", fmt.Errorf("no address found for %s", names)
+	}
+	if isAPIPA(ipAddr) {
+		level.Warn(logger).Log("msg", "using automatic private ip", "address", ipAddr)
+	}
+	return ipAddr.String(), nil
+}
+
+func isAPIPA(ip4 net.IP) bool {
+	return ip4[0] == 169 && ip4[1] == 254
+}
+
+// filterIPs attempts to return the first non automatic private IP (APIPA /
+// 169.254.x.x) if possible, only returning APIPA if available and no other
+// valid IP is found.
+func filterIPs(addrs []net.Addr) net.IP {
+	ipAddr := net.IPv4zero
+	for _, addr := range addrs {
+		if ip, ok := ipForAddr(addr); ok {
+			if ip4 := ip.To4(); ip4 != nil {
+				ipAddr = ip4
+				if isAPIPA(ip4) {
+					return ipAddr
+				}
+			}
+		}
+	}
+	return ipAddr
+}

--- a/ring/util.go
+++ b/ring/util.go
@@ -2,17 +2,14 @@ package ring
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"net"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 
 	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/netutil"
 )
 
 // GenerateTokens make numTokens unique random tokens, none of which clash
@@ -55,7 +52,7 @@ func GetInstanceAddr(configAddr string, netInterfaces []string, logger log.Logge
 		return configAddr, nil
 	}
 
-	addr, err := getFirstAddressOf(netInterfaces, logger)
+	addr, err := netutil.FirstAddressOf(netInterfaces, logger)
 	if err != nil {
 		return "", err
 	}
@@ -170,55 +167,4 @@ func searchToken(tokens []uint32, key uint32) int {
 		i = 0
 	}
 	return i
-}
-
-// GetFirstAddressOf returns the first IPv4 address of the supplied interface names, omitting any 169.254.x.x automatic private IPs if possible.
-func getFirstAddressOf(names []string, logger log.Logger) (string, error) {
-	var ipAddr string
-	for _, name := range names {
-		inf, err := net.InterfaceByName(name)
-		if err != nil {
-			level.Warn(logger).Log("msg", "error getting interface", "inf", name, "err", err)
-			continue
-		}
-		addrs, err := inf.Addrs()
-		if err != nil {
-			level.Warn(logger).Log("msg", "error getting addresses for interface", "inf", name, "err", err)
-			continue
-		}
-		if len(addrs) <= 0 {
-			level.Warn(logger).Log("msg", "no addresses found for interface", "inf", name, "err", err)
-			continue
-		}
-		if ip := filterIPs(addrs); ip != "" {
-			ipAddr = ip
-		}
-		if strings.HasPrefix(ipAddr, `169.254.`) || ipAddr == "" {
-			continue
-		}
-		return ipAddr, nil
-	}
-	if ipAddr == "" {
-		return "", fmt.Errorf("No address found for %s", names)
-	}
-	if strings.HasPrefix(ipAddr, `169.254.`) {
-		level.Warn(logger).Log("msg", "using automatic private ip", "address", ipAddr)
-	}
-	return ipAddr, nil
-}
-
-// filterIPs attempts to return the first non automatic private IP (APIPA / 169.254.x.x) if possible, only returning APIPA if available and no other valid IP is found.
-func filterIPs(addrs []net.Addr) string {
-	var ipAddr string
-	for _, addr := range addrs {
-		if v, ok := addr.(*net.IPNet); ok {
-			if ip := v.IP.To4(); ip != nil {
-				ipAddr = v.IP.String()
-				if !strings.HasPrefix(ipAddr, `169.254.`) {
-					return ipAddr
-				}
-			}
-		}
-	}
-	return ipAddr
 }


### PR DESCRIPTION
**What this PR does**:

The new netutil package contains a new function
`PrivateNetworkInterfaces` which can be used to obtain a list of
non-loopback network interfaces that have private IP addresses.

This is useful for providing default network interfaces in e.g. the ring
configuration, like so:

```go
cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfaces()
f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), ringFlagsPrefix+"instance-interface-names", "Name of network interface to read address from.")
```

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->


**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
