### PR TITLE
multierror: add provenance

### DIFF
--- a/multierror/multierror.go
+++ b/multierror/multierror.go
@@ -1,3 +1,6 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/2027fb30/pkg/errutil/multierror.go
+// Provenance-includes-copyright: The Thanos Authors.
+
 package multierror
 
 import (


### PR DESCRIPTION
**What this PR does**:

Add back the copyright notice we are required to retain under Apache 2 licence.
I did it in the style we have used elsewhere, pared down to the minimum as this repo is also under Apache 2.
Commit hash was derived from the date of #21.

**Checklist**
- NA Tests updated
- NA `CHANGELOG.md` updated 
