### PR TITLE
wrong comment

### DIFF
--- a/services/basic_service.go
+++ b/services/basic_service.go
@@ -15,7 +15,7 @@ import (
 type StartingFn func(serviceContext context.Context) error
 
 // RunningFn function is called when service enters Running state. When it returns, service will move to Stopping state.
-// If RunningFn or Stopping return error, Service will end in Failed state, otherwise if both functions return without
+// If RunningFn or StoppingFn return error, Service will end in Failed state, otherwise if both functions return without
 // error, service will end in Terminated state.
 type RunningFn func(serviceContext context.Context) error
 


### PR DESCRIPTION
**What this PR does**:
fix a wrong description in comment

+ // If RunningFn or StoppingFn return error
- // If RunningFn or Stopping return error

for Stopping is a state, is not a function