### PR TITLE
bump default gRPC send max size to 100Mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
 * [CHANGE] grpcutil: Convert Resolver into concrete type. #105
 * [CHANGE] grpcutil.Resolver.Resolve: Take a service parameter. #102
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
+* [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [CHANGE] grpcclient: Bump default `grpc-max-send-msg-size` flag to 100 Mb. #123
-* [CHANGE] concurrency._ForEach_: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
 * [CHANGE] Lifecycler: Default value of lifecycler's `final-sleep` is now `0s` (i.e. no sleep). #121
 * [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 * [CHANGE] grpcutil: Convert Resolver into concrete type. #105
 * [CHANGE] grpcutil.Resolver.Resolve: Take a service parameter. #102
 * [CHANGE] grpcutil.Update: Remove gRPC LB related metadata. #102
-* [CHANGE] concurrency.ForEach: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
+* [CHANGE] grpcclient: Bump default `grpc-max-send-msg-size` flag to 100 Mb. #123
+* [CHANGE] concurrency._ForEach_: deprecated and reimplemented by new `concurrency.ForEachJob`. #113
 * [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
 * [CHANGE] Lifecycler: Default value of lifecycler's `final-sleep` is now `0s` (i.e. no sleep). #121
 * [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -584,7 +584,7 @@ type grpcConfig struct {
 // RegisterFlags registers flags.
 func (cfg *grpcConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRecvMsgSize, ".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
-	f.IntVar(&cfg.MaxSendMsgSize, ".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
+	f.IntVar(&cfg.MaxSendMsgSize, ".grpc-max-send-msg-size", 100<<20, "gRPC client max send message size (bytes).")
 	f.StringVar(&cfg.GRPCCompression, ".grpc-compression", "", "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)")
 	f.Float64Var(&cfg.RateLimit, ".grpc-client-rate-limit", 0., "Rate limit for gRPC client; 0 means disabled.")
 	f.IntVar(&cfg.RateLimitBurst, ".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -39,7 +39,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // RegisterFlagsWithPrefix registers flags with prefix.
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
-	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
+	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 100<<20, "gRPC client max send message size (bytes).")
 	f.StringVar(&cfg.GRPCCompression, prefix+".grpc-compression", "", "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)")
 	f.Float64Var(&cfg.RateLimit, prefix+".grpc-client-rate-limit", 0., "Rate limit for gRPC client; 0 means disabled.")
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Bump `grpcclient` default max send size from 16Mb to 100Mb.

**Which issue(s) this PR fixes**:

Fixes N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
