### PR TITLE
Parallelize memberlist notified message processing

### DIFF
--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -1125,6 +1125,9 @@ func TestNotifyMsgResendsOnlyChanges(t *testing.T) {
 			"c": {Timestamp: now.Unix(), State: ACTIVE},
 		}}))
 
+	// Wait until notified message has been processed by some worker.
+	time.Sleep(time.Millisecond * 100)
+
 	// Check two things here:
 	// 1) state of value in KV store
 	// 2) broadcast message only has changed members
@@ -1219,6 +1222,9 @@ func TestSendingOldTombstoneShouldNotForwardMessage(t *testing.T) {
 			}
 
 			kv.NotifyMsg(marshalKeyValuePair(t, key, codec, tc.msgToSend))
+
+			// Wait until notified message has been processed by some worker.
+			time.Sleep(time.Millisecond * 100)
 
 			bs := kv.GetBroadcasts(0, math.MaxInt32)
 			if tc.broadcastMessage == nil {


### PR DESCRIPTION
This PR adapts KV memberlist to process notified messages in parallel.

It aims to facilitate vertical scalability in conditions where UDP packet pressure is high due to a high number of instances in a memberlist cluster.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
