### PR TITLE
Remove ring component keys

### DIFF
--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// ringKey is the key under which we store the ingesters ring in the KVStore.
+	// ring key used for testware
 	ringKey = "ring"
 )
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -29,18 +29,6 @@ import (
 const (
 	unhealthy = "Unhealthy"
 
-	// IngesterRingKey is the key under which we store the ingesters ring in the KVStore.
-	IngesterRingKey = "ring"
-
-	// RulerRingKey is the key under which we store the rulers ring in the KVStore.
-	RulerRingKey = "ring"
-
-	// DistributorRingKey is the key under which we store the distributors ring in the KVStore.
-	DistributorRingKey = "distributor"
-
-	// CompactorRingKey is the key under which we store the compactors ring in the KVStore.
-	CompactorRingKey = "compactor"
-
 	// GetBufferSize is the suggested size of buffers passed to Ring.Get(). It's based on
 	// a typical replication factor 3, plus extra room for a JOINING + LEAVING instance.
 	GetBufferSize = 5


### PR DESCRIPTION
Removes project-specific references from the `dskit` library.
Reference: https://github.com/grafana/dskit/pull/101