### PR TITLE
Remove unused metrics exported by ring lifecycler and client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
 * [CHANGE] Minor cosmetic changes in ring and memberlist HTTP status templates. #149
 * [CHANGE] flagext.Secret: `value` field is no longer exported. Value can be read using `String()` method and set using `Set` method. #154
 * [CHANGE] spanlogger.SpanLogger: Log the user ID from the context with the `user` label instead of `org_id`. #156
+* [CHANGE] ring: removed the following metrics from ring client and lifecycler: #161
+  * `member_ring_tokens_owned`
+  * `member_ring_tokens_to_own`
+  * `ring_tokens_owned`
+  * `ring_member_ownership_percent`
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/ring/http.go
+++ b/ring/http.go
@@ -93,7 +93,7 @@ func (h *ringPageHandler) handle(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	_, ownedTokens := ringDesc.countTokens()
+	ownedTokens := ringDesc.countTokens()
 
 	var ingesterIDs []string
 	for id := range ringDesc.Ingesters {

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -176,8 +176,6 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 		logger:               logger,
 	}
 
-	l.lifecyclerMetrics.tokensToOwn.Set(float64(cfg.NumTokens))
-
 	l.BasicService = services.
 		NewBasicService(nil, l.loop, l.stopping).
 		WithName(fmt.Sprintf("%s ring lifecycler", ringName))
@@ -304,8 +302,6 @@ func (i *Lifecycler) getTokens() Tokens {
 }
 
 func (i *Lifecycler) setTokens(tokens Tokens) {
-	i.lifecyclerMetrics.tokensOwned.Set(float64(len(tokens)))
-
 	i.stateMtx.Lock()
 	defer i.stateMtx.Unlock()
 

--- a/ring/lifecycler_metrics.go
+++ b/ring/lifecycler_metrics.go
@@ -19,16 +19,6 @@ func NewLifecyclerMetrics(ringName string, reg prometheus.Registerer) *Lifecycle
 			Help:        "The total number of heartbeats sent to consul.",
 			ConstLabels: prometheus.Labels{"name": ringName},
 		}),
-		tokensOwned: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name:        "member_ring_tokens_owned",
-			Help:        "The number of tokens owned in the ring.",
-			ConstLabels: prometheus.Labels{"name": ringName},
-		}),
-		tokensToOwn: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name:        "member_ring_tokens_to_own",
-			Help:        "The number of tokens to own in the ring.",
-			ConstLabels: prometheus.Labels{"name": ringName},
-		}),
 		shutdownDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:        "shutdown_duration_seconds",
 			Help:        "Duration (in seconds) of shutdown procedure (ie transfer or flush).",

--- a/ring/lifecycler_metrics.go
+++ b/ring/lifecycler_metrics.go
@@ -7,8 +7,6 @@ import (
 
 type LifecyclerMetrics struct {
 	consulHeartbeats prometheus.Counter
-	tokensOwned      prometheus.Gauge
-	tokensToOwn      prometheus.Gauge
 	shutdownDuration *prometheus.HistogramVec
 }
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -183,10 +183,8 @@ type Ring struct {
 	// If set to nil, no caching is done (used by tests, and subrings).
 	shuffledSubringCache map[subringCacheKey]*Ring
 
-	memberOwnershipGaugeVec *prometheus.GaugeVec
 	numMembersGaugeVec      *prometheus.GaugeVec
 	totalTokensGauge        prometheus.Gauge
-	numTokensGaugeVec       *prometheus.GaugeVec
 	oldestTimestampGaugeVec *prometheus.GaugeVec
 
 	logger log.Logger

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -188,7 +188,6 @@ type Ring struct {
 	totalTokensGauge        prometheus.Gauge
 	numTokensGaugeVec       *prometheus.GaugeVec
 	oldestTimestampGaugeVec *prometheus.GaugeVec
-	reportedOwners          map[string]struct{}
 
 	logger log.Logger
 }
@@ -227,11 +226,6 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 		strategy:             strategy,
 		ringDesc:             &Desc{},
 		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		memberOwnershipGaugeVec: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name:        "ring_member_ownership_percent",
-			Help:        "The percent ownership of the ring by member",
-			ConstLabels: map[string]string{"name": name}},
-			[]string{"member"}),
 		numMembersGaugeVec: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "ring_members",
 			Help:        "Number of members in the ring",
