### PR TITLE
Don't unmarshal and merge runtime config files if they haven't changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [CHANGE] Memberlist: KV store now fast-joins memberlist cluster before serving any KV requests. #195
 * [CHANGE] Ring: remove duplicate state in NewOp func #203
 * [CHANGE] Memberlist: Increase the leave timeout to 10x the connection timeout, so that we can communicate the leave to at least 1 node, if the first 9 we try to contact times out.
+* [CHANGE] Runtimeconfig: Listener channels created by Manager no longer receive current value on every reload period, but only if any configuration file has changed. #218
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41
@@ -60,7 +61,7 @@
 * [ENHANCEMENT] ring: optimize shuffle-shard computation when lookback is used, and all instances have registered timestamp within the lookback window. In that case we can immediately return origial ring, because we would select all instances anyway. #181
 * [ENHANCEMENT] Runtimeconfig: Allow providing multiple runtime config yaml files as comma separated list file paths. #183
 * [ENHANCEMENT] Memberlist: Add cluster label support to memberlist client. #187
-* [ENHANCEMENT] Runtimeconfig: Don't unmarshal and merge runtime config yaml files if they haven't changed since last check.
+* [ENHANCEMENT] Runtimeconfig: Don't unmarshal and merge runtime config yaml files if they haven't changed since last check. #218
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [ENHANCEMENT] ring: optimize shuffle-shard computation when lookback is used, and all instances have registered timestamp within the lookback window. In that case we can immediately return origial ring, because we would select all instances anyway. #181
 * [ENHANCEMENT] Runtimeconfig: Allow providing multiple runtime config yaml files as comma separated list file paths. #183
 * [ENHANCEMENT] Memberlist: Add cluster label support to memberlist client. #187
+* [ENHANCEMENT] Runtimeconfig: Don't unmarshal and merge runtime config yaml files if they haven't changed since last check.
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -58,7 +58,7 @@ type Manager struct {
 	configLoadSuccess prometheus.Gauge
 	configHash        *prometheus.GaugeVec
 
-	// Maps path to hash. Only used by loadConfig in Starting and Running, so it doesn't need synchronization.
+	// Maps path to hash. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
 	fileHashes map[string]string
 }
 

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -57,6 +57,9 @@ type Manager struct {
 
 	configLoadSuccess prometheus.Gauge
 	configHash        *prometheus.GaugeVec
+
+	// Maps path to hash. Only used by loadConfig in Starting and Running, so it doesn't need synchronization.
+	fileHashes map[string]string
 }
 
 // New creates an instance of Manager and starts reload config loop based on config
@@ -73,7 +76,7 @@ func New(cfg Config, registerer prometheus.Registerer, logger log.Logger) (*Mana
 		}),
 		configHash: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "runtime_config_hash",
-			Help: "Hash of the currently active runtime config file.",
+			Help: "Hash of the currently active runtime configuration, merged from all configured files.",
 		}, []string{"sha256"}),
 		logger: logger,
 	}
@@ -147,26 +150,51 @@ func (om *Manager) loop(ctx context.Context) error {
 // loadConfig loads all configuration files using the loader function then merges the yaml configuration files into one yaml document.
 // and notifies listeners if successful.
 func (om *Manager) loadConfig() error {
-	mergedConfig := map[string]interface{}{}
+	rawData := map[string][]byte{}
+	hashes := map[string]string{}
+
 	for _, f := range om.cfg.LoadPath {
-		yamlFile := map[string]interface{}{}
 		buf, err := os.ReadFile(f)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
 			return errors.Wrapf(err, "read file %q", f)
 		}
-		err = yaml.Unmarshal(buf, &yamlFile)
+
+		rawData[f] = buf
+		hashes[f] = fmt.Sprintf("%x", sha256.Sum256(buf))
+	}
+
+	// check if new hashes are the same as before
+	sameHashes := true
+	for f, h := range hashes {
+		if om.fileHashes[f] != h {
+			sameHashes = false
+			break
+		}
+	}
+
+	if sameHashes {
+		// No need to rebuild runtime config.
+		return nil
+	}
+
+	mergedConfig := map[string]interface{}{}
+	for _, f := range om.cfg.LoadPath {
+		yamlFile := map[string]interface{}{}
+		err := yaml.Unmarshal(rawData[f], &yamlFile)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
 			return errors.Wrapf(err, "unmarshal file %q", f)
 		}
 		mergedConfig = mergeConfigMaps(mergedConfig, yamlFile)
 	}
