### PR TITLE
Reorder CHANGELOG entries for lifecycler config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 * [CHANGE] grpcclient: Bump default `grpc-max-send-msg-size` flag to 100 Mb. #123
 * [CHANGE] ring/client: It's now possible to set different value than `consul` as default KV store. #120
 * [CHANGE] Lifecycler: Default value of lifecycler's `final-sleep` is now `0s` (i.e. no sleep). #121
-* [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [CHANGE] Minor cosmetic changes in ring and memberlist HTTP status templates. #149
 * [CHANGE] flagext.Secret: `value` field is no longer exported. Value can be read using `String()` method and set using `Set` method. #154
 * [ENHANCEMENT] Add middleware package. #38
@@ -39,6 +38,7 @@
 * [ENHANCEMENT] Trigger metrics update on ring changes instead of doing it periodically to speed up tests that wait for certain metrics. #107
 * [ENHANCEMENT] Add an HTTP hedging library. #115
 * [ENHANCEMENT] Ring: Add ring page handler to BasicLifecycler and Lifecycler. #112
+* [ENHANCEMENT] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109


### PR DESCRIPTION
**What this PR does**:

A follow up of https://github.com/grafana/dskit/pull/121: The CHANGELOG entries added there aren't really both breaking changes. Only one of them is. This PR reflects that.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [na] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
