### PR TITLE
Allow in-memory kv-client to support multiple codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109
+* [BUGFIX] Allow in-memory kv-client to support multiple codec #132

--- a/kv/client.go
+++ b/kv/client.go
@@ -33,8 +33,10 @@ func (r *role) Labels() prometheus.Labels {
 // The NewInMemoryKVClient returned by NewClient() is a singleton, so
 // that distributors and ingesters started in the same process can
 // find themselves.
-var inmemoryStoreInit sync.Once
-var inmemoryStore Client
+var (
+	inmemoryStoreInit sync.Once
+	inmemoryStore     *consul.Client
+)
 
 // StoreConfig is a configuration used for building single store client, either
 // Consul, Etcd, Memberlist or MultiClient. It was extracted from Config to keep
@@ -146,7 +148,8 @@ func createClient(backend string, prefix string, cfg StoreConfig, codec codec.Co
 		inmemoryStoreInit.Do(func() {
 			inmemoryStore, _ = consul.NewInMemoryClient(codec, logger, reg)
 		})
-		client = inmemoryStore
+		// however we swap the codec so that we can encode different type of values.
+		client = inmemoryStore.Clone().WithCodec(codec)
 
 	case "memberlist":
 		kv, err := cfg.MemberlistKV()

--- a/kv/client.go
+++ b/kv/client.go
@@ -149,7 +149,7 @@ func createClient(backend string, prefix string, cfg StoreConfig, codec codec.Co
 			inmemoryStore, _ = consul.NewInMemoryClient(codec, logger, reg)
 		})
 		// however we swap the codec so that we can encode different type of values.
-		client = inmemoryStore.Clone().WithCodec(codec)
+		client = inmemoryStore.WithCodec(codec)
 
 	case "memberlist":
 		kv, err := cfg.MemberlistKV()

--- a/kv/client_test.go
+++ b/kv/client_test.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"context"
 	"flag"
-	"os"
 	"testing"
 	"time"
 
@@ -186,7 +185,7 @@ func (c stringCodec) Encode(interface{}) ([]byte, error) {
 func (c stringCodec) CodecID() string { return c.value }
 
 func TestMultipleInMemoryClient(t *testing.T) {
-	logger := log.NewJSONLogger(os.Stdout)
+	logger := log.NewNopLogger()
 	foo, err := NewClient(Config{
 		Store: "inmemory",
 	}, stringCodec{value: "foo"}, prometheus.NewRegistry(), logger)

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -397,14 +397,9 @@ func (c *Client) createRateLimiter() *rate.Limiter {
 	return rate.NewLimiter(rate.Limit(c.cfg.WatchKeyRateLimit), burst)
 }
 
-// Clone clone the current consul client.
-func (c *Client) Clone() *Client {
-	new := *c
-	return &new
-}
-
 // WithCodec changes the codec of the consul client.
 func (c *Client) WithCodec(codec codec.Codec) *Client {
-	c.codec = codec
-	return c
+	new := *c
+	new.codec = codec
+	return &new
 }

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -397,7 +397,7 @@ func (c *Client) createRateLimiter() *rate.Limiter {
 	return rate.NewLimiter(rate.Limit(c.cfg.WatchKeyRateLimit), burst)
 }
 
-// WithCodec changes the codec of the consul client.
+// WithCodec Clones and changes the codec of the consul client.
 func (c *Client) WithCodec(codec codec.Codec) *Client {
 	new := *c
 	new.codec = codec

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -234,7 +234,6 @@ func (c *Client) WatchKey(ctx context.Context, key string, f func(interface{}) b
 		}
 
 		kvp, meta, err := c.kv.Get(key, queryOptions.WithContext(ctx))
-
 		// Don't backoff if value is not found (kvp == nil). In that case, Consul still returns index value,
 		// and next call to Get will block as expected. We handle missing value below.
 		if err != nil {
@@ -396,4 +395,16 @@ func (c *Client) createRateLimiter() *rate.Limiter {
 		burst = 1
 	}
 	return rate.NewLimiter(rate.Limit(c.cfg.WatchKeyRateLimit), burst)
+}
+
+// Clone clone the current consul client.
+func (c *Client) Clone() *Client {
+	new := *c
+	return &new
+}
+
+// WithCodec changes the codec of the consul client.
+func (c *Client) WithCodec(codec codec.Codec) *Client {
+	c.codec = codec
+	return c
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR allows to create multiple in-memory client with different codec. Before it would always the first codec registered because of the singleton.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/dskit/issues/131

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
