### PR TITLE
Import Bytes type, DeleteAll function and DNS package from Thanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [ENHANCEMENT] Added `<prefix>.tls-min-version` and `<prefix>.tls-cipher-suites` flags to client configurations. #217
 * [ENHANCEMENT] Concurrency: Add LimitedConcurrencySingleFlight to run jobs concurrently and with in-flight deduplication. #214
 * [ENHANCEMENT] Add the ability to define custom gRPC health checks. #227
+* [ENHANCEMENT] Import Bytes type, DeleteAll function and DNS package from Thanos. #228
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/dns/godns/resolver.go
+++ b/dns/godns/resolver.go
@@ -1,0 +1,26 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/discovery/dns/godns/resolver.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package godns
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+// Resolver is a wrapper for net.Resolver.
+type Resolver struct {
+	*net.Resolver
+}
+
+// IsNotFound checkout if DNS record is not found.
+func (r *Resolver) IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	err = errors.Cause(err)
+	dnsErr, ok := err.(*net.DNSError)
+	return ok && dnsErr.IsNotFound
+}

--- a/dns/miekgdns/lookup.go
+++ b/dns/miekgdns/lookup.go
@@ -1,0 +1,157 @@
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/be3c082539d8/discovery/dns/dns.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/discovery/dns/miekgdns/provider.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package miekgdns
+
+import (
+	"bytes"
+	"net"
+
+	"github.com/miekg/dns"
+	"github.com/pkg/errors"
+)
+
+var ErrNoSuchHost = errors.New("no such host")
+
+// Copied and slightly adjusted from Prometheus DNS SD:
+// https://github.com/prometheus/prometheus/blob/be3c082539d85908ce03b6d280f83343e7c930eb/discovery/dns/dns.go#L212
+
+// lookupWithSearchPath tries to get an answer for various permutations of
+// the given name, appending the system-configured search path as necessary.
+//
+// There are three possible outcomes:
+//
+//  1. One of the permutations of the given name is recognized as
+//     "valid" by the DNS, in which case we consider ourselves "done"
+//     and that answer is returned.  Note that, due to the way the DNS
+//     handles "name has resource records, but none of the specified type",
+//     the answer received may have an empty set of results.
+//
+//  2. All of the permutations of the given name are responded to by one of
+//     the servers in the "nameservers" list with the answer "that name does
+//     not exist" (NXDOMAIN).  In that case, it can be considered
+//     pseudo-authoritative that there are no records for that name.
+//
+//  3. One or more of the names was responded to by all servers with some
+//     sort of error indication.  In that case, we can't know if, in fact,
+//     there are records for the name or not, so whatever state the
+//     configuration is in, we should keep it that way until we know for
+//     sure (by, presumably, all the names getting answers in the future).
+//
+// Outcomes 1 and 2 are indicated by a valid response message (possibly an
+// empty one) and no error.  Outcome 3 is indicated by an error return.  The
+// error will be generic-looking, because trying to return all the errors
+// returned by the combination of all name permutations and servers is a
+// nightmare.
+func (r *Resolver) lookupWithSearchPath(name string, qtype dns.Type) (*dns.Msg, error) {
+	conf, err := dns.ClientConfigFromFile(r.ResolvConf)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not load resolv.conf: %s", err)
+	}
+
+	var errs []error
+	for _, lname := range conf.NameList(name) {
+		response, err := lookupFromAnyServer(lname, qtype, conf)
+		if err != nil {
+			// We can't go home yet, because a later name
+			// may give us a valid, successful answer.  However
+			// we can no longer say "this name definitely doesn't
+			// exist", because we did not get that answer for
+			// at least one name.
+			errs = append(errs, err)
+			continue
+		}
+
+		if response.Rcode == dns.RcodeSuccess {
+			// Outcome 1: GOLD!
+			return response, nil
+		}
+	}
+
+	if len(errs) == 0 {
+		// Outcome 2: everyone says NXDOMAIN.
+		return &dns.Msg{}, ErrNoSuchHost
+	}
+	// Outcome 3: boned.
+	return nil, errors.Errorf("could not resolve %q: all servers responded with errors to at least one search domain. Errs %s", name, fmtErrs(errs))
+}
+
+// lookupFromAnyServer uses all configured servers to try and resolve a specific
+// name.  If a viable answer is received from a server, then it is
+// immediately returned, otherwise the other servers in the config are
+// tried, and if none of them return a viable answer, an error is returned.
+//
+// A "viable answer" is one which indicates either:
+//
+//  1. "yes, I know that name, and here are its records of the requested type"
+//     (RCODE==SUCCESS, ANCOUNT > 0);
+//  2. "yes, I know that name, but it has no records of the requested type"
+//     (RCODE==SUCCESS, ANCOUNT==0); or
+//  3. "I know that name doesn't exist" (RCODE==NXDOMAIN).
+//
+// A non-viable answer is "anything else", which encompasses both various
+// system-level problems (like network timeouts) and also
+// valid-but-unexpected DNS responses (SERVFAIL, REFUSED, etc).
+func lookupFromAnyServer(name string, qtype dns.Type, conf *dns.ClientConfig) (*dns.Msg, error) {
+	client := &dns.Client{}
+
+	var errs []error
+
+	// TODO(bwplotka): Worth to do fanout and grab fastest as golang native lib?
+	for _, server := range conf.Servers {
+		servAddr := net.JoinHostPort(server, conf.Port)
+		msg, err := askServerForName(name, qtype, client, servAddr, true)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "resolution against server %s for %s", server, name))
+			continue
+		}
+
+		if msg.Rcode == dns.RcodeSuccess || msg.Rcode == dns.RcodeNameError {
+			return msg, nil
+		}
+	}
+
+	return nil, errors.Errorf("could not resolve %s: no servers returned a viable answer. Errs %v", name, fmtErrs(errs))
+}
+
+func fmtErrs(errs []error) string {
+	b := bytes.Buffer{}
+	for _, err := range errs {
+		b.WriteString(";")
+		b.WriteString(err.Error())
+	}
+	return b.String()
+}
+
+// askServerForName makes a request to a specific DNS server for a specific
+// name (and qtype). Retries with TCP in the event of response truncation,
+// but otherwise just sends back whatever the server gave, whether that be a
+// valid-looking response, or an error.
+func askServerForName(name string, qType dns.Type, client *dns.Client, servAddr string, edns bool) (*dns.Msg, error) {
+	msg := &dns.Msg{}
+
+	msg.SetQuestion(dns.Fqdn(name), uint16(qType))
+	if edns {
+		msg.SetEdns0(dns.DefaultMsgSize, false)
+	}
+
+	response, _, err := client.Exchange(msg, servAddr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "exchange")
+	}
+
+	if response.Truncated {
+		if client.Net == "tcp" {
+			return nil, errors.New("got truncated message on TCP (64kiB limit exceeded?)")
+		}
+
+		// TCP fallback.
+		client.Net = "tcp"
+		return askServerForName(name, qType, client, servAddr, false)
+	}
+
+	return response, nil
+}

