### PR TITLE
Move ring network handling to netutil and update for IPv6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 * [ENHANCEMENT] Memcached: add `MinIdleConnectionsHeadroomPercentage` support. It configures the minimum number of idle connections to keep open as a percentage of the number of recently used idle connections. If negative (default), idle connections are kept open indefinitely. #269
 * [ENHANCEMENT] Memcached: Add support for using TLS or mTLS with Memcached based caching. #278
 * [ENHANCEMENT] Ring: improve performance of shuffle sharding computation. #281
+* [ENHANCEMENT] Add option to enable IPv6 address detection in ring and memberlist handling. #185
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -394,9 +394,6 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 			// Use the IP that we're bound to, based on the first
 			// TCP listener, which we already ensure is there.
 			advertiseAddr = t.tcpListeners[0].Addr().(*net.TCPAddr).IP
-			if advertiseAddr == nil {
-				return nil, 0, fmt.Errorf("failed to parse advertise address from tcp listener %q", ip)
-			}
 		}
 
 		// Use the port we are bound to.

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -378,16 +378,12 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 				return nil, 0, fmt.Errorf("no private IP address found, and explicit IP not provided")
 			}
 
-			addr, err := netip.ParseAddr(ip)
+			advertiseAddr, err = netip.ParseAddr(ip)
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to parse advertise address %q", ip)
 			}
-
-			if addr.IsValid() {
-				advertiseAddr = addr
-			}
 		case colonColonZero:
