### PR TITLE
Allow custom status page templates

### DIFF
--- a/kv/memberlist/kv_init_service_test.go
+++ b/kv/memberlist/kv_init_service_test.go
@@ -21,7 +21,7 @@ func TestPage(t *testing.T) {
 		_ = ml.Shutdown()
 	})
 
-	require.NoError(t, pageTemplate.Execute(&bytes.Buffer{}, pageData{
+	require.NoError(t, defaultPageTemplate.Execute(&bytes.Buffer{}, statusPageData{
 		Now:           time.Now(),
 		Memberlist:    ml,
 		SortedMembers: ml.Members(),

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"html/template"
 	"math"
 	"strings"
 	"sync"
@@ -164,6 +165,10 @@ type KVConfig struct {
 
 	// Codecs to register. Codecs need to be registered before joining other members.
 	Codecs []codec.Codec `yaml:"-"`
+
+	// CustomHTTPHandlerTemplate will be rendered by HTTPHandler instead of the embedded default one, if provided.
+	// This option is set internally and never exposed to the user.
+	CustomHTTPHandlerTemplate *template.Template `yaml:"-"`
 }
 
 // RegisterFlagsWithPrefix registers flags.

--- a/kv/memberlist/status.gohtml
+++ b/kv/memberlist/status.gohtml
@@ -1,0 +1,142 @@
+{{- /*gotype: github.com/grafana/dskit/kv/memberlist.statusPageData */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Memberlist Status</title>
+</head>
+<body>
+<h1>Memberlist Status</h1>
+<p>Current time: {{ .Now }}</p>
+
+<ul>
+    <li>Health Score: {{ .Memberlist.GetHealthScore }} (lower = better, 0 = healthy)</li>
+    <li>Members: {{ .Memberlist.NumMembers }}</li>
+</ul>
+
+<h2>KV Store</h2>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>Key</th>
+        <th>Value Details</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range $k, $v := .Store }}
+        <tr>
+            <td>{{ $k }}</td>
+            <td>{{ $v }}</td>
+            <td>
+                <a href="?viewKey={{ $k }}&format=json">json</a>
+                | <a href="?viewKey={{ $k }}&format=json-pretty">json-pretty</a>
+                | <a href="?viewKey={{ $k }}&format=struct">struct</a>
+                | <a href="?downloadKey={{ $k }}">download</a>
+            </td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+
+<p>Note that value "version" is node-specific. It starts with 0 (on restart), and increases on each received update. Size is in bytes.</p>
+
+<h2>Memberlist Cluster Members</h2>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th>Address</th>
+        <th>State</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range .SortedMembers }}
+        <tr>
+            <td>{{ .Name }}</td>
+            <td>{{ .Address }}</td>
+            <td>{{ .State }}</td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+
+<p>State: 0 = Alive, 1 = Suspect, 2 = Dead, 3 = Left</p>
+
+<h2>Received Messages</h2>
+
+<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Time</th>
+        <th>Key</th>
+        <th>Value in the Message</th>
+        <th>Version After Update (0 = no change)</th>
+        <th>Changes</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range .ReceivedMessages }}
+        <tr>
+            <td>{{ .ID }}</td>
+            <td>{{ .Time.Format "15:04:05.000" }}</td>
+            <td>{{ .Pair.Key }}</td>
+            <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
+            <td>{{ .Version }}</td>
+            <td>{{ StringsJoin .Changes ", " }}</td>
+            <td>
+                <a href="?viewMsg={{ .ID }}&format=json">json</a>
+                | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
+                | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
+            </td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+
+<h2>Sent Messages</h2>
+
+<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Time</th>
+        <th>Key</th>
+        <th>Value</th>
+        <th>Version</th>
+        <th>Changes</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range .SentMessages }}
+        <tr>
+            <td>{{ .ID }}</td>
+            <td>{{ .Time.Format "15:04:05.000" }}</td>
+            <td>{{ .Pair.Key }}</td>
+            <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
+            <td>{{ .Version }}</td>
+            <td>{{ StringsJoin .Changes ", " }}</td>
+            <td>
+                <a href="?viewMsg={{ .ID }}&format=json">json</a>
+                | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
+                | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
+            </td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/kv/memberlist/status.gohtml
+++ b/kv/memberlist/status.gohtml
@@ -41,7 +41,8 @@
     </tbody>
 </table>
 
-<p>Note that value "version" is node-specific. It starts with 0 (on restart), and increases on each received update. Size is in bytes.</p>
+<p>Note that value "version" is node-specific. It starts with 0 (on restart), and increases on each received update.
+    Size is in bytes.</p>
 
 <h2>Memberlist Cluster Members</h2>
 

--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -3,6 +3,7 @@ package ring
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"net/http"
 	"sort"
 	"sync"
@@ -55,6 +56,9 @@ type BasicLifecyclerConfig struct {
 	// If true lifecycler doesn't unregister instance from the ring when it's stopping. Default value is false,
 	// which means unregistering.
 	KeepInstanceInTheRingOnShutdown bool
+
+	// CustomHTTPHandlerTemplate will be rendered by HTTPHandler instead of the embedded default one, if provided.
+	CustomHTTPHandlerTemplate *template.Template
 }
 
 // BasicLifecycler is a basic ring lifecycler which allows to hook custom
