### PR TITLE
runtutil: add ExhaustCloseWithErrCapture

### DIFF
--- a/runutil/runutil.go
+++ b/runutil/runutil.go
@@ -1,3 +1,7 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/runutil/runutil.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
 package runutil
 
 import (
@@ -13,8 +17,12 @@ import (
 )
 
 // CloseWithErrCapture closes closer and wraps any error with the provided message and assigns it to err.
-func CloseWithErrCapture(err *error, closer io.Closer, msg string) {
-	merr := multierror.New(*err, errors.Wrap(closer.Close(), msg))
+func CloseWithErrCapture(err *error, closer io.Closer, format string, a ...interface{}) {
+	merr := multierror.MultiError{}
+
+	merr.Add(*err)
+	merr.Add(errors.Wrapf(closer.Close(), format, a...))
+
 	*err = merr.Err()
 }
 
@@ -28,4 +36,18 @@ func CloseWithLogOnErr(logger log.Logger, closer io.Closer, format string, args 
 
 	msg := fmt.Sprintf(format, args...)
 	level.Warn(logger).Log("msg", "detected close error", "err", fmt.Sprintf("%s: %s", msg, err.Error()))
+}
+
+// ExhaustCloseWithErrCapture closes the io.ReadCloser with error capture but exhausts the reader before.
+func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ...interface{}) {
+	_, copyErr := io.Copy(io.Discard, r)
+
+	CloseWithErrCapture(err, r, format, a...)
+
+	// Prepend the io.Copy error.
+	merr := multierror.MultiError{}
+	merr.Add(copyErr)
+	merr.Add(*err)
+
+	*err = merr.Err()
 }

--- a/runutil/runutil_test.go
+++ b/runutil/runutil_test.go
@@ -1,11 +1,18 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/runutil/runutil_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
 package runutil
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,4 +62,108 @@ type fakeLogger struct {
 func (l *fakeLogger) Log(keyvals ...interface{}) error {
 	l.keyvals = keyvals
 	return nil
+}
+
+type testCloser = fakeCloser
+
+func TestCloseWithErrCapture(t *testing.T) {
+	for _, tcase := range []struct {
+		err    error
+		closer io.Closer
+
+		expectedErrStr string
+	}{
+		{
+			err:            nil,
+			closer:         testCloser{err: nil},
+			expectedErrStr: "",
+		},
+		{
+			err:            errors.New("test"),
+			closer:         testCloser{err: nil},
+			expectedErrStr: "test",
+		},
+		{
+			err:            nil,
+			closer:         testCloser{err: errors.New("test")},
+			expectedErrStr: "close: test",
+		},
+		{
+			err:            errors.New("test"),
+			closer:         testCloser{err: errors.New("test")},
+			expectedErrStr: "2 errors: test; close: test",
+		},
+	} {
+		if ok := t.Run("", func(t *testing.T) {
+			ret := tcase.err
+			CloseWithErrCapture(&ret, tcase.closer, "close")
+
+			if tcase.expectedErrStr == "" {
+				if ret != nil {
+					t.Error("Expected error to be nil")
+					t.Fail()
+				}
+			} else {
+				if ret == nil {
+					t.Error("Expected error to be not nil")
+					t.Fail()
+				}
+
+				if tcase.expectedErrStr != ret.Error() {
+					t.Errorf("%s != %s", tcase.expectedErrStr, ret.Error())
+					t.Fail()
+				}
+			}
+
+		}); !ok {
+			return
+		}
+	}
+}
+
+type loggerCapturer struct {
+	// WasCalled is true if the Log() function has been called.
+	WasCalled bool
+}
+
+func (lc *loggerCapturer) Log(keyvals ...interface{}) error {
+	lc.WasCalled = true
+	return nil
+}
+
+type emulatedCloser struct {
+	io.Reader
+
+	calls int
+}
+
+func (e *emulatedCloser) Close() error {
+	e.calls++
+	if e.calls == 1 {
+		return nil
+	}
+	if e.calls == 2 {
+		return errors.Wrap(os.ErrClosed, "can even be a wrapped one")
+	}
+	return errors.New("something very bad happened")
+}
+
+// newEmulatedCloser returns a ReadCloser with a Close method
+// that at first returns success but then returns that
+// it has been closed already. After that, it returns that
+// something very bad had happened.
+func newEmulatedCloser(r io.Reader) io.ReadCloser {
+	return &emulatedCloser{Reader: r}
+}
+
+func TestCloseMoreThanOnce(t *testing.T) {
+	lc := &loggerCapturer{}
+	r := newEmulatedCloser(strings.NewReader("somestring"))
+
+	CloseWithLogOnErr(lc, r, "should not be called")
+	CloseWithLogOnErr(lc, r, "should not be called")
+	assert.Equal(t, false, lc.WasCalled)
+
+	CloseWithLogOnErr(lc, r, "should be called")
+	assert.Equal(t, true, lc.WasCalled)
 }

--- a/runutil/runutil_test.go
+++ b/runutil/runutil_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloseWithLogOnErr(t *testing.T) {
@@ -94,30 +95,17 @@ func TestCloseWithErrCapture(t *testing.T) {
 			expectedErrStr: "2 errors: test; close: test",
 		},
 	} {
-		if ok := t.Run("", func(t *testing.T) {
+		t.Run(tcase.expectedErrStr, func(t *testing.T) {
 			ret := tcase.err
 			CloseWithErrCapture(&ret, tcase.closer, "close")
 
 			if tcase.expectedErrStr == "" {
-				if ret != nil {
-					t.Error("Expected error to be nil")
-					t.Fail()
-				}
+				assert.NoError(t, ret)
 			} else {
-				if ret == nil {
-					t.Error("Expected error to be not nil")
-					t.Fail()
-				}
-
-				if tcase.expectedErrStr != ret.Error() {
-					t.Errorf("%s != %s", tcase.expectedErrStr, ret.Error())
-					t.Fail()
-				}
+				require.Error(t, ret)
+				assert.Equal(t, tcase.expectedErrStr, ret.Error())
 			}
-
-		}); !ok {
-			return
-		}
+		})
 	}
 }
 
@@ -162,8 +150,8 @@ func TestCloseMoreThanOnce(t *testing.T) {
 
 	CloseWithLogOnErr(lc, r, "should not be called")
 	CloseWithLogOnErr(lc, r, "should not be called")
-	assert.Equal(t, false, lc.WasCalled)
+	assert.False(t, lc.WasCalled)
 
 	CloseWithLogOnErr(lc, r, "should be called")
-	assert.Equal(t, true, lc.WasCalled)
+	assert.True(t, lc.WasCalled)
 }


### PR DESCRIPTION
Code from https://github.com/thanos-io/thanos/blob/6d1b98d49781/pkg/runutil/, slightly modified for consistency.

This enables grafana/e2e to build without a dependency on Thanos - https://github.com/grafana/e2e/pull/4

**Checklist**
- [x] Tests updated
- NA `CHANGELOG.md` updated
