### PR TITLE
Add functionality to clear tokens on lifecycler shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [ENHANCEMENT] Lifecycler: It's now possible to change default value of lifecycler's `final-sleep`. #121
 * [ENHANCEMENT] Memberlist: Update to latest fork of memberlist. #160
 * [ENHANCEMENT] Memberlist: extracted HTTP status page handler to `memberlist.HTTPStatusHandler` which now can be instantiated with a custom template. #163
+* [ENHANCEMENT] Lifecycler: add flag to clear tokens on shutdown. #167
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -520,7 +520,7 @@ heartbeatLoop:
 		if err := os.Remove(i.cfg.TokensFilePath); err != nil {
 			return errors.Wrapf(err, "failed to delete tokens file %s", i.cfg.TokensFilePath)
 		}
-		level.Info(i.logger).Log("msg", "removed tokens file from disk", "filename", i.cfg.TokensFilePath)
+		level.Info(i.logger).Log("msg", "removed tokens file from disk", "path", i.cfg.TokensFilePath)
 	}
 
 	return nil

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -110,8 +110,9 @@ type Lifecycler struct {
 	Zone     string
 
 	// Whether to flush if transfer fails on shutdown.
-	flushOnShutdown      *atomic.Bool
-	unregisterOnShutdown *atomic.Bool
+	flushOnShutdown       *atomic.Bool
+	unregisterOnShutdown  *atomic.Bool
+	clearTokensOnShutdown *atomic.Bool
 
 	// We need to remember the ingester state, tokens and registered timestamp just in case the KV store
 	// goes away and comes back empty. The state changes during lifecycle of instance.
@@ -160,20 +161,21 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 	}
 
 	l := &Lifecycler{
-		cfg:                  cfg,
-		flushTransferer:      flushTransferer,
-		KVStore:              store,
-		Addr:                 fmt.Sprintf("%s:%d", addr, port),
-		ID:                   cfg.ID,
-		RingName:             ringName,
-		RingKey:              ringKey,
-		flushOnShutdown:      atomic.NewBool(flushOnShutdown),
-		unregisterOnShutdown: atomic.NewBool(cfg.UnregisterOnShutdown),
-		Zone:                 cfg.Zone,
-		actorChan:            make(chan func()),
-		state:                PENDING,
-		lifecyclerMetrics:    NewLifecyclerMetrics(ringName, reg),
-		logger:               logger,
+		cfg:                   cfg,
+		flushTransferer:       flushTransferer,
+		KVStore:               store,
+		Addr:                  fmt.Sprintf("%s:%d", addr, port),
+		ID:                    cfg.ID,
+		RingName:              ringName,
+		RingKey:               ringKey,
+		flushOnShutdown:       atomic.NewBool(flushOnShutdown),
+		unregisterOnShutdown:  atomic.NewBool(cfg.UnregisterOnShutdown),
+		clearTokensOnShutdown: atomic.NewBool(false),
+		Zone:                  cfg.Zone,
+		actorChan:             make(chan func()),
+		state:                 PENDING,
+		lifecyclerMetrics:     NewLifecyclerMetrics(ringName, reg),
+		logger:                logger,
 	}
 
 	l.BasicService = services.
@@ -515,6 +517,13 @@ heartbeatLoop:
 		level.Info(i.logger).Log("msg", "instance removed from the KV store", "ring", i.RingName)
 	}
 
+	if i.cfg.TokensFilePath != "" && i.ClearTokensOnShutdown() {
+		if err := os.Remove(i.cfg.TokensFilePath); err != nil {
+			return perrors.Wrapf(err, "failed to delete tokens file %s", i.cfg.TokensFilePath)
+		}
+		level.Info(i.logger).Log("msg", "removed tokens file from disk", "filename", i.cfg.TokensFilePath)
+	}
+
 	return nil
 }
 
@@ -825,8 +834,20 @@ func (i *Lifecycler) SetUnregisterOnShutdown(enabled bool) {
 	i.unregisterOnShutdown.Store(enabled)
 }
 
