### PR TITLE
Mark memberlist cluster label config as advanced

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -141,8 +141,8 @@ type KVConfig struct {
 	AdvertiseAddr string `yaml:"advertise_addr"`
 	AdvertisePort int    `yaml:"advertise_port"`
 
-	ClusterLabel                     string `yaml:"cluster_label"`
-	ClusterLabelVerificationDisabled bool   `yaml:"cluster_label_verification_disabled"`
+	ClusterLabel                     string `yaml:"cluster_label" category:"advanced"`
+	ClusterLabelVerificationDisabled bool   `yaml:"cluster_label_verification_disabled" category:"advanced"`
 
 	// List of members to join
 	JoinMembers      flagext.StringSlice `yaml:"join_members"`


### PR DESCRIPTION
**What this PR does**:
In https://github.com/grafana/dskit/pull/222 I've removed the experimental categorization from memberlist cluster label config, but I think it's better to switch to advanced. We currently consider "basic" config the options that you have to configure to get it working (or config we expect everyone to set), while I think the cluster label is more for an advanced usage (e.g. multiple memberlist clusters deployed).

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
