### PR TITLE
Extract status page templates to files

### DIFF
--- a/kv/memberlist/kv_init_service.go
+++ b/kv/memberlist/kv_init_service.go
@@ -2,6 +2,7 @@ package memberlist
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -183,7 +184,7 @@ func (kvs *KVInitService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err := pageTemplate.Execute(w, v)
+	err := defaultPageTemplate.Execute(w, v)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -285,149 +286,8 @@ type pageData struct {
 	ReceivedMessages []message
 }
 
-var pageTemplate = template.Must(template.New("webpage").Funcs(template.FuncMap{
+//go:embed status.gohtml
+var defaultPageContent string
+var defaultPageTemplate = template.Must(template.New("webpage").Funcs(template.FuncMap{
 	"StringsJoin": strings.Join,
-}).Parse(pageContent))
-
-const pageContent = `
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="UTF-8">
-		<title>Memberlist Status</title>
-	</head>
-	<body>
-		<h1>Memberlist Status</h1>
-		<p>Current time: {{ .Now }}</p>
-
-		<ul>
-		<li>Health Score: {{ .Memberlist.GetHealthScore }} (lower = better, 0 = healthy)</li>
-		<li>Members: {{ .Memberlist.NumMembers }}</li>
-		</ul>
-
-		<h2>KV Store</h2>
-
-		<table width="100%" border="1">
-			<thead>
-				<tr>
-					<th>Key</th>
-					<th>Value Details</th>
-					<th>Actions</th>
-				</tr>
-			</thead>
-
-			<tbody>
-				{{ range $k, $v := .Store }}
-				<tr>
-					<td>{{ $k }}</td>
-					<td>{{ $v }}</td>
-					<td>
-						<a href="?viewKey={{ $k }}&format=json">json</a>
-						| <a href="?viewKey={{ $k }}&format=json-pretty">json-pretty</a>
-						| <a href="?viewKey={{ $k }}&format=struct">struct</a>
-						| <a href="?downloadKey={{ $k }}">download</a>
-					</td>
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-
-		<p>Note that value "version" is node-specific. It starts with 0 (on restart), and increases on each received update. Size is in bytes.</p>
-
-		<h2>Memberlist Cluster Members</h2>
-
-		<table width="100%" border="1">
-			<thead>
-				<tr>
-					<th>Name</th>
-					<th>Address</th>
-					<th>State</th>
-				</tr>
-			</thead>
-
-			<tbody>
-				{{ range .SortedMembers }}
-				<tr>
-					<td>{{ .Name }}</td>
-					<td>{{ .Address }}</td>
-					<td>{{ .State }}</td>
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-
-		<p>State: 0 = Alive, 1 = Suspect, 2 = Dead, 3 = Left</p>
-
-		<h2>Received Messages</h2>
-
-		<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
-
-		<table width="100%" border="1">
-			<thead>
-				<tr>
-					<th>ID</th>
-					<th>Time</th>
-					<th>Key</th>
-					<th>Value in the Message</th>
-					<th>Version After Update (0 = no change)</th>
-					<th>Changes</th>
-					<th>Actions</th>
-				</tr>
-			</thead>
-
-			<tbody>
-				{{ range .ReceivedMessages }}
-				<tr>
-					<td>{{ .ID }}</td>
-					<td>{{ .Time.Format "15:04:05.000" }}</td>
-					<td>{{ .Pair.Key }}</td>
-					<td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
-					<td>{{ .Version }}</td>
-					<td>{{ StringsJoin .Changes ", " }}</td>
-					<td>
-						<a href="?viewMsg={{ .ID }}&format=json">json</a>
-						| <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
-						| <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
-					</td>
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-
-		<h2>Sent Messages</h2>
-
-		<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
-
-		<table width="100%" border="1">
-			<thead>
-				<tr>
-					<th>ID</th>
-					<th>Time</th>
-					<th>Key</th>
-					<th>Value</th>
-					<th>Version</th>
-					<th>Changes</th>
-					<th>Actions</th>
-				</tr>
-			</thead>
-
-			<tbody>
-				{{ range .SentMessages }}
-				<tr>
-					<td>{{ .ID }}</td>
-					<td>{{ .Time.Format "15:04:05.000" }}</td>
-					<td>{{ .Pair.Key }}</td>
-					<td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
-					<td>{{ .Version }}</td>
-					<td>{{ StringsJoin .Changes ", " }}</td>
-					<td>
-						<a href="?viewMsg={{ .ID }}&format=json">json</a>
-						| <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
-						| <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
-					</td>
-				</tr>
-				{{ end }}
-			</tbody>
-		</table>
-	</body>
-</html>`
+}).Parse(defaultPageContent))

--- a/kv/memberlist/kv_init_service_test.go
+++ b/kv/memberlist/kv_init_service_test.go
@@ -21,7 +21,7 @@ func TestPage(t *testing.T) {
 		_ = ml.Shutdown()
 	})
 
