### PR TITLE
Don't wait until next heartbeat to update ring on initialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,4 @@
 * [BUGFIX] Multi KV: fix panic when using function to modify primary KV store in runtime. #153
 * [BUGFIX] Lifecycler: if the ring backend storage is reset, the instance adds itself back to the ring with an updated registration timestamp set to current time. #165
 * [BUGFIX] Ring: fix bug where hash ring instances may appear unhealthy in the web UI even though they are not. #172
+* [BUGFIX] Lifecycler: if existing ring entry is reused, ring is updated immediately, and not on next heartbeat. #174

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,4 +57,4 @@
 * [BUGFIX] Multi KV: fix panic when using function to modify primary KV store in runtime. #153
 * [BUGFIX] Lifecycler: if the ring backend storage is reset, the instance adds itself back to the ring with an updated registration timestamp set to current time. #165
 * [BUGFIX] Ring: fix bug where hash ring instances may appear unhealthy in the web UI even though they are not. #172
-* [BUGFIX] Lifecycler: if existing ring entry is reused, ring is updated immediately, and not on next heartbeat. #174
+* [BUGFIX] Lifecycler: if existing ring entry is reused, ring is updated immediately, and not on next heartbeat. #175

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -648,6 +648,57 @@ func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testi
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), l2))
 }
 
+func TestRestartIngester_NoUnregister_LongHeartbeat(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	origTokens := GenerateTokens(100, nil)
+
+	const id = "test"
+
+	ringStore.CAS(context.Background(), ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		// Create ring with LEAVING entry with some tokens
+		r := GetOrCreateRingDesc(in)
+		r.AddIngester(id, "3.3.3.3:333", "old", origTokens, LEAVING, time.Now().Add(-1*time.Hour))
+		return r, true, err
+	})
+
+	var lifecyclerConfig LifecyclerConfig
+	flagext.DefaultValues(&lifecyclerConfig)
+	lifecyclerConfig.Addr = "1.1.1.1"
+	lifecyclerConfig.Port = 111
+	lifecyclerConfig.Zone = "new"
+	lifecyclerConfig.RingConfig.KVStore.Mock = ringStore
+	lifecyclerConfig.NumTokens = len(origTokens)
+	lifecyclerConfig.ID = id
+	lifecyclerConfig.HeartbeatPeriod = 5 * time.Minute // Long hearbeat period.
+	lifecyclerConfig.MinReadyDuration = 0              // Disable waiting extra time for Ready
+	lifecyclerConfig.JoinAfter = 1 * time.Minute       // Use long value to make sure that we don't use "join" code path.
+
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "test", ringKey, false, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l))
+	defer services.StopAndAwaitTerminated(context.Background(), l)
+
+	test.Poll(t, 1*time.Second, nil, func() interface{} {
+		return l.CheckReady(context.Background())
+	})
+
+	// Lifecycler should be in ACTIVE state, using tokens from the ring.
+	require.Equal(t, ACTIVE, l.GetState())
+	require.Equal(t, Tokens(origTokens), l.getTokens())
+
+	// check that ring entry has updated address and state
+	desc, err := ringStore.Get(context.Background(), ringKey)
+	require.NoError(t, err)
+
+	r := GetOrCreateRingDesc(desc)
+	require.Equal(t, ACTIVE, r.Ingesters[id].State)
+	require.Equal(t, "1.1.1.1:111", r.Ingesters[id].Addr)
+	require.Equal(t, "new", r.Ingesters[id].Zone)
+}
+
 func TestTokensOnDisk(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })


### PR DESCRIPTION
**What this PR does**:
This PR changes lifecycler initialization such that it always updates ring immediately when it finds existing ring entry that it can reuse, instead of waiting for next heartbeat, since heartbeat period can be configured with long time.

**Which issue(s) this PR fixes**:

Fixes #174

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
