### PR TITLE
Make FailureWatcher.WatchService() and FailureWatcher.WatchManager() panic if FailureWatcher is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [CHANGE] Ring: remove duplicate state in NewOp func #203
 * [CHANGE] Memberlist: Increase the leave timeout to 10x the connection timeout, so that we can communicate the leave to at least 1 node, if the first 9 we try to contact times out.
 * [CHANGE] Runtimeconfig: Listener channels created by Manager no longer receive current value on every reload period, but only if any configuration file has changed. #218
+* [CHANGE] Services: `FailureWatcher.WatchService()` and `FailureWatcher.WatchManager()` now panic if `FailureWatcher` is `nil`. #219
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/services/failure_watch_test.go
+++ b/services/failure_watch_test.go
@@ -14,6 +14,19 @@ func TestNilServiceFailureWatcher(t *testing.T) {
 
 	// prove it doesn't fail, but returns nil channel.
 	require.Nil(t, w.Chan())
+
+	// Ensure WatchService() panics.
+	require.Panics(t, func() {
+		w.WatchService(NewIdleService(nil, nil))
+	})
+
+	// Ensure WatchManager() panics.
+	m, err := NewManager(NewIdleService(nil, nil))
+	require.NoError(t, err)
+
+	require.Panics(t, func() {
+		w.WatchManager(m)
+	})
 }
 
 func TestServiceFailureWatcher(t *testing.T) {

--- a/services/failure_watcher.go
+++ b/services/failure_watcher.go
@@ -4,6 +4,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	failureWatcherNotInitializedErr = errors.New("FailureWatcher has not been initialized")
+)
+
 // FailureWatcher waits for service failures, and passed them to the channel.
 type FailureWatcher struct {
 	ch chan error
@@ -16,6 +20,8 @@ func NewFailureWatcher() *FailureWatcher {
 // Chan returns channel for this watcher. If watcher is nil, returns nil channel.
 // Errors returned on the channel include failure case and service description.
 func (w *FailureWatcher) Chan() <-chan error {
+	// Graceful handle the case FailureWatcher has not been initialized,
+	// to simplify the code in the components using it.
 	if w == nil {
 		return nil
 	}
@@ -23,12 +29,24 @@ func (w *FailureWatcher) Chan() <-chan error {
 }
 
 func (w *FailureWatcher) WatchService(service Service) {
+	// Ensure that if the caller request to watch a service, then the FailureWatcher
+	// has been initialized.
+	if w == nil {
+		panic(failureWatcherNotInitializedErr)
+	}
+
 	service.AddListener(NewListener(nil, nil, nil, nil, func(from State, failure error) {
 		w.ch <- errors.Wrapf(failure, "service %s failed", DescribeService(service))
 	}))
 }
 
 func (w *FailureWatcher) WatchManager(manager *Manager) {
+	// Ensure that if the caller request to watch services, then the FailureWatcher
+	// has been initialized.
+	if w == nil {
+		panic(failureWatcherNotInitializedErr)
+	}
+
 	manager.AddListener(NewManagerListener(nil, nil, func(service Service) {
 		w.ch <- errors.Wrapf(service.FailureCase(), "service %s failed", DescribeService(service))
 	}))

--- a/services/failure_watcher.go
+++ b/services/failure_watcher.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	failureWatcherNotInitializedErr = errors.New("FailureWatcher has not been initialized")
+	errFailureWatcherNotInitialized = errors.New("FailureWatcher has not been initialized")
 )
 
 // FailureWatcher waits for service failures, and passed them to the channel.
@@ -32,7 +32,7 @@ func (w *FailureWatcher) WatchService(service Service) {
 	// Ensure that if the caller request to watch a service, then the FailureWatcher
 	// has been initialized.
 	if w == nil {
-		panic(failureWatcherNotInitializedErr)
+		panic(errFailureWatcherNotInitialized)
 	}
 
 	service.AddListener(NewListener(nil, nil, nil, nil, func(from State, failure error) {
@@ -44,7 +44,7 @@ func (w *FailureWatcher) WatchManager(manager *Manager) {
 	// Ensure that if the caller request to watch services, then the FailureWatcher
 	// has been initialized.
 	if w == nil {
-		panic(failureWatcherNotInitializedErr)
+		panic(errFailureWatcherNotInitialized)
 	}
 
 	manager.AddListener(NewManagerListener(nil, nil, func(service Service) {


### PR DESCRIPTION
**What this PR does**:
Today I realized few places in Mimir where we were using `FailureWatcher` but it was `nil`, so it was doing nothing (fixed in https://github.com/grafana/mimir/pull/2978). Finding these bugs is very hard, so I propose to make `FailureWatcher.WatchService()` and `FailureWatcher.WatchManager()` panicking very loudly if that happens.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
