### PR TITLE
Memberlist: disabled TCP-based ping fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   * `ring_member_ownership_percent`
 * [CHANGE] Memberlist: `-memberlist.abort-if-join-fails` option now defaults to false.
 * [CHANGE] Remove middleware package. #182
+* [CHANGE] Memberlist: disabled TCP-based ping fallback, because dskit already uses a custom transport based on TCP. #194
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -427,6 +427,11 @@ func (m *KV) buildMemberlistConfig() (*memberlist.Config, error) {
 	mlCfg.ProbeInterval = 5 * time.Second // Probe a random node every this interval. This setting is also the total timeout for the direct + indirect probes.
 	mlCfg.ProbeTimeout = 2 * time.Second  // Timeout for the direct probe.
 
+	// Since we use a custom transport based on TCP, having TCP-based fallbacks doesn't give us any benefit.
+	// On the contrary, if we keep TCP pings enabled, each node will effectively run 2x pings against a dead
+	// node, because the TCP-based fallback will always trigger.
+	mlCfg.DisableTcpPings = true
+
 	level.Info(m.logger).Log("msg", "Using memberlist cluster label and node name", "cluster_label", mlCfg.Label, "node", mlCfg.Name)
 
 	return mlCfg, nil


### PR DESCRIPTION
**What this PR does**:
Memberlist pinging mechanism (used to detect if a node is dead) has a fallback mechanism based on TCP. Memberlist assumes that you're using UDP protocol for message passing, so if the UDP-based ping fails it will try to ping the remote node using TCP.

However, dskit uses a custom transport based on TCP, which means all message passing is TCP based. The TCP-based fallback mechanism doesn't give any additional value but, on the other hand, causes to run the double of expected pings if the remote node is dead (because the fallback mechanism will always trigger).

I propose to just disable the TCP-based ping fallback.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
