### PR TITLE
grpcutil: Convert Resolver into concrete type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #90
 * [CHANGE] Remove package `math`. #104
 * [CHANGE] time: Remove time package. #103
+* [CHANGE] grpcutil: Convert Resolver into concrete type. #105
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/grpcutil/dns_resolver.go
+++ b/grpcutil/dns_resolver.go
@@ -29,8 +29,8 @@ var (
 
 // NewDNSResolverWithFreq creates a DNS Resolver that can resolve DNS names, and
 // create watchers that poll the DNS server using the frequency set by freq.
-func NewDNSResolverWithFreq(freq time.Duration, logger log.Logger) (Resolver, error) {
-	return &dnsResolver{
+func NewDNSResolverWithFreq(freq time.Duration, logger log.Logger) (*Resolver, error) {
+	return &Resolver{
 		logger: logger,
 		freq:   freq,
 	}, nil
@@ -38,12 +38,12 @@ func NewDNSResolverWithFreq(freq time.Duration, logger log.Logger) (Resolver, er
 
 // NewDNSResolver creates a DNS Resolver that can resolve DNS names, and create
 // watchers that poll the DNS server using the default frequency defined by defaultFreq.
-func NewDNSResolver(logger log.Logger) (Resolver, error) {
+func NewDNSResolver(logger log.Logger) (*Resolver, error) {
 	return NewDNSResolverWithFreq(defaultFreq, logger)
 }
 
-// dnsResolver handles name resolution for names following the DNS scheme
-type dnsResolver struct {
+// Resolver handles name resolution for names following the DNS scheme.
+type Resolver struct {
 	logger log.Logger
 	// frequency of polling the DNS server that the watchers created by this resolver will use.
 	freq time.Duration
@@ -102,7 +102,7 @@ func parseTarget(target string) (host, port string, err error) {
 }
 
 // Resolve creates a watcher that watches the name resolution of the target.
-func (r *dnsResolver) Resolve(target string) (Watcher, error) {
+func (r *Resolver) Resolve(target string) (Watcher, error) {
 	host, port, err := parseTarget(target)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (r *dnsResolver) Resolve(target string) (Watcher, error) {
 
 // dnsWatcher watches for the name resolution update for a specific target
 type dnsWatcher struct {
-	r      *dnsResolver
+	r      *Resolver
 	logger log.Logger
 	host   string
 	port   string

--- a/grpcutil/naming.go
+++ b/grpcutil/naming.go
@@ -24,12 +24,6 @@ type Update struct {
 	Metadata interface{}
 }
 
-// Resolver creates a Watcher for a target to track its resolution changes.
-type Resolver interface {
-	// Resolve creates a Watcher for target.
-	Resolve(target string) (Watcher, error)
-}
-
 // Watcher watches for the updates on the specified target.
 type Watcher interface {
 	// Next blocks until an update or error happens. It may return one or more


### PR DESCRIPTION
**What this PR does**:
Convert grpcutil.Resolver into concrete type instead of `interface`. Requested by @pstibrany.

**Which issue(s) this PR fixes**:

**Checklist**
- [na] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
