### PR TITLE
Lifecycler: if the ring backend storage is reset, the instance adds itself back to the ring with an updated registration timestamp set to current time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,4 @@
 * [BUGFIX] Allow in-memory kv-client to support multiple codec #132
 * [BUGFIX] Modules: fix a module waiting for other modules depending on it before stopping. #141
 * [BUGFIX] Multi KV: fix panic when using function to modify primary KV store in runtime. #153
+* [BUGFIX] Lifecycler: if the ring backend storage is reset, the instance adds itself back to the ring with an updated registration timestamp set to current time. #165

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -292,14 +292,14 @@ func TestBasicLifecycler_HeartbeatWhileStopping(t *testing.T) {
 	assert.True(t, onStoppingCalled)
 }
 
-func TestBasicLifecycler_HeartbeatAfterBackendRest(t *testing.T) {
+func TestBasicLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
 	ctx := context.Background()
 	cfg := prepareBasicLifecyclerConfig()
 	cfg.HeartbeatPeriod = 10 * time.Millisecond
 
 	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
-	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler)) })
 
 	registerTokens := Tokens{1, 2, 3, 4, 5}
 	delegate.onRegister = func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ InstanceDesc) (state InstanceState, tokens Tokens) {
@@ -309,7 +309,11 @@ func TestBasicLifecycler_HeartbeatAfterBackendRest(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
 
 	// At this point the instance has been registered to the ring.
-	expectedRegisteredAt := lifecycler.GetRegisteredAt()
+	prevRegisteredAt := lifecycler.GetRegisteredAt()
+
+	// Wait at least 1s because the registration timestamp has seconds precision
+	// and we want to assert it gets updates later on in this test.
+	time.Sleep(time.Second)
 
 	// Now we delete it from the ring to simulate a ring storage reset and we expect the next heartbeat
 	// will restore it.
@@ -323,9 +327,12 @@ func TestBasicLifecycler_HeartbeatAfterBackendRest(t *testing.T) {
 			desc.GetTimestamp() > 0 &&
 			desc.GetState() == ACTIVE &&
 			Tokens(desc.GetTokens()).Equals(registerTokens) &&
-			desc.GetAddr() == cfg.Addr &&
-			desc.GetRegisteredAt().Unix() == expectedRegisteredAt.Unix()
+			desc.GetAddr() == cfg.Addr
 	})
+
+	// Ensure the registration timestamp has been updated.
+	desc, _ := getInstanceFromStore(t, store, testInstanceID)
+	assert.Greater(t, desc.GetRegisteredTimestamp(), prevRegisteredAt.Unix())
 }
 
 func TestBasicLifecycler_ChangeState(t *testing.T) {

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -333,6 +333,7 @@ func TestBasicLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
 	// Ensure the registration timestamp has been updated.
 	desc, _ := getInstanceFromStore(t, store, testInstanceID)
 	assert.Greater(t, desc.GetRegisteredTimestamp(), prevRegisteredAt.Unix())
+	assert.Greater(t, lifecycler.GetRegisteredAt().Unix(), prevRegisteredAt.Unix())
 }
 
 func TestBasicLifecycler_ChangeState(t *testing.T) {

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -254,6 +254,66 @@ func TestLifecycler_ShouldHandleInstanceAbruptlyRestarted(t *testing.T) {
 	})
 }
 
+func TestLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
+	ctx := context.Background()
+
+	store, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringCfg Config
+	flagext.DefaultValues(&ringCfg)
+	ringCfg.KVStore.Mock = store
+
+	r, err := New(ringCfg, "ingester", testRingKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(ctx, r)) })
+
+	lifecyclerCfg := testLifecyclerConfig(ringCfg, testInstanceID)
+
+	lifecycler, err := NewLifecycler(lifecyclerCfg, nil, testRingName, testRingKey, true, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler)) })
+
+	// Wait until the instance has joined, is active, and has one token.
+	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
+		d, err := r.KVClient.Get(ctx, testRingKey)
+		require.NoError(t, err)
+		return checkNormalised(d, testInstanceID)
+	})
+
+	// At this point the instance has been registered to the ring.
+	prevRegisteredAt := lifecycler.getRegisteredAt()
+	prevTokens := lifecycler.getTokens()
+
+	// Wait at least 1s because the registration timestamp has seconds precision
+	// and we want to assert it gets updates later on in this test.
+	time.Sleep(time.Second)
+
+	// Now we delete it from the ring to simulate a ring storage reset and we expect the next heartbeat
+	// will restore it.
+	require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		return NewDesc(), true, nil
+	}))
+
+	test.Poll(t, time.Second, true, func() interface{} {
+		_, ok := getInstanceFromStore(t, store, testInstanceID)
+		return ok
+	})
+
+	// Ensure the registration timestamp has been updated.
+	desc, _ := getInstanceFromStore(t, store, testInstanceID)
+	assert.Greater(t, desc.GetRegisteredTimestamp(), prevRegisteredAt.Unix())
+
+	// Ensure other information has been preserved.
+	assert.Greater(t, desc.GetTimestamp(), int64(0))
+	assert.Equal(t, ACTIVE, desc.GetState())
+	assert.Equal(t, fmt.Sprintf("%s:%d", lifecyclerCfg.Addr, lifecyclerCfg.Port), desc.GetAddr())
+	assert.Equal(t, lifecyclerCfg.Zone, desc.Zone)
+	assert.Equal(t, prevTokens, Tokens(desc.GetTokens()))
+}
+
 type MockClient struct {
 	ListFunc        func(ctx context.Context, prefix string) ([]string, error)
 	GetFunc         func(ctx context.Context, key string) (interface{}, error)

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -305,6 +305,7 @@ func TestLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
 	// Ensure the registration timestamp has been updated.
 	desc, _ := getInstanceFromStore(t, store, testInstanceID)
 	assert.Greater(t, desc.GetRegisteredTimestamp(), prevRegisteredAt.Unix())
+	assert.Greater(t, lifecycler.getRegisteredAt().Unix(), prevRegisteredAt.Unix())
 
 	// Ensure other information has been preserved.
 	assert.Greater(t, desc.GetTimestamp(), int64(0))


### PR DESCRIPTION
**What this PR does**:
This PR introduces a change to `Lifecycler` and `BasicLifecycler` to fix the issue described in this comment:
https://github.com/grafana/mimir/issues/1766#issuecomment-1116147117

The TL;DR is:
- Shuffle sharding lookback period uses the registration timestamp to check which instances should be queried
- If the ring is running on consul or etcd and the storage is reset/flushed, then each instance lifecycler will add itself back to the ring (this will happen at a slightly different time for each instance)
- Since the instance is adding back to the ring, it should set a registration timestamp set to "now" (like if they're joining the ring for the first time) otherwise the shuffle sharding lookback doesn't work as expected and could lead to partial query results (it's an issue we experienced in Mimir)

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/mimir/issues/1766

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