--- a/dns/miekgdns/resolver.go
+++ b/dns/miekgdns/resolver.go
@@ -1,0 +1,95 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/discovery/dns/miekgdns/resolver.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package miekgdns
+
+import (
+	"context"
+	"net"
+
+	"github.com/miekg/dns"
+	"github.com/pkg/errors"
+)
+
+// DefaultResolvConfPath is a common, default resolv.conf file present on linux server.
+const DefaultResolvConfPath = "/etc/resolv.conf"
+
+// Resolver is a drop-in Resolver for *part* of std lib Golang net.DefaultResolver methods.
+type Resolver struct {
+	ResolvConf string
+}
+
+func (r *Resolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	var target string
+	if service == "" && proto == "" {
+		target = name
+	} else {
+		target = "_" + service + "._" + proto + "." + name
+	}
+
+	response, err := r.lookupWithSearchPath(target, dns.Type(dns.TypeSRV))
+	if err != nil {
+		return "", nil, err
+	}
+
+	for _, record := range response.Answer {
+		switch addr := record.(type) {
+		case *dns.SRV:
+			addrs = append(addrs, &net.SRV{
+				Weight:   addr.Weight,
+				Target:   addr.Target,
+				Priority: addr.Priority,
+				Port:     addr.Port,
+			})
+		default:
+			return "", nil, errors.Errorf("invalid SRV response record %s", record)
+		}
+	}
+
+	return "", addrs, nil
+}
+
+func (r *Resolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
+	return r.lookupIPAddr(host, 1, 8)
+}
+
+func (r *Resolver) lookupIPAddr(host string, currIteration, maxIterations int) ([]net.IPAddr, error) {
+	// We want to protect from infinite loops when resolving DNS records recursively.
+	if currIteration > maxIterations {
+		return nil, errors.Errorf("maximum number of recursive iterations reached (%d)", maxIterations)
+	}
+
+	response, err := r.lookupWithSearchPath(host, dns.Type(dns.TypeAAAA))
+	if err != nil || len(response.Answer) == 0 {
+		// Ugly fallback to A lookup.
+		response, err = r.lookupWithSearchPath(host, dns.Type(dns.TypeA))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var resp []net.IPAddr
+	for _, record := range response.Answer {
+		switch addr := record.(type) {
+		case *dns.A:
+			resp = append(resp, net.IPAddr{IP: addr.A})
+		case *dns.AAAA:
+			resp = append(resp, net.IPAddr{IP: addr.AAAA})
+		case *dns.CNAME:
+			// Recursively resolve it.
+			addrs, err := r.lookupIPAddr(addr.Target, currIteration+1, maxIterations)
+			if err != nil {
+				return nil, errors.Wrapf(err, "recursively resolve %s", addr.Target)
+			}
+			resp = append(resp, addrs...)
+		default:
+			return nil, errors.Errorf("invalid A, AAAA or CNAME response record %s", record)
+		}
+	}
+	return resp, nil
+}
+
+func (r *Resolver) IsNotFound(err error) bool {
+	return errors.Is(errors.Cause(err), ErrNoSuchHost)
+}

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -1,0 +1,167 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/discovery/provider.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package dns
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/dskit/dns/godns"
+	"github.com/grafana/dskit/dns/miekgdns"
+	"github.com/grafana/dskit/multierror"
+	"github.com/thanos-io/thanos/pkg/extprom"
+)
+
+// Provider is a stateful cache for asynchronous DNS resolutions. It provides a way to resolve addresses and obtain them.
+type Provider struct {
+	sync.RWMutex
+	resolver Resolver
+	// A map from domain name to a slice of resolved targets.
+	resolved map[string][]string
+	logger   log.Logger
+
+	resolverAddrs         *extprom.TxGaugeVec
+	resolverLookupsCount  prometheus.Counter
+	resolverFailuresCount prometheus.Counter
+}
+
+type ResolverType string
+
+const (
+	GolangResolverType   ResolverType = "golang"
+	MiekgdnsResolverType ResolverType = "miekgdns"
+)
+
+func (t ResolverType) ToResolver(logger log.Logger) ipLookupResolver {
+	var r ipLookupResolver
+	switch t {
+	case GolangResolverType:
+		r = &godns.Resolver{Resolver: net.DefaultResolver}
+	case MiekgdnsResolverType:
+		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath}
+	default:
+		level.Warn(logger).Log("msg", "no such resolver type, defaulting to golang", "type", t)
+		r = &godns.Resolver{Resolver: net.DefaultResolver}
+	}
+	return r
+}
+
+// NewProvider returns a new empty provider with a given resolver type.
+// If empty resolver type is net.DefaultResolver.
+func NewProvider(logger log.Logger, reg prometheus.Registerer, resolverType ResolverType) *Provider {
+	p := &Provider{
+		resolver: NewResolver(resolverType.ToResolver(logger), logger),
+		resolved: make(map[string][]string),
+		logger:   logger,
+		resolverAddrs: extprom.NewTxGaugeVec(reg, prometheus.GaugeOpts{
+			Name: "dns_provider_results",
+			Help: "The number of resolved endpoints for each configured address",
+		}, []string{"addr"}),
+		resolverLookupsCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "dns_lookups_total",
+			Help: "The number of DNS lookups resolutions attempts",
+		}),
+		resolverFailuresCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "dns_failures_total",
+			Help: "The number of DNS lookup failures",
+		}),
+	}
+
+	return p
+}
+
+// Clone returns a new provider from an existing one.
+func (p *Provider) Clone() *Provider {
+	return &Provider{
+		resolver:              p.resolver,
+		resolved:              make(map[string][]string),
+		logger:                p.logger,
+		resolverAddrs:         p.resolverAddrs,
+		resolverLookupsCount:  p.resolverLookupsCount,
+		resolverFailuresCount: p.resolverFailuresCount,
+	}
+}
+
+// IsDynamicNode returns if the specified StoreAPI addr uses
+// any kind of SD mechanism.
+func IsDynamicNode(addr string) bool {
+	qtype, _ := GetQTypeName(addr)
+	return qtype != ""
+}
+
+// GetQTypeName splits the provided addr into two parts: the QType (if any)
+// and the name.
+func GetQTypeName(addr string) (qtype, name string) {
+	qtypeAndName := strings.SplitN(addr, "+", 2)
+	if len(qtypeAndName) != 2 {
+		return "", addr
+	}
+	return qtypeAndName[0], qtypeAndName[1]
+}
+
+// Resolve stores a list of provided addresses or their DNS records if requested.
+// Addresses prefixed with `dns+` or `dnssrv+` will be resolved through respective DNS lookup (A/AAAA or SRV).
+// For non-SRV records, it will return an error if a port is not supplied.
+func (p *Provider) Resolve(ctx context.Context, addrs []string) error {
+	resolvedAddrs := map[string][]string{}
+	errs := multierror.MultiError{}
+
+	for _, addr := range addrs {
+		var resolved []string
+		qtype, name := GetQTypeName(addr)
+		if qtype == "" {
+			resolvedAddrs[name] = []string{name}
+			continue
+		}
+
+		resolved, err := p.resolver.Resolve(ctx, name, QType(qtype))
+		p.resolverLookupsCount.Inc()
+		if err != nil {
+			// Append all the failed dns resolution in the error list.
+			errs.Add(err)
+			// The DNS resolution failed. Continue without modifying the old records.
+			p.resolverFailuresCount.Inc()
+			// Use cached values.
+			p.RLock()
+			resolved = p.resolved[addr]
+			p.RUnlock()
+		}
+		resolvedAddrs[addr] = resolved
+	}
+
+	// All addresses have been resolved. We can now take an exclusive lock to
+	// update the resolved addresses metric and update the local state.
+	p.Lock()
+	defer p.Unlock()
+
+	p.resolverAddrs.ResetTx()
+	for name, addrs := range resolvedAddrs {
+		p.resolverAddrs.WithLabelValues(name).Set(float64(len(addrs)))
+	}
+	p.resolverAddrs.Submit()
+
+	p.resolved = resolvedAddrs
+
+	return errs.Err()
+}
+
+// Addresses returns the latest addresses present in the Provider.
+func (p *Provider) Addresses() []string {
+	p.RLock()
+	defer p.RUnlock()
+
+	var result []string
+	for _, addrs := range p.resolved {
+		result = append(result, addrs...)
+	}
+	return result
+}

