### PR TITLE
`concurrency.ForEachJob()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [CHANGE] grpcutil: Convert Resolver into concrete type. #105
 * [CHANGE] grpcutil.Resolver.Resolve: Take a service parameter. #102
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
-* [CHANGE] concurrency.ForEach: replaced by `concurrency.ForEachJob`. #113
+* [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] grpcutil: Convert Resolver into concrete type. #105
 * [CHANGE] grpcutil.Resolver.Resolve: Take a service parameter. #102
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
+* [CHANGE] concurrency.ForEach: replaced by `concurrency.ForEachJob`. #113
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/concurrency/runner.go
+++ b/concurrency/runner.go
@@ -63,7 +63,7 @@ func ForEachUser(ctx context.Context, userIDs []string, concurrency int, userFun
 
 // ForEach runs the provided jobFunc for each job up to concurrency concurrent workers.
 // The execution breaks on first error encountered.
-// 
+//
 // Deprecated: use ForEachJob instead.
 func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc func(ctx context.Context, job interface{}) error) error {
 	return ForEachJob(ctx, len(jobs), concurrency, func(ctx context.Context, idx int) error {

--- a/concurrency/runner.go
+++ b/concurrency/runner.go
@@ -63,8 +63,8 @@ func ForEachUser(ctx context.Context, userIDs []string, concurrency int, userFun
 
 // ForEach runs the provided jobFunc for each job up to concurrency concurrent workers.
 // The execution breaks on first error encountered.
-// Deprecated.
-// Use ForEachJob instead.
+// 
+// Deprecated: use ForEachJob instead.
 func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc func(ctx context.Context, job interface{}) error) error {
 	return ForEachJob(ctx, len(jobs), concurrency, func(ctx context.Context, idx int) error {
 		return jobFunc(ctx, jobs[idx])
@@ -72,8 +72,8 @@ func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc f
 }
 
 // CreateJobsFromStrings is an utility to create jobs from an slice of strings.
-// Deprecated.
-// Will be removed. Not needed when using ForEachJob.
+//
+// Deprecated: will be removed as it's not needed when using ForEachJob.
 func CreateJobsFromStrings(values []string) []interface{} {
 	jobs := make([]interface{}, len(values))
 	for i := 0; i < len(values); i++ {

--- a/concurrency/runner.go
+++ b/concurrency/runner.go
@@ -61,6 +61,27 @@ func ForEachUser(ctx context.Context, userIDs []string, concurrency int, userFun
 	return errs.Err()
 }
 
+// ForEach runs the provided jobFunc for each job up to concurrency concurrent workers.
+// The execution breaks on first error encountered.
+// Deprecated.
+// Use ForEachJob instead.
+func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc func(ctx context.Context, job interface{}) error) error {
+	return ForEachJob(ctx, len(jobs), concurrency, func(ctx context.Context, idx int) error {
+		return jobFunc(ctx, jobs[idx])
+	})
+}
+
+// CreateJobsFromStrings is an utility to create jobs from an slice of strings.
+// Deprecated.
+// Will be removed. Not needed when using ForEachJob.
+func CreateJobsFromStrings(values []string) []interface{} {
+	jobs := make([]interface{}, len(values))
+	for i := 0; i < len(values); i++ {
+		jobs[i] = values[i]
+	}
+	return jobs
+}
+
 // ForEachJob runs the provided jobFunc for each job index in [0, jobs) up to concurrency concurrent workers.
 // The execution breaks on first error encountered.
 func ForEachJob(ctx context.Context, jobs int, concurrency int, jobFunc func(ctx context.Context, idx int) error) error {

--- a/concurrency/runner_test.go
+++ b/concurrency/runner_test.go
@@ -14,8 +14,6 @@ import (
 
 func TestForEachUser(t *testing.T) {
 	var (
-		ctx = context.Background()
-
 		// Keep track of processed users.
 		processedMx sync.Mutex
 		processed   []string
@@ -23,7 +21,7 @@ func TestForEachUser(t *testing.T) {
 
 	input := []string{"a", "b", "c"}
 
-	err := ForEachUser(ctx, input, 2, func(ctx context.Context, user string) error {
+	err := ForEachUser(context.Background(), input, 2, func(ctx context.Context, user string) error {
 		processedMx.Lock()
 		defer processedMx.Unlock()
 		processed = append(processed, user)
@@ -35,16 +33,12 @@ func TestForEachUser(t *testing.T) {
 }
 
 func TestForEachUser_ShouldContinueOnErrorButReturnIt(t *testing.T) {
-	var (
-		ctx = context.Background()
-
-		// Keep the processed users count.
-		processed atomic.Int32
-	)
+	// Keep the processed users count.
+	var processed atomic.Int32
 
 	input := []string{"a", "b", "c"}
 
-	err := ForEachUser(ctx, input, 2, func(ctx context.Context, user string) error {
+	err := ForEachUser(context.Background(), input, 2, func(ctx context.Context, user string) error {
 		if processed.CAS(0, 1) {
 			return errors.New("the first request is failing")
 		}
@@ -73,14 +67,10 @@ func TestForEachUser_ShouldReturnImmediatelyOnNoUsersProvided(t *testing.T) {
 }
 
 func TestForEachJob(t *testing.T) {
-	var (
-		ctx = context.Background()
-	)
-
 	jobs := []string{"a", "b", "c"}
 	processed := make([]string, len(jobs))
 
-	err := ForEachJob(ctx, len(jobs), 2, func(ctx context.Context, idx int) error {
+	err := ForEachJob(context.Background(), len(jobs), 2, func(ctx context.Context, idx int) error {
 		processed[idx] = jobs[idx]
 		return nil
 	})
@@ -90,14 +80,10 @@ func TestForEachJob(t *testing.T) {
 }
 
 func TestForEachJob_ShouldBreakOnFirstError_ContextCancellationHandled(t *testing.T) {
-	var (
-		ctx = context.Background()
+	// Keep the processed jobs count.
+	var processed atomic.Int32
 
-		// Keep the processed jobs count.
-		processed atomic.Int32
-	)
-
-	err := ForEachJob(ctx, 3, 2, func(ctx context.Context, idx int) error {
+	err := ForEachJob(context.Background(), 3, 2, func(ctx context.Context, idx int) error {
 		if processed.CAS(0, 1) {
 			return errors.New("the first request is failing")
 		}
@@ -121,18 +107,14 @@ func TestForEachJob_ShouldBreakOnFirstError_ContextCancellationHandled(t *testin
 }
 
 func TestForEachJob_ShouldBreakOnFirstError_ContextCancellationUnhandled(t *testing.T) {
-	var (
-		ctx = context.Background()
-
-		// Keep the processed jobs count.
-		processed atomic.Int32
-	)
+	// Keep the processed jobs count.
+	var processed atomic.Int32
 
 	// waitGroup to await the start of the first two jobs
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	err := ForEachJob(ctx, 3, 2, func(ctx context.Context, idx int) error {
+	err := ForEachJob(context.Background(), 3, 2, func(ctx context.Context, idx int) error {
 		wg.Done()
 
 		if processed.CAS(0, 1) {
@@ -157,6 +139,7 @@ func TestForEachJob_ShouldBreakOnFirstError_ContextCancellationUnhandled(t *test
 }
 
 func TestForEachJob_ShouldReturnImmediatelyOnNoJobsProvided(t *testing.T) {
+	// Keep the processed jobs count.
 	var processed atomic.Int32
 	require.NoError(t, ForEachJob(context.Background(), 0, 2, func(ctx context.Context, idx int) error {
 		processed.Inc()
@@ -167,8 +150,6 @@ func TestForEachJob_ShouldReturnImmediatelyOnNoJobsProvided(t *testing.T) {
 
 func TestForEach(t *testing.T) {
 	var (
-		ctx = context.Background()
-
 		// Keep track of processed jobs.
 		processedMx sync.Mutex
 		processed   []string
@@ -176,7 +157,7 @@ func TestForEach(t *testing.T) {
 
 	jobs := []string{"a", "b", "c"}
 
-	err := ForEach(ctx, CreateJobsFromStrings(jobs), 2, func(ctx context.Context, job interface{}) error {
+	err := ForEach(context.Background(), CreateJobsFromStrings(jobs), 2, func(ctx context.Context, job interface{}) error {
 		processedMx.Lock()
 		defer processedMx.Unlock()
 		processed = append(processed, job.(string))
@@ -219,18 +200,14 @@ func TestForEach_ShouldBreakOnFirstError_ContextCancellationHandled(t *testing.T
 }
 
 func TestForEach_ShouldBreakOnFirstError_ContextCancellationUnhandled(t *testing.T) {
-	var (
-		ctx = context.Background()
-
-		// Keep the processed jobs count.
-		processed atomic.Int32
-	)
+	// Keep the processed jobs count.
+	var processed atomic.Int32
 
 	// waitGroup to await the start of the first two jobs
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	err := ForEach(ctx, []interface{}{"a", "b", "c"}, 2, func(ctx context.Context, job interface{}) error {
+	err := ForEach(context.Background(), []interface{}{"a", "b", "c"}, 2, func(ctx context.Context, job interface{}) error {
 		wg.Done()
 
 		if processed.CAS(0, 1) {

--- a/concurrency/runner_test.go
+++ b/concurrency/runner_test.go
@@ -3,7 +3,6 @@ package concurrency
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -164,38 +163,4 @@ func TestForEachJob_ShouldReturnImmediatelyOnNoJobsProvided(t *testing.T) {
 		return nil
 	}))
 	require.Zero(t, processed.Load())
-}
-
-func BenchmarkForEachJob(b *testing.B) {
-	var ctx = context.Background()
-
-	for _, jobsCount := range []int{2, 16, 256, 1024} {
-		jobs := make([]string, jobsCount)
-		for j := 0; j < jobsCount; j++ {
-			jobs[j] = string(byte('a' + j%26))
-		}
-		concurrencies := []int{1, 2, 16}
-		if jobsCount/2 > concurrencies[len(concurrencies)-1] {
-			concurrencies = append(concurrencies, jobsCount/2)
-		}
-		if jobsCount > concurrencies[len(concurrencies)-1] {
-			concurrencies = append(concurrencies, jobsCount)
-		}
-
-		for _, concurrency := range concurrencies {
-			name := fmt.Sprintf("%d jobs / concurrency %d", jobsCount, concurrency)
-			{
-				b.Run(name, func(b *testing.B) {
-					for i := 0; i < b.N; i++ {
-						processed := make([]string, len(jobs))
-						err := ForEachJob(ctx, len(jobs), concurrency, func(ctx context.Context, idx int) error {
-							processed[idx] = jobs[idx]
-							return nil
-						})
-						require.NoError(b, err)
-					}
-				})
-			}
-		}
-	}
 }

--- a/concurrency/runner_test.go
+++ b/concurrency/runner_test.go
@@ -164,3 +164,98 @@ func TestForEachJob_ShouldReturnImmediatelyOnNoJobsProvided(t *testing.T) {
 	}))
 	require.Zero(t, processed.Load())
 }
+
+func TestForEach(t *testing.T) {
+	var (
+		ctx = context.Background()
+
+		// Keep track of processed jobs.
+		processedMx sync.Mutex
+		processed   []string
+	)
+
+	jobs := []string{"a", "b", "c"}
+
+	err := ForEach(ctx, CreateJobsFromStrings(jobs), 2, func(ctx context.Context, job interface{}) error {
+		processedMx.Lock()
+		defer processedMx.Unlock()
+		processed = append(processed, job.(string))
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, jobs, processed)
+}
+
+func TestForEach_ShouldBreakOnFirstError_ContextCancellationHandled(t *testing.T) {
+	var (
+		ctx = context.Background()
+
+		// Keep the processed jobs count.
+		processed atomic.Int32
+	)
+
+	err := ForEach(ctx, []interface{}{"a", "b", "c"}, 2, func(ctx context.Context, job interface{}) error {
+		if processed.CAS(0, 1) {
+			return errors.New("the first request is failing")
+		}
+
+		// Wait 1s and increase the number of processed jobs, unless the context get canceled earlier.
+		select {
+		case <-time.After(time.Second):
+			processed.Add(1)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		return nil
+	})
+
+	require.EqualError(t, err, "the first request is failing")
+
+	// Since we expect the first error interrupts the workers, we should only see
+	// 1 job processed (the one which immediately returned error).
+	assert.Equal(t, int32(1), processed.Load())
+}
+
+func TestForEach_ShouldBreakOnFirstError_ContextCancellationUnhandled(t *testing.T) {
+	var (
+		ctx = context.Background()
+
+		// Keep the processed jobs count.
+		processed atomic.Int32
+	)
+
+	// waitGroup to await the start of the first two jobs
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	err := ForEach(ctx, []interface{}{"a", "b", "c"}, 2, func(ctx context.Context, job interface{}) error {
+		wg.Done()
+
+		if processed.CAS(0, 1) {
+			// wait till two jobs have been started
+			wg.Wait()
+			return errors.New("the first request is failing")
+		}
+
+		// Wait till context is cancelled to add processed jobs.
+		<-ctx.Done()
+		processed.Add(1)
+
+		return nil
+	})
+
+	require.EqualError(t, err, "the first request is failing")
+
+	// Since we expect the first error interrupts the workers, we should only
+	// see 2 job processed (the one which immediately returned error and the
+	// job with "b").
+	assert.Equal(t, int32(2), processed.Load())
+}
+
+func TestForEach_ShouldReturnImmediatelyOnNoJobsProvided(t *testing.T) {
+	require.NoError(t, ForEach(context.Background(), nil, 2, func(ctx context.Context, job interface{}) error {
+		return nil
+	}))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Replaces old and used `concurrency.ForEach()` by a shiny new `concurrency.ForEachJob()`.

Previous `ForEach()` required transforming the input into a slice of interfaces (causing an allocation on heap for each job, although that's minor here), and type asserting each job in the function later (generics will save us, but they're still not here). Plus since job index is not known, most use cases require a mutex to concatenate the results.

This replaces it with `ForEachJob` instead, which provides the index of the job to `jobFunc` instead, letting it decide how to handle it. In most cases that usage will be accessing the original jobs slice, with proper type checking. Given the index of the job is known, no mutex is needed to store the result in a slice afterwards (see test change), plus since indexes are just ints, we don't even need a channel.

Sometimes there's also a value in getting the results in the same order as the jobs were, this was the trigger for this change.

This fits all the `concurrency.ForEach` uses I could find, and since there's no released version of dskit yet, I just removed that function.

Even though the objective of this change is not a performance improvement, there's some (notice that as concurrency grows, most of the time of the benchmark is spent creating worker goroutines):

```
$ benchstat old new
name                                        old time/op  new time/op  delta
ForEachJob/2_jobs_/_concurrency_1           1.14µs ± 2%  0.81µs ± 0%  -29.13%  (p=0.008 n=5+5)
ForEachJob/2_jobs_/_concurrency_1-4         1.55µs ± 3%  1.41µs ± 1%   -8.94%  (p=0.008 n=5+5)
ForEachJob/2_jobs_/_concurrency_1-16        1.71µs ± 1%  0.98µs ± 1%  -42.87%  (p=0.008 n=5+5)
ForEachJob/2_jobs_/_concurrency_2           1.32µs ± 1%  1.01µs ± 3%  -23.14%  (p=0.008 n=5+5)
ForEachJob/2_jobs_/_concurrency_2-4         1.63µs ± 1%  1.23µs ± 1%  -24.71%  (p=0.008 n=5+5)
ForEachJob/2_jobs_/_concurrency_2-16        1.63µs ± 1%  1.22µs ± 1%  -24.84%  (p=0.008 n=5+5)
ForEachJob/2_jobs_/_concurrency_16          1.32µs ± 1%  1.00µs ± 0%  -23.78%  (p=0.008 n=5+5)
ForEachJob/2_jobs_/_concurrency_16-4        1.61µs ± 0%  1.23µs ± 0%  -23.56%  (p=0.000 n=5+4)
ForEachJob/2_jobs_/_concurrency_16-16       1.62µs ± 1%  1.23µs ± 1%  -23.96%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_1          2.18µs ± 1%  1.10µs ± 0%  -49.45%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_1-4        2.94µs ± 2%  1.60µs ± 2%  -45.68%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_1-16       2.80µs ± 1%  1.48µs ± 1%  -47.35%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_2          2.42µs ± 1%  1.28µs ± 0%  -47.29%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_2-4        3.28µs ± 1%  1.45µs ± 0%  -55.84%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_2-16       3.59µs ± 0%  1.50µs ± 1%  -58.05%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_16         5.14µs ± 1%  3.81µs ± 3%  -25.88%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_16-4       5.99µs ± 0%  4.28µs ± 0%  -28.60%  (p=0.008 n=5+5)
ForEachJob/16_jobs_/_concurrency_16-16      6.54µs ± 0%  4.46µs ± 0%  -31.80%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_1         19.9µs ± 1%   5.4µs ± 1%  -73.02%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_1-4       21.8µs ± 0%   6.6µs ± 1%  -69.57%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_1-16      22.1µs ± 1%   6.1µs ± 1%  -72.23%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_2         20.3µs ± 1%   5.7µs ± 1%  -72.11%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_2-4       24.3µs ± 1%   6.6µs ± 0%  -72.85%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_2-16      24.1µs ± 0%   6.9µs ± 1%  -71.34%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_16        23.2µs ± 0%   8.1µs ± 1%  -64.96%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_16-4      28.8µs ± 0%  11.9µs ± 0%  -58.61%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_16-16     33.2µs ± 0%  11.7µs ± 1%  -64.77%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_128       45.2µs ± 0%  28.4µs ± 0%  -37.17%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_128-4     46.4µs ± 1%  35.0µs ± 1%  -24.71%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_128-16    52.8µs ± 2%  42.1µs ± 0%  -20.37%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_256       72.7µs ± 2%  53.4µs ± 0%  -26.54%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_256-4     77.8µs ± 1%  64.6µs ± 0%  -16.89%  (p=0.008 n=5+5)
ForEachJob/256_jobs_/_concurrency_256-16    85.7µs ± 1%  69.4µs ± 0%  -18.97%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_1        77.5µs ± 1%  19.4µs ± 1%  -75.00%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_1-4      77.8µs ± 0%  21.1µs ± 0%  -72.85%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_1-16     79.5µs ± 1%  21.3µs ± 1%  -73.24%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_2        78.8µs ± 0%  19.6µs ± 1%  -75.17%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_2-4      87.2µs ± 1%  23.2µs ± 0%  -73.36%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_2-16     89.8µs ± 2%  23.8µs ± 0%  -73.49%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_16       81.0µs ± 1%  22.6µs ± 2%  -72.03%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_16-4      105µs ± 0%    45µs ± 1%  -56.96%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_16-16     193µs ± 2%    50µs ± 0%  -73.99%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_512       198µs ± 1%   124µs ± 2%  -37.55%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_512-4     166µs ± 3%   152µs ± 0%   -8.42%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_512-16    262µs ± 1%   212µs ± 2%  -19.03%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_1024      328µs ± 1%   246µs ± 1%  -25.07%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_1024-4    273µs ± 1%   225µs ± 1%  -17.54%  (p=0.008 n=5+5)
ForEachJob/1024_jobs_/_concurrency_1024-16   334µs ± 0%   273µs ± 1%  -18.16%  (p=0.008 n=5+5)
```

I ran the memory benchmarks only for the `1024 workers / concurrency 1` test case (to be honest, the most favorable for the new implementation):

```
$ benchstat old_1024_1_mem new_1024_1_mem 
name                                  old time/op    new time/op    delta
ForEachJob/1024_jobs_/_concurrency_1    73.4µs ± 2%    18.2µs ± 1%  -75.15%  (p=0.008 n=5+5)

