### PR TITLE
Support ring handler on lifecycler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [ENHANCEMENT] Added option to BasicLifecycler to keep instance in the ring when stopping. #97
 * [ENHANCEMENT] Add WaitRingTokensStability function to ring, to be able to wait on ring stability excluding allowed state transitions. #95
 * [ENHANCEMENT] Trigger metrics update on ring changes instead of doing it periodically to speed up tests that wait for certain metrics. #107
+* [ENHANCEMENT] Ring: Add ring page handler to BasicLifecycler and Lifecycler. #112
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -3,6 +3,7 @@ package ring
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sort"
 	"sync"
 	"time"
@@ -490,4 +491,21 @@ func (l *BasicLifecycler) run(fn func() error) error {
 	case l.actorChan <- wrappedFn:
 		return <-errCh
 	}
+}
+
+func (l *BasicLifecycler) casRing(ctx context.Context, f func(in interface{}) (out interface{}, retry bool, err error)) error {
+	return l.store.CAS(ctx, l.ringKey, f)
+}
+
+func (l *BasicLifecycler) getRing(ctx context.Context) (*Desc, error) {
+	obj, err := l.store.Get(ctx, l.ringKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetOrCreateRingDesc(obj), nil
+}
+
+func (l *BasicLifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	newRingPageHandler(l.logger, l, l.cfg.HeartbeatPeriod).handle(w, req)
 }

--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -507,5 +507,5 @@ func (l *BasicLifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (l *BasicLifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(l.logger, l, l.cfg.HeartbeatPeriod).handle(w, req)
+	newRingPageHandler(l, l.cfg.HeartbeatPeriod).handle(w, req)
 }

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -854,17 +854,13 @@ func (i *Lifecycler) casRing(ctx context.Context, f func(in interface{}) (out in
 	return i.KVStore.CAS(ctx, i.RingKey, f)
 }
 
-func (i *Lifecycler) getRing(ctx context.Context) (*Desc, map[string]uint32, error) {
+func (i *Lifecycler) getRing(ctx context.Context) (*Desc, error) {
 	obj, err := i.KVStore.Get(ctx, i.RingKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	ringDesc := obj.(*Desc)
-
-	_, ownedTokens := countTokens(ringDesc, ringDesc.GetTokens(), ringDesc.getTokensInfo())
-
-	return ringDesc, ownedTokens, nil
+	return GetOrCreateRingDesc(obj), nil
 }
 
 func (i *Lifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -864,7 +864,7 @@ func (i *Lifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (i *Lifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(i.logger, i, i.cfg.HeartbeatPeriod).handle(w, req)
+	newRingPageHandler(i, i.cfg.HeartbeatPeriod).handle(w, req)
 }
 
 // unregister removes our entry from consul.

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"sort"
 	"sync"
@@ -847,6 +848,27 @@ func (i *Lifecycler) processShutdown(ctx context.Context) {
 	// Sleep so the shutdownDuration metric can be collected.
 	level.Info(i.logger).Log("msg", "lifecycler entering final sleep before shutdown", "final_sleep", i.cfg.FinalSleep)
 	time.Sleep(i.cfg.FinalSleep)
+}
+
+func (i *Lifecycler) casRing(ctx context.Context, f func(in interface{}) (out interface{}, retry bool, err error)) error {
+	return i.KVStore.CAS(ctx, i.RingKey, f)
+}
+
+func (i *Lifecycler) getRing(ctx context.Context) (*Desc, map[string]uint32, error) {
+	obj, err := i.KVStore.Get(ctx, i.RingKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ringDesc := obj.(*Desc)
+
+	_, ownedTokens := countTokens(ringDesc, ringDesc.GetTokens(), ringDesc.getTokensInfo())
+
+	return ringDesc, ownedTokens, nil
+}
+
+func (i *Lifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	newRingPageHandler(i.logger, i, i.cfg.HeartbeatPeriod).handle(w, req)
 }
 
 // unregister removes our entry from consul.

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -861,7 +861,7 @@ func (r *Ring) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(r.logger, r, r.cfg.HeartbeatTimeout).handle(w, req)
+	newRingPageHandler(r, r.cfg.HeartbeatTimeout).handle(w, req)
 }
 
 // Operation describes which instances can be included in the replica set, based on their state.


### PR DESCRIPTION
**What this PR does**:

This PR exposes the ring introspection handlers to the lifecycler. This allow e.g. the ingester ring to be exposed on the ingester without requiring to watch the ingester ring.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
