### PR TITLE
Watch runtime configuration with file notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [CHANGE] Minor cosmetic changes in ring and memberlist HTTP status templates. #149
 * [CHANGE] flagext.Secret: `value` field is no longer exported. Value can be read using `String()` method and set using `Set` method. #154
+* [CHANGE] Added the `runtime-config.change_detector` option, which accepts the values `poll` (the previous behavior and default) and `notify`, where `notify` uses file events in order to trigger rereading the runtime configuration.
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [CHANGE] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [CHANGE] Minor cosmetic changes in ring and memberlist HTTP status templates. #149
 * [CHANGE] flagext.Secret: `value` field is no longer exported. Value can be read using `String()` method and set using `Set` method. #154
-* [CHANGE] Added the `runtime-config.change_detector` option, which accepts the values `poll` (the previous behavior and default) and `notify`, where `notify` uses file events in order to trigger rereading the runtime configuration.
+* [CHANGE] Added the `runtime-config.change_detector` option, which accepts the values `periodic-reload` (the previous behavior and default) and `notify`, where `notify` uses file events in order to trigger rereading the runtime configuration.
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/armon/go-metrics v0.3.0
 	github.com/cristalhq/hedgedhttp v0.7.0
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-kit/log v0.1.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.0
@@ -79,7 +80,7 @@ require (
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
 	google.golang.org/protobuf v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -563,8 +565,9 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -48,7 +48,7 @@ func (mc *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&mc.LoadPath, "runtime-config.file", "", "File with the configuration that can be updated in runtime.")
 	f.DurationVar(&mc.ReloadPeriod, "runtime-config.reload-period", 10*time.Second, "How often to check runtime config file.")
 	f.StringVar(&mc.ChangeDetector, "runtime-config.change-detector", PeriodicReload,
-		"How to detect changes in the runtime configuration. Supported values are: poll and notify. The notify option may not work in every case e.g. NFS")
+		"How to detect changes in the runtime configuration. Supported values are: periodic-reload and notify. The notify option may not work in every case e.g. NFS")
 }
 
 // Manager periodically reloads the configuration from a file, and keeps this


### PR DESCRIPTION
**What this PR does**:

Introduces a new way to detect changes in the runtime configuration file using file notifications. The underlying library used, `fsnotify`, supports multiple platforms, but I've written this largely with Linux's `inotify` in mind.

After initialization, instead of continuously reading a file every reload period, reads are not performed until a change actually happens. Runtime configuration changes are often rare and initiated manually, so it wouldn't be uncommon for no notifications to happen at all. From a thread perspective, an OS thread is blocked on an [epoll wait system call with an infinite timeout](https://github.com/fsnotify/fsnotify/blob/master/inotify_poller.go#L87) waiting for event notifications from inotify. If an event is detected on the runtime configuration file a read loop is initiated until a successful read occurs, then it reverts to waiting for another notification.

The benefit of these changes is reducing unnecessary CPU work and unnecessary IOPS. It could allow for users to set a shorter reload period duration if they were unwilling to pay the cost of many background reads previously.

The downside of these changes is the complexity. The kernel has to know about the file changes, so a file stored in NFS or FUSE can deliver no notifications at all. The notification watch is also based on an inode rather than a name, so the directory containing the runtime configuration file is watched rather than the file itself to catch replacements. This leaves the possibility that the directory itself could be replaced, or even mounted against, both of which are currently unhandled. If the runtime configuration file is placed in a busy directory, this could also result in even more CPU work than polling. I also can't speak to the performance or behavior of other platform implementations.

I'm testing these changes still, but wanted to open this draft PR early for feedback given the tradeoffs. My thoughts are that this could be interesting if there is a known workflow for runtime configuration updates and this is tested with that workflow beforehand. Otherwise, I wouldn't recommend this be used.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
