### PR TITLE
Add error class tracking to ring.DoBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [ENHANCEMENT] Runtimeconfig: Allow providing multiple runtime config yaml files as comma separated list file paths. #183
 * [ENHANCEMENT] Memberlist: Add cluster label support to memberlist client. #187
 * [ENHANCEMENT] Runtimeconfig: Don't unmarshal and merge runtime config yaml files if they haven't changed since last check. #218
-* [ENHANCEMENT] ring: DoBatch now differentiates between 4xx and 5xx GRPC errors and keeps track of them separately. It only returns when there is a quorum of either error class. If your errors do not implement `GRPCStatus() *Status` from google.golang.org/grpc/status, then this change does not affect you.
+* [ENHANCEMENT] ring: DoBatch now differentiates between 4xx and 5xx GRPC errors and keeps track of them separately. It only returns when there is a quorum of either error class. If your errors do not implement `GRPCStatus() *Status` from google.golang.org/grpc/status, then this change does not affect you. #201
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [ENHANCEMENT] Runtimeconfig: Allow providing multiple runtime config yaml files as comma separated list file paths. #183
 * [ENHANCEMENT] Memberlist: Add cluster label support to memberlist client. #187
 * [ENHANCEMENT] Runtimeconfig: Don't unmarshal and merge runtime config yaml files if they haven't changed since last check. #218
