### PR TITLE
grpcutil: Remove gRPC load balancer references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [CHANGE] Remove package `math`. #104
 * [CHANGE] time: Remove time package. #103
 * [CHANGE] grpcutil: Convert Resolver into concrete type. #105
+* [CHANGE] grpcutil.Resolver.Resolve: Take a service parameter. #102
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [CHANGE] time: Remove time package. #103
 * [CHANGE] grpcutil: Convert Resolver into concrete type. #105
 * [CHANGE] grpcutil.Resolver.Resolve: Take a service parameter. #102
+* [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/grpcutil/dns_resolver.go
+++ b/grpcutil/dns_resolver.go
@@ -190,7 +190,6 @@ func (w *dnsWatcher) compileUpdate(newAddrs map[string]*Update) []*Update {
 
 func (w *dnsWatcher) lookupSRV() map[string]*Update {
 	if w.service == "" {
-		level.Debug(w.logger).Log("msg", "not looking up DNS SRV record since w.service is empty")
 		return nil
 	}
 

--- a/grpcutil/dns_resolver.go
+++ b/grpcutil/dns_resolver.go
@@ -169,26 +169,6 @@ func (i *ipWatcher) Close() {
 	close(i.updateChan)
 }
 
-// AddressType indicates the address type returned by name resolution.
-type AddressType uint8
-
-const (
-	// Backend indicates the server is a backend server.
-	Backend AddressType = iota
-	// GRPCLB indicates the server is a grpclb load balancer.
-	GRPCLB
-)
-
-// AddrMetadataGRPCLB contains the information the name resolver for grpclb should provide. The
-// name resolver used by the grpclb balancer is required to provide this type of metadata in
-// its address updates.
-type AddrMetadataGRPCLB struct {
-	// AddrType is the type of server (grpc load balancer or backend).
-	AddrType AddressType
-	// ServerName is the name of the grpc load balancer. Used for authentication.
-	ServerName string
-}
-
 // compileUpdate compares the old resolved addresses and newly resolved addresses,
 // and generates an update list
 func (w *dnsWatcher) compileUpdate(newAddrs map[string]*Update) []*Update {
@@ -232,8 +212,7 @@ func (w *dnsWatcher) lookupSRV() map[string]*Update {
 				continue
 			}
 			addr := a + ":" + strconv.Itoa(int(s.Port))
-			newAddrs[addr] = &Update{Addr: addr,
-				Metadata: AddrMetadataGRPCLB{AddrType: GRPCLB, ServerName: s.Target}}
+			newAddrs[addr] = &Update{Addr: addr}
 		}
 	}
 	return newAddrs

--- a/grpcutil/dns_resolver.go
+++ b/grpcutil/dns_resolver.go
@@ -105,6 +105,7 @@ func parseTarget(target string) (host, port string, err error) {
 //
 // If service is not empty, the watcher will first attempt to resolve an SRV record.
 // If that fails, or service is empty, hostname record resolution is attempted instead.
+// If target can be parsed as an IP address, the watcher will return it, and will not send any more updates afterwards.
 func (r *Resolver) Resolve(target, service string) (Watcher, error) {
 	host, port, err := parseTarget(target)
 	if err != nil {

--- a/grpcutil/naming.go
+++ b/grpcutil/naming.go
@@ -24,7 +24,7 @@ type Update struct {
 	Metadata interface{}
 }
 
-// Watcher watches for the updates on the specified target.
+// Watcher watches for the SRV updates on the specified target.
 type Watcher interface {
 	// Next blocks until an update or error happens. It may return one or more
 	// updates. The first call should get the full set of the results. It should

--- a/grpcutil/naming.go
+++ b/grpcutil/naming.go
@@ -24,7 +24,7 @@ type Update struct {
 	Metadata interface{}
 }
 
-// Watcher watches for the SRV updates on the specified target.
+// Watcher watches for SRV updates on the specified target.
 type Watcher interface {
 	// Next blocks until an update or error happens. It may return one or more
 	// updates. The first call should get the full set of the results. It should


### PR DESCRIPTION
**What this PR does**:
`grpcutil.Resolver.Resolve` assumes that [SRV records](https://en.wikipedia.org/wiki/SRV_record) will use "grpclb" for the service part (which typically corresponds to a Kubernetes service named port), but that isn't necessarily the case. I propose we parameterize it, in order to support systems not following this convention.

The PR, on request from @pstibrany, also generally removes references to gRPC load balancers as the code is no longer for this use case.

TODO: Consider adding test.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
