### PR TITLE
Add doc:default tag to ring lifecycler instance ID too

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -44,9 +44,9 @@ type LifecyclerConfig struct {
 	ReadinessCheckRingHealth bool          `yaml:"readiness_check_ring_health" category:"advanced"`
 
 	// For testing, you can override the address and ID of this ingester
-	Addr string `yaml:"address" doc:"hidden" category:"advanced"`
-	Port int    `doc:"hidden" category:"advanced"`
-	ID   string `doc:"hidden" category:"advanced"`
+	Addr string `yaml:"address" doc:"default=<hostname>" category:"advanced"`
+	Port int    `category:"advanced"`
+	ID   string `category:"advanced"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -44,9 +44,9 @@ type LifecyclerConfig struct {
 	ReadinessCheckRingHealth bool          `yaml:"readiness_check_ring_health" category:"advanced"`
 
 	// For testing, you can override the address and ID of this ingester
-	Addr string `yaml:"address" doc:"default=<hostname>" category:"advanced"`
+	Addr string `yaml:"address" category:"advanced"`
 	Port int    `category:"advanced"`
-	ID   string `category:"advanced"`
+	ID   string `doc:"default=<hostname>" category:"advanced"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`


### PR DESCRIPTION
**What this PR does**:
Similar to https://github.com/grafana/dskit/pull/139, but for ring lifecycler address. I've also removed the doc:hidden from address and port (now that we have the "advanced" categorization).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
