### PR TITLE
Run tests with both Go 1.18 and 1.19 on CI

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,4 +1,12 @@
-local image = 'golang:1.18.4';
+local supported_golang_versions = [
+  '1.18.4',
+  '1.19.3',
+];
+
+local images = {
+  golang(version):: 'golang:%s' % version,
+  default:: self.golang(supported_golang_versions[0]),
+};
 
 local pipeline = {
   new(name):: {
@@ -10,21 +18,35 @@ local pipeline = {
 local step = {
   make(target, commands=[]):: {
     name: 'make-%s' % target,
-    image: image,
+    image: images.default,
     commands: commands + ['make %s' % target],
+  },
+
+  test(golang_version):: {
+    name: 'make-test (go %s)' % golang_version,
+    image: images.golang(golang_version),
+    commands: ['make test'],
   },
 };
 
+local test_steps = [step.test(v) for v in supported_golang_versions];
+
 [
   pipeline.new('validate-pr') {
-    steps: [
-      step.make('mod-check'),
-      step.make('lint'),
-      step.make('test'),
-      step.make('check-protos', commands=[
-        'apt-get update && apt-get -y install unzip',
-        'go mod vendor',
-      ]),
-    ],
+    steps:
+      [
+        step.make('mod-check'),
+        step.make('lint'),
+      ] +
+      test_steps +
+      [
+        step.make(
+          'check-protos',
+          commands=[
+            'apt-get update && apt-get -y install unzip',
+            'go mod vendor',
+          ]
+        ),
+      ],
   },
 ]

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -22,7 +22,14 @@
             "make test"
          ],
          "image": "golang:1.18.4",
-         "name": "make-test"
+         "name": "make-test (go 1.18.4)"
+      },
+      {
+         "commands": [
+            "make test"
+         ],
+         "image": "golang:1.19.3",
+         "name": "make-test (go 1.19.3)"
       },
       {
          "commands": [
@@ -37,6 +44,6 @@
 }
 ---
 kind: signature
-hmac: 59146de8cd97a9baf7d86dd30178bfc99415358fc4f4f4cafc4a128005bc05fe
+hmac: b9e3e4dbdfad99c1969c6617ed95fe1f32e2a111c7b51690311bd4bb17a18397
 
 ...


### PR DESCRIPTION
**What this PR does**:

Adds an additional step to the CI job to run the unit tests with Go 1.19, in addition to the existing step that runs the tests with Go 1.18

**Which issue(s) this PR fixes**:

Fixes #212.

**Checklist**
- [n/a] Tests updated
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
