### PR TITLE
change the ruler ring key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] spanlogger: Take interface implementation for extracting tenant ID. #59
 * [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. #68
 * [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #90
+* [CHANGE] Ring: change the ruler's ring key from `ring` -> `ruler` to avoid conflicts with ingester's ring key
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -33,7 +33,7 @@ const (
 	IngesterRingKey = "ring"
 
 	// RulerRingKey is the key under which we store the rulers ring in the KVStore.
-	RulerRingKey = "ring"
+	RulerRingKey = "ruler"
 
 	// DistributorRingKey is the key under which we store the distributors ring in the KVStore.
 	DistributorRingKey = "distributor"


### PR DESCRIPTION
**What this PR does**:

Changes the ruler's ring key from `ring` to `ruler` so it does not conflict with the ingester's ring key.

**Which issue(s) this PR fixes**:

If the ruler and ingester's rings have the same prefix, then they will both register to the same ring. This can result in the querier trying to query the ruler, which fails. As I don't think there's any need to explicitly prevent rings from sharing a common prefix (for instance, if the KV store is being used for other types of data, they may want to prefix everything grafana related under `grafana`, or `loki`, for example), we should make sure each ring key is unique.

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
