### PR TITLE
Explain why memberlist message history is empty

### DIFF
--- a/kv/memberlist/http_status_handler.go
+++ b/kv/memberlist/http_status_handler.go
@@ -22,12 +22,13 @@ type HTTPStatusHandler struct {
 
 // StatusPageData represents the data passed to the template rendered by HTTPStatusHandler
 type StatusPageData struct {
-	Now              time.Time
-	Memberlist       *memberlist.Memberlist
-	SortedMembers    []*memberlist.Node
-	Store            map[string]ValueDesc
-	SentMessages     []Message
-	ReceivedMessages []Message
+	Now                       time.Time
+	Memberlist                *memberlist.Memberlist
+	SortedMembers             []*memberlist.Node
+	Store                     map[string]ValueDesc
+	MessageHistoryBufferBytes int
+	SentMessages              []Message
+	ReceivedMessages          []Message
 }
 
 // NewHTTPStatusHandler creates a new HTTPStatusHandler that will render the provided template using the data from StatusPageData.
@@ -100,12 +101,13 @@ func (h HTTPStatusHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	sent, received := kv.getSentAndReceivedMessages()
 
 	v := StatusPageData{
-		Now:              time.Now(),
-		Memberlist:       kv.memberlist,
-		SortedMembers:    members,
-		Store:            kv.storeCopy(),
-		SentMessages:     sent,
-		ReceivedMessages: received,
+		Now:                       time.Now(),
+		Memberlist:                kv.memberlist,
+		SortedMembers:             members,
+		Store:                     kv.storeCopy(),
+		MessageHistoryBufferBytes: kv.cfg.MessageHistoryBufferBytes,
+		SentMessages:              sent,
+		ReceivedMessages:          received,
 	}
 
 	accept := req.Header.Get("Accept")

--- a/kv/memberlist/status.gohtml
+++ b/kv/memberlist/status.gohtml
@@ -70,76 +70,83 @@
 
 <p>State: 0 = Alive, 1 = Suspect, 2 = Dead, 3 = Left</p>
 
-<h2>Received Messages</h2>
+<h2>Message History</h2>
 
-<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
+{{ if .MessageHistoryBufferBytes }}
 
-<table width="100%" border="1">
-    <thead>
-    <tr>
-        <th>ID</th>
-        <th>Time</th>
-        <th>Key</th>
-        <th>Value in the Message</th>
-        <th>Version After Update (0 = no change)</th>
-        <th>Changes</th>
-        <th>Actions</th>
-    </tr>
-    </thead>
+    <h3>Received Messages</h3>
 
-    <tbody>
-    {{ range .ReceivedMessages }}
+    <a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
+
+    <table width="100%" border="1">
+        <thead>
         <tr>
-            <td>{{ .ID }}</td>
-            <td>{{ .Time.Format "15:04:05.000" }}</td>
-            <td>{{ .Pair.Key }}</td>
-            <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
-            <td>{{ .Version }}</td>
-            <td>{{ StringsJoin .Changes ", " }}</td>
-            <td>
-                <a href="?viewMsg={{ .ID }}&format=json">json</a>
-                | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
-                | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
-            </td>
+            <th>ID</th>
+            <th>Time</th>
+            <th>Key</th>
+            <th>Value in the Message</th>
+            <th>Version After Update (0 = no change)</th>
+            <th>Changes</th>
+            <th>Actions</th>
         </tr>
-    {{ end }}
-    </tbody>
-</table>
+        </thead>
 
-<h2>Sent Messages</h2>
+        <tbody>
+        {{ range .ReceivedMessages }}
+            <tr>
+                <td>{{ .ID }}</td>
+                <td>{{ .Time.Format "15:04:05.000" }}</td>
+                <td>{{ .Pair.Key }}</td>
+                <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
+                <td>{{ .Version }}</td>
+                <td>{{ StringsJoin .Changes ", " }}</td>
+                <td>
+                    <a href="?viewMsg={{ .ID }}&format=json">json</a>
+                    | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
+                    | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
+                </td>
+            </tr>
+        {{ end }}
+        </tbody>
+    </table>
 
-<a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
+    <h3>Sent Messages</h3>
 
-<table width="100%" border="1">
-    <thead>
-    <tr>
-        <th>ID</th>
-        <th>Time</th>
-        <th>Key</th>
-        <th>Value</th>
-        <th>Version</th>
-        <th>Changes</th>
-        <th>Actions</th>
-    </tr>
-    </thead>
+    <a href="?deleteMessages=true">Delete All Messages (received and sent)</a>
 
-    <tbody>
-    {{ range .SentMessages }}
+    <table width="100%" border="1">
+        <thead>
         <tr>
-            <td>{{ .ID }}</td>
-            <td>{{ .Time.Format "15:04:05.000" }}</td>
-            <td>{{ .Pair.Key }}</td>
-            <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
-            <td>{{ .Version }}</td>
-            <td>{{ StringsJoin .Changes ", " }}</td>
-            <td>
-                <a href="?viewMsg={{ .ID }}&format=json">json</a>
-                | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
-                | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
-            </td>
+            <th>ID</th>
+            <th>Time</th>
+            <th>Key</th>
+            <th>Value</th>
+            <th>Version</th>
+            <th>Changes</th>
+            <th>Actions</th>
         </tr>
-    {{ end }}
-    </tbody>
-</table>
+        </thead>
+
+        <tbody>
+        {{ range .SentMessages }}
+            <tr>
+                <td>{{ .ID }}</td>
+                <td>{{ .Time.Format "15:04:05.000" }}</td>
+                <td>{{ .Pair.Key }}</td>
+                <td>size: {{ .Pair.Value | len }}, codec: {{ .Pair.Codec }}</td>
+                <td>{{ .Version }}</td>
+                <td>{{ StringsJoin .Changes ", " }}</td>
+                <td>
+                    <a href="?viewMsg={{ .ID }}&format=json">json</a>
+                    | <a href="?viewMsg={{ .ID }}&format=json-pretty">json-pretty</a>
+                    | <a href="?viewMsg={{ .ID }}&format=struct">struct</a>
+                </td>
+            </tr>
+        {{ end }}
+        </tbody>
+    </table>
+{{ else }}
+    <p><i>Message history buffer is disabled, refer to the configuration to enable it in order to troubleshoot the message history.</i></p>
+{{ end }}
 </body>
 </html>


### PR DESCRIPTION
This section is almost always empty, unless the buffer is not zero. Mention that on the status page to make troubleshooting easier.

I didn't want to mention the specific configuration option or link since that may depend on the service that is using the library.

This is how it would look now:

![image](https://user-images.githubusercontent.com/1511481/166903610-7dc3ba4b-fc1c-4a57-a2ec-927ca4e56c14.png)

And when history is enabled:

![image](https://user-images.githubusercontent.com/1511481/166903760-fd2fc01a-39de-4421-a9f9-06ebefeee749.png)

