### PR TITLE
Fix log message in memberlist join method

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -568,7 +568,7 @@ func (m *KV) fastJoinMembersOnStartup(ctx context.Context) {
 func (m *KV) joinMembersOnStartup(ctx context.Context) bool {
 	startTime := time.Now()
 
-	level.Info(m.logger).Log("msg", "joining memberlist cluster", "join_members", []string(m.cfg.JoinMembers))
+	level.Info(m.logger).Log("msg", "joining memberlist cluster", "join_members", strings.Join(m.cfg.JoinMembers, ","))
 
 	cfg := backoff.Config{
 		MinBackoff: m.cfg.MinJoinBackoff,


### PR DESCRIPTION
**What this PR does**:

This PR fixes log message:

```
level=info ts=2022-07-26T15:52:20.891053096Z caller=memberlist_client.go:571 msg="joining memberlist cluster" join_members="unsupported value type"
```

**Checklist**
- [na] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
