### PR TITLE
Log how long it took to join the memberlist cluster.

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -534,9 +534,11 @@ func (m *KV) JoinMembers(members []string) (int, error) {
 }
 
 func (m *KV) joinMembersOnStartup(ctx context.Context, members []string) error {
+	startTime := time.Now()
+
 	reached, err := m.memberlist.Join(members)
 	if err == nil {
-		level.Info(m.logger).Log("msg", "joined memberlist cluster", "reached_nodes", reached)
+		level.Info(m.logger).Log("msg", "joined memberlist cluster", "reached_nodes", reached, "join_time", time.Since(startTime))
 		return nil
 	}
 
@@ -565,7 +567,7 @@ func (m *KV) joinMembersOnStartup(ctx context.Context, members []string) error {
 			continue
 		}
 
-		level.Info(m.logger).Log("msg", "joined memberlist cluster", "reached_nodes", reached)
+		level.Info(m.logger).Log("msg", "joined memberlist cluster", "reached_nodes", reached, "join_time", time.Since(startTime))
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does**:
This PR adds "join_time" to "joined memberlist cluster" log message to log how long it took to join the cluster.

Related to https://github.com/grafana/dskit/pull/195.

**Checklist**
- [na] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