+
 	buf, err := yaml.Marshal(mergedConfig)
 	if err != nil {
 		om.configLoadSuccess.Set(0)
 		return errors.Wrap(err, "marshal file")
 	}
+
 	hash := sha256.Sum256(buf)
 	cfg, err := om.cfg.Loader(bytes.NewReader(buf))
 	if err != nil {
@@ -180,7 +208,10 @@ func (om *Manager) loadConfig() error {
 
 	// expose hash of runtime config
 	om.configHash.Reset()
-	om.configHash.WithLabelValues(fmt.Sprintf("%x", hash[:])).Set(1)
+	om.configHash.WithLabelValues(fmt.Sprintf("%x", hash)).Set(1)
+
+	// preserve hashes for next loop
+	om.fileHashes = hashes
 	return nil
 }
 

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/test"
 )
 
 type TestLimits struct {
@@ -54,26 +55,48 @@ func testLoadOverrides(r io.Reader) (interface{}, error) {
 	return overrides, nil
 }
 
-func newTestOverridesManagerConfig(t *testing.T, i int32) (*atomic.Int32, Config) {
-	var config = atomic.NewInt32(i)
+type value struct {
+	Value int `yaml:"value"`
+}
 
+func valueLoader(r io.Reader) (i interface{}, err error) {
+	v := value{Value: 0}
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(buf, &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func writeValueToFile(t *testing.T, path string, v value) {
+	buf, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path+".tmp", buf, 0777))
+	// Atomically replace file with new file, so that manager cannot see unfinished modification.
+	require.NoError(t, os.Rename(path+".tmp", path))
+}
+
+func newTestOverridesManagerConfig(t *testing.T, reloadPeriod time.Duration, loader func(reader io.Reader) (interface{}, error)) Config {
 	// create empty file
 	tempFile, err := os.CreateTemp("", "test-validation")
 	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
 
 	t.Cleanup(func() {
-		tempFile.Close()
-		os.Remove(tempFile.Name())
+		_ = os.Remove(tempFile.Name())
 	})
 
 	// testing runtimeconfig Manager with overrides reload config set
-	return config, Config{
-		ReloadPeriod: 5 * time.Second,
+	return Config{
+		ReloadPeriod: reloadPeriod,
 		LoadPath:     []string{tempFile.Name()},
-		Loader: func(_ io.Reader) (i interface{}, err error) {
-			val := int(config.Load())
-			return val, nil
-		},
+		Loader:       loader,
 	}
 }
 
@@ -284,7 +307,7 @@ func TestManager_ListenerWithDefaultLimits(t *testing.T) {
 
 	// check if the metrics is set to the config map value before
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-					# HELP runtime_config_hash Hash of the currently active runtime config file.
+					# HELP runtime_config_hash Hash of the currently active runtime configuration, merged from all configured files.
 					# TYPE runtime_config_hash gauge
 					runtime_config_hash{sha256="%s"} 1
 					# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
@@ -303,15 +326,12 @@ func TestManager_ListenerWithDefaultLimits(t *testing.T) {
 	err = os.WriteFile(tempFile.Name(), config, 0600)
 	require.NoError(t, err)
 
-	// reload
-	err = overridesManager.loadConfig()
-	require.NoError(t, err)
-
+	// Wait for reload.
 	var newValue interface{}
 	select {
 	case newValue = <-ch:
 		// ok
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("listener was not called")
 	}
 
@@ -321,7 +341,7 @@ func TestManager_ListenerWithDefaultLimits(t *testing.T) {
 
 	// check if the metrics have been updated
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-					# HELP runtime_config_hash Hash of the currently active runtime config file.
+					# HELP runtime_config_hash Hash of the currently active runtime configuration, merged from all configured files.
 					# TYPE runtime_config_hash gauge
 					runtime_config_hash{sha256="%s"} 1
 					# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
@@ -337,33 +357,31 @@ func TestManager_ListenerWithDefaultLimits(t *testing.T) {
 }
 
 func TestManager_ListenerChannel(t *testing.T) {
-	config, overridesManagerConfig := newTestOverridesManagerConfig(t, 555)
+	cfg := newTestOverridesManagerConfig(t, 500*time.Millisecond, valueLoader)
 
-	overridesManager, err := New(overridesManagerConfig, nil, log.NewNopLogger())
+	writeValueToFile(t, cfg.LoadPath.String(), value{Value: 555})
+
+	overridesManager, err := New(cfg, nil, log.NewNopLogger())
 	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
 	// need to use buffer, otherwise loadConfig will throw away update
 	ch := overridesManager.CreateListenerChannel(1)
 
-	err = overridesManager.loadConfig()
-	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
 	select {
 	case newValue := <-ch:
-		require.Equal(t, 555, newValue)
-	case <-time.After(time.Second):
+		require.Equal(t, value{Value: 555}, newValue)
+	case <-time.After(5 * time.Second):
 		t.Fatal("listener was not called")
 	}
 
-	config.Store(1111)
-	err = overridesManager.loadConfig()
-	require.NoError(t, err)
+	writeValueToFile(t, cfg.LoadPath.String(), value{Value: 1111})
 
 	select {
 	case newValue := <-ch:
-		require.Equal(t, 1111, newValue)
-	case <-time.After(time.Second):
+		require.Equal(t, value{Value: 1111}, newValue)
+	case <-time.After(5 * time.Second):
 		t.Fatal("listener was not called")
 	}
 
@@ -377,13 +395,12 @@ func TestManager_ListenerChannel(t *testing.T) {
 }
 
 func TestManager_StopClosesListenerChannels(t *testing.T) {
-	_, overridesManagerConfig := newTestOverridesManagerConfig(t, 555)
+	cfg := newTestOverridesManagerConfig(t, time.Second, valueLoader)
 
-	overridesManager, err := New(overridesManagerConfig, nil, log.NewNopLogger())
+	overridesManager, err := New(cfg, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
-	// need to use buffer, otherwise loadConfig will throw away update
 	ch := overridesManager.CreateListenerChannel(0)
 
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
@@ -418,4 +435,38 @@ func TestManager_ShouldFastFailOnInvalidConfigAtStartup(t *testing.T) {
 	m, err := New(cfg, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.Error(t, services.StartAndAwaitRunning(context.Background(), m))
+}
+
+func TestManager_UnchangedFileDoesntTriggerReload(t *testing.T) {
+	loadCounter := atomic.NewInt32(0)
+
+	cfg := newTestOverridesManagerConfig(t, 100*time.Millisecond, func(reader io.Reader) (interface{}, error) {
+		loadCounter.Inc()
+		return valueLoader(reader)
+	})
+
+	overridesManager, err := New(cfg, nil, log.NewNopLogger())
+	require.NoError(t, err)
+
+	ch := overridesManager.CreateListenerChannel(10) // must be big enough to hold all modifications.
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
+
+	test.Poll(t, time.Second, 1, func() interface{} {
+		return int(loadCounter.Load())
+	})
+
+	// Let's make some modifications to the config
+	const mods = 3
+	const modDelay = 500 * time.Millisecond
+	for i := 0; i < mods; i++ {
+		writeValueToFile(t, cfg.LoadPath[0], value{Value: i})
+		// wait before next rewrite, but also after last rewrite to give manager a chance to reload the file again
+		time.Sleep(modDelay)
+	}
+
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
+
+	assert.Equal(t, int(loadCounter.Load()), mods+1)  // + 1 for initial load, before modifications
+	assert.Equal(t, int(loadCounter.Load()), len(ch)) // Loaded values
 }

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -75,6 +75,7 @@ func valueLoader(r io.Reader) (i interface{}, err error) {
 }
 
 func writeValueToFile(t *testing.T, path string, v value) {
+	t.Helper()
 	buf, err := yaml.Marshal(v)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path+".tmp", buf, 0777))
@@ -467,6 +468,6 @@ func TestManager_UnchangedFileDoesntTriggerReload(t *testing.T) {
 
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
 
-	assert.Equal(t, int(loadCounter.Load()), mods+1)  // + 1 for initial load, before modifications
-	assert.Equal(t, int(loadCounter.Load()), len(ch)) // Loaded values
+	assert.Equal(t, mods+1, int(loadCounter.Load())) // + 1 for initial load, before modifications
+	assert.Equal(t, mods+1, len(ch))                 // Loaded values
 }


### PR DESCRIPTION
**What this PR does**:

This PR modifies `runtimeconfig.Manager` to avoid unmarshaling and merging config files that haven't changed since last check.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
