### PR TITLE
Added missing CHANGELOG entry for PR 141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109
 * [BUGFIX] Allow in-memory kv-client to support multiple codec #132
+* [BUGFIX] Modules: fix a module waiting for other modules depending on it before stopping. #141


### PR DESCRIPTION
**What this PR does**:
I did a terrible mistake in PR #141: I forgot to add a CHANGELOG entry. This PR should fix it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