@@ -507,5 +511,5 @@ func (l *BasicLifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (l *BasicLifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(l, l.cfg.HeartbeatPeriod).handle(w, req)
+	newRingPageHandler(l, l.cfg.HeartbeatPeriod, l.cfg.CustomHTTPHandlerTemplate).handle(w, req)
 }

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"html/template"
 	"net/http"
 	"os"
 	"sort"
@@ -50,6 +51,10 @@ type LifecyclerConfig struct {
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
+
+	// CustomHTTPHandlerTemplate will be rendered by HTTPHandler instead of the embedded default one, if provided.
+	// This option is set internally and never exposed to the user.
+	CustomHTTPHandlerTemplate *template.Template `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -870,7 +875,7 @@ func (i *Lifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (i *Lifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(i, i.cfg.HeartbeatPeriod).handle(w, req)
+	newRingPageHandler(i, i.cfg.HeartbeatPeriod, i.cfg.CustomHTTPHandlerTemplate).handle(w, req)
 }
 
 // unregister removes our entry from consul.

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"html/template"
 	"math"
 	"math/rand"
 	"net/http"
@@ -131,6 +132,10 @@ type Config struct {
 	// Whether the shuffle-sharding subring cache is disabled. This option is set
 	// internally and never exposed to the user.
 	SubringCacheDisabled bool `yaml:"-"`
+
+	// CustomHTTPHandlerTemplate will be rendered by HTTPHandler instead of the embedded default one, if provided.
+	// This option is set internally and never exposed to the user.
+	CustomHTTPHandlerTemplate *template.Template `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet with a specified prefix
@@ -861,7 +866,7 @@ func (r *Ring) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(r, r.cfg.HeartbeatTimeout).handle(w, req)
+	newRingPageHandler(r, r.cfg.HeartbeatTimeout, r.cfg.CustomHTTPHandlerTemplate).handle(w, req)
 }
 
 // Operation describes which instances can be included in the replica set, based on their state.

--- a/ring/status.gohtml
+++ b/ring/status.gohtml
@@ -1,0 +1,67 @@
+{{- /*gotype: github.com/grafana/dskit/ring.httpResponse */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Ring Status</title>
+</head>
+<body>
+<h1>Ring Status</h1>
+<p>Current time: {{ .Now }}</p>
+<form action="" method="POST">
+    <input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
+    <table width="100%" border="1">
+        <thead>
+        <tr>
+            <th>Instance ID</th>
+            <th>Availability Zone</th>
+            <th>State</th>
+            <th>Address</th>
+            <th>Registered At</th>
+            <th>Last Heartbeat</th>
+            <th>Tokens</th>
+            <th>Ownership</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{ range $i, $ing := .Ingesters }}
+            {{ if mod $i 2 }}
+                <tr>
+            {{ else }}
+                <tr bgcolor="#BEBEBE">
+            {{ end }}
+            <td>{{ .ID }}</td>
+            <td>{{ .Zone }}</td>
+            <td>{{ .State }}</td>
+            <td>{{ .Address }}</td>
+            <td>{{ .RegisteredTimestamp }}</td>
+            <td>{{ .HeartbeatTimestamp }}</td>
+            <td>{{ .NumTokens }}</td>
+            <td>{{ .Ownership }}%</td>
+            <td><button name="forget" value="{{ .ID }}" type="submit">Forget</button></td>
+            </tr>
+        {{ end }}
+        </tbody>
+    </table>
+    <br>
+    {{ if .ShowTokens }}
+        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' " />
+    {{ else }}
+        <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'" />
+    {{ end }}
+
+    {{ if .ShowTokens }}
+        {{ range $i, $ing := .Ingesters }}
+            <h2>Instance: {{ .ID }}</h2>
+            <p>
+                Tokens:<br />
+                {{ range $token := .Tokens }}
+                    {{ $token }}
+                {{ end }}
+            </p>
+        {{ end }}
+    {{ end }}
+</form>
+</body>
+</html>

--- a/ring/status.gohtml
+++ b/ring/status.gohtml
@@ -39,23 +39,25 @@
             <td>{{ .HeartbeatTimestamp }}</td>
             <td>{{ .NumTokens }}</td>
             <td>{{ .Ownership }}%</td>
-            <td><button name="forget" value="{{ .ID }}" type="submit">Forget</button></td>
+            <td>
+                <button name="forget" value="{{ .ID }}" type="submit">Forget</button>
+            </td>
             </tr>
         {{ end }}
         </tbody>
     </table>
     <br>
     {{ if .ShowTokens }}
-        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' " />
+        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' "/>
     {{ else }}
-        <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'" />
+        <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'"/>
     {{ end }}
 
     {{ if .ShowTokens }}
         {{ range $i, $ing := .Ingesters }}
             <h2>Instance: {{ .ID }}</h2>
             <p>
-                Tokens:<br />
+                Tokens:<br/>
                 {{ range $token := .Tokens }}
                     {{ $token }}
                 {{ end }}


### PR DESCRIPTION
**What this PR does**:

Upstream projects may want to render pages in different ways, applying custom branding where necessary. This allows passing a custom page template to both memberlist and ring status handlers through the configuration.

Also extracted the templates into separate .gohtml files, this enables proper syntax highlighting in the IDEs. Sorry for the noise here as it's not really important for the change I'm proposing, but I just couldn't see that long constants along with the code.

**Which issue(s) this PR fixes**:

None

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
