### PR TITLE
Zone aware replication is stable

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -153,11 +153,6 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 		return nil, err
 	}
 
-	zone := cfg.Zone
-	if zone != "" {
-		level.Warn(logger).Log("msg", "experimental feature in use", "feature", "Zone aware replication")
-	}
-
 	// We do allow a nil FlushTransferer, but to keep the ring logic easier we assume
 	// it's always set, so we use a noop FlushTransferer
 	if flushTransferer == nil {
@@ -174,7 +169,7 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 		RingKey:              ringKey,
 		flushOnShutdown:      atomic.NewBool(flushOnShutdown),
 		unregisterOnShutdown: atomic.NewBool(cfg.UnregisterOnShutdown),
-		Zone:                 zone,
+		Zone:                 cfg.Zone,
 		actorChan:            make(chan func()),
 		state:                PENDING,
 		lifecyclerMetrics:    NewLifecyclerMetrics(ringName, reg),


### PR DESCRIPTION
**What this PR does**:
Zone-aware replication is considered stable. We shouldn't log it as experimental anymore.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
