### PR TITLE
Make Consul CasRetryDelay configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Added new `consul.cas-retry-delay` flag. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71
 * [CHANGE] Closer: remove the closer package since it's trivial to just copy/paste. #70
 * [CHANGE] Memberlist: allow specifying address and port advertised to the memberlist cluster members by setting the following configuration: #37

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 * [CHANGE] Added new `consul.cas-retry-delay` flag. #178
+  * It has a default of `1s`, different from the previous behavior, which is the same as `0`.
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71
 * [CHANGE] Closer: remove the closer package since it's trivial to just copy/paste. #70
 * [CHANGE] Memberlist: allow specifying address and port advertised to the memberlist cluster members by setting the following configuration: #37

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Changelog
 
-* [CHANGE] Added new `consul.cas-retry-delay` flag. #178
-  * It has a default of `1s`, different from the previous behavior, which is the same as `0`.
+* [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71
 * [CHANGE] Closer: remove the closer package since it's trivial to just copy/paste. #70
 * [CHANGE] Memberlist: allow specifying address and port advertised to the memberlist cluster members by setting the following configuration: #37

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -78,7 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.ConsistentReads, prefix+"consul.consistent-reads", false, "Enable consistent reads to Consul.")
 	f.Float64Var(&cfg.WatchKeyRateLimit, prefix+"consul.watch-rate-limit", 1, "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.")
 	f.IntVar(&cfg.WatchKeyBurstSize, prefix+"consul.watch-burst-size", 1, "Burst size used in rate limit. Values less than 1 are treated as 1.")
-	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 1*time.Second, "Max duration to wait before retrying a Compare And Swap (CAS) operation.")
+	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 1*time.Second, "Maximum duration to wait before retrying a Compare And Swap (CAS) operation.")
 }
 
 // NewClient returns a new Client.

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -46,10 +46,10 @@ type Config struct {
 	ConsistentReads   bool           `yaml:"consistent_reads" category:"advanced"`
 	WatchKeyRateLimit float64        `yaml:"watch_rate_limit" category:"advanced"` // Zero disables rate limit
 	WatchKeyBurstSize int            `yaml:"watch_burst_size" category:"advanced"` // Burst when doing rate-limit, defaults to 1
+	CasRetryDelay     time.Duration  `yaml:"cas_retry_delay" category:"advanced"`
 
 	// Used in tests only.
-	MaxCasRetries int           `yaml:"-"`
-	CasRetryDelay time.Duration `yaml:"cas_retry_delay" category:"advanced"`
+	MaxCasRetries int `yaml:"-"`
 }
 
 type kv interface {

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -49,7 +49,7 @@ type Config struct {
 
 	// Used in tests only.
 	MaxCasRetries int           `yaml:"-"`
-	CasRetryDelay time.Duration `yaml:"-"`
+	CasRetryDelay time.Duration `yaml:"retry_delay" category:"advanced"`
 }
 
 type kv interface {
@@ -78,6 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.ConsistentReads, prefix+"consul.consistent-reads", false, "Enable consistent reads to Consul.")
 	f.Float64Var(&cfg.WatchKeyRateLimit, prefix+"consul.watch-rate-limit", 1, "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.")
 	f.IntVar(&cfg.WatchKeyBurstSize, prefix+"consul.watch-burst-size", 1, "Burst size used in rate limit. Values less than 1 are treated as 1.")
+	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 0, "Duration (in nanoseconds) to be waited before retrying a CAS failure.")
 }
 
 // NewClient returns a new Client.

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -78,7 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.ConsistentReads, prefix+"consul.consistent-reads", false, "Enable consistent reads to Consul.")
 	f.Float64Var(&cfg.WatchKeyRateLimit, prefix+"consul.watch-rate-limit", 1, "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.")
 	f.IntVar(&cfg.WatchKeyBurstSize, prefix+"consul.watch-burst-size", 1, "Burst size used in rate limit. Values less than 1 are treated as 1.")
-	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 0, "Max duration to wait before retrying a Compare And Swap (CAS) operation.")
+	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 1*time.Second, "Max duration to wait before retrying a Compare And Swap (CAS) operation.")
 }
 
 // NewClient returns a new Client.

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -78,7 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.ConsistentReads, prefix+"consul.consistent-reads", false, "Enable consistent reads to Consul.")
 	f.Float64Var(&cfg.WatchKeyRateLimit, prefix+"consul.watch-rate-limit", 1, "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.")
 	f.IntVar(&cfg.WatchKeyBurstSize, prefix+"consul.watch-burst-size", 1, "Burst size used in rate limit. Values less than 1 are treated as 1.")
-	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 0, "Duration (in nanoseconds) to be waited before retrying a CAS failure.")
+	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 0, "Duration to be waited before retrying a Compare And Swap (CAS) failure.")
 }
 
 // NewClient returns a new Client.

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -49,7 +49,7 @@ type Config struct {
 
 	// Used in tests only.
 	MaxCasRetries int           `yaml:"-"`
-	CasRetryDelay time.Duration `yaml:"retry_delay" category:"advanced"`
+	CasRetryDelay time.Duration `yaml:"cas_retry_delay" category:"advanced"`
 }
 
 type kv interface {

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -78,7 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.ConsistentReads, prefix+"consul.consistent-reads", false, "Enable consistent reads to Consul.")
 	f.Float64Var(&cfg.WatchKeyRateLimit, prefix+"consul.watch-rate-limit", 1, "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.")
 	f.IntVar(&cfg.WatchKeyBurstSize, prefix+"consul.watch-burst-size", 1, "Burst size used in rate limit. Values less than 1 are treated as 1.")
-	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 0, "Duration to be waited before retrying a Compare And Swap (CAS) failure.")
+	f.DurationVar(&cfg.CasRetryDelay, prefix+"consul.cas-retry-delay", 0, "Max duration to wait before retrying a Compare And Swap (CAS) operation.")
 }
 
 // NewClient returns a new Client.


### PR DESCRIPTION
**What this PR does**:
Adds a new flag `consul.cas-retry-delay` that allows the configuration of freezing period before retrying CAS operations for Consul.
Without this, the CAS just retries too quickly what in some occasions is the same as not retrying.

**Which issue(s) this PR fixes**:
N/A

Fixes #<issue number>
N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