+// ClearTokensOnShutdown returns if persisted tokens should be cleared on shutdown.
+func (i *Lifecycler) ClearTokensOnShutdown() bool {
+	return i.clearTokensOnShutdown.Load()
+}
+
+// SetClearTokensOnShutdown enables/disables deletions of tokens on shutdown.
+// Set to `true` in case one wants to clear tokens on shutdown which are
+// otherwise persisted, e.g. useful in custom shutdown handlers.
+func (i *Lifecycler) SetClearTokensOnShutdown(enabled bool) {
+	i.clearTokensOnShutdown.Store(enabled)
+}
+
 func (i *Lifecycler) processShutdown(ctx context.Context) {
-	flushRequired := i.flushOnShutdown.Load()
+	flushRequired := i.FlushOnShutdown()
 	transferStart := time.Now()
 	if err := i.flushTransferer.TransferOut(ctx); err != nil {
 		if err == ErrTransferDisabled {

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
-	perrors "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 
@@ -395,7 +394,7 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 	// First, see if we exist in the cluster, update our state to match if we do,
 	// and add ourselves (without tokens) if we don't.
 	if err := i.initRing(context.Background()); err != nil {
-		return perrors.Wrapf(err, "failed to join the ring %s", i.RingName)
+		return errors.Wrapf(err, "failed to join the ring %s", i.RingName)
 	}
 
 	// We do various period tasks
@@ -418,14 +417,14 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 					// let's observe the ring. By using JOINING state, this ingester will be ignored by LEAVING
 					// ingesters, but we also signal that it is not fully functional yet.
 					if err := i.autoJoin(context.Background(), JOINING); err != nil {
-						return perrors.Wrapf(err, "failed to pick tokens in the KV store, ring: %s", i.RingName)
+						return errors.Wrapf(err, "failed to pick tokens in the KV store, ring: %s", i.RingName)
 					}
 
 					level.Info(i.logger).Log("msg", "observing tokens before going ACTIVE", "ring", i.RingName)
 					observeChan = time.After(i.cfg.ObservePeriod)
 				} else {
 					if err := i.autoJoin(context.Background(), ACTIVE); err != nil {
-						return perrors.Wrapf(err, "failed to pick tokens in the KV store, ring: %s", i.RingName)
+						return errors.Wrapf(err, "failed to pick tokens in the KV store, ring: %s", i.RingName)
 					}
 				}
 			}
@@ -512,14 +511,14 @@ heartbeatLoop:
 
 	if i.ShouldUnregisterOnShutdown() {
 		if err := i.unregister(context.Background()); err != nil {
-			return perrors.Wrapf(err, "failed to unregister from the KV store, ring: %s", i.RingName)
+			return errors.Wrapf(err, "failed to unregister from the KV store, ring: %s", i.RingName)
 		}
 		level.Info(i.logger).Log("msg", "instance removed from the KV store", "ring", i.RingName)
 	}
 
 	if i.cfg.TokensFilePath != "" && i.ClearTokensOnShutdown() {
 		if err := os.Remove(i.cfg.TokensFilePath); err != nil {
-			return perrors.Wrapf(err, "failed to delete tokens file %s", i.cfg.TokensFilePath)
+			return errors.Wrapf(err, "failed to delete tokens file %s", i.cfg.TokensFilePath)
 		}
 		level.Info(i.logger).Log("msg", "removed tokens file from disk", "filename", i.cfg.TokensFilePath)
 	}


### PR DESCRIPTION
**What this PR does**:

This PR adds a flag to the ingester lifecycler that, when set to `true`,
allows the component to delete the ring token file if the
`-<prefix>.tokens-file-path` is set to persist tokens across restarts.

This enables components that use the lifecycler to implement a handler
that deletes the ring token file to "clear" tokens from the instance and
force a re-distribution of them when the instance is restarted.

**Which issue(s) this PR fixes**:

~~Fixes #<issue number>~~

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
