### PR TITLE
autodetect interfaces on private networks

### DIFF
--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -36,7 +36,6 @@ func privateNetworkInterfaces(all []net.Interface, logger log.Logger) []string {
 				level.Warn(logger).Log("msg", "error getting ip address", "inf", i.Name, "addr", s, "err", err)
 			}
 			if ip.IsPrivate() {
-				level.Info(logger).Log(i.Name, "is private with address", s)
 				privInts = append(privInts, i.Name)
 				break
 			}

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -2,7 +2,6 @@ package netutil
 
 import (
 	"net"
-	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -12,11 +11,11 @@ var (
 	getInterfaceAddrs = (*net.Interface).Addrs
 )
 
-// Parses network interfaces and returns those having an address conformant to RFC1918
+// PrivateNetworkInterfaces lists network interfaces and returns those having an address conformant to RFC1918
 func PrivateNetworkInterfaces(logger log.Logger) []string {
 	ints, err := net.Interfaces()
 	if err != nil {
-		level.Warn(logger).Log("msg", "error getting interfaces", "err", err)
+		level.Warn(logger).Log("msg", "error getting network interfaces", "err", err)
 	}
 	return privateNetworkInterfaces(ints, logger)
 }
@@ -27,13 +26,13 @@ func privateNetworkInterfaces(all []net.Interface, logger log.Logger) []string {
 	for _, i := range all {
 		addrs, err := getInterfaceAddrs(&i)
 		if err != nil {
-			level.Warn(logger).Log("msg", "error getting addresses", "inf", i.Name, "err", err)
+			level.Warn(logger).Log("msg", "error getting addresses from network interface", "interface", i.Name, "err", err)
 		}
 		for _, a := range addrs {
 			s := a.String()
 			ip, _, err := net.ParseCIDR(s)
 			if err != nil {
-				level.Warn(logger).Log("msg", "error getting ip address", "inf", i.Name, "addr", s, "err", err)
+				level.Warn(logger).Log("msg", "error parsing network interface IP address", "inf", i.Name, "addr", s, "err", err)
 			}
 			if ip.IsPrivate() {
 				privInts = append(privInts, i.Name)
@@ -44,6 +43,6 @@ func privateNetworkInterfaces(all []net.Interface, logger log.Logger) []string {
 	if len(privInts) == 0 {
 		return []string{"eth0", "en0"}
 	}
-	level.Info(logger).Log("msg", "found interfaces on private networks:", "["+strings.Join(privInts, ", ")+"]")
+	level.Debug(logger).Log("msg", "found network interfaces with private IP addresses assigned", "interfaces", privInts)
 	return privInts
 }

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -1,0 +1,50 @@
+package netutil
+
+import (
+	"net"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+var (
+	getInterfaceAddrs = (*net.Interface).Addrs
+)
+
+// Parses network interfaces and returns those having an address conformant to RFC1918
+func PrivateNetworkInterfaces(logger log.Logger) []string {
+	ints, err := net.Interfaces()
+	if err != nil {
+		level.Warn(logger).Log("msg", "error getting interfaces", "err", err)
+	}
+	return privateNetworkInterfaces(ints, logger)
+}
+
+// private testable function that checks each given interface
+func privateNetworkInterfaces(all []net.Interface, logger log.Logger) []string {
+	var privInts []string
+	for _, i := range all {
+		addrs, err := getInterfaceAddrs(&i)
+		if err != nil {
+			level.Warn(logger).Log("msg", "error getting addresses", "inf", i.Name, "err", err)
+		}
+		for _, a := range addrs {
+			s := a.String()
+			ip, _, err := net.ParseCIDR(s)
+			if err != nil {
+				level.Warn(logger).Log("msg", "error getting ip address", "inf", i.Name, "addr", s, "err", err)
+			}
+			if ip.IsPrivate() {
+				level.Info(logger).Log(i.Name, "is private with address", s)
+				privInts = append(privInts, i.Name)
+				break
+			}
+		}
+	}
+	if len(privInts) == 0 {
+		return []string{"eth0", "en0"}
+	}
+	level.Info(logger).Log("msg", "found interfaces on private networks:", "["+strings.Join(privInts, ", ")+"]")
+	return privInts
+}

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -107,6 +107,7 @@ func TestPrivateInterface(t *testing.T) {
 		t.Run(scenario.description, func(t *testing.T) {
 			privInts := privateNetworkInterfaces(
 				generateTestInterfaces(scenario.interfaces),
+				defaultOutput,
 				log.NewNopLogger(),
 			)
 			assert.Equal(t, privInts, scenario.expectedOutput)
@@ -121,6 +122,6 @@ func TestPrivateInterfaceError(t *testing.T) {
 		return []net.Addr{mockAddr{netAddr: ipaddr}}, nil
 	}
 	logger := log.NewLogfmtLogger(os.Stdout)
-	privInts := privateNetworkInterfaces(interfaces, logger)
-	assert.Equal(t, privInts, []string{"eth0", "en0"})
+	privInts := privateNetworkInterfaces(interfaces, []string{}, logger)
+	assert.Equal(t, privInts, []string{})
 }

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -3,10 +3,10 @@ package netutil
 import (
 	"net"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
 )
 
 // Setup required logger and example interface names and addresses
@@ -56,9 +56,7 @@ func TestEmptyInterface(t *testing.T) {
 		return []net.Addr{}, nil
 	}
 	privInts := privateNetworkInterfaces(ints, logger)
-	if !reflect.DeepEqual(privInts, []string{"eth0", "en0"}) {
-		t.Errorf("Expected default/fallback interfaces, got %v\n", privInts)
-	}
+	assert.Equal(t, privInts, []string{"eth0", "en0"})
 }
 
 func TestSinglePrivateInterface(t *testing.T) {
@@ -74,9 +72,7 @@ func TestSinglePrivateInterface(t *testing.T) {
 		return []net.Addr{MockAddr{netAddr: testIntsAddrs[ifname]}}, nil
 	}
 	privInts := privateNetworkInterfaces(ints, logger)
-	if !reflect.DeepEqual(privInts, []string{ifname}) {
-		t.Errorf("Expected single result {\"%s\"}, got %v\n", ifname, privInts)
-	}
+	assert.Equal(t, privInts, []string{ifname})
 }
 
 func TestSinglePublicInterface(t *testing.T) {
@@ -92,9 +88,7 @@ func TestSinglePublicInterface(t *testing.T) {
 		return []net.Addr{MockAddr{netAddr: testIntsAddrs[ifname]}}, nil
 	}
 	privInts := privateNetworkInterfaces(ints, logger)
-	if !reflect.DeepEqual(privInts, []string{"eth0", "en0"}) {
-		t.Errorf("Expected default/fallback interfaces, got %v\n", privInts)
-	}
+	assert.Equal(t, privInts, []string{"eth0", "en0"})
 }
 
 func TestListAllPrivate(t *testing.T) {
@@ -106,9 +100,7 @@ func TestListAllPrivate(t *testing.T) {
 		}, nil
 	}
 	privInts := privateNetworkInterfaces(ints, logger)
-	if !reflect.DeepEqual(privInts, intNames) {
-		t.Errorf("Expected all input interfaces, got %v\n", privInts)
-	}
+	assert.Equal(t, privInts, intNames)
 }
 
 func TestMixPrivatePublic(t *testing.T) {
@@ -120,7 +112,5 @@ func TestMixPrivatePublic(t *testing.T) {
 		}, nil
 	}
 	privInts := privateNetworkInterfaces(ints, logger)
-	if !reflect.DeepEqual(privInts, []string{"privNetA", "privNetB", "privNetC"}) {
-		t.Errorf("Expected all private interfaces, got %v\n", privInts)
-	}
+	assert.Equal(t, privInts, []string{"privNetA", "privNetB", "privNetC"})
 }

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -1,0 +1,126 @@
+package netutil
+
+import (
+	"net"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/go-kit/log"
+)
+
+// Setup required logger and example interface names and addresses
+var (
+	logger        log.Logger = log.NewLogfmtLogger(os.Stdout)
+	testIntsAddrs            = map[string]string{
+		"privNetA": "10.6.19.34/8",
+		"privNetB": "172.16.0.7/12",
+		"privNetC": "192.168.3.29/24",
+		"pubNet":   "34.120.177.193/24",
+	}
+)
+
+// A type that implements the net.Addr interface
+// Only String() is called by netutil logic
+type MockAddr struct {
+	netAddr string
+}
+
+func (ma MockAddr) Network() string {
+	return "tcp"
+}
+
+func (ma MockAddr) String() string {
+	return ma.netAddr
+}
+
+// Helper function to test a list of interfaces
+func generateTestInterfaces(names []string) []net.Interface {
+	testInts := []net.Interface{}
+	for i, j := range names {
+		k := net.Interface{
+			Index:        i + 1,
+			MTU:          1500,
+			Name:         j,
+			HardwareAddr: []byte{},
+			Flags:        0,
+		}
+		testInts = append(testInts, k)
+	}
+	return testInts
+}
+
+func TestEmptyInterface(t *testing.T) {
+	ints := []net.Interface{}
+	getInterfaceAddrs = func(i *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{}, nil
+	}
+	privInts := privateNetworkInterfaces(ints, logger)
+	if !reflect.DeepEqual(privInts, []string{"eth0", "en0"}) {
+		t.Errorf("Expected default/fallback interfaces, got %v\n", privInts)
+	}
+}
+
+func TestSinglePrivateInterface(t *testing.T) {
+	ifname := "privNetA"
+	ints := []net.Interface{{
+		Index:        1,
+		MTU:          1500,
+		Name:         ifname,
+		HardwareAddr: []byte{},
+		Flags:        0,
+	}}
+	getInterfaceAddrs = func(i *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{MockAddr{netAddr: testIntsAddrs[ifname]}}, nil
+	}
+	privInts := privateNetworkInterfaces(ints, logger)
+	if !reflect.DeepEqual(privInts, []string{ifname}) {
+		t.Errorf("Expected single result {\"%s\"}, got %v\n", ifname, privInts)
+	}
+}
+
+func TestSinglePublicInterface(t *testing.T) {
+	ifname := "pubNet"
+	ints := []net.Interface{{
+		Index:        1,
+		MTU:          1500,
+		Name:         ifname,
+		HardwareAddr: []byte{},
+		Flags:        0,
+	}}
+	getInterfaceAddrs = func(i *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{MockAddr{netAddr: testIntsAddrs[ifname]}}, nil
+	}
+	privInts := privateNetworkInterfaces(ints, logger)
+	if !reflect.DeepEqual(privInts, []string{"eth0", "en0"}) {
+		t.Errorf("Expected default/fallback interfaces, got %v\n", privInts)
+	}
+}
+
+func TestListAllPrivate(t *testing.T) {
+	intNames := []string{"privNetA", "privNetB", "privNetC"}
+	ints := generateTestInterfaces(intNames)
+	getInterfaceAddrs = func(i *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{
+			MockAddr{netAddr: testIntsAddrs[i.Name]},
+		}, nil
+	}
+	privInts := privateNetworkInterfaces(ints, logger)
+	if !reflect.DeepEqual(privInts, intNames) {
+		t.Errorf("Expected all input interfaces, got %v\n", privInts)
+	}
+}
+
+func TestMixPrivatePublic(t *testing.T) {
+	intNames := []string{"pubNet", "privNetA", "privNetB", "privNetC"}
+	ints := generateTestInterfaces(intNames)
+	getInterfaceAddrs = func(i *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{
+			MockAddr{netAddr: testIntsAddrs[i.Name]},
+		}, nil
+	}
+	privInts := privateNetworkInterfaces(ints, logger)
+	if !reflect.DeepEqual(privInts, []string{"privNetA", "privNetB", "privNetC"}) {
+		t.Errorf("Expected all private interfaces, got %v\n", privInts)
+	}
+}

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/services"
 )
 
@@ -81,7 +82,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 		panic(fmt.Errorf("failed to get hostname %s", err))
 	}
 
-	cfg.InfNames = []string{"eth0", "en0"}
+	cfg.InfNames = netutil.PrivateNetworkInterfaces(log.NewLogfmtLogger(os.Stdout))
 	f.Var((*flagext.StringSlice)(&cfg.InfNames), prefix+"lifecycler.interface", "Name of network interface to read address from.")
 	f.StringVar(&cfg.Addr, prefix+"lifecycler.addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.Port, prefix+"lifecycler.port", 0, "port to advertise in consul (defaults to server.grpc-listen-port).")

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -54,13 +54,13 @@ type LifecyclerConfig struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 // The default values of some flags can be changed; see docs of LifecyclerConfig.
-func (cfg *LifecyclerConfig) RegisterFlags(f *flag.FlagSet) {
-	cfg.RegisterFlagsWithPrefix("", f)
+func (cfg *LifecyclerConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+	cfg.RegisterFlagsWithPrefix("", f, logger)
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet.
 // The default values of some flags can be changed; see docs of LifecyclerConfig.
-func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet, logger log.Logger) {
 	cfg.RingConfig.RegisterFlagsWithPrefix(prefix, f)
 
 	// In order to keep backwards compatibility all of these need to be prefixed
@@ -82,7 +82,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 		panic(fmt.Errorf("failed to get hostname %s", err))
 	}
 
-	cfg.InfNames = netutil.PrivateNetworkInterfaces(log.NewLogfmtLogger(os.Stdout))
+	cfg.InfNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
 	f.Var((*flagext.StringSlice)(&cfg.InfNames), prefix+"lifecycler.interface", "Name of network interface to read address from.")
 	f.StringVar(&cfg.Addr, prefix+"lifecycler.addr", "", "IP address to advertise in the ring.")
 	f.IntVar(&cfg.Port, prefix+"lifecycler.port", 0, "port to advertise in consul (defaults to server.grpc-listen-port).")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR adds a new package `netutil` which includes a function `PrivateNetworkInterfaces` that scans all system network interfaces and return those that are on a private network. This will make some configuration steps easier, especially for systems that use consistent network device naming.

**Which issue(s) this PR fixes**:

This is similar to [PR 100](https://github.com/grafana/dskit/pull/100) but takes advantage of the new `IsPrivate` function in Go 1.17 and includes unit tests.

Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