-	require.NoError(t, pageTemplate.Execute(&bytes.Buffer{}, pageData{
+	require.NoError(t, defaultPageTemplate.Execute(&bytes.Buffer{}, pageData{
 		Now:           time.Now(),
 		Memberlist:    ml,
 		SortedMembers: ml.Members(),

--- a/kv/memberlist/status.gohtml
+++ b/kv/memberlist/status.gohtml
@@ -1,0 +1,143 @@
+{{- /*gotype: github.com/grafana/dskit/kv/memberlist.statusPageData */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Memberlist Status</title>
+</head>
+<body>
+<h1>Memberlist Status</h1>
+<p>Current time: {{ .Now }}</p>
+
+<ul>
+    <li>Health Score: {{ .Memberlist.GetHealthScore }} (lower = better, 0 = healthy)</li>
+    <li>Members: {{ .Memberlist.NumMembers }}</li>
+</ul>
+
+<h2>KV Store</h2>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>Key</th>
+        <th>Value Details</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range $k, $v := .Store }}
+        <tr>
+            <td>{{ $k }}</td>
+            <td>{{ $v }}</td>
+            <td>
+                <a href="?viewKey={{ $k }}&format=json">json</a>
+                | <a href="?viewKey={{ $k }}&format=json-pretty">json-pretty</a>
+                | <a href="?viewKey={{ $k }}&format=struct">struct</a>
+                | <a href="?downloadKey={{ $k }}">download</a>
+            </td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+
+<p>Note that value "version" is node-specific. It starts with 0 (on restart), and increases on each received update.
+    Size is in bytes.</p>
+
+<h2>Memberlist Cluster Members</h2>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th>Address</th>
+        <th>State</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range .SortedMembers }}
+        <tr>
+            <td>{{ .Name }}</td>
+            <td>{{ .Address }}</td>
+            <td>{{ .State }}</td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+
+<p>State: 0 = Alive, 1 = Suspect, 2 = Dead, 3 = Left</p>
+
+<h2>Received Messages</h2>
+
+<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Time</th>
+        <th>Key</th>
+        <th>Value in the Message</th>
+        <th>Version After Update (0 = no change)</th>
+        <th>Changes</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range .ReceivedMessages }}
+        <tr>
+            <td>{{ .ID }}</td>
+            <td>{{ .Time.Format "15:04:05.000" }}</td>
+            <td>{{ .Pair.Key }}</td>
+            <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
+            <td>{{ .Version }}</td>
+            <td>{{ StringsJoin .Changes ", " }}</td>
+            <td>
+                <a href="?viewMsg={{ .ID }}&format=json">json</a>
+                | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
+                | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
+            </td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+
+<h2>Sent Messages</h2>
+
+<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
+
+<table width="100%" border="1">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Time</th>
+        <th>Key</th>
+        <th>Value</th>
+        <th>Version</th>
+        <th>Changes</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {{ range .SentMessages }}
+        <tr>
+            <td>{{ .ID }}</td>
+            <td>{{ .Time.Format "15:04:05.000" }}</td>
+            <td>{{ .Pair.Key }}</td>
+            <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
+            <td>{{ .Version }}</td>
+            <td>{{ StringsJoin .Changes ", " }}</td>
+            <td>
+                <a href="?viewMsg={{ .ID }}&format=json">json</a>
+                | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
+                | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
+            </td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/ring/http.go
+++ b/ring/http.go
@@ -2,6 +2,7 @@ package ring
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -12,81 +13,11 @@ import (
 	"time"
 )
 
-const pageContent = `
-<!DOCTYPE html>
-<html>
-	<head>
-		<meta charset="UTF-8">
-		<title>Ring Status</title>
-	</head>
-	<body>
-		<h1>Ring Status</h1>
-		<p>Current time: {{ .Now }}</p>
-		<form action="" method="POST">
-			<input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
-			<table width="100%" border="1">
-				<thead>
-					<tr>
-						<th>Instance ID</th>
-						<th>Availability Zone</th>
-						<th>State</th>
-						<th>Address</th>
-						<th>Registered At</th>
-						<th>Last Heartbeat</th>
-						<th>Tokens</th>
-						<th>Ownership</th>
-						<th>Actions</th>
-					</tr>
-				</thead>
-				<tbody>
-					{{ range $i, $ing := .Ingesters }}
-					{{ if mod $i 2 }}
-					<tr>
-					{{ else }}
-					<tr bgcolor="#BEBEBE">
-					{{ end }}
-						<td>{{ .ID }}</td>
-						<td>{{ .Zone }}</td>
-						<td>{{ .State }}</td>
-						<td>{{ .Address }}</td>
-						<td>{{ .RegisteredTimestamp }}</td>
-						<td>{{ .HeartbeatTimestamp }}</td>
-						<td>{{ .NumTokens }}</td>
-						<td>{{ .Ownership }}%</td>
-						<td><button name="forget" value="{{ .ID }}" type="submit">Forget</button></td>
-					</tr>
-					{{ end }}
-				</tbody>
-			</table>
-			<br>
-			{{ if .ShowTokens }}
-			<input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' " />
-			{{ else }}
-			<input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'" />
-			{{ end }}
-
-			{{ if .ShowTokens }}
-				{{ range $i, $ing := .Ingesters }}
-					<h2>Instance: {{ .ID }}</h2>
-					<p>
-						Tokens:<br />
-						{{ range $token := .Tokens }}
-							{{ $token }}
-						{{ end }}
-					</p>
-				{{ end }}
-			{{ end }}
-		</form>
-	</body>
-</html>`
-
-var pageTemplate *template.Template
-
-func init() {
-	t := template.New("webpage")
-	t.Funcs(template.FuncMap{"mod": func(i, j int) bool { return i%j == 0 }})
-	pageTemplate = template.Must(t.Parse(pageContent))
-}
+//go:embed status.gohtml
+var defaultPageContent string
+var defaultPageTemplate = template.Must(template.New("webpage").Funcs(template.FuncMap{
+	"mod": func(i, j int) bool { return i%j == 0 },
+}).Parse(defaultPageContent))
 
 type ingesterDesc struct {
 	ID                  string   `json:"id"`
@@ -195,7 +126,7 @@ func (h *ringPageHandler) handle(w http.ResponseWriter, req *http.Request) {
 		Ingesters:  ingesters,
 		Now:        now,
 		ShowTokens: tokensParam == "true",
-	}, pageTemplate, req)
+	}, defaultPageTemplate, req)
 }
 
 // RenderHTTPResponse either responds with json or a rendered html page using the passed in template