+* [ENHANCEMENT] ring: DoBatch now differentiates between 4xx and 5xx GRPC errors and keeps track of them separately. It only returns when there is a quorum of either error class. If your errors do not implement `GRPCStatus() *Status` from google.golang.org/grpc/status, then this change does not affect you.
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -1,3 +1,5 @@
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/ring/batch.go
+
 package ring
 
 import (
@@ -6,6 +8,7 @@ import (
 	"sync"
 
 	"go.uber.org/atomic"
+	"google.golang.org/grpc/status"
 )
 
 type batchTracker struct {
@@ -25,7 +28,20 @@ type itemTracker struct {
 	minSuccess  int
 	maxFailures int
 	succeeded   atomic.Int32
-	failed      atomic.Int32
+	failed4xx   atomic.Int32
+	failed5xx   atomic.Int32
+	remaining   atomic.Int32
+	err         atomic.Error
+}
+
+func (i *itemTracker) recordError(err error) int32 {
+	i.err.Store(err)
+
+	if s, ok := status.FromError(err); ok && s.Code()/100 == 4 {
+		return i.failed4xx.Inc()
+	}
+
+	return i.failed5xx.Inc()
 }
 
 // DoBatch request against a set of keys in the ring, handling replication and
@@ -62,6 +78,7 @@ func DoBatch(ctx context.Context, op Operation, r ReadRing, keys []uint32, callb
 		}
 		itemTrackers[i].minSuccess = len(replicationSet.Instances) - replicationSet.MaxErrors
 		itemTrackers[i].maxFailures = replicationSet.MaxErrors
+		itemTrackers[i].remaining.Store(int32(len(replicationSet.Instances)))
 
 		for _, desc := range replicationSet.Instances {
 			curr, found := instances[desc.Addr]
@@ -112,29 +129,45 @@ func DoBatch(ctx context.Context, op Operation, r ReadRing, keys []uint32, callb
 }
 
 func (b *batchTracker) record(sampleTrackers []*itemTracker, err error) {
-	// If we succeed, decrement each sample's pending count by one.  If we reach
-	// the required number of successful puts on this sample, then decrement the
-	// number of pending samples by one.  If we successfully push all samples to
-	// min success instances, wake up the waiting rpc so it can return early.
-	// Similarly, track the number of errors, and if it exceeds maxFailures
-	// shortcut the waiting rpc.
+	// If we reach the required number of successful puts on this sample, then decrement the
+	// number of pending samples by one.
 	//
-	// The use of atomic increments here guarantees only a single sendSamples
-	// goroutine will write to either channel.
+	// The use of atomic increments here is needed as:
+	// * rpcsPending and rpcsFailed guarantees only a single sendSamples goroutine will write to either channel
+	// * succeeded, failed4xx, failed5xx and remaining guarantees that the "return decision" is made atomically
+	// avoiding race condition
 	for i := range sampleTrackers {
 		if err != nil {
-			if sampleTrackers[i].failed.Inc() <= int32(sampleTrackers[i].maxFailures) {
-				continue
-			}
-			if b.rpcsFailed.Inc() == 1 {
-				b.err <- err
+			// Track the number of errors by error family, and if it exceeds maxFailures
+			// shortcut the waiting rpc.
+			errCount := sampleTrackers[i].recordError(err)
+			// We should return an error if we reach the maxFailure (quorum) on a given error family OR
+			// we dont have any remaining instances to try
+			// Ex: 2xx, 4xx, 5xx -> return 5xx
+			// Ex: 4xx, 4xx, _ -> return 4xx
+			// Ex: 5xx, _, 5xx -> return 5xx
+			if errCount > int32(sampleTrackers[i].maxFailures) || sampleTrackers[i].remaining.Dec() == 0 {
+				if b.rpcsFailed.Inc() == 1 {
+					b.err <- err
+				}
 			}
 		} else {
-			if sampleTrackers[i].succeeded.Inc() != int32(sampleTrackers[i].minSuccess) {
+			// If we successfully push all samples to min success instances,
+			// wake up the waiting rpc so it can return early.
+			if sampleTrackers[i].succeeded.Inc() >= int32(sampleTrackers[i].minSuccess) {
+				if b.rpcsPending.Dec() == 0 {
+					b.done <- struct{}{}
+				}
 				continue
 			}
-			if b.rpcsPending.Dec() == 0 {
-				b.done <- struct{}{}
+
+			// If we succeeded to call this particular instance but we dont have any remaining instances to try
+			// and we did not succeeded calling `minSuccess` instances we need to return the last error
+			// Ex: 4xx, 5xx, 2xx
+			if sampleTrackers[i].remaining.Dec() == 0 {
+				if b.rpcsFailed.Inc() == 1 {
+					b.err <- sampleTrackers[i].err.Load()
+				}
 			}
 		}
 	}

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -133,8 +133,8 @@ func (b *batchTracker) record(itemTrackers []*itemTracker, err error) {
 	// number of pending items by one.
 	//
 	// The use of atomic increments here is needed as:
-	// * rpcsPending and rpcsFailed guarantees only a single goroutine will write to either channel
-	// * succeeded, failed4xx, failed5xx and remaining guarantees that the "return decision" is made atomically
+	// * rpcsPending and rpcsFailed guarantee only a single goroutine will write to either channel
+	// * succeeded, failed4xx, failed5xx and remaining guarantee that the "return decision" is made atomically
 	// avoiding race condition
 	for i := range itemTrackers {
 		if err != nil {
@@ -171,8 +171,8 @@ func (b *batchTracker) record(itemTrackers []*itemTracker, err error) {
 				continue
 			}
 
-			// If we succeeded to call this particular instance, but we don't have any remaining instances to try,
-			// and we did not succeed calling minSuccess instances, then we need to return the last error
+			// If we successfully called this particular instance, but we don't have any remaining instances to try,
+			// and we failed to call minSuccess instances, then we need to return the last error
 			// Ex: 4xx, 5xx, 2xx
 			if itemTrackers[i].remaining.Dec() == 0 {
 				if b.rpcsFailed.Inc() == 1 {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -175,7 +175,7 @@ func TestDoBatchZeroInstances(t *testing.T) {
 }
 
 func TestDoBatch_QuorumError(t *testing.T) {
-	// we should run several write request to make sure we dont have any race condition on the batchTracker#record code
+	// we should run several write request to make sure we dont have any race condition on the batchTracker.record code
 	const numberOfOperations = 10000
 	instanceReturnErrors := [3]error{nil, nil, nil}
 	desc := NewDesc()

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
@@ -168,6 +171,100 @@ func TestDoBatchZeroInstances(t *testing.T) {
 		strategy: NewDefaultReplicationStrategy(),
 	}
 	require.Error(t, DoBatch(ctx, Write, &r, keys, callback, cleanup))
+}
+
+func TestDoBatch_QuorumError(t *testing.T) {
+	// we should run several write request to make sure we dont have any race condition on the batchTracker#record code
+	const numberOfOperations = 10000
+	instanceReturnErrors := [3]error{nil, nil, nil}
+	desc := NewDesc()
+	for address := range instanceReturnErrors {
+		instTokens := GenerateTokens(128, nil)
+		instanceID := fmt.Sprintf("%d", address)
+		desc.AddIngester(instanceID, instanceID, "", instTokens, ACTIVE, time.Now())
+	}
+	ringConfig := Config{
+		HeartbeatTimeout:  time.Hour,
+		ReplicationFactor: 3,
+	}
+	ring, err := NewWithStoreClientAndStrategy(ringConfig, "ingester", ringKey, nil, NewDefaultReplicationStrategy(), nil, log.NewNopLogger())
+	require.NoError(t, err)
+	ring.updateRingState(desc)
+	operationKeys := []uint32{1, 10, 100}
+	ctx := context.Background()
+	runDoBatch := func() error {
+		returnInstanceError := func(i InstanceDesc, _ []int) error {
+			instanceID, err := strconv.Atoi(i.Addr)
+			require.NoError(t, err)
+			return instanceReturnErrors[instanceID]
+		}
+		return DoBatch(ctx, Write, ring, operationKeys, returnInstanceError, func() {})
+	}
+
+	// Using 429 just to make sure we are not hitting the &limits
+	// Simulating 2 4xx and 1 5xx -> Should return 4xx
+	instanceReturnErrors[0] = httpgrpc.Errorf(429, "Throttling")
+	instanceReturnErrors[1] = httpgrpc.Errorf(500, "InternalServerError")
+	instanceReturnErrors[2] = httpgrpc.Errorf(429, "Throttling")
+
+	for i := 0; i < numberOfOperations; i++ {
+		err := runDoBatch()
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.Code(429), s.Code())
+	}
+
+	// Simulating 2 5xx and 1 4xx -> Should return 5xx
+	instanceReturnErrors[0] = httpgrpc.Errorf(500, "InternalServerError")
+	instanceReturnErrors[1] = httpgrpc.Errorf(429, "Throttling")
+	instanceReturnErrors[2] = httpgrpc.Errorf(500, "InternalServerError")
+
+	for i := 0; i < numberOfOperations; i++ {
+		err = runDoBatch()
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.Code(500), s.Code())
+	}
+
+	// Simulating 2 different errors and 1 success -> This case we may return any of the errors
+	instanceReturnErrors[0] = httpgrpc.Errorf(500, "InternalServerError")
+	instanceReturnErrors[1] = httpgrpc.Errorf(429, "Throttling")
+	instanceReturnErrors[2] = nil
+
+	for i := 0; i < numberOfOperations; i++ {
+		err = runDoBatch()
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.True(t, s.Code() == 429 || s.Code() == 500)
+	}
+
+	// Simulating 1 error -> Should return 2xx
+	instanceReturnErrors[0] = httpgrpc.Errorf(500, "InternalServerError")
+	instanceReturnErrors[1] = nil
+	instanceReturnErrors[2] = nil
+
+	for i := 0; i < 1; i++ {
+		require.NoError(t, runDoBatch())
+	}
+
+	// Simulating an unhealthy instance (instance 2)
+	instanceReturnErrors[0] = httpgrpc.Errorf(500, "InternalServerError")
+	instanceReturnErrors[1] = nil
+	instanceReturnErrors[2] = nil
+
+	instance2 := ring.ringDesc.Ingesters["2"]
+	instance2.State = LEFT
+	instance2.Timestamp = time.Now().Unix()
+	ring.ringDesc.Ingesters["2"] = instance2
+	ring.updateRingState(ring.ringDesc)
+
+	for i := 0; i < numberOfOperations; i++ {
+		err := runDoBatch()
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.Code(500), s.Code())
+	}
 }
 
 func TestAddIngester(t *testing.T) {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -204,7 +204,7 @@ func TestDoBatch_QuorumError(t *testing.T) {
 		return DoBatch(ctx, Write, ring, operationKeys, returnInstanceError, unfinishedDoBatchCalls.Done)
 	}
 
-	// Using 429 just to make sure we are not hitting the &limits
+	// Using 429 just to make sure we are not hitting the limits
 	// Simulating 2 4xx and 1 5xx -> Should return 4xx
 	instanceReturnErrors[0] = httpgrpc.Errorf(429, "Throttling")
 	instanceReturnErrors[1] = httpgrpc.Errorf(500, "InternalServerError")
@@ -231,7 +231,7 @@ func TestDoBatch_QuorumError(t *testing.T) {
 	}
 	unfinishedDoBatchCalls.Wait()
 
-	// Simulating 2 different errors and 1 success -> This case we may return any of the errors
+	// Simulating 2 different errors and 1 success -> In this case we may return any of the errors
 	instanceReturnErrors[0] = httpgrpc.Errorf(500, "InternalServerError")
 	instanceReturnErrors[1] = httpgrpc.Errorf(429, "Throttling")
 	instanceReturnErrors[2] = nil


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adapts code from https://github.com/cortexproject/cortex/pull/4388 by @alanprot. Thank you @alanprot!

DoBatch now tracks errors based on their grpc error code.
4xx and 5xx errors are tracked differently. DoBatch returns
when there is a quorum of either 4xx or 5xx errors, but
does not combine them.

Examples (order does not matter):
* 2xx, 2xx, _   -> 2xx (current behaviour; early return)
* 4xx, 4xx, _   -> 4xx (current behaviour; early return)
* 5xx, 5xx, _   -> 5xx (current behaviour; early return)
* 5xx, 5xx, 4xx -> 5xx (previously whichever error came first)
* 5xx, 4xx, 4xx -> 4xx (previously whichever error came first)
* 2xx, 4xx, 5xx -> either 4xx or 5xx, whichever error came last (current behaviour)


**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
