### PR TITLE
Add doc:default tag to ring lifecycler network interfaces field

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -33,7 +33,7 @@ type LifecyclerConfig struct {
 	ObservePeriod    time.Duration `yaml:"observe_period" category:"advanced"`
 	JoinAfter        time.Duration `yaml:"join_after" category:"advanced"`
 	MinReadyDuration time.Duration `yaml:"min_ready_duration" category:"advanced"`
-	InfNames         []string      `yaml:"interface_names"`
+	InfNames         []string      `yaml:"interface_names" doc:"default=[<private network interfaces>]"`
 
 	// FinalSleep's default value can be overridden by
 	// setting it before calling RegisterFlags or RegisterFlagsWithPrefix.


### PR DESCRIPTION
**What this PR does**:
https://github.com/grafana/dskit/pull/126 has introduced dynamic config default for network interfaces. This breaks the doc generator, cause the default value changes depending on which machine you're running on. I'm adding the support for `doc:"default=foo"` in the doc generator, to override it.

This PR leverages on that.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
