### PR TITLE
netutil: remove debug log line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [CHANGE] Memberlist: KV store now fast-joins memberlist cluster before serving any KV requests. #195
 * [CHANGE] Ring: remove duplicate state in NewOp func #203
 * [CHANGE] Memberlist: Increase the leave timeout to 10x the connection timeout, so that we can communicate the leave to at least 1 node, if the first 9 we try to contact times out.
+* [CHANGE] Netutil: removed debug log message "found network interfaces with private IP addresses assigned". #216
 * [CHANGE] Runtimeconfig: Listener channels created by Manager no longer receive current value on every reload period, but only if any configuration file has changed. #218
 * [CHANGE] Services: `FailureWatcher.WatchService()` and `FailureWatcher.WatchManager()` now panic if `FailureWatcher` is `nil`. #219
 * [CHANGE] Memberlist: cluster label verification feature (`-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled`) is now marked as stable. #222

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -2,7 +2,6 @@ package netutil
 
 import (
 	"net"
-	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -53,6 +52,5 @@ func privateNetworkInterfaces(all []net.Interface, fallback []string, logger log
 	if len(privInts) == 0 {
 		return fallback
 	}
-	level.Debug(logger).Log("msg", "found network interfaces with private IP addresses assigned", "interfaces", strings.Join(privInts, " "))
 	return privInts
 }


### PR DESCRIPTION
**What this PR does**:

When running in a container it is the expected state that `eth0` has a private address, so programs using this library always emit debug log lines saying so.

```
level=debug ts=2022-09-01T16:46:48.433117094Z caller=netutil.go:56 msg="found network interfaces with private IP addresses assigned" interfaces=eth0
level=debug ts=2022-09-01T16:46:48.433436393Z caller=netutil.go:56 msg="found network interfaces with private IP addresses assigned" interfaces=eth0
level=debug ts=2022-09-01T16:46:48.433869992Z caller=netutil.go:56 msg="found network interfaces with private IP addresses assigned" interfaces=eth0
level=debug ts=2022-09-01T16:46:48.435141188Z caller=netutil.go:56 msg="found network interfaces with private IP addresses assigned" interfaces=eth0
```

I couldn't figure out what anyone is supposed to learn from that debug message, so I propose to delete it.

**Checklist**
- NA Tests updated
- [x] `CHANGELOG.md` updated