--- a/dns/provider_test.go
+++ b/dns/provider_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package dns
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/go-kit/log"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestProvider(t *testing.T) {
+	ips := []string{
+		"127.0.0.1:19091",
+		"127.0.0.2:19092",
+		"127.0.0.3:19093",
+		"127.0.0.4:19094",
+		"127.0.0.5:19095",
+	}
+
+	prv := NewProvider(log.NewNopLogger(), nil, "")
+	prv.resolver = &mockResolver{
+		res: map[string][]string{
+			"a": ips[:2],
+			"b": ips[2:4],
+			"c": {ips[4]},
+		},
+	}
+	ctx := context.TODO()
+
+	err := prv.Resolve(ctx, []string{"any+x"})
+	testutil.Ok(t, err)
+	result := prv.Addresses()
+	sort.Strings(result)
+	testutil.Equals(t, []string(nil), result)
+	testutil.Equals(t, 1, promtestutil.CollectAndCount(prv.resolverAddrs))
+	testutil.Equals(t, float64(0), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+x")))
+
+	err = prv.Resolve(ctx, []string{"any+a", "any+b", "any+c"})
+	testutil.Ok(t, err)
+	result = prv.Addresses()
+	sort.Strings(result)
+	testutil.Equals(t, ips, result)
+	testutil.Equals(t, 3, promtestutil.CollectAndCount(prv.resolverAddrs))
+	testutil.Equals(t, float64(2), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+a")))
+	testutil.Equals(t, float64(2), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+b")))
+	testutil.Equals(t, float64(1), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+c")))
+
+	err = prv.Resolve(ctx, []string{"any+b", "any+c"})
+	testutil.Ok(t, err)
+	result = prv.Addresses()
+	sort.Strings(result)
+	testutil.Equals(t, ips[2:], result)
+	testutil.Equals(t, 2, promtestutil.CollectAndCount(prv.resolverAddrs))
+	testutil.Equals(t, float64(2), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+b")))
+	testutil.Equals(t, float64(1), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+c")))
+
+	err = prv.Resolve(ctx, []string{"any+x"})
+	testutil.Ok(t, err)
+	result = prv.Addresses()
+	sort.Strings(result)
+	testutil.Equals(t, []string(nil), result)
+	testutil.Equals(t, 1, promtestutil.CollectAndCount(prv.resolverAddrs))
+	testutil.Equals(t, float64(0), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+x")))
+
+	err = prv.Resolve(ctx, []string{"any+a", "any+b", "any+c"})
+	testutil.Ok(t, err)
+	result = prv.Addresses()
+	sort.Strings(result)
+	testutil.Equals(t, ips, result)
+	testutil.Equals(t, 3, promtestutil.CollectAndCount(prv.resolverAddrs))
+	testutil.Equals(t, float64(2), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+a")))
+	testutil.Equals(t, float64(2), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+b")))
+	testutil.Equals(t, float64(1), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+c")))
+
+	err = prv.Resolve(ctx, []string{"any+b", "example.com:90", "any+c"})
+	testutil.Ok(t, err)
+	result = prv.Addresses()
+	sort.Strings(result)
+	testutil.Equals(t, append(ips[2:], "example.com:90"), result)
+	testutil.Equals(t, 3, promtestutil.CollectAndCount(prv.resolverAddrs))
+	testutil.Equals(t, float64(2), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+b")))
+	testutil.Equals(t, float64(1), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("example.com:90")))
+	testutil.Equals(t, float64(1), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+c")))
+
+	err = prv.Resolve(ctx, []string{"any+b", "any+c"})
+	testutil.Ok(t, err)
+	result = prv.Addresses()
+	sort.Strings(result)
+	testutil.Equals(t, ips[2:], result)
+	testutil.Equals(t, 2, promtestutil.CollectAndCount(prv.resolverAddrs))
+	testutil.Equals(t, float64(2), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+b")))
+	testutil.Equals(t, float64(1), promtestutil.ToFloat64(prv.resolverAddrs.WithLabelValues("any+c")))
+
+}
+
+type mockResolver struct {
+	res map[string][]string
+	err error
+}
+
+func (d *mockResolver) Resolve(_ context.Context, name string, _ QType) ([]string, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	return d.res[name], nil
+}
+
+// TestIsDynamicNode tests whether we properly catch dynamically defined nodes.
+func TestIsDynamicNode(t *testing.T) {
+	for _, tcase := range []struct {
+		node      string
+		isDynamic bool
+	}{
+		{
+			node:      "1.2.3.4",
+			isDynamic: false,
+		},
+		{
+			node:      "gibberish+1.1.1.1+noa",
+			isDynamic: true,
+		},
+		{
+			node:      "",
+			isDynamic: false,
+		},
+		{
+			node:      "dns+aaa",
+			isDynamic: true,
+		},
+		{
+			node:      "dnssrv+asdasdsa",
+			isDynamic: true,
+		},
+	} {
+		isDynamic := IsDynamicNode(tcase.node)
+		testutil.Equals(t, tcase.isDynamic, isDynamic, "mismatch between results")
+	}
+}

--- a/dns/provider_test.go
+++ b/dns/provider_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
-
-	"github.com/thanos-io/thanos/pkg/testutil"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProvider(t *testing.T) {
@@ -40,65 +39,65 @@ func TestProvider(t *testing.T) {
 		# TYPE dns_provider_results gauge
 		`
 		expected := strings.NewReader(metadata + metrics + "\n")
-		testutil.Ok(t, promtestutil.CollectAndCompare(prv, expected))
+		assert.NoError(t, testutil.CollectAndCompare(prv, expected))
 	}
 	err := prv.Resolve(ctx, []string{"any+x"})
-	testutil.Ok(t, err)
+	assert.NoError(t, err)
 	result := prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, []string(nil), result)
+	assert.Equal(t, []string(nil), result)
 	checkMetrics(`dns_provider_results{addr="any+x"} 0`)
 
 	err = prv.Resolve(ctx, []string{"any+a", "any+b", "any+c"})
-	testutil.Ok(t, err)
+	assert.NoError(t, err)
 	result = prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, ips, result)
+	assert.Equal(t, ips, result)
 	checkMetrics(`
 		dns_provider_results{addr="any+a"} 2
 		dns_provider_results{addr="any+b"} 2
 		dns_provider_results{addr="any+c"} 1`)
 
 	err = prv.Resolve(ctx, []string{"any+b", "any+c"})
-	testutil.Ok(t, err)
+	assert.NoError(t, err)
 	result = prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, ips[2:], result)
+	assert.Equal(t, ips[2:], result)
 	checkMetrics(`
 		dns_provider_results{addr="any+b"} 2
 		dns_provider_results{addr="any+c"} 1`)
 
 	err = prv.Resolve(ctx, []string{"any+x"})
-	testutil.Ok(t, err)
+	assert.NoError(t, err)
 	result = prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, []string(nil), result)
+	assert.Equal(t, []string(nil), result)
 	checkMetrics(`dns_provider_results{addr="any+x"} 0`)
 
 	err = prv.Resolve(ctx, []string{"any+a", "any+b", "any+c"})
-	testutil.Ok(t, err)
+	assert.NoError(t, err)
 	result = prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, ips, result)
+	assert.Equal(t, ips, result)
 	checkMetrics(`
 		dns_provider_results{addr="any+a"} 2
 		dns_provider_results{addr="any+b"} 2
 		dns_provider_results{addr="any+c"} 1`)
 
 	err = prv.Resolve(ctx, []string{"any+b", "example.com:90", "any+c"})
-	testutil.Ok(t, err)
+	assert.NoError(t, err)
 	result = prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, append(ips[2:], "example.com:90"), result)
+	assert.Equal(t, append(ips[2:], "example.com:90"), result)
 	checkMetrics(`
 		dns_provider_results{addr="any+b"} 2
 		dns_provider_results{addr="example.com:90"} 1
 		dns_provider_results{addr="any+c"} 1`)
 	err = prv.Resolve(ctx, []string{"any+b", "any+c"})
-	testutil.Ok(t, err)
+	assert.NoError(t, err)
 	result = prv.Addresses()
 	sort.Strings(result)
-	testutil.Equals(t, ips[2:], result)
+	assert.Equal(t, ips[2:], result)
 	checkMetrics(`
 		dns_provider_results{addr="any+b"} 2
 		dns_provider_results{addr="any+c"} 1`)
@@ -144,6 +143,6 @@ func TestIsDynamicNode(t *testing.T) {
 		},
 	} {
 		isDynamic := IsDynamicNode(tcase.node)
-		testutil.Equals(t, tcase.isDynamic, isDynamic, "mismatch between results")
+		assert.Equal(t, tcase.isDynamic, isDynamic, "mismatch between results")
 	}
 }

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -1,0 +1,145 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/discovery/provider.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package dns
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+
+	"github.com/pkg/errors"
+)
+
+type QType string
+
+const (
+	// A qtype performs A/AAAA lookup.
+	A = QType("dns")
+	// SRV qtype performs SRV lookup with A/AAAA lookup for each SRV result.
+	SRV = QType("dnssrv")
+	// SRVNoA qtype performs SRV lookup without any A/AAAA lookup for each SRV result.
+	SRVNoA = QType("dnssrvnoa")
+)
+
+type Resolver interface {
+	// Resolve performs a DNS lookup and returns a list of records.
+	// name is the domain name to be resolved.
+	// qtype is the query type. Accepted values are `dns` for A/AAAA lookup and `dnssrv` for SRV lookup.
+	// If scheme is passed through name, it is preserved on IP results.
+	Resolve(ctx context.Context, name string, qtype QType) ([]string, error)
+}
+
+type ipLookupResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+	LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
+	IsNotFound(err error) bool
+}
+
+type dnsSD struct {
+	resolver ipLookupResolver
+	logger   log.Logger
+}
+
+// NewResolver creates a resolver with given underlying resolver.
+func NewResolver(resolver ipLookupResolver, logger log.Logger) Resolver {
+	return &dnsSD{resolver: resolver, logger: logger}
+}
+
+func (s *dnsSD) Resolve(ctx context.Context, name string, qtype QType) ([]string, error) {
+	var (
+		res    []string
+		scheme string
+	)
+
+	schemeSplit := strings.Split(name, "//")
+	if len(schemeSplit) > 1 {
+		scheme = schemeSplit[0]
+		name = schemeSplit[1]
+	}
+
+	// Split the host and port if present.
+	host, port, err := net.SplitHostPort(name)
+	if err != nil {
+		// The host could be missing a port.
+		host, port = name, ""
+	}
+
+	switch qtype {
+	case A:
+		if port == "" {
+			return nil, errors.Errorf("missing port in address given for dns lookup: %v", name)
+		}
+		ips, err := s.resolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			// We exclude error from std Golang resolver for the case of the domain (e.g `NXDOMAIN`) not being found by DNS
+			// server. Since `miekg` does not consider this as an error,  when the host cannot be found, empty slice will be
+			// returned.
+			if !s.resolver.IsNotFound(err) {
+				return nil, errors.Wrapf(err, "lookup IP addresses %q", host)
+			}
+			if ips == nil {
+				level.Error(s.logger).Log("msg", "failed to lookup IP addresses", "host", host, "err", err)
+			}
+		}
+		for _, ip := range ips {
+			res = append(res, appendScheme(scheme, net.JoinHostPort(ip.String(), port)))
+		}
+	case SRV, SRVNoA:
+		_, recs, err := s.resolver.LookupSRV(ctx, "", "", host)
+		if err != nil {
+			if !s.resolver.IsNotFound(err) {
+				return nil, errors.Wrapf(err, "lookup SRV records %q", host)
+			}
+			if len(recs) == 0 {
+				level.Error(s.logger).Log("msg", "failed to lookup SRV records", "host", host, "err", err)
+			}
+		}
+
+		for _, rec := range recs {
+			// Only use port from SRV record if no explicit port was specified.
+			resPort := port
+			if resPort == "" {
+				resPort = strconv.Itoa(int(rec.Port))
+			}
+
+			if qtype == SRVNoA {
+				res = append(res, appendScheme(scheme, net.JoinHostPort(rec.Target, resPort)))
+				continue
+			}
+			// Do A lookup for the domain in SRV answer.
+			resIPs, err := s.resolver.LookupIPAddr(ctx, rec.Target)
+			if err != nil {
+				if !s.resolver.IsNotFound(err) {
+					return nil, errors.Wrapf(err, "lookup IP addresses %q", host)
+				}
+				if len(resIPs) == 0 {
+					level.Error(s.logger).Log("msg", "failed to lookup IP addresses", "srv", host, "a", rec.Target, "err", err)
+				}
+			}
+			for _, resIP := range resIPs {
+				res = append(res, appendScheme(scheme, net.JoinHostPort(resIP.String(), resPort)))
+			}
+		}
+	default:
+		return nil, errors.Errorf("invalid lookup scheme %q", qtype)
+	}
+
+	if res == nil && err == nil {
+		level.Warn(s.logger).Log("msg", "IP address lookup yielded no results. No host found or no addresses found", "host", host)
+	}
+
+	return res, nil
+}
+
+func appendScheme(scheme, host string) string {
+	if scheme == "" {
+		return host
+	}
+	return scheme + "//" + host
+}

--- a/dns/resolver_test.go
+++ b/dns/resolver_test.go
@@ -183,12 +183,12 @@ var (
 func TestDnsSD_Resolve(t *testing.T) {
 	for _, tt := range dnsSDTests {
 		t.Run(tt.testName, func(t *testing.T) {
-			testDnsSd(t, tt)
+			testDNSSd(t, tt)
 		})
 	}
 }
 
-func testDnsSd(t *testing.T, tt DNSSDTest) {
+func testDNSSd(t *testing.T, tt DNSSDTest) {
 	ctx := context.TODO()
 	dnsSD := dnsSD{tt.resolver, log.NewNopLogger()}
 

--- a/dns/resolver_test.go
+++ b/dns/resolver_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package dns
+
+import (
+	"context"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/go-kit/log"
+
+	"github.com/pkg/errors"
+
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+type mockHostnameResolver struct {
+	resultIPs  map[string][]net.IPAddr
+	resultSRVs map[string][]*net.SRV
+	err        error
+}
+
+func (m mockHostnameResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.resultIPs[host], nil
+}
+
+func (m mockHostnameResolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	if m.err != nil {
+		return "", nil, m.err
+	}
+	return "", m.resultSRVs[name], nil
+}
+
+func (m mockHostnameResolver) IsNotFound(err error) bool {
+	return false
+}
+
+type DNSSDTest struct {
+	testName       string
+	addr           string
+	qtype          QType
+	expectedResult []string
+	expectedErr    error
+	resolver       *mockHostnameResolver
+}
+
+var (
+	errorFromResolver = errors.New("error from resolver")
+
+	dnsSDTests = []DNSSDTest{
+		{
+			testName:       "single ip from dns lookup of host port",
+			addr:           "test.mycompany.com:8080",
+			qtype:          A,
+			expectedResult: []string{"192.168.0.1:8080"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultIPs: map[string][]net.IPAddr{
+					"test.mycompany.com": {net.IPAddr{IP: net.ParseIP("192.168.0.1")}},
+				},
+			},
+		},
+		// Scheme is preserved.
+		{
+			testName:       "single ip from dns lookup of host port with scheme",
+			addr:           "http://test.mycompany.com:8080",
+			qtype:          A,
+			expectedResult: []string{"http://192.168.0.1:8080"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultIPs: map[string][]net.IPAddr{
+					"test.mycompany.com": {net.IPAddr{IP: net.ParseIP("192.168.0.1")}},
+				},
+			},
+		},
+		{
+			testName:       "error on dns lookup when no port is specified",
+			addr:           "test.mycompany.com",
+			qtype:          A,
+			expectedResult: nil,
+			expectedErr:    errors.New("missing port in address given for dns lookup: test.mycompany.com"),
+			resolver:       &mockHostnameResolver{},
+		},
+		{
+			testName:       "multiple SRV records from SRV lookup",
+			addr:           "_test._tcp.mycompany.com",
+			qtype:          SRV,
+			expectedResult: []string{"192.168.0.1:8080", "192.168.0.2:8081"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultSRVs: map[string][]*net.SRV{
+					"_test._tcp.mycompany.com": {
+						&net.SRV{Target: "alt1.mycompany.com.", Port: 8080},
+						&net.SRV{Target: "alt2.mycompany.com.", Port: 8081},
+					},
+				},
+				resultIPs: map[string][]net.IPAddr{
+					"alt1.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.1")}},
+					"alt2.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.2")}},
+				},
+			},
+		},
+		{
+			testName:       "multiple SRV records from SRV lookup with specified port",
+			addr:           "_test._tcp.mycompany.com:8082",
+			qtype:          SRV,
+			expectedResult: []string{"192.168.0.1:8082", "192.168.0.2:8082"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultSRVs: map[string][]*net.SRV{
+					"_test._tcp.mycompany.com": {
+						&net.SRV{Target: "alt1.mycompany.com.", Port: 8080},
+						&net.SRV{Target: "alt2.mycompany.com.", Port: 8081},
+					},
+				},
+				resultIPs: map[string][]net.IPAddr{
+					"alt1.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.1")}},
+					"alt2.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.2")}},
+				},
+			},
+		},
+		{
+			testName:       "error from SRV resolver",
+			addr:           "_test._tcp.mycompany.com",
+			qtype:          SRV,
+			expectedResult: nil,
+			expectedErr:    errors.Wrapf(errorFromResolver, "lookup SRV records \"_test._tcp.mycompany.com\""),
+			resolver:       &mockHostnameResolver{err: errorFromResolver},
+		},
+		{
+			testName:       "multiple SRV records from SRV no A lookup",
+			addr:           "_test._tcp.mycompany.com",
+			qtype:          SRVNoA,
+			expectedResult: []string{"192.168.0.1:8080", "192.168.0.2:8081"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultSRVs: map[string][]*net.SRV{
+					"_test._tcp.mycompany.com": {
+						&net.SRV{Target: "192.168.0.1", Port: 8080},
+						&net.SRV{Target: "192.168.0.2", Port: 8081},
+					},
+				},
+			},
+		},
+		{
+			testName:       "multiple SRV records from SRV no A lookup with specified port",
+			addr:           "_test._tcp.mycompany.com:8082",
+			qtype:          SRVNoA,
+			expectedResult: []string{"192.168.0.1:8082", "192.168.0.2:8082"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultSRVs: map[string][]*net.SRV{
+					"_test._tcp.mycompany.com": {
+						&net.SRV{Target: "192.168.0.1", Port: 8080},
+						&net.SRV{Target: "192.168.0.2", Port: 8081},
+					},
+				},
+			},
+		},
+		{
+			testName:       "error from SRV no A lookup",
+			addr:           "_test._tcp.mycompany.com",
+			qtype:          SRV,
+			expectedResult: nil,
+			expectedErr:    errors.Wrapf(errorFromResolver, "lookup SRV records \"_test._tcp.mycompany.com\""),
+			resolver:       &mockHostnameResolver{err: errorFromResolver},
+		},
+		{
+			testName:       "error on bad qtype",
+			addr:           "test.mycompany.com",
+			qtype:          "invalid",
+			expectedResult: nil,
+			expectedErr:    errors.New("invalid lookup scheme \"invalid\""),
+			resolver:       &mockHostnameResolver{},
+		},
+	}
+)
+
+func TestDnsSD_Resolve(t *testing.T) {
+	for _, tt := range dnsSDTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			testDnsSd(t, tt)
+		})
+	}
+}
+
+func testDnsSd(t *testing.T, tt DNSSDTest) {
+	ctx := context.TODO()
+	dnsSD := dnsSD{tt.resolver, log.NewNopLogger()}
+
+	result, err := dnsSD.Resolve(ctx, tt.addr, tt.qtype)
+	if tt.expectedErr != nil {
+		testutil.NotOk(t, err)
+		testutil.Assert(t, tt.expectedErr.Error() == err.Error(), "expected error '%v', but got '%v'", tt.expectedErr.Error(), err.Error())
+	} else {
+		testutil.Ok(t, err)
+	}
+	sort.Strings(result)
+	testutil.Equals(t, tt.expectedResult, result)
+}

--- a/dns/resolver_test.go
+++ b/dns/resolver_test.go
@@ -10,10 +10,9 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/pkg/errors"
-
-	"github.com/thanos-io/thanos/pkg/testutil"
 )
 
 type mockHostnameResolver struct {
@@ -195,11 +194,10 @@ func testDnsSd(t *testing.T, tt DNSSDTest) {
 
 	result, err := dnsSD.Resolve(ctx, tt.addr, tt.qtype)
 	if tt.expectedErr != nil {
-		testutil.NotOk(t, err)
-		testutil.Assert(t, tt.expectedErr.Error() == err.Error(), "expected error '%v', but got '%v'", tt.expectedErr.Error(), err.Error())
+		assert.EqualError(t, err, tt.expectedErr.Error())
 	} else {
-		testutil.Ok(t, err)
+		assert.NoError(t, err)
 	}
 	sort.Strings(result)
-	testutil.Equals(t, tt.expectedResult, result)
+	assert.Equal(t, tt.expectedResult, result)
 }

--- a/flagext/bytes.go
+++ b/flagext/bytes.go
@@ -1,0 +1,33 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/model/units.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package flagext
+
+import (
+	"github.com/alecthomas/units"
+)
+
+// Bytes is a data type which supports yaml serialization/deserialization
+// with units.
+type Bytes uint64
+
+func (b *Bytes) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var value string
+	err := unmarshal(&value)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := units.ParseBase2Bytes(value)
+	if err != nil {
+		return err
+	}
+
+	*b = Bytes(bytes)
+	return nil
+}
+
+func (b *Bytes) MarshalYAML() (interface{}, error) {
+	return units.Base2Bytes(*b).String(), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/dskit
 go 1.18
 
 require (
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/armon/go-metrics v0.3.0
 	github.com/cristalhq/hedgedhttp v0.7.0
 	github.com/go-kit/log v0.2.0
@@ -14,6 +15,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/memberlist v0.2.3
+	github.com/miekg/dns v1.1.26
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
@@ -59,7 +61,6 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/miekg/dns v1.1.26 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=

--- a/runutil/runutil.go
+++ b/runutil/runutil.go
@@ -7,7 +7,10 @@ package runutil
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -50,4 +53,61 @@ func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ..
 	merr.Add(*err)
 
 	*err = merr.Err()
+}
+
+// DeleteAll deletes all files and directories inside the given
+// dir except for the ignoreDirs directories.
+// NOTE: DeleteAll is not idempotent.
+func DeleteAll(dir string, ignoreDirs ...string) error {
+	entries, err := ioutil.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "read dir")
+	}
+	var groupErrs multierror.MultiError
+
+	var matchingIgnores []string
+	for _, d := range entries {
+		if !d.IsDir() {
+			if err := os.RemoveAll(filepath.Join(dir, d.Name())); err != nil {
+				groupErrs.Add(err)
+			}
+			continue
+		}
+
+		// ignoreDirs might be multi-directory paths.
+		matchingIgnores = matchingIgnores[:0]
+		ignore := false
+		for _, ignoreDir := range ignoreDirs {
+			id := strings.Split(ignoreDir, "/")
+			if id[0] == d.Name() {
+				if len(id) == 1 {
+					ignore = true
+					break
+				}
+				matchingIgnores = append(matchingIgnores, filepath.Join(id[1:]...))
+			}
+		}
+
+		if ignore {
+			continue
+		}
+
+		if len(matchingIgnores) == 0 {
+			if err := os.RemoveAll(filepath.Join(dir, d.Name())); err != nil {
+				groupErrs.Add(err)
+			}
+			continue
+		}
+		if err := DeleteAll(filepath.Join(dir, d.Name()), matchingIgnores...); err != nil {
+			groupErrs.Add(err)
+		}
+	}
+
+	if groupErrs.Err() != nil {
+		return errors.Wrap(groupErrs.Err(), "delete file/dir")
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does**:

Adds:
* `flagext.Bytes` type, so you can define a quantity like 10GB.  (Note this is only implemented for Yaml so far).
* `runutil.DeleteAll` to delete files.
* `dns` package for service discovery, with two implementations `miekgdns` and `godns`.

**Checklist**
- [x] Tests updated.
- [x] `CHANGELOG.md` updated.
