### PR TITLE
Add the ability to define custom gRPC health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@
 * [ENHANCEMENT] Runtimeconfig: Don't unmarshal and merge runtime config yaml files if they haven't changed since last check. #218
 * [ENHANCEMENT] ring: DoBatch now differentiates between 4xx and 5xx GRPC errors and keeps track of them separately. It only returns when there is a quorum of either error class. If your errors do not implement `GRPCStatus() *Status` from google.golang.org/grpc/status, then this change does not affect you. #201
 * [ENHANCEMENT] Added `<prefix>.tls-min-version` and `<prefix>.tls-cipher-suites` flags to client configurations. #217
-* [ENHANCEMENT] Concurrency: Add LimitedConcurrencySingleFlight to run jobs concurrently and with in-flight deduplication. 214
+* [ENHANCEMENT] Concurrency: Add LimitedConcurrencySingleFlight to run jobs concurrently and with in-flight deduplication. #214
+* [ENHANCEMENT] Add the ability to define custom gRPC health checks. #227
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/grpcutil/health_check.go
+++ b/grpcutil/health_check.go
@@ -4,29 +4,64 @@ import (
 	"context"
 
 	"github.com/gogo/status"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/dskit/services"
 )
 
+// Check is a function that determines if this gRPC application is healthy.
+type Check func(ctx context.Context) bool
+
+// WithManager returns a new Check that tests if the managed services are healthy.
+func WithManager(manager *services.Manager) Check {
+	return func(ctx context.Context) bool {
+		states := manager.ServicesByState()
+
+		// Given this is a health check endpoint for the whole instance, we should consider
+		// it healthy after all services have been started (running) and until all
+		// services are terminated. Some services, like ingesters, are still
+		// fully functioning while stopping.
+		if len(states[services.New]) > 0 || len(states[services.Starting]) > 0 || len(states[services.Failed]) > 0 {
+			return false
+		}
+
+		return len(states[services.Running]) > 0 || len(states[services.Stopping]) > 0
+	}
+}
+
+// WithShutdownRequested returns a new Check that returns false when shutting down.
+func WithShutdownRequested(requested *atomic.Bool) Check {
+	return func(ctx context.Context) bool {
+		return !requested.Load()
+	}
+}
+
 // HealthCheck fulfills the grpc_health_v1.HealthServer interface by ensuring
-// the services being managed by the provided service manager are healthy.
+// each of the provided Checks indicates the application is healthy.
 type HealthCheck struct {
-	sm *services.Manager
+	checks []Check
 }
 
 // NewHealthCheck returns a new HealthCheck for the provided service manager.
 func NewHealthCheck(sm *services.Manager) *HealthCheck {
+	return NewHealthCheckFrom(WithManager(sm))
+}
+
+// NewHealthCheckFrom returns a new HealthCheck that uses each of the provided Checks.
+func NewHealthCheckFrom(checks ...Check) *HealthCheck {
 	return &HealthCheck{
-		sm: sm,
+		checks: checks,
 	}
 }
 
 // Check implements the grpc healthcheck.
-func (h *HealthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	if !h.isHealthy() {
-		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+func (h *HealthCheck) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	for _, check := range h.checks {
+		if !check(ctx) {
+			return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+		}
 	}
 
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
@@ -35,19 +70,4 @@ func (h *HealthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequ
 // Watch implements the grpc healthcheck.
 func (h *HealthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
 	return status.Error(codes.Unimplemented, "Watching is not supported")
-}
-
-// isHealthy returns whether the instance should be considered healthy.
-func (h *HealthCheck) isHealthy() bool {
-	states := h.sm.ServicesByState()
-
-	// Given this is an health check endpoint for the whole instance, we should consider
-	// it healthy after all services have been started (running) and until all
-	// services are terminated. Some services, like ingesters, are still
-	// fully functioning while stopping.
-	if len(states[services.New]) > 0 || len(states[services.Starting]) > 0 || len(states[services.Failed]) > 0 {
-		return false
-	}
-
-	return len(states[services.Running]) > 0 || len(states[services.Stopping]) > 0
 }


### PR DESCRIPTION
**What this PR does**:

Extend the gRPC HealthCheck struct to allow it to make use of multiple types of health checks such as a services.Manager or atomic.Bool shutdown request.

**Which issue(s) this PR fixes**:

See grafana/mimir#3298

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
