### PR TITLE
Allow to override default of `final-sleep` and change default to `0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
 * [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
-* [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep` to other than `30s`. #121
+* [CHANGE] Lifecycler: Default value of lifecycler's `final-sleep` is now `0s` (i.e. no sleep). #121
+* [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
 * [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
-* [CHANGE] Lifecycler: Change default value of `-[ingester.]final-sleep` (YAML: `[ingester.]final_sleep`) to `0s`. 
+* [CHANGE] Lifecycler: Change default value of `-[ingester.]final-sleep` (YAML: `[ingester.]final_sleep`) to `0s`.  #121
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
 * [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
-* [CHANGE] Lifecycler: Change default value of `-[ingester.]final-sleep` (YAML: `[ingester.]final_sleep`) to `0s`.  #121
+* [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep` to other than `30s`. #121
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
 * [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
+* [CHANGE] Lifecycler: Change default value of `-[ingester.]final-sleep` (YAML: `[ingester.]final_sleep`) to `0s`. 
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -27,12 +27,15 @@ type LifecyclerConfig struct {
 	RingConfig Config `yaml:"ring"`
 
 	// Config for the ingester lifecycle control
-	NumTokens                int           `yaml:"num_tokens"`
-	HeartbeatPeriod          time.Duration `yaml:"heartbeat_period"`
-	ObservePeriod            time.Duration `yaml:"observe_period"`
-	JoinAfter                time.Duration `yaml:"join_after"`
-	MinReadyDuration         time.Duration `yaml:"min_ready_duration"`
-	InfNames                 []string      `yaml:"interface_names"`
+	NumTokens        int           `yaml:"num_tokens"`
+	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period"`
+	ObservePeriod    time.Duration `yaml:"observe_period"`
+	JoinAfter        time.Duration `yaml:"join_after"`
+	MinReadyDuration time.Duration `yaml:"min_ready_duration"`
+	InfNames         []string      `yaml:"interface_names"`
+
+	// FinalSleep's default value can be overridden by
+	// setting it before calling RegisterFlags or RegisterFlagsWithPrefix.
 	FinalSleep               time.Duration `yaml:"final_sleep"`
 	TokensFilePath           string        `yaml:"tokens_file_path"`
 	Zone                     string        `yaml:"availability_zone"`
@@ -48,12 +51,14 @@ type LifecyclerConfig struct {
 	ListenPort int `yaml:"-"`
 }
 
-// RegisterFlags adds the flags required to config this to the given FlagSet
+// RegisterFlags adds the flags required to config this to the given FlagSet.
+// The default values of some flags can be changed; see docs of LifecyclerConfig.
 func (cfg *LifecyclerConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.RegisterFlagsWithPrefix("", f)
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet.
+// The default values of some flags can be changed; see docs of LifecyclerConfig.
 func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.RingConfig.RegisterFlagsWithPrefix(prefix, f)
 
@@ -63,12 +68,17 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 		prefix = "ingester."
 	}
 
+	// Allow clients to override default value by setting it before calling this method.
+	if cfg.FinalSleep == 0 {
+		cfg.FinalSleep = 30 * time.Second
+	}
+
 	f.IntVar(&cfg.NumTokens, prefix+"num-tokens", 128, "Number of tokens for each ingester.")
 	f.DurationVar(&cfg.HeartbeatPeriod, prefix+"heartbeat-period", 5*time.Second, "Period at which to heartbeat to consul. 0 = disabled.")
 	f.DurationVar(&cfg.JoinAfter, prefix+"join-after", 0*time.Second, "Period to wait for a claim from another member; will join automatically after this.")
 	f.DurationVar(&cfg.ObservePeriod, prefix+"observe-period", 0*time.Second, "Observe tokens after generating to resolve collisions. Useful when using gossiping ring.")
 	f.DurationVar(&cfg.MinReadyDuration, prefix+"min-ready-duration", 15*time.Second, "Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates.")
-	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", 0*time.Second, "Duration to sleep for before exiting, to ensure metrics are scraped.")
+	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", cfg.FinalSleep, "Duration to sleep for before exiting, to ensure metrics are scraped.")
 	f.StringVar(&cfg.TokensFilePath, prefix+"tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 
 	hostname, err := os.Hostname()

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -68,11 +68,6 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 		prefix = "ingester."
 	}
 
-	// Allow clients to override default value by setting it before calling this method.
-	if cfg.FinalSleep == 0 {
-		cfg.FinalSleep = 30 * time.Second
-	}
-
 	f.IntVar(&cfg.NumTokens, prefix+"num-tokens", 128, "Number of tokens for each ingester.")
 	f.DurationVar(&cfg.HeartbeatPeriod, prefix+"heartbeat-period", 5*time.Second, "Period at which to heartbeat to consul. 0 = disabled.")
 	f.DurationVar(&cfg.JoinAfter, prefix+"join-after", 0*time.Second, "Period to wait for a claim from another member; will join automatically after this.")

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -68,7 +68,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 	f.DurationVar(&cfg.JoinAfter, prefix+"join-after", 0*time.Second, "Period to wait for a claim from another member; will join automatically after this.")
 	f.DurationVar(&cfg.ObservePeriod, prefix+"observe-period", 0*time.Second, "Observe tokens after generating to resolve collisions. Useful when using gossiping ring.")
 	f.DurationVar(&cfg.MinReadyDuration, prefix+"min-ready-duration", 15*time.Second, "Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates.")
-	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", 30*time.Second, "Duration to sleep for before exiting, to ensure metrics are scraped.")
+	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", 0*time.Second, "Duration to sleep for before exiting, to ensure metrics are scraped.")
 	f.StringVar(&cfg.TokensFilePath, prefix+"tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 
 	hostname, err := os.Hostname()

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -848,3 +848,18 @@ func waitRingInstance(t *testing.T, timeout time.Duration, l *Lifecycler, check 
 		return check(instance)
 	})
 }
+
+func TestDefaultFinalSleepValue(t *testing.T) {
+	t.Run("default value is 0", func(t *testing.T) {
+		cfg := &LifecyclerConfig{}
+		flagext.DefaultValues(cfg)
+		assert.Equal(t, time.Duration(0), cfg.FinalSleep)
+	})
+
+	t.Run("default value is overridable", func(t *testing.T) {
+		cfg := &LifecyclerConfig{}
+		cfg.FinalSleep = time.Minute
+		flagext.DefaultValues(cfg)
+		assert.Equal(t, time.Minute, cfg.FinalSleep)
+	})
+}


### PR DESCRIPTION
**What this PR does**:
Allows to override default of `final-sleep` and change default to `0`

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ n/a ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
