### PR TITLE
Remove outdated comment in spanlogger.go

### DIFF
--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -97,8 +97,6 @@ func (s *SpanLogger) Error(err error) error {
 }
 
 func withContext(ctx context.Context, logger log.Logger, resolver TenantResolver) log.Logger {
-	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
-	// even though the code-base generally uses `userID` to refer to the same thing.
 	userID, err := resolver.TenantID(ctx)
 	if err == nil && userID != "" {
 		logger = log.With(logger, "user", userID)


### PR DESCRIPTION
**What this PR does**:

Follows up on https://github.com/grafana/dskit/pull/156 to remove an outdated comment.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
