### PR TITLE
Make flagext.Secret value unexported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [CHANGE] Lifecycler: Default value of lifecycler's `final-sleep` is now `0s` (i.e. no sleep). #121
 * [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [CHANGE] Minor cosmetic changes in ring and memberlist HTTP status templates. #149
+* [CHANGE] flagext.Secret: `value` field is no longer exported. Value can be read using `String()` method and set using `Set` method. #154
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/flagext/secret.go
+++ b/flagext/secret.go
@@ -1,17 +1,17 @@
 package flagext
 
 type Secret struct {
-	Value string
+	value string
 }
 
 // String implements flag.Value
 func (v Secret) String() string {
-	return v.Value
+	return v.value
 }
 
 // Set implements flag.Value
 func (v *Secret) Set(s string) error {
-	v.Value = s
+	v.value = s
 	return nil
 }
 
@@ -27,7 +27,7 @@ func (v *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // MarshalYAML implements yaml.Marshaler.
 func (v Secret) MarshalYAML() (interface{}, error) {
-	if len(v.Value) == 0 {
+	if len(v.value) == 0 {
 		return "", nil
 	}
 	return "********", nil


### PR DESCRIPTION
**What this PR does**: This PR makes internal field of `flagext.Secret` unexported. Reason for this change is to make fields of this type work properly with flag categorization in Mimir. This is currently implemented by using field addresses, but address of outward struct and single field in it is the same. Mimir can instead ignore unexported fields.

For clients using `flagext.Secret` this is a breaking change, but one that's easy to fix, simply by using `String()` to access the current value, or `Set` to set it.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/mimir/pull/1587#discussion_r839531434.

**Checklist**
- [na] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
