### PR TITLE
Allow change of default KV store.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [CHANGE] grpcutil.Resolver.Resolve: Take a service parameter. #102
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
 * [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
+* [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/kv/client.go
+++ b/kv/client.go
@@ -76,8 +76,14 @@ func (cfg *Config) RegisterFlagsWithPrefix(flagsPrefix, defaultPrefix string, f 
 	if flagsPrefix == "" {
 		flagsPrefix = "ring."
 	}
+
+	// Allow clients to override default store by setting it before calling this method.
+	if cfg.Store == "" {
+		cfg.Store = "consul"
+	}
+
 	f.StringVar(&cfg.Prefix, flagsPrefix+"prefix", defaultPrefix, "The prefix for the keys in the store. Should end with a /.")
-	f.StringVar(&cfg.Store, flagsPrefix+"store", "consul", "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi.")
+	f.StringVar(&cfg.Store, flagsPrefix+"store", cfg.Store, "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi.")
 }
 
 // Client is a high-level client for key-value stores (such as Etcd and

--- a/kv/client_test.go
+++ b/kv/client_test.go
@@ -2,11 +2,13 @@ package kv
 
 import (
 	"context"
+	"flag"
 	"testing"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
@@ -156,4 +158,15 @@ type testLogger struct {
 
 func (l testLogger) Log(keyvals ...interface{}) error {
 	return nil
+}
+
+func TestDefaultStoreValue(t *testing.T) {
+	cfg1 := Config{}
+	cfg1.RegisterFlagsWithPrefix("", "", flag.NewFlagSet("test", flag.PanicOnError))
+	assert.Equal(t, "consul", cfg1.Store)
+
+	cfg2 := Config{}
+	cfg2.Store = "memberlist"
+	cfg2.RegisterFlagsWithPrefix("", "", flag.NewFlagSet("test", flag.PanicOnError))
+	assert.Equal(t, "memberlist", cfg2.Store)
 }


### PR DESCRIPTION
**What this PR does**: This PR allows clients of `dskit` to change default KV store to use with ring, if they wish to do so. If no default is set, then `consul` is used, as before.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