name                                  old alloc/op   new alloc/op   delta
ForEachJob/1024_jobs_/_concurrency_1    65.9kB ± 0%    16.7kB ± 0%  -74.72%  (p=0.008 n=5+5)

name                                  old allocs/op  new allocs/op  delta
ForEachJob/1024_jobs_/_concurrency_1     1.04k ± 0%     0.01k ± 0%  -99.13%  (p=0.008 n=5+5)
```

<details>
<summary>Benchmark used for `concurrency.ForEach`</summary>

```go
func BenchmarkForEachJob(b *testing.B) {
	var ctx = context.Background()

	for _, jobsCount := range []int{2, 16, 256, 1024} {
		jobs := make([]string, jobsCount)
		for j := 0; j < jobsCount; j++ {
			jobs[j] = string(byte('a' + j%26))
		}
		concurrencies := []int{1, 2, 16}
		if jobsCount/2 > concurrencies[len(concurrencies)-1] {
			concurrencies = append(concurrencies, jobsCount/2)
		}
		if jobsCount > concurrencies[len(concurrencies)-1] {
			concurrencies = append(concurrencies, jobsCount)
		}

		for _, concurrency := range concurrencies {
			name := fmt.Sprintf("%d jobs / concurrency %d", jobsCount, concurrency)
			{
				b.Run(name, func(b *testing.B) {
					for i := 0; i < b.N; i++ {
						mtx := sync.Mutex{}
						processed := make([]string, 0, len(jobs))
						err := ForEach(ctx, CreateJobsFromStrings(jobs), concurrency, func(ctx context.Context, job interface{}) error {
							mtx.Lock()
							processed = append(processed, job.(string))
							mtx.Unlock()
							return nil
						})
						require.NoError(b, err)
					}
				})
			}
		}
	}
}

// ForEach runs the provided jobFunc for each job up to concurrency concurrent workers.
// The execution breaks on first error encountered.
func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc func(ctx context.Context, job interface{}) error) error {
	if len(jobs) == 0 {
		return nil
	}

	// Push all jobs to a channel.
	ch := make(chan interface{}, len(jobs))
	for _, job := range jobs {
		ch <- job
	}
	close(ch)

	// Start workers to process jobs.
	g, ctx := errgroup.WithContext(ctx)
	for ix := 0; ix < math.Min(concurrency, len(jobs)); ix++ {
		g.Go(func() error {
			for job := range ch {
				if err := ctx.Err(); err != nil {
					return err
				}

				if err := jobFunc(ctx, job); err != nil {
					return err
				}
			}

			return nil
		})
	}

	// Wait until done (or context has canceled).
	return g.Wait()
}

// CreateJobsFromStrings is an utility to create jobs from an slice of strings.
func CreateJobsFromStrings(values []string) []interface{} {
	jobs := make([]interface{}, len(values))
	for i := 0; i < len(values); i++ {
		jobs[i] = values[i]
	}
	return jobs
}
```
</details>


**Which issue(s) this PR fixes**:

None

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