@@ -241,11 +235,6 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 			Name:        "ring_tokens_total",
 			Help:        "Number of tokens in the ring",
 			ConstLabels: map[string]string{"name": name}}),
-		numTokensGaugeVec: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name:        "ring_tokens_owned",
-			Help:        "The number of tokens in the ring owned by the member",
-			ConstLabels: map[string]string{"name": name}},
-			[]string{"member"}),
 		oldestTimestampGaugeVec: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "ring_oldest_member_timestamp",
 			Help:        "Timestamp of the oldest member in the ring.",
@@ -514,12 +503,10 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	}, nil
 }
 
-// countTokens returns the number of tokens and tokens within the range for each instance.
-func (r *Desc) countTokens() (map[string]uint32, map[string]uint32) {
+// countTokens returns the number tokens within the range for each instance.
+func (r *Desc) countTokens() map[string]uint32 {
 	var (
-		owned     = map[string]uint32{}
-		numTokens = map[string]uint32{}
-
+		owned               = map[string]uint32{}
 		ringTokens          = r.GetTokens()
 		ringInstanceByToken = r.getTokensInfo()
 	)
@@ -535,7 +522,6 @@ func (r *Desc) countTokens() (map[string]uint32, map[string]uint32) {
 		}
 
 		info := ringInstanceByToken[token]
-		numTokens[info.InstanceID] = numTokens[info.InstanceID] + 1
 		owned[info.InstanceID] = owned[info.InstanceID] + diff
 	}
 
@@ -543,11 +529,10 @@ func (r *Desc) countTokens() (map[string]uint32, map[string]uint32) {
 	for id := range r.Ingesters {
 		if _, ok := owned[id]; !ok {
 			owned[id] = 0
-			numTokens[id] = 0
 		}
 	}
 
-	return numTokens, owned
+	return owned
 }
 
 // updateRingMetrics updates ring metrics. Caller must be holding the Write lock!
@@ -585,21 +570,6 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 
 	if compareResult == EqualButStatesAndTimestamps {
 		return
-	}
-
-	prevOwners := r.reportedOwners
-	r.reportedOwners = make(map[string]struct{})
-	numTokens, ownedRange := r.ringDesc.countTokens()
-	for id, totalOwned := range ownedRange {
-		r.memberOwnershipGaugeVec.WithLabelValues(id).Set(float64(totalOwned) / float64(math.MaxUint32))
-		r.numTokensGaugeVec.WithLabelValues(id).Set(float64(numTokens[id]))
-		delete(prevOwners, id)
-		r.reportedOwners[id] = struct{}{}
-	}
-
-	for k := range prevOwners {
-		r.memberOwnershipGaugeVec.DeleteLabelValues(k)
-		r.numTokensGaugeVec.DeleteLabelValues(k)
 	}
 
 	r.totalTokensGauge.Set(float64(len(r.ringTokens)))

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2247,10 +2247,6 @@ func TestUpdateMetrics(t *testing.T) {
 	ring.updateRingState(&ringDesc)
 
 	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
-		# HELP ring_member_ownership_percent The percent ownership of the ring by member
-		# TYPE ring_member_ownership_percent gauge
-		ring_member_ownership_percent{member="A",name="test"} 0.500000000349246
-		ring_member_ownership_percent{member="B",name="test"} 0.49999999965075403
 		# HELP ring_members Number of members in the ring
 		# TYPE ring_members gauge
 		ring_members{name="test",state="ACTIVE"} 2
@@ -2265,10 +2261,6 @@ func TestUpdateMetrics(t *testing.T) {
 		ring_oldest_member_timestamp{name="test",state="LEAVING"} 0
 		ring_oldest_member_timestamp{name="test",state="PENDING"} 0
 		ring_oldest_member_timestamp{name="test",state="Unhealthy"} 0
-		# HELP ring_tokens_owned The number of tokens in the ring owned by the member
-		# TYPE ring_tokens_owned gauge
-		ring_tokens_owned{member="A",name="test"} 2
-		ring_tokens_owned{member="B",name="test"} 2
 		# HELP ring_tokens_total Number of tokens in the ring
 		# TYPE ring_tokens_total gauge
 		ring_tokens_total{name="test"} 4
@@ -2299,10 +2291,6 @@ func TestUpdateMetricsWithRemoval(t *testing.T) {
 	ring.updateRingState(&ringDesc)
 
 	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
-		# HELP ring_member_ownership_percent The percent ownership of the ring by member
-		# TYPE ring_member_ownership_percent gauge
-		ring_member_ownership_percent{member="A",name="test"} 0.500000000349246
-		ring_member_ownership_percent{member="B",name="test"} 0.49999999965075403
 		# HELP ring_members Number of members in the ring
 		# TYPE ring_members gauge
 		ring_members{name="test",state="ACTIVE"} 2
@@ -2317,10 +2305,6 @@ func TestUpdateMetricsWithRemoval(t *testing.T) {
 		ring_oldest_member_timestamp{name="test",state="LEAVING"} 0
 		ring_oldest_member_timestamp{name="test",state="PENDING"} 0
 		ring_oldest_member_timestamp{name="test",state="Unhealthy"} 0
-		# HELP ring_tokens_owned The number of tokens in the ring owned by the member
-		# TYPE ring_tokens_owned gauge
-		ring_tokens_owned{member="A",name="test"} 2
-		ring_tokens_owned{member="B",name="test"} 2
 		# HELP ring_tokens_total Number of tokens in the ring
 		# TYPE ring_tokens_total gauge
 		ring_tokens_total{name="test"} 4
@@ -2335,9 +2319,6 @@ func TestUpdateMetricsWithRemoval(t *testing.T) {
 	ring.updateRingState(&ringDescNew)
 
 	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
-		# HELP ring_member_ownership_percent The percent ownership of the ring by member
-		# TYPE ring_member_ownership_percent gauge
-		ring_member_ownership_percent{member="A",name="test"} 1
 		# HELP ring_members Number of members in the ring
 		# TYPE ring_members gauge
 		ring_members{name="test",state="ACTIVE"} 1
@@ -2352,9 +2333,6 @@ func TestUpdateMetricsWithRemoval(t *testing.T) {
 		ring_oldest_member_timestamp{name="test",state="LEAVING"} 0
 		ring_oldest_member_timestamp{name="test",state="PENDING"} 0
 		ring_oldest_member_timestamp{name="test",state="Unhealthy"} 0
-		# HELP ring_tokens_owned The number of tokens in the ring owned by the member
-		# TYPE ring_tokens_owned gauge
-		ring_tokens_owned{member="A",name="test"} 2
 		# HELP ring_tokens_total Number of tokens in the ring
 		# TYPE ring_tokens_total gauge
 		ring_tokens_total{name="test"} 2


### PR DESCRIPTION
**What this PR does**:
This PR proposes to remove some metrics exported by ring client and lifecycler. This proposed change originates from a discussion we had in https://github.com/grafana/mimir/issues/1750 about some high cardinality metrics exposed by large Mimir clusters (running hundreds of instances).

In this PR I propose to remove the following metrics, which don't look to be much useful:
- `member_ring_tokens_owned`: actual number of tokens (ring virtual nodes) registered by the ring lifecycler (e.g. 128)
- `member_ring_tokens_to_own`: configured number of tokens (ring virtual nodes) in the ring lifecycler (e.g. 128)
- `ring_tokens_owned`:  exposes how many tokens (ring virtual nodes) that member has registered in the ring (e.g. 128)
- `ring_member_ownership_percent`: exposes the % of tokens owned in the ring (exposed by web UI too)

I checked Mimir / Loki / Tempo mixins and I can't find any reference of these metrics.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/mimir/issues/1750

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
