### PR TITLE
lifecycler: Remove parameters from YAML

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -43,9 +43,9 @@ type LifecyclerConfig struct {
 	ReadinessCheckRingHealth bool          `yaml:"readiness_check_ring_health" category:"advanced"`
 
 	// For testing, you can override the address and ID of this ingester
-	Addr string `yaml:"address" doc:"hidden"`
-	Port int    `doc:"hidden"`
-	ID   string `doc:"hidden"`
+	Addr string `yaml:"address" doc:"hidden" category:"advanced"`
+	Port int    `doc:"hidden" category:"advanced"`
+	ID   string `doc:"hidden" category:"advanced"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`


### PR DESCRIPTION
**What this PR does**:

Removes `lifecycler` parameters, which according to the comment should only be used in tests.

**Which issue(s) this PR fixes**:

**Checklist**
- [N/A] Tests updated
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
