### PR TITLE
Add support in the manager to load multiple runtime config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [ENHANCEMENT] Lifecycler: add flag to clear tokens on shutdown. #167
 * [ENHANCEMENT] ring: Added InstanceRegisterDelegate. #177
 * [ENHANCEMENT] ring: optimize shuffle-shard computation when lookback is used, and all instances have registered timestamp within the lookback window. In that case we can immediately return origial ring, because we would select all instances anyway. #181
+* [ENHANCEMENT] Runtimeconfig: Allow providing multiple runtime config yaml files as comma separated list file paths. #183
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	google.golang.org/grpc v1.38.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 require (
@@ -87,7 +88,6 @@ require (
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.21.4

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -22,14 +22,14 @@ import (
 	"github.com/grafana/dskit/services"
 )
 
-// Loader loads the configuration from file.
+// Loader loads the configuration from files.
 type Loader func(r io.Reader) (interface{}, error)
 
 // Config holds the config for an Manager instance.
 // It holds config related to loading per-tenant config.
 type Config struct {
 	ReloadPeriod time.Duration `yaml:"period" category:"advanced"`
-	// LoadPath contains the path to the runtime config file, requires an
+	// LoadPath contains the path to the runtime config files, requires a
 	// non-empty value
 	LoadPath string `yaml:"file"`
 	Loader   Loader `yaml:"-"`
@@ -37,11 +37,11 @@ type Config struct {
 
 // RegisterFlags registers flags.
 func (mc *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&mc.LoadPath, "runtime-config.file", "", "Comma separated list of yaml files with the configuration that can be updated at runtime.")
-	f.DurationVar(&mc.ReloadPeriod, "runtime-config.reload-period", 10*time.Second, "How often to check runtime config file.")
+	f.StringVar(&mc.LoadPath, "runtime-config.file", "", "Comma separated list of yaml files with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
+	f.DurationVar(&mc.ReloadPeriod, "runtime-config.reload-period", 10*time.Second, "How often to check runtime config files.")
 }
 
-// Manager periodically reloads the configuration from a file, and keeps this
+// Manager periodically reloads the configuration from specified files, and keeps this
 // configuration available for clients.
 type Manager struct {
 	services.Service

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -29,8 +29,8 @@ type Loader func(r io.Reader) (interface{}, error)
 // It holds config related to loading per-tenant config.
 type Config struct {
 	ReloadPeriod time.Duration `yaml:"period" category:"advanced"`
-	// LoadPath contains the path to the runtime config files, requires a
-	// non-empty value
+	// LoadPath contains the path to the runtime config files.
+	// Requires a non-empty value
 	LoadPath string `yaml:"file"`
 	Loader   Loader `yaml:"-"`
 }
@@ -144,7 +144,7 @@ func (om *Manager) loop(ctx context.Context) error {
 	}
 }
 
-// loadConfig loads all configuration files using the loader function, merges the yaml configuration files into one yaml document,
+// loadConfig loads all configuration files using the loader function then merges the yaml configuration files into one yaml document.
 // and notifies listeners if successful.
 func (om *Manager) loadConfig() error {
 	mergedConfig := map[string]interface{}{}
@@ -153,12 +153,12 @@ func (om *Manager) loadConfig() error {
 		buf, err := os.ReadFile(f)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
-			return errors.Wrap(err, "read file")
+			return errors.Wrapf(err, "read file %q", f)
 		}
 		err = yaml.Unmarshal(buf, &yamlFile)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
-			return errors.Wrap(err, "unmarshal file")
+			return errors.Wrapf(err, "unmarshal file %q", f)
 		}
 		mergedConfig = mergeConfigMaps(mergedConfig, yamlFile)
 	}

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gopkg.in/yaml.v3"
 
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
 )
 
@@ -31,13 +31,13 @@ type Config struct {
 	ReloadPeriod time.Duration `yaml:"period" category:"advanced"`
 	// LoadPath contains the path to the runtime config files.
 	// Requires a non-empty value
-	LoadPath string `yaml:"file"`
-	Loader   Loader `yaml:"-"`
+	LoadPath flagext.StringSliceCSV `yaml:"file"`
+	Loader   Loader                 `yaml:"-"`
 }
 
 // RegisterFlags registers flags.
 func (mc *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&mc.LoadPath, "runtime-config.file", "", "Comma separated list of yaml files with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
+	f.Var(&mc.LoadPath, "runtime-config.file", "Comma separated list of yaml files with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
 	f.DurationVar(&mc.ReloadPeriod, "runtime-config.reload-period", 10*time.Second, "How often to check runtime config files.")
 }
 
@@ -61,7 +61,7 @@ type Manager struct {
 
 // New creates an instance of Manager and starts reload config loop based on config
 func New(cfg Config, registerer prometheus.Registerer, logger log.Logger) (*Manager, error) {
-	if cfg.LoadPath == "" {
+	if len(cfg.LoadPath) == 0 {
 		return nil, errors.New("LoadPath is empty")
 	}
 
@@ -83,7 +83,7 @@ func New(cfg Config, registerer prometheus.Registerer, logger log.Logger) (*Mana
 }
 
 func (om *Manager) starting(_ context.Context) error {
-	if om.cfg.LoadPath == "" {
+	if len(om.cfg.LoadPath) == 0 {
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func (om *Manager) CloseListenerChannel(listener <-chan interface{}) {
 }
 
 func (om *Manager) loop(ctx context.Context) error {
-	if om.cfg.LoadPath == "" {
+	if len(om.cfg.LoadPath) == 0 {
 		level.Info(om.logger).Log("msg", "runtime config disabled: file not specified")
 		<-ctx.Done()
 		return nil
@@ -148,7 +148,7 @@ func (om *Manager) loop(ctx context.Context) error {
 // and notifies listeners if successful.
 func (om *Manager) loadConfig() error {
 	mergedConfig := map[string]interface{}{}
-	for _, f := range strings.Split(om.cfg.LoadPath, ",") {
+	for _, f := range om.cfg.LoadPath {
 		yamlFile := map[string]interface{}{}
 		buf, err := os.ReadFile(f)
 		if err != nil {

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -92,7 +92,7 @@ func generateRuntimeFiles(t *testing.T, overrideStrings []string) ([]*os.File, e
 		overrideFiles = append(overrideFiles, tempFile)
 	}
 	t.Cleanup(func() {
-		cleanupOverridesFiles(overrideFiles)
+		require.NoError(t, cleanupOverridesFiles(overrideFiles))
 	})
 	return overrideFiles, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: This PR enables users to provide a comma separated list of yaml runtime config files where they will be merged into one yaml document and sent to the underlying service. 

**Which issue(s) this PR fixes**: 

Fixes https://github.com/grafana/mimir/issues/1798

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
