### PR TITLE
Update incorrect comment on runtimeconfig.New.

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -62,7 +62,7 @@ type Manager struct {
 	fileHashes map[string]string
 }
 
-// New creates an instance of Manager and starts reload config loop based on config
+// New creates an instance of Manager. Manager is a services.Service, and must be explicitly started to perform any work.
 func New(cfg Config, registerer prometheus.Registerer, logger log.Logger) (*Manager, error) {
 	if len(cfg.LoadPath) == 0 {
 		return nil, errors.New("LoadPath is empty")


### PR DESCRIPTION
**What this PR does**: This PR updates incorrect comment on `runtimeconfig.New`. Comment said that this function started the reload loop, but that's not true.

**Checklist**
- [na] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
