### PR TITLE
Multikv: Register metrics before starting watcher goroutine.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109
 * [BUGFIX] Allow in-memory kv-client to support multiple codec #132
 * [BUGFIX] Modules: fix a module waiting for other modules depending on it before stopping. #141
+* [BUGFIX] Multi KV: fix panic when using function to modify primary KV store in runtime. #153

--- a/kv/multi.go
+++ b/kv/multi.go
@@ -98,6 +98,10 @@ func NewMultiClient(cfg MultiConfig, clients []kvclient, logger log.Logger, regi
 		logger: log.With(logger, "component", "multikv"),
 	}
 
+	c.registerMetrics(registerer)
+	c.updatePrimaryStoreGauge()
+	c.updateMirrorEnabledGauge()
+
 	ctx, cancelFn := context.WithCancel(context.Background())
 	c.cancel = cancelFn
 
@@ -105,9 +109,6 @@ func NewMultiClient(cfg MultiConfig, clients []kvclient, logger log.Logger, regi
 		go c.watchConfigChannel(ctx, cfg.ConfigProvider())
 	}
 
-	c.registerMetrics(registerer)
-	c.updatePrimaryStoreGauge()
-	c.updateMirrorEnabledGauge()
 	return c
 }
 

--- a/kv/multi_test.go
+++ b/kv/multi_test.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
@@ -29,4 +30,20 @@ func TestMultiRuntimeConfigWithVariousEnabledValues(t *testing.T) {
 			assert.Equal(t, tc.expected, c.Mirroring, tc.yaml)
 		})
 	}
+}
+
+// This simple test could reproduce panic in watchConfigChannel goroutine, if metrics didn't exist yet.
+func TestNewMulti(t *testing.T) {
+	cfg := MultiConfig{ConfigProvider: func() <-chan MultiRuntimeConfig {
+		ch := make(chan MultiRuntimeConfig, 1)
+		ch <- MultiRuntimeConfig{
+			PrimaryStore: "b",
+		}
+		return ch
+	}}
+
+	clients := []kvclient{{name: "a"}, {name: "b"}}
+
+	mc := NewMultiClient(cfg, clients, log.NewNopLogger(), nil)
+	mc.cancel()
 }


### PR DESCRIPTION
****What this PR does****:
This PR fixes panic in MultiKV client caused by starting watcher goroutine before metrics registration:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xce4abf]

goroutine 298 [running]:
github.com/grafana/dskit/kv.(*MultiClient).updateMirrorEnabledGauge(0xc000d29760)
	/.../vendor/github.com/grafana/dskit/kv/multi.go:224 +0x3f
github.com/grafana/dskit/kv.(*MultiClient).watchConfigChannel(0xc0004ef180, {0x2718ae0, 0xc000964640}, 0xc00051ef00)
	/.../vendor/github.com/grafana/dskit/kv/multi.go:128 +0x26f
created by github.com/grafana/dskit/kv.NewMultiClient
	/.../vendor/github.com/grafana/dskit/kv/multi.go:105 +0x2dd
```

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