--- a/ring/status.gohtml
+++ b/ring/status.gohtml
@@ -1,0 +1,69 @@
+{{- /*gotype: github.com/grafana/dskit/ring.httpResponse */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Ring Status</title>
+</head>
+<body>
+<h1>Ring Status</h1>
+<p>Current time: {{ .Now }}</p>
+<form action="" method="POST">
+    <input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
+    <table width="100%" border="1">
+        <thead>
+        <tr>
+            <th>Instance ID</th>
+            <th>Availability Zone</th>
+            <th>State</th>
+            <th>Address</th>
+            <th>Registered At</th>
+            <th>Last Heartbeat</th>
+            <th>Tokens</th>
+            <th>Ownership</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{ range $i, $ing := .Ingesters }}
+            {{ if mod $i 2 }}
+                <tr>
+            {{ else }}
+                <tr bgcolor="#BEBEBE">
+            {{ end }}
+            <td>{{ .ID }}</td>
+            <td>{{ .Zone }}</td>
+            <td>{{ .State }}</td>
+            <td>{{ .Address }}</td>
+            <td>{{ .RegisteredTimestamp }}</td>
+            <td>{{ .HeartbeatTimestamp }}</td>
+            <td>{{ .NumTokens }}</td>
+            <td>{{ .Ownership }}%</td>
+            <td>
+                <button name="forget" value="{{ .ID }}" type="submit">Forget</button>
+            </td>
+            </tr>
+        {{ end }}
+        </tbody>
+    </table>
+    <br>
+    {{ if .ShowTokens }}
+        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' "/>
+    {{ else }}
+        <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'"/>
+    {{ end }}
+
+    {{ if .ShowTokens }}
+        {{ range $i, $ing := .Ingesters }}
+            <h2>Instance: {{ .ID }}</h2>
+            <p>
+                Tokens:<br/>
+                {{ range $token := .Tokens }}
+                    {{ $token }}
+                {{ end }}
+            </p>
+        {{ end }}
+    {{ end }}
+</form>
+</body>
+</html>


### PR DESCRIPTION
**What this PR does**:

Instead of having a const with a huge string, now we have `.gohtml` files that are properly understood by the IDEs (at least by Goland) and we embed them into global string vars using the `//go:embed` directive.

Also standarized how both status pages templates for ring and memberlist are initialized.

**Which issue(s) this PR fixes**:

None, cleaning up for future refactor.

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]` (not needed since this only changes unexported vars)
