### PR TITLE
Optimize ring computation when lookback period is so large that it selects all instances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [ENHANCEMENT] Memberlist: extracted HTTP status page handler to `memberlist.HTTPStatusHandler` which now can be instantiated with a custom template. #163
 * [ENHANCEMENT] Lifecycler: add flag to clear tokens on shutdown. #167
 * [ENHANCEMENT] ring: Added InstanceRegisterDelegate. #177
+* [ENHANCEMENT] Ring: When using big lookback period that selects all instances, we don't need to recompute the ring from scratch, but can use original ring instead. #180
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -709,6 +709,11 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 		}
 	}
 
+	// If we have selected ALL instances (eg. due to lookback), we can simply return "this" ring.
+	if len(shard) == len(r.ringDesc.Ingesters) {
+		return r
+	}
+
 	// Build a read-only ring for the shard.
 	shardDesc := &Desc{Ingesters: shard}
 	shardTokensByZone := shardDesc.getTokensByZone()

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2199,27 +2199,27 @@ func TestShuffleShardWithCaching(t *testing.T) {
 	// Change of shard size -> new subring needed.
 	subring = newSubring
 	newSubring = ring.ShuffleShard("user", 1)
-	require.False(t, subring == newSubring)
+	require.NotSame(t, subring, newSubring)
 	// Zone-aware shuffle-shard gives all zones the same number of instances (at least one).
 	require.Equal(t, zones, newSubring.InstancesCount())
 
 	// Verify that getting the same subring uses cached instance.
 	subring = newSubring
 	newSubring = ring.ShuffleShard("user", 1)
-	require.True(t, subring == newSubring)
+	require.Same(t, subring, newSubring)
 
 	// But after cleanup, it doesn't.
 	ring.CleanupShuffleShardCache("user")
 	newSubring = ring.ShuffleShard("user", 1)
-	require.False(t, subring == newSubring)
+	require.NotSame(t, subring, newSubring)
 
 	// If we ask for ALL instances, we get original ring.
 	newSubring = ring.ShuffleShard("user", numLifecyclers)
-	require.True(t, ring == newSubring)
+	require.Same(t, ring, newSubring)
 
 	// If we ask for single instance, but use long lookback, we get all instances again (original ring).
 	newSubring = ring.ShuffleShardWithLookback("user", 1, 10*time.Minute, time.Now())
-	require.True(t, ring == newSubring)
+	require.Same(t, ring, newSubring)
 }
 
 // User shuffle shard token.

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2165,7 +2165,7 @@ func TestShuffleShardWithCaching(t *testing.T) {
 	sleep := (2 * time.Second) / iters
 	for i := 0; i < iters; i++ {
 		newSubring := ring.ShuffleShard(user, shardSize)
-		require.True(t, subring == newSubring, "cached subring reused")
+		require.Same(t, subring, newSubring, "cached subring reused")
 		require.Equal(t, shardSize, subring.InstancesCount())
 		time.Sleep(sleep)
 	}
@@ -2193,7 +2193,7 @@ func TestShuffleShardWithCaching(t *testing.T) {
 
 	// Change of instances -> new subring needed.
 	newSubring := ring.ShuffleShard("user", zones)
-	require.False(t, subring == newSubring)
+	require.NotSame(t, subring, newSubring)
 	require.Equal(t, zones, subring.InstancesCount())
 
 	// Change of shard size -> new subring needed.


### PR DESCRIPTION
**What this PR does**:
When using big lookback period that selects all instances, we don't need to recompute the ring from scratch, but can use original ring instead.

We have encountered this problem when running ring with almost 400 instances and large lookback period:

<img width="1911" alt="Screenshot 2022-06-28 at 15 59 35" src="https://user-images.githubusercontent.com/895919/176213187-5b411a92-582a-4891-b7e9-95c4928f7d44.png">


**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
