### PR TITLE
SpanLogger: Change `org_id` log labels to `user`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [CHANGE] Minor cosmetic changes in ring and memberlist HTTP status templates. #149
 * [CHANGE] flagext.Secret: `value` field is no longer exported. Value can be read using `String()` method and set using `Set` method. #154
+* [CHANGE] spanlogger.SpanLogger: Log the user ID from the context with the `user` label instead of `org_id`
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [CHANGE] Minor cosmetic changes in ring and memberlist HTTP status templates. #149
 * [CHANGE] flagext.Secret: `value` field is no longer exported. Value can be read using `String()` method and set using `Set` method. #154
-* [CHANGE] spanlogger.SpanLogger: Log the user ID from the context with the `user` label instead of `org_id`
+* [CHANGE] spanlogger.SpanLogger: Log the user ID from the context with the `user` label instead of `org_id`. #156
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -101,7 +101,7 @@ func withContext(ctx context.Context, logger log.Logger, resolver TenantResolver
 	// even though the code-base generally uses `userID` to refer to the same thing.
 	userID, err := resolver.TenantID(ctx)
 	if err == nil && userID != "" {
-		logger = log.With(logger, "org_id", userID)
+		logger = log.With(logger, "user", userID)
 	}
 
 	traceID, ok := tracing.ExtractSampledTraceID(ctx)


### PR DESCRIPTION
**What this PR does**:

Changes `org_id` to `user` for consistency with the code base.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
