### PR TITLE
memberlist: allow retries when dns returns no peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,4 +70,4 @@
 * [BUGFIX] Ring: fix bug where hash ring instances may appear unhealthy in the web UI even though they are not. #172
 * [BUGFIX] Lifecycler: if existing ring entry is reused, ring is updated immediately, and not on next heartbeat. #175
 * [BUGFIX] stringslicecsv: handle unmarshalling empty yaml string #206
-* [BUGFIX] Memberlist: retry discoverMembers is join-members is set, but discoverMembers return zero node. #215
+* [BUGFIX] Memberlist: retry joining memberlist cluster on startup when no nodes are resolved. #215

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,4 +70,4 @@
 * [BUGFIX] Ring: fix bug where hash ring instances may appear unhealthy in the web UI even though they are not. #172
 * [BUGFIX] Lifecycler: if existing ring entry is reused, ring is updated immediately, and not on next heartbeat. #175
 * [BUGFIX] stringslicecsv: handle unmarshalling empty yaml string #206
-
+* [BUGFIX] Memberlist: retry discoverMembers is join-members is set, but discoverMembers return zero node. #215

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -475,11 +475,9 @@ func (m *KV) starting(ctx context.Context) error {
 var errFailedToJoinCluster = errors.New("failed to join memberlist cluster on startup")
 
 func (m *KV) running(ctx context.Context) error {
-	if len(m.cfg.JoinMembers) > 0 {
-		ok := m.joinMembersOnStartup(ctx)
-		if !ok && m.cfg.AbortIfJoinFails {
-			return errFailedToJoinCluster
-		}
+	ok := m.joinMembersOnStartup(ctx)
+	if !ok && m.cfg.AbortIfJoinFails {
+		return errFailedToJoinCluster
 	}
 
 	var tickerChan <-chan time.Time
@@ -600,7 +598,7 @@ func (m *KV) joinMembersOnStartup(ctx context.Context) bool {
 			level.Warn(m.logger).Log("msg", "joining memberlist cluster: failed to reach any nodes", "retries", boff.NumRetries(), "err", err)
 			lastErr = err
 		} else {
-			level.Warn(m.logger).Log("msg", "joining memberlist cluster: failed to resolve nodes", "retries", boff.NumRetries())
+			level.Warn(m.logger).Log("msg", "joining memberlist cluster: found no nodes to join", "retries", boff.NumRetries())
 		}
 
 		boff.Wait()

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -585,12 +585,12 @@ func (m *KV) joinMembersOnStartup(ctx context.Context) bool {
 		nodes := m.discoverMembers(ctx, m.cfg.JoinMembers)
 
 		reached, err := m.memberlist.Join(nodes) // err is only returned if reached==0.
-		if err == nil {
+		if err == nil && !(len(m.cfg.JoinMembers) > 0 && len(nodes) == 0) {
 			level.Info(m.logger).Log("msg", "joining memberlist cluster succeeded", "reached_nodes", reached, "elapsed_time", time.Since(startTime))
 			return true
 		}
 
-		level.Warn(m.logger).Log("msg", "joining memberlist cluster: failed to reach any nodes", "retries", boff.NumRetries(), "err", err)
+		level.Warn(m.logger).Log("msg", "joining memberlist cluster: failed to reach any nodes", "retries", boff.NumRetries(), "err", err, "discover_nodes", len(nodes))
 		lastErr = err
 
 		boff.Wait()

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -880,7 +880,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 				now := time.Now()
 				t.Log("Update", now.Sub(startTime).String(), ": Ring has", len(r.Members), "members, and", len(r.getAllTokens()),
 					"tokens")
-				return true // yes, keep watching
+				return observedMembers != members // wait until expected members reached
 			})
 			cancel() // make linter happy
 

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -839,7 +839,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 					time.Sleep(testData.startDelayForRest)
 				}
 
-				mkv := NewKV(cfg, log.NewNopLogger(), &delayedDnsProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
+				mkv := NewKV(cfg, log.NewNopLogger(), &delayedDNSProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
 				watcher.WatchService(mkv)
 
 				kv, err := NewClient(mkv, c)
@@ -1507,12 +1507,12 @@ func (p dnsProviderMock) Addresses() []string {
 	return p.resolved
 }
 
-type delayedDnsProviderMock struct {
+type delayedDNSProviderMock struct {
 	resolved []string
 	delay    int
 }
 
-func (p *delayedDnsProviderMock) Resolve(ctx context.Context, addrs []string) error {
+func (p *delayedDNSProviderMock) Resolve(ctx context.Context, addrs []string) error {
 	if p.delay == 0 {
 		p.resolved = make([]string, len(addrs))
 		for _, addr := range addrs {
@@ -1524,6 +1524,6 @@ func (p *delayedDnsProviderMock) Resolve(ctx context.Context, addrs []string) er
 	return nil
 }
 
-func (p delayedDnsProviderMock) Addresses() []string {
+func (p delayedDNSProviderMock) Addresses() []string {
 	return p.resolved
 }

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -762,107 +763,134 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 	const members = 3
 	const key = "ring"
 
-	var clients []*Client
-
-	stop := make(chan struct{})
-	start := make(chan struct{})
-
-	ports, err := getFreePorts(members)
-	require.NoError(t, err)
-
-	watcher := services.NewFailureWatcher()
-	go func() {
-		for {
-			select {
-			case err := <-watcher.Chan():
-				t.Errorf("service reported error: %v", err)
-			case <-stop:
-				return
-			}
-		}
-	}()
-
-	for i, port := range ports {
-		id := fmt.Sprintf("Member-%d", i)
-		var cfg KVConfig
-		flagext.DefaultValues(&cfg)
-		cfg.NodeName = id
-
-		cfg.GossipInterval = 100 * time.Millisecond
-		cfg.GossipNodes = 3
-		cfg.PushPullInterval = 5 * time.Second
-
-		cfg.MinJoinBackoff = 100 * time.Millisecond
-		cfg.MaxJoinBackoff = 1 * time.Minute
-		cfg.MaxJoinRetries = 10
-		cfg.AbortIfJoinFails = true
-
-		cfg.TCPTransport = TCPTransportConfig{
-			BindAddrs: []string{"localhost"},
-			BindPort:  port,
-		}
-
-		cfg.Codecs = []codec.Codec{c}
-
-		if i == 0 {
-			// Add members to first KV config to join immediately on initialization.
-			// This will enforce backoff as each next members listener is not open yet.
-			cfg.JoinMembers = []string{fmt.Sprintf("localhost:%d", ports[1])}
-		} else {
-			// Add delay to each next member to force backoff
-			time.Sleep(1 * time.Second)
-		}
-
-		mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry()) // Not started yet.
-		watcher.WatchService(mkv)
-
-		kv, err := NewClient(mkv, c)
-		require.NoError(t, err)
-
-		clients = append(clients, kv)
-
-		startKVAndRunClient := func(kv *Client, id string, port int) {
-			err = services.StartAndAwaitRunning(context.Background(), mkv)
-			if err != nil {
-				t.Errorf("failed to start KV: %v", err)
-			}
-			err = runClient(kv, id, key, port, time.Second, start, stop)
-			require.NoError(t, err)
-		}
-
-		if i == 0 {
-			go startKVAndRunClient(kv, id, 0)
-		} else {
-			go startKVAndRunClient(kv, id, ports[i-1])
-		}
+	tests := map[string]struct {
+		dnsDelayForFirstKV int
+		startDelayForRest  time.Duration
+		queryType          string
+	}{
+		"Test late start of members with fast join": {
+			dnsDelayForFirstKV: 0,
+			startDelayForRest:  1 * time.Second,
+			queryType:          "",
+		},
+		"Test late start of members with DNS lookup": {
+			dnsDelayForFirstKV: 0,
+			startDelayForRest:  1 * time.Second,
+			queryType:          "dns+",
+		},
+		"Test late start of DNS service": {
+			dnsDelayForFirstKV: 5, // fail DNS lookup for 5 times (fast join and first couple of normal join DNS lookups)
+			startDelayForRest:  0,
+			queryType:          "dns+",
+		},
 	}
 
-	t.Log("Waiting for all members to join memberlist cluster")
-	close(start)
-	time.Sleep(2 * time.Second)
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			var clients []*Client
 
-	t.Log("Observing ring ...")
+			stop := make(chan struct{})
+			start := make(chan struct{})
 
-	startTime := time.Now()
-	firstKv := clients[0]
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	observedMembers := 0
-	firstKv.WatchKey(ctx, key, func(in interface{}) bool {
-		r := in.(*data)
-		observedMembers = len(r.Members)
+			ports, err := getFreePorts(members)
+			require.NoError(t, err)
 
-		now := time.Now()
-		t.Log("Update", now.Sub(startTime).String(), ": Ring has", len(r.Members), "members, and", len(r.getAllTokens()),
-			"tokens")
-		return true // yes, keep watching
-	})
-	cancel() // make linter happy
+			watcher := services.NewFailureWatcher()
+			go func() {
+				for {
+					select {
+					case err := <-watcher.Chan():
+						t.Errorf("service reported error: %v", err)
+					case <-stop:
+						return
+					}
+				}
+			}()
 
-	// Let clients exchange messages for a while
-	close(stop)
+			for i, port := range ports {
+				id := fmt.Sprintf("Member-%d", i)
+				var cfg KVConfig
+				flagext.DefaultValues(&cfg)
+				cfg.NodeName = id
 
-	if observedMembers < members {
-		t.Errorf("expected to see at least %d but saw %d", members, observedMembers)
+				cfg.GossipInterval = 100 * time.Millisecond
+				cfg.GossipNodes = 3
+				cfg.PushPullInterval = 5 * time.Second
+
+				cfg.MinJoinBackoff = 100 * time.Millisecond
+				cfg.MaxJoinBackoff = 1 * time.Minute
+				cfg.MaxJoinRetries = 10
+				cfg.AbortIfJoinFails = true
+
+				cfg.TCPTransport = TCPTransportConfig{
+					BindAddrs: []string{"localhost"},
+					BindPort:  port,
+				}
+
+				cfg.Codecs = []codec.Codec{c}
+				dnsDelay := 0
+				if i == 0 {
+					// Add members to first KV config to join immediately on initialization.
+					// This will enforce backoff as each next members listener is not open yet.
+					cfg.JoinMembers = []string{fmt.Sprintf("%slocalhost:%d", testData.queryType, ports[1])}
+					dnsDelay = testData.dnsDelayForFirstKV
+				} else {
+					// Add possible delay to each next member to force backoff
+					time.Sleep(testData.startDelayForRest)
+				}
+
+				mkv := NewKV(cfg, log.NewNopLogger(), &delayedDnsProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
+				watcher.WatchService(mkv)
+
+				kv, err := NewClient(mkv, c)
+				require.NoError(t, err)
+
+				clients = append(clients, kv)
+
+				startKVAndRunClient := func(kv *Client, id string, port int) {
+					err = services.StartAndAwaitRunning(context.Background(), mkv)
+					if err != nil {
+						t.Errorf("failed to start KV: %v", err)
+					}
+					err = runClient(kv, id, key, port, time.Second, start, stop)
+					require.NoError(t, err)
+				}
+
+				if i < 2 {
+					go startKVAndRunClient(kv, id, 0)
+				} else {
+					go startKVAndRunClient(kv, id, ports[i-1])
+				}
+			}
+
+			t.Log("Waiting for all members to join memberlist cluster")
+			close(start)
+			time.Sleep(2 * time.Second)
+
+			t.Log("Observing ring ...")
+
+			startTime := time.Now()
+			firstKv := clients[0]
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			observedMembers := 0
+			firstKv.WatchKey(ctx, key, func(in interface{}) bool {
+				r := in.(*data)
+				observedMembers = len(r.Members)
+
+				now := time.Now()
+				t.Log("Update", now.Sub(startTime).String(), ": Ring has", len(r.Members), "members, and", len(r.getAllTokens()),
+					"tokens")
+				return true // yes, keep watching
+			})
+			cancel() // make linter happy
+
+			// Let clients exchange messages for a while
+			close(stop)
+
+			if observedMembers < members {
+				t.Errorf("expected to see at least %d but saw %d", members, observedMembers)
+			}
+		})
 	}
 }
 
@@ -1476,5 +1504,26 @@ func (p *dnsProviderMock) Resolve(ctx context.Context, addrs []string) error {
 }
 
 func (p dnsProviderMock) Addresses() []string {
+	return p.resolved
+}
+
+type delayedDnsProviderMock struct {
+	resolved []string
+	delay    int
+}
+
+func (p *delayedDnsProviderMock) Resolve(ctx context.Context, addrs []string) error {
+	if p.delay == 0 {
+		p.resolved = make([]string, len(addrs))
+		for _, addr := range addrs {
+			p.resolved = append(p.resolved, addr[strings.Index(addr, "+")+1:])
+		}
+		return nil
+	}
+	p.delay--
+	return nil
+}
+
+func (p delayedDnsProviderMock) Addresses() []string {
 	return p.resolved
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

When join-members is set, assume that the list of nodes from
discoverMembers should be non zero (eventually). Retry the
discoverMembers with backoff if the result is no nodes instead
of giving up right away and starting without peers.

This fixes the case when K8S DNS is slow to register multiple services,
which happens in low resource Kind cluster in CI.


**Which issue(s) this PR fixes**:

N/A
CI fails in grafana/mimir

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