-			inet6Ip, err := netutil.GetFirstAddressOf([]string{}, t.logger, true)
+			inet6Ip, err := netutil.GetFirstAddressOf(nil, t.logger, true)
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to get private inet6 address: %w", err)
 			}

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -354,16 +354,14 @@ func (t *TCPTransport) GetAutoBindPort() int {
 func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, error) {
 	var advertiseAddr netip.Addr
 	var advertisePort int
+	var err error
 	if ip != "" {
 		// If they've supplied a prefix, use that.
-		prefix, err := netip.ParsePrefix(ip)
+		advertiseAddr, err = netip.ParseAddr(ip)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to parse advertise address prefix %q", ip)
+			return nil, 0, fmt.Errorf("failed to parse advertise address %q", ip)
 		}
 
-		if addr := prefix.Addr(); addr.IsValid() {
-			advertiseAddr = addr
-		}
 		advertisePort = port
 	} else {
 
@@ -499,7 +497,7 @@ func (t *TCPTransport) writeTo(b []byte, addr string) error {
 
 	if t.cfg.PacketWriteTimeout > 0 {
 		deadline := time.Now().Add(t.cfg.PacketWriteTimeout)
-		err := c.SetDeadline(deadline)
+		err = c.SetDeadline(deadline)
 		if err != nil {
 			return fmt.Errorf("setting deadline: %v", err)
 		}

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -396,11 +396,10 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 		default:
 			// Use the IP that we're bound to, based on the first
 			// TCP listener, which we already ensure is there.
-			addr, err := netip.ParseAddr(t.tcpListeners[0].Addr().(*net.TCPAddr).IP.String())
+			advertiseAddr, err = netip.ParseAddr(t.tcpListeners[0].Addr().(*net.TCPAddr).IP.String())
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to parse advertise address from tcp listener %q", ip)
 			}
-			advertiseAddr = addr
 		}
 
 		// Use the port we are bound to.

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -487,7 +487,7 @@ func (t *TCPTransport) writeTo(b []byte, addr string) error {
 
 	if t.cfg.PacketWriteTimeout > 0 {
 		deadline := time.Now().Add(t.cfg.PacketWriteTimeout)
-		err = c.SetDeadline(deadline)
+		err := c.SetDeadline(deadline)
 		if err != nil {
 			return fmt.Errorf("setting deadline: %v", err)
 		}

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -356,7 +356,7 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 	var advertisePort int
 	var err error
 	if ip != "" {
-		// If they've supplied a prefix, use that.
+		// If they've supplied an address, use that.
 		advertiseAddr, err = netip.ParseAddr(ip)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to parse advertise address %q", ip)

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -35,7 +35,7 @@ const (
 )
 
 const zeroZeroZeroZero = "0.0.0.0"
-const colonColonZero = "[::0]"
+const colonColon = "::"
 
 // TCPTransportConfig is a configuration structure for creating new TCPTransport.
 type TCPTransportConfig struct {
@@ -380,7 +380,7 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 			if advertiseAddr == nil {
 				return nil, 0, fmt.Errorf("failed to parse advertise address %q", ip)
 			}
-		case colonColonZero:
+		case colonColon:
 			inet6Ip, err := netutil.GetFirstAddressOf(nil, t.logger, true)
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to get private inet6 address: %w", err)

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -59,3 +59,38 @@ func TestTCPTransport_WriteTo_ShouldNotLogAsWarningExpectedFailures(t *testing.T
 		})
 	}
 }
+
+func TestFinalAdvertiseAddr(t *testing.T) {
+	tests := map[string]struct {
+		advertiseAddr string
+		bindAddrs     []string
+		bindPort      int
+	}{
+		"should not fail with local address specified": {
+			advertiseAddr: "127.0.0.1",
+			bindAddrs:     []string{"localhost"},
+			bindPort:      0,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			logs := &concurrency.SyncBuffer{}
+			logger := log.NewLogfmtLogger(logs)
+
+			cfg := TCPTransportConfig{}
+			flagext.DefaultValues(&cfg)
+			cfg.BindAddrs = testData.bindAddrs
+			cfg.BindPort = testData.bindPort
+
+			transport, err := NewTCPTransport(cfg, logger)
+			require.NoError(t, err)
+
+			ip, port, err := transport.FinalAdvertiseAddr(testData.advertiseAddr, testData.bindPort)
+			require.NoError(t, err)
+			require.Equal(t, testData.advertiseAddr, ip.String())
+			require.Equal(t, testData.bindPort, port)
+
+		})
+	}
+}

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -182,10 +182,15 @@ func filterIPs(addrs []netip.Addr, preferInet6 bool) netip.Addr {
 // A high quality address is one that is considered routeable, and not in the link-local address space.
 // A low quality address is a link-local address.
 // When an IPv6 preference is indicated using preferInet6, an IPv6 will be preferred over an equivalent quality IPv4 address.
+// Loopback addresses are never selected.
 func filterBestIP(addrs []netip.Addr, preferInet6 bool) netip.Addr {
 	var invalid, inetAddr, inet6Addr netip.Addr
 
 	for _, addr := range addrs {
+		if addr.IsLoopback() {
+			continue
+		}
+
 		if addr.IsValid() {
 			if addr.Is4() {
 				// If we have already been set, can we improve on the quality?

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -1,10 +1,13 @@
 package netutil
 
 import (
+	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -53,4 +56,139 @@ func privateNetworkInterfaces(all []net.Interface, fallback []string, logger log
 		return fallback
 	}
 	return privInts
+}
+
+// GetFirstAddressOf returns the first IPv4/IPV6 address of the supplied interface names, omitting any link-local addresses.
+func GetFirstAddressOf(names []string, logger log.Logger) (string, error) {
+	return getFirstAddressOf(names, logger, getInterfaceAddresses, false)
+}
+
+// GetPrivateInet6Address returns the first IPv6 address found on any interface, omitting link-local addresses.
+func GetPrivateInet6Address(logger log.Logger) (string, error) {
+	return getFirstInet6AddressOf([]string{}, logger, getInterfaceAddresses)
+}
+
+func getFirstInet6AddressOf(names []string, logger log.Logger, interfaceAddrs NetworkInterfaceAddressGetter) (string, error) {
+	addr, err := getFirstAddressOf(names, logger, interfaceAddrs, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to get valid address: %w", err)
+	}
+
+	a, err := netip.ParseAddr(addr)
+	if err != nil {
+		return "", fmt.Errorf("faild to parse address: %w", err)
+	}
+
+	if !a.Is6() || !a.IsValid() {
+		return "", fmt.Errorf("no inet6 address available")
+	}
+
+	return addr, nil
+}
+
+// NetworkInterfaceGetter matches the signature of net.InterfaceByName() to allow for test mocks.
+type NetworkInterfaceAddressGetter func(name string) ([]netip.Addr, error)
+
+// getFirstAddressOf returns the first IPv4/IPV6 address of the supplied interface names, omitting any link-local addresses.
+func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc NetworkInterfaceAddressGetter, preferInet6 bool) (string, error) {
+	var ipAddr netip.Addr
+
+	// When passing an empty list of interface names, we select all interfaces.
+	if len(names) == 0 {
+		infs, err := net.Interfaces()
+		if err != nil {
+			return "", fmt.Errorf("failed to get interface list and no interface names supplied: %w", err)
+		}
+		ifNames := make([]string, len(infs))
+		for i, v := range infs {
+			ifNames[i] = v.Name
+		}
+	}
+
+	// Replace a nil func with the standard approach.
+	if interfaceAddrsFunc == nil {
+		interfaceAddrsFunc = getInterfaceAddresses
+	}
+
+	for _, name := range names {
+		addrs, err := interfaceAddrsFunc(name)
+		if err != nil {
+			level.Warn(logger).Log("msg", "error getting addresses for interface", "inf", name, "err", err)
+			continue
+		}
+		level.Debug(logger).Log("msg", "addresses for interface", "addrs", fmt.Sprintf("%+v", addrs), "inf", name, "inet6pref", preferInet6)
+
+		if len(addrs) <= 0 {
+			level.Warn(logger).Log("msg", "no addresses found for interface", "inf", name, "err", err)
+			continue
+		}
+		if ip := filterIPs(addrs, preferInet6); ip.IsValid() {
+			ipAddr = ip
+		}
+
+		level.Debug(logger).Log("msg", "filtered", "ipAddr", ipAddr.String(), "inf", name)
+
+		if ipAddr.IsLinkLocalUnicast() || !ipAddr.IsValid() {
+			continue
+		}
+		if preferInet6 && !ipAddr.Is6() {
+			continue
+		}
+		return ipAddr.String(), nil
+	}
+	level.Debug(logger).Log("msg", "ipAddr", "addrs", ipAddr)
+	if !ipAddr.IsValid() {
+		return "", fmt.Errorf("no useable address found for interfaces %s", names)
+	}
+	if ipAddr.IsLinkLocalUnicast() {
+		level.Warn(logger).Log("msg", "using link-local address", "address", ipAddr.String())
+	}
+	return ipAddr.String(), nil
+}
+
+// getInterfaceAddresses is the standard approach to collecting []net.Addr from a network interface by name.
+func getInterfaceAddresses(name string) ([]netip.Addr, error) {
+	inf, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := inf.Addrs()
+	if err != nil {
+		return nil, err
+	}
+
+	// Using netip.Addr to allow for easier and consistent address parsing.
+	// Without this, the net.ParseCIDR() that we might like to use in a test does
+	// not have the same net.Addr implementation that we get from calling
+	// interface.Addrs() as above.  Here we normalize on netip.Addr.
+	netaddrs := make([]netip.Addr, len(addrs))
+	for i, a := range addrs {
+		prefix, err := netip.ParsePrefix(a.String())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse netip.Prefix")
+		}
+		netaddrs[i] = prefix.Addr()
+	}
+
+	return netaddrs, nil
+}
+
+// filterIPs attempts to return the first non automatic private IP (APIPA / 169.254.x.x / link-local) if possible, only returning APIPA if available and no other valid IP is found.
+func filterIPs(addrs []netip.Addr, preferInet6 bool) netip.Addr {
+	var ipAddr netip.Addr
+	for _, addr := range addrs {
+		if addr.IsValid() {
+			ipAddr = addr
+		}
+
+		if preferInet6 && !addr.Is6() {
+			continue
+		}
+
+		if !addr.IsLinkLocalUnicast() {
+			return addr
+		}
+	}
+	return ipAddr
 }

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -76,11 +76,10 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 		if err != nil {
 			return "", fmt.Errorf("failed to get interface list and no interface names supplied: %w", err)
 		}
-		ifNames := make([]string, len(infs))
+		names = make([]string, len(infs))
 		for i, v := range infs {
-			ifNames[i] = v.Name
+			names[i] = v.Name
 		}
-		names = ifNames
 	}
 
 	level.Debug(logger).Log("msg", "looking for addresses", "inf", fmt.Sprintf("%s", names), "inet6enabled", enableInet6)

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -59,15 +59,15 @@ func privateNetworkInterfaces(all []net.Interface, fallback []string, logger log
 }
 
 // GetFirstAddressOf returns the first IPv4/IPV6 address of the supplied interface names, omitting any link-local addresses.
-func GetFirstAddressOf(names []string, logger log.Logger, preferInet6 bool) (string, error) {
-	return getFirstAddressOf(names, logger, getInterfaceAddresses, preferInet6)
+func GetFirstAddressOf(names []string, logger log.Logger, enableInet6 bool) (string, error) {
+	return getFirstAddressOf(names, logger, getInterfaceAddresses, enableInet6)
 }
 
 // NetworkInterfaceGetter matches the signature of net.InterfaceByName() to allow for test mocks.
 type NetworkInterfaceAddressGetter func(name string) ([]netip.Addr, error)
 
 // getFirstAddressOf returns the first IPv4/IPV6 address of the supplied interface names, omitting any link-local addresses.
-func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc NetworkInterfaceAddressGetter, preferInet6 bool) (string, error) {
+func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc NetworkInterfaceAddressGetter, enableInet6 bool) (string, error) {
 	var ipAddr netip.Addr
 
 	// When passing an empty list of interface names, we select all interfaces.
@@ -83,7 +83,7 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 		names = ifNames
 	}
 
-	level.Debug(logger).Log("msg", "looking for addresses", "inf", fmt.Sprintf("%s", names), "inet6pref", preferInet6)
+	level.Debug(logger).Log("msg", "looking for addresses", "inf", fmt.Sprintf("%s", names), "inet6pref", enableInet6)
 
 	// Replace a nil func with the standard approach.
 	if interfaceAddrsFunc == nil {
@@ -101,9 +101,9 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 			level.Warn(logger).Log("msg", "no addresses found for interface", "inf", name, "err", err)
 			continue
 		}
-		if ip := filterBestIP(addrs, preferInet6); ip.IsValid() {
+		if ip := filterBestIP(addrs, enableInet6); ip.IsValid() {
 			// Select the best between what we've received
-			ipAddr = filterBestIP([]netip.Addr{ip, ipAddr}, preferInet6)
+			ipAddr = filterBestIP([]netip.Addr{ip, ipAddr}, enableInet6)
 		}
 		level.Debug(logger).Log("msg", "filtered best", "ipAddr", ipAddr.String(), "inf", name)
 		if ipAddr.IsLinkLocalUnicast() || !ipAddr.IsValid() {
@@ -111,7 +111,7 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 			continue
 		}
 
-		if preferInet6 {
+		if enableInet6 {
 			if ipAddr.Is6() {
 				return ipAddr.String(), nil
 			}
@@ -162,9 +162,9 @@ func getInterfaceAddresses(name string) ([]netip.Addr, error) {
 // filterBestIP returns an opinionated "best" address from a list of addresses.
 // A high quality address is one that is considered routeable, and not in the link-local address space.
 // A low quality address is a link-local address.
-// When an IPv6 preference is indicated using preferInet6, an IPv6 will be preferred over an equivalent quality IPv4 address.
+// When an IPv6 preference is indicated using enableInet6, an IPv6 will be preferred over an equivalent quality IPv4 address.
 // Loopback addresses are never selected.
-func filterBestIP(addrs []netip.Addr, preferInet6 bool) netip.Addr {
+func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 	var invalid, inetAddr, inet6Addr netip.Addr
 
 	for _, addr := range addrs {
@@ -204,7 +204,7 @@ func filterBestIP(addrs []netip.Addr, preferInet6 bool) netip.Addr {
 		if inet6Addr.IsLinkLocalUnicast() && !inetAddr.IsLinkLocalUnicast() {
 			return inetAddr
 		}
-		if preferInet6 {
+		if enableInet6 {
 			return inet6Addr
 		}
 		return inetAddr

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -157,7 +157,8 @@ func getInterfaceAddresses(name string) ([]netip.Addr, error) {
 // filterBestIP returns an opinionated "best" address from a list of addresses.
 // A high quality address is one that is considered routable, and not in the link-local address space.
 // A low quality address is a link-local address.
-// When an IPv6 preference is indicated using enableInet6, an IPv6 will be preferred over an equivalent quality IPv4 address.
+// When an IPv6 is enabled using enableInet6, an IPv6 will be preferred over an equivalent quality IPv4 address,
+// otherwise IPv6 addresses are guaranteed to not be returned from this function.
 // Loopback addresses are never selected.
 func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 	var invalid, inetAddr, inet6Addr netip.Addr

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -179,15 +179,17 @@ func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 				}
 				inetAddr = addr
 			}
-			if addr.Is6() {
-				// If we have already been set, can we improve on the quality?
-				if inet6Addr.IsValid() {
-					if inet6Addr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
-						inet6Addr = addr
+			if enableInet6 {
+				if addr.Is6() {
+					// If we have already been set, can we improve on the quality?
+					if inet6Addr.IsValid() {
+						if inet6Addr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
+							inet6Addr = addr
+						}
+						continue
 					}
-					continue
+					inet6Addr = addr
 				}
-				inet6Addr = addr
 			}
 		}
 	}
@@ -210,8 +212,10 @@ func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 		return inetAddr
 	}
 
-	if inet6Addr.IsValid() {
-		return inet6Addr
+	if enableInet6 {
+		if inet6Addr.IsValid() {
+			return inet6Addr
+		}
 	}
 
 	return invalid

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -63,7 +63,7 @@ func GetFirstAddressOf(names []string, logger log.Logger, enableInet6 bool) (str
 	return getFirstAddressOf(names, logger, getInterfaceAddresses, enableInet6)
 }
 
-// NetworkInterfaceGetter matches the signature of net.InterfaceByName() to allow for test mocks.
+// NetworkInterfaceAddressGetter matches the signature of net.InterfaceByName() to allow for test mocks.
 type NetworkInterfaceAddressGetter func(name string) ([]netip.Addr, error)
 
 // getFirstAddressOf returns the first IPv4/IPV6 address of the supplied interface names, omitting any link-local addresses.
@@ -83,7 +83,7 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 		names = ifNames
 	}
 
-	level.Debug(logger).Log("msg", "looking for addresses", "inf", fmt.Sprintf("%s", names), "inet6pref", enableInet6)
+	level.Debug(logger).Log("msg", "looking for addresses", "inf", fmt.Sprintf("%s", names), "inet6enabled", enableInet6)
 
 	// Replace a nil func with the standard approach.
 	if interfaceAddrsFunc == nil {

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -159,25 +159,6 @@ func getInterfaceAddresses(name string) ([]netip.Addr, error) {
 	return netaddrs, nil
 }
 
-// filterIPs attempts to return the first non automatic private IP (APIPA / 169.254.x.x / link-local) if possible, only returning APIPA if available and no other valid IP is found.
-func filterIPs(addrs []netip.Addr, preferInet6 bool) netip.Addr {
-	var ipAddr netip.Addr
-	for _, addr := range addrs {
-		if addr.IsValid() {
-			ipAddr = addr
-		}
-
-		if preferInet6 && !addr.Is6() {
-			continue
-		}
-
-		if !addr.IsLinkLocalUnicast() {
-			return addr
-		}
-	}
-	return ipAddr
-}
-
 // filterBestIP returns an opinionated "best" address from a list of addresses.
 // A high quality address is one that is considered routeable, and not in the link-local address space.
 // A low quality address is a link-local address.

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -164,7 +164,7 @@ func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 	var invalid, inetAddr, inet6Addr netip.Addr
 
 	for _, addr := range addrs {
-		if addr.IsLoopback() {
+		if addr.IsLoopback() || !addr.IsValid() {
 			continue
 		}
 

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -100,7 +100,7 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 			// Select the best between what we've received
 			ipAddr = filterBestIP([]netip.Addr{ip, ipAddr}, enableInet6)
 		}
-		level.Debug(logger).Log("msg", "detected hightest quality address", "ipAddr", ipAddr.String(), "inf", name)
+		level.Debug(logger).Log("msg", "detected highest quality address", "ipAddr", ipAddr.String(), "inf", name)
 		if ipAddr.IsLinkLocalUnicast() || !ipAddr.IsValid() {
 			level.Debug(logger).Log("msg", "ignoring address", "ipAddr", ipAddr.String(), "inf", name)
 			continue

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -167,29 +167,30 @@ func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 			continue
 		}
 
-		if addr.IsValid() {
-			if addr.Is4() {
-				// If we have already been set, can we improve on the quality?
-				if inet4Addr.IsValid() {
-					if inet4Addr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
-						inet4Addr = addr
-					}
-					continue
+		if addr.Is6() && !enableInet6 {
+			continue
+		}
+
+		if addr.Is4() {
+			// If we have already been set, can we improve on the quality?
+			if inet4Addr.IsValid() {
+				if inet4Addr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
+					inet4Addr = addr
 				}
-				inet4Addr = addr
+				continue
 			}
-			if enableInet6 {
-				if addr.Is6() {
-					// If we have already been set, can we improve on the quality?
-					if inet6Addr.IsValid() {
-						if inet6Addr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
-							inet6Addr = addr
-						}
-						continue
-					}
+			inet4Addr = addr
+		}
+
+		if addr.Is6() {
+			// If we have already been set, can we improve on the quality?
+			if inet6Addr.IsValid() {
+				if inet6Addr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
 					inet6Addr = addr
 				}
+				continue
 			}
+			inet6Addr = addr
 		}
 	}
 
@@ -211,10 +212,8 @@ func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 		return inet4Addr
 	}
 
-	if enableInet6 {
-		if inet6Addr.IsValid() {
-			return inet6Addr
-		}
+	if inet6Addr.IsValid() {
+		return inet6Addr
 	}
 
 	return invalid

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -85,11 +85,6 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 
 	level.Debug(logger).Log("msg", "looking for addresses", "inf", fmt.Sprintf("%s", names), "inet6enabled", enableInet6)
 
-	// Replace a nil func with the standard approach.
-	if interfaceAddrsFunc == nil {
-		interfaceAddrsFunc = getInterfaceAddresses
-	}
-
 	for _, name := range names {
 		addrs, err := interfaceAddrsFunc(name)
 		if err != nil {
@@ -105,9 +100,9 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 			// Select the best between what we've received
 			ipAddr = filterBestIP([]netip.Addr{ip, ipAddr}, enableInet6)
 		}
-		level.Debug(logger).Log("msg", "filtered best", "ipAddr", ipAddr.String(), "inf", name)
+		level.Debug(logger).Log("msg", "detected hightest quality address", "ipAddr", ipAddr.String(), "inf", name)
 		if ipAddr.IsLinkLocalUnicast() || !ipAddr.IsValid() {
-			level.Debug(logger).Log("msg", "skipping", "ipAddr", ipAddr.String(), "inf", name)
+			level.Debug(logger).Log("msg", "ignoring address", "ipAddr", ipAddr.String(), "inf", name)
 			continue
 		}
 
@@ -121,7 +116,7 @@ func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrsFunc Net
 		return ipAddr.String(), nil
 	}
 
-	level.Debug(logger).Log("msg", "ipAddr after all interface names", "ipAddr", ipAddr.String())
+	level.Debug(logger).Log("msg", "detected IP address after looking up all configured interface names", "ipAddr", ipAddr.String())
 	if !ipAddr.IsValid() {
 		return "", fmt.Errorf("no useable address found for interfaces %s", names)
 	}
@@ -160,7 +155,7 @@ func getInterfaceAddresses(name string) ([]netip.Addr, error) {
 }
 
 // filterBestIP returns an opinionated "best" address from a list of addresses.
-// A high quality address is one that is considered routeable, and not in the link-local address space.
+// A high quality address is one that is considered routable, and not in the link-local address space.
 // A low quality address is a link-local address.
 // When an IPv6 preference is indicated using enableInet6, an IPv6 will be preferred over an equivalent quality IPv4 address.
 // Loopback addresses are never selected.

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -160,7 +160,7 @@ func getInterfaceAddresses(name string) ([]netip.Addr, error) {
 // otherwise IPv6 addresses are guaranteed to not be returned from this function.
 // Loopback addresses are never selected.
 func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
-	var invalid, inetAddr, inet6Addr netip.Addr
+	var invalid, inet4Addr, inet6Addr netip.Addr
 
 	for _, addr := range addrs {
 		if addr.IsLoopback() || !addr.IsValid() {
@@ -170,13 +170,13 @@ func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 		if addr.IsValid() {
 			if addr.Is4() {
 				// If we have already been set, can we improve on the quality?
-				if inetAddr.IsValid() {
-					if inetAddr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
-						inetAddr = addr
+				if inet4Addr.IsValid() {
+					if inet4Addr.IsLinkLocalUnicast() && !addr.IsLinkLocalUnicast() {
+						inet4Addr = addr
 					}
 					continue
 				}
-				inetAddr = addr
+				inet4Addr = addr
 			}
 			if enableInet6 {
 				if addr.Is6() {
@@ -194,21 +194,21 @@ func filterBestIP(addrs []netip.Addr, enableInet6 bool) netip.Addr {
 	}
 
 	// If both address families have been set, compare.
-	if inetAddr.IsValid() && inet6Addr.IsValid() {
-		if inetAddr.IsLinkLocalUnicast() && !inet6Addr.IsLinkLocalUnicast() {
+	if inet4Addr.IsValid() && inet6Addr.IsValid() {
+		if inet4Addr.IsLinkLocalUnicast() && !inet6Addr.IsLinkLocalUnicast() {
 			return inet6Addr
 		}
-		if inet6Addr.IsLinkLocalUnicast() && !inetAddr.IsLinkLocalUnicast() {
-			return inetAddr
+		if inet6Addr.IsLinkLocalUnicast() && !inet4Addr.IsLinkLocalUnicast() {
+			return inet4Addr
 		}
 		if enableInet6 {
 			return inet6Addr
 		}
-		return inetAddr
+		return inet4Addr
 	}
 
-	if inetAddr.IsValid() {
-		return inetAddr
+	if inet4Addr.IsValid() {
+		return inet4Addr
 	}
 
 	if enableInet6 {

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -194,11 +194,21 @@ func TestGetFirstAddressOf(t *testing.T) {
 		},
 		{
 			names: []string{"em0"},
-			addr:  "fc99::9a",
+			err:   fmt.Errorf("no useable address found for interfaces [em0]"),
+		},
+		{
+			names:       []string{"em0"},
+			addr:        "fc99::9a",
+			enableInet6: true,
 		},
 		{
 			names: []string{"lo1"},
-			addr:  "fe80::ec62:ed39:f931:bf6d",
+			err:   fmt.Errorf("no useable address found for interfaces [lo1]"),
+		},
+		{
+			names:       []string{"lo1"},
+			addr:        "fe80::ec62:ed39:f931:bf6d",
+			enableInet6: true,
 		},
 		{
 			names: []string{"lo2"},
@@ -218,11 +228,12 @@ func TestGetFirstAddressOf(t *testing.T) {
 		},
 		{
 			names: []string{"lo1", "lo2", "enp0s31f7"},
-			addr:  "2001::1111",
+			addr:  "169.254.1.1",
 		},
 		{
-			names: []string{"lo1", "lo2", "enp0s31f7", "enp0s31f6"},
-			addr:  "2001::1111",
+			names:       []string{"lo1", "lo2", "enp0s31f7", "enp0s31f6"},
+			addr:        "2001::1111",
+			enableInet6: true,
 		},
 		{
 			names: []string{"lo1", "lo2", "enp0s31f6", "enp0s31f7"},
@@ -334,7 +345,7 @@ func TestFilterBestIP(t *testing.T) {
 				toAddr("fc99::1"),
 				toAddr("fe80::1"),
 			},
-			addr: "fc99::1",
+			addr: "invalid IP", // inet6 is not enabled
 		},
 		{
 			addrs: []netip.Addr{

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -286,6 +286,13 @@ func TestFilterBestIP(t *testing.T) {
 	}{
 		{
 			addrs: []netip.Addr{
+				toAddr("169.254.1.1"),
+				toAddr("127.0.0.1"),
+			},
+			addr: "169.254.1.1",
+		},
+		{
+			addrs: []netip.Addr{
 				toAddr("1.1.1.1"),
 			},
 			addr: "1.1.1.1",

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -261,13 +261,15 @@ func TestGetFirstAddressOf(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		addr, err := getFirstAddressOf(tc.names, logger, getMockInterfaceAddresses, tc.enableInet6)
-		if tc.err != nil {
-			require.Equal(t, tc.err, err)
-		} else {
-			require.NoError(t, err)
-		}
-		require.Equal(t, tc.addr, addr)
+		t.Run(fmt.Sprintf("%s", tc.names), func(t *testing.T) {
+			addr, err := getFirstAddressOf(tc.names, logger, getMockInterfaceAddresses, tc.enableInet6)
+			if tc.err != nil {
+				require.Equal(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.addr, addr)
+		})
 	}
 }
 

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -186,7 +186,7 @@ func TestGetFirstAddressOf(t *testing.T) {
 		names       []string
 		addr        string
 		err         error
-		preferInet6 bool
+		enableInet6 bool
 	}{
 		{
 			names: []string{"wlan0"},
@@ -231,37 +231,37 @@ func TestGetFirstAddressOf(t *testing.T) {
 		{
 			names:       []string{"lo1", "lo2", "enp0s31f6", "enp0s31f7"},
 			addr:        "2001::1111",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			names:       []string{"em0", "em1"},
 			addr:        "fc99::9a",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			names:       []string{"em1"},
 			addr:        "fcca::e6:9274:f580:7a1b:c335",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			names:       []string{"lo1", "enp0s31f6"},
 			addr:        "1.1.1.1",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			names:       []string{"lo2", "enp0s31f6"},
 			addr:        "1.1.1.1",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			names:       []string{"em2"},
 			addr:        "10.54.99.53",
-			preferInet6: true,
+			enableInet6: true,
 		},
 	}
 
 	for _, tc := range cases {
-		addr, err := getFirstAddressOf(tc.names, logger, getMockInterfaceAddresses, tc.preferInet6)
+		addr, err := getFirstAddressOf(tc.names, logger, getMockInterfaceAddresses, tc.enableInet6)
 		if tc.err != nil {
 			require.Equal(t, tc.err, err)
 		} else {
@@ -282,7 +282,7 @@ func TestFilterBestIP(t *testing.T) {
 	cases := []struct {
 		addrs       []netip.Addr
 		addr        string
-		preferInet6 bool
+		enableInet6 bool
 	}{
 		{
 			addrs: []netip.Addr{
@@ -317,7 +317,7 @@ func TestFilterBestIP(t *testing.T) {
 				toAddr("fe80::1"),
 			},
 			addr:        "fe80::1",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			addrs: []netip.Addr{
@@ -325,7 +325,7 @@ func TestFilterBestIP(t *testing.T) {
 				toAddr("fe80::1"),
 			},
 			addr:        "fe80::1",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			addrs: []netip.Addr{
@@ -342,7 +342,7 @@ func TestFilterBestIP(t *testing.T) {
 				toAddr("fe80::1"),
 			},
 			addr:        "fc99::1",
-			preferInet6: true,
+			enableInet6: true,
 		},
 		{
 			addrs: []netip.Addr{
@@ -356,7 +356,7 @@ func TestFilterBestIP(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		addr := filterBestIP(tc.addrs, tc.preferInet6)
+		addr := filterBestIP(tc.addrs, tc.enableInet6)
 		require.Equal(t, tc.addr, addr.String())
 	}
 

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -92,7 +92,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 	f.StringVar(&cfg.Zone, prefix+"availability-zone", "", "The availability zone where this instance is running.")
 	f.BoolVar(&cfg.UnregisterOnShutdown, prefix+"unregister-on-shutdown", true, "Unregister from the ring upon clean shutdown. It can be useful to disable for rolling restarts with consistent naming in conjunction with -distributor.extend-writes=false.")
 	f.BoolVar(&cfg.ReadinessCheckRingHealth, prefix+"readiness-check-ring-health", true, "When enabled the readiness probe succeeds only after all instances are ACTIVE and healthy in the ring, otherwise only the instance itself is checked. This option should be disabled if in your cluster multiple instances can be rolled out simultaneously, otherwise rolling updates may be slowed down.")
-	f.BoolVar(&cfg.EnableInet6, prefix+"enable-inet6", false, "Enable IPv6 support.  Required to make use of IP addresses from IPv6 interfaces.")
+	f.BoolVar(&cfg.EnableInet6, prefix+"enable-inet6", false, "Enable IPv6 support. Required to make use of IP addresses from IPv6 interfaces.")
 }
 
 // Lifecycler is responsible for managing the lifecycle of entries in the ring.

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -34,6 +34,7 @@ type LifecyclerConfig struct {
 	JoinAfter        time.Duration `yaml:"join_after" category:"advanced"`
 	MinReadyDuration time.Duration `yaml:"min_ready_duration" category:"advanced"`
 	InfNames         []string      `yaml:"interface_names" doc:"default=[<private network interfaces>]"`
+	PreferInet6      bool          `yaml:"prefer_inet6" category:"advanced"`
 
 	// FinalSleep's default value can be overridden by
 	// setting it before calling RegisterFlags or RegisterFlagsWithPrefix.
@@ -140,7 +141,7 @@ type Lifecycler struct {
 
 // NewLifecycler creates new Lifecycler. It must be started via StartAsync.
 func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringName, ringKey string, flushOnShutdown bool, logger log.Logger, reg prometheus.Registerer) (*Lifecycler, error) {
-	addr, err := GetInstanceAddr(cfg.Addr, cfg.InfNames, logger)
+	addr, err := GetInstanceAddr(cfg.Addr, cfg.InfNames, logger, cfg.PreferInet6)
 	if err != nil {
 		return nil, err
 	}

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"sort"
+	strconv "strconv"
 	"sync"
 	"time"
 
@@ -169,7 +171,7 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 		cfg:                   cfg,
 		flushTransferer:       flushTransferer,
 		KVStore:               store,
-		Addr:                  fmt.Sprintf("%s:%d", addr, port),
+		Addr:                  net.JoinHostPort(addr, strconv.Itoa(port)),
 		ID:                    cfg.ID,
 		RingName:              ringName,
 		RingKey:               ringKey,

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -34,7 +34,7 @@ type LifecyclerConfig struct {
 	JoinAfter        time.Duration `yaml:"join_after" category:"advanced"`
 	MinReadyDuration time.Duration `yaml:"min_ready_duration" category:"advanced"`
 	InfNames         []string      `yaml:"interface_names" doc:"default=[<private network interfaces>]"`
-	PreferInet6      bool          `yaml:"prefer_inet6" category:"advanced"`
+	EnableInet6      bool          `yaml:"enable_inet6" category:"advanced"`
 
 	// FinalSleep's default value can be overridden by
 	// setting it before calling RegisterFlags or RegisterFlagsWithPrefix.
@@ -92,6 +92,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 	f.StringVar(&cfg.Zone, prefix+"availability-zone", "", "The availability zone where this instance is running.")
 	f.BoolVar(&cfg.UnregisterOnShutdown, prefix+"unregister-on-shutdown", true, "Unregister from the ring upon clean shutdown. It can be useful to disable for rolling restarts with consistent naming in conjunction with -distributor.extend-writes=false.")
 	f.BoolVar(&cfg.ReadinessCheckRingHealth, prefix+"readiness-check-ring-health", true, "When enabled the readiness probe succeeds only after all instances are ACTIVE and healthy in the ring, otherwise only the instance itself is checked. This option should be disabled if in your cluster multiple instances can be rolled out simultaneously, otherwise rolling updates may be slowed down.")
+	f.BoolVar(&cfg.EnableInet6, prefix+"enable-inet6", false, "Enable IPv6 support.  Required to make use of IP addresses from IPv6 interfaces.")
 }
 
 // Lifecycler is responsible for managing the lifecycle of entries in the ring.
@@ -141,7 +142,7 @@ type Lifecycler struct {
 
 // NewLifecycler creates new Lifecycler. It must be started via StartAsync.
 func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringName, ringKey string, flushOnShutdown bool, logger log.Logger, reg prometheus.Registerer) (*Lifecycler, error) {
-	addr, err := GetInstanceAddr(cfg.Addr, cfg.InfNames, logger, cfg.PreferInet6)
+	addr, err := GetInstanceAddr(cfg.Addr, cfg.InfNames, logger, cfg.EnableInet6)
 	if err != nil {
 		return nil, err
 	}

--- a/ring/util.go
+++ b/ring/util.go
@@ -2,18 +2,14 @@ package ring
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"net"
-	"net/netip"
 	"sort"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 
 	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/netutil"
 )
 
 // GenerateTokens make numTokens unique random tokens, none of which clash
@@ -56,7 +52,7 @@ func GetInstanceAddr(configAddr string, netInterfaces []string, logger log.Logge
 		return configAddr, nil
 	}
 
-	addr, err := GetFirstAddressOf(netInterfaces, logger)
+	addr, err := netutil.GetFirstAddressOf(netInterfaces, logger)
 	if err != nil {
 		return "", err
 	}
@@ -171,83 +167,4 @@ func searchToken(tokens []uint32, key uint32) int {
 		i = 0
 	}
 	return i
-}
-
-// GetFirstAddressOf returns the first IPv4/IPV6 address of the supplied interface names, omitting any link-local addresses.
-func GetFirstAddressOf(names []string, logger log.Logger) (string, error) {
-	return getFirstAddressOf(names, logger, getInterfaceAddresses)
-}
-
-// NetworkInterfaceGetter matches the signature of net.InterfaceByName() to allow for test mocks.
-type NetworkInterfaceAddressGetter func(name string) ([]netip.Addr, error)
-
-// GetFirstAddressOf returns the first IPv4/IPV6 address of the supplied interface names, omitting any link-local addresses.
-func getFirstAddressOf(names []string, logger log.Logger, interfaceAddrs NetworkInterfaceAddressGetter) (string, error) {
-	var ipAddr netip.Addr
-	for _, name := range names {
-		addrs, err := interfaceAddrs(name)
-		if err != nil {
-			level.Warn(logger).Log("msg", "error getting addresses for interface", "inf", name, "err", err)
-			continue
-		}
-		if len(addrs) <= 0 {
-			level.Warn(logger).Log("msg", "no addresses found for interface", "inf", name, "err", err)
-			continue
-		}
-		if ip := filterIPs(addrs); ip.IsValid() {
-			ipAddr = ip
-		}
-		if ipAddr.IsLinkLocalUnicast() || !ipAddr.IsValid() {
-			continue
-		}
-		return ipAddr.String(), nil
-	}
-	if !ipAddr.IsValid() {
-		return "", fmt.Errorf("no useable address found for interfaces %s", names)
-	}
-	if ipAddr.IsLinkLocalUnicast() {
-		level.Warn(logger).Log("msg", "using link-local address", "address", ipAddr.String())
-	}
-	return ipAddr.String(), nil
-}
-
-// getInterfaceAddresses is the standard approach to collecting []net.Addr from a network interface by name.
-func getInterfaceAddresses(name string) ([]netip.Addr, error) {
-	inf, err := net.InterfaceByName(name)
-	if err != nil {
-		return nil, err
-	}
-
-	addrs, err := inf.Addrs()
-	if err != nil {
-		return nil, err
-	}
-
-	// Using netip.Addr to allow for easier and consistent address parsing.
-	// Without this, the net.ParseCIDR() that we might like to use in a test does
-	// not have the same net.Addr implementation that we get from calling
-	// interface.Addrs() as above.  Here we normalize on netip.Addr.
-	netaddrs := make([]netip.Addr, len(addrs))
-	for i, a := range addrs {
-		netaddrs[i], err = netip.ParseAddr(a.String())
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse netip.Addr")
-		}
-	}
-
-	return netaddrs, nil
-}
-
-// filterIPs attempts to return the first non automatic private IP (APIPA / 169.254.x.x) if possible, only returning APIPA if available and no other valid IP is found.
-func filterIPs(addrs []netip.Addr) netip.Addr {
-	var ipAddr netip.Addr
-	for _, addr := range addrs {
-		if addr.String() != "" {
-			ipAddr = addr
-		}
-		if !addr.IsLinkLocalUnicast() {
-			return addr
-		}
-	}
-	return ipAddr
 }

--- a/ring/util.go
+++ b/ring/util.go
@@ -47,12 +47,12 @@ func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 
 // GetInstanceAddr returns the address to use to register the instance
 // in the ring.
-func GetInstanceAddr(configAddr string, netInterfaces []string, logger log.Logger, preferInet6 bool) (string, error) {
+func GetInstanceAddr(configAddr string, netInterfaces []string, logger log.Logger, enableInet6 bool) (string, error) {
 	if configAddr != "" {
 		return configAddr, nil
 	}
 
-	addr, err := netutil.GetFirstAddressOf(netInterfaces, logger, preferInet6)
+	addr, err := netutil.GetFirstAddressOf(netInterfaces, logger, enableInet6)
 	if err != nil {
 		return "", err
 	}

--- a/ring/util.go
+++ b/ring/util.go
@@ -47,12 +47,12 @@ func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 
 // GetInstanceAddr returns the address to use to register the instance
 // in the ring.
-func GetInstanceAddr(configAddr string, netInterfaces []string, logger log.Logger) (string, error) {
+func GetInstanceAddr(configAddr string, netInterfaces []string, logger log.Logger, preferInet6 bool) (string, error) {
 	if configAddr != "" {
 		return configAddr, nil
 	}
 
-	addr, err := netutil.GetFirstAddressOf(netInterfaces, logger)
+	addr, err := netutil.GetFirstAddressOf(netInterfaces, logger, preferInet6)
 	if err != nil {
 		return "", err
 	}

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -3,12 +3,9 @@ package ring
 import (
 	"context"
 	"fmt"
-	"net/netip"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -417,105 +414,4 @@ func TestWaitInstanceState_ExitsAfterActualStateEqualsState(t *testing.T) {
 
 	assert.Nil(t, err)
 	ring.AssertNumberOfCalls(t, "GetInstanceState", 1)
-}
-
-func getMockInterfaceAddresses(name string) ([]netip.Addr, error) {
-	toAddr := func(addr string) netip.Addr {
-		prefix := netip.MustParsePrefix(addr)
-		return prefix.Addr()
-	}
-
-	interfaces := map[string][]netip.Addr{
-		"wlan0": {
-			toAddr("172.16.16.51/24"),
-			toAddr("fc16::c9a7:1d89:2dd8:f59a/64"),
-			toAddr("fe80::ec62:ed39:f931:bf6d/64"),
-		},
-		"em0": {
-			toAddr("fe80::ec62:ed39:f931:bf6d/64"),
-			toAddr("fc99::9a/64"),
-		},
-		"lo1": {
-			toAddr("fe80::ec62:ed39:f931:bf6d/64"),
-		},
-		"lo2": {
-			toAddr("169.254.1.1/16"),
-		},
-		"lo9":  {},
-		"lo10": {},
-		"enp0s31f6": {
-			toAddr("1.1.1.1/31"),
-		},
-		"enp0s31f7": {
-			toAddr("2001::1111/120"),
-		},
-	}
-
-	if val, ok := interfaces[name]; ok {
-		return val, nil
-	}
-
-	return nil, fmt.Errorf("no such network interface")
-}
-
-func TestGetFirstAddressOf(t *testing.T) {
-	// logger := log.NewNopLogger()
-	logger := log.NewLogfmtLogger(os.Stdout)
-
-	cases := []struct {
-		names []string
-		addr  string
-		err   error
-	}{
-		{
-			names: []string{"wlan0"},
-			addr:  "172.16.16.51",
-		},
-		{
-			names: []string{"em0"},
-			addr:  "fc99::9a",
-		},
-		{
-			names: []string{"lo1"},
-			addr:  "fe80::ec62:ed39:f931:bf6d",
-		},
-		{
-			names: []string{"lo2"},
-			addr:  "169.254.1.1",
-		},
-		{
-			names: []string{"lo9"},
-			err:   fmt.Errorf("no useable address found for interfaces [lo9]"),
-		},
-		{
-			names: []string{"lo9", "lo10"},
-			err:   fmt.Errorf("no useable address found for interfaces [lo9 lo10]"),
-		},
-		{
-			names: []string{"lo1", "lo2", "enp0s31f6"},
-			addr:  "1.1.1.1",
-		},
-		{
-			names: []string{"lo1", "lo2", "enp0s31f7"},
-			addr:  "2001::1111",
-		},
-		{
-			names: []string{"lo1", "lo2", "enp0s31f7", "enp0s31f6"},
-			addr:  "2001::1111",
-		},
-		{
-			names: []string{"lo1", "lo2", "enp0s31f6", "enp0s31f7"},
-			addr:  "1.1.1.1",
-		},
-	}
-
-	for _, tc := range cases {
-		addr, err := getFirstAddressOf(tc.names, logger, getMockInterfaceAddresses)
-		if tc.err != nil {
-			require.Equal(t, tc.err, err)
-		} else {
-			require.NoError(t, err)
-		}
-		require.Equal(t, tc.addr, addr)
-	}
 }


### PR DESCRIPTION
**What this PR does**:

Here we add IPv6 support to the ring util code by removing IPv4 references and utilizing the `net` package methods to determine which interface addresses we want to skip, in an inet family agnostic way.

**Which issue(s) this PR fixes**:

Related: grafana/tempo#1544

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
