### PR TITLE
Fix issue running TLS integration tests on macOS

### DIFF
--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -206,13 +206,10 @@ func TestServerWithLocalhostCertNoClientCertAuth(t *testing.T) {
 	(&cfg).RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
 
 	unavailableDescErr := errorContainsString("rpc error: code = Unavailable desc =")
-
-	var notTrustedErr func(*testing.T, error)
+	notTrustedErr := errorContainsString("x509: certificate signed by unknown authority")
 
 	if runtime.GOOS == "darwin" {
 		notTrustedErr = errorContainsString("x509: “server” certificate is not trusted")
-	} else {
-		notTrustedErr = errorContainsString("x509: certificate signed by unknown authority")
 	}
 
 	cfg.HTTPTLSConfig.TLSCertPath = certs.serverCertFile
@@ -280,13 +277,10 @@ func TestServerWithoutLocalhostCertNoClientCertAuth(t *testing.T) {
 	(&cfg).RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
 
 	unavailableDescErr := errorContainsString("rpc error: code = Unavailable desc =")
-
-	var invalidCertErr func(*testing.T, error)
+	invalidCertErr := errorContainsString("x509: certificate is valid for my-other-name, not localhost")
 
 	if runtime.GOOS == "darwin" {
 		invalidCertErr = errorContainsString("x509: “server-no-localhost” certificate is not trusted")
-	} else {
-		invalidCertErr = errorContainsString("x509: certificate is valid for my-other-name, not localhost")
 	}
 
 	// Test a TLS server without localhost cert without any client certificate enforcement


### PR DESCRIPTION
**What this PR does**:

Running `make test` on my macOS machine fails, with a few of the TLS integration tests failing:

```
time="2022-11-10T11:52:56+11:00" level=info msg="server listening on addresses" grpc="[::]:52898" http="[::]:52899"
time="2022-11-10T11:52:56+11:00" level=info msg="server listening on addresses" grpc="[::]:52906" http="[::]:52907"
2022/11/10 11:52:56 http: TLS handshake error from [::1]:52908: remote error: tls: bad certificate
2022/11/10 11:52:56 http: TLS handshake error from [::1]:52910: remote error: tls: bad certificate
--- FAIL: TestServerWithLocalhostCertNoClientCertAuth (0.51s)
    --- FAIL: TestServerWithLocalhostCertNoClientCertAuth/HTTP/no-config (0.04s)
        tls_integration_test.go:566:
            	Error Trace:	/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:566
            	            				/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:125
            	Error:      	"Get \"https://localhost:52907/hello\": x509: “server” certificate is not trusted" does not contain "x509: certificate signed by unknown authority"
            	Test:       	TestServerWithLocalhostCertNoClientCertAuth/HTTP/no-config
    --- FAIL: TestServerWithLocalhostCertNoClientCertAuth/HTTP/grpc-tls-enabled (0.01s)
        tls_integration_test.go:566:
            	Error Trace:	/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:566
            	            				/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:125
            	Error:      	"Get \"https://localhost:52907/hello\": x509: “server” certificate is not trusted" does not contain "x509: certificate signed by unknown authority"
            	Test:       	TestServerWithLocalhostCertNoClientCertAuth/HTTP/grpc-tls-enabled
    --- FAIL: TestServerWithLocalhostCertNoClientCertAuth/GRPC/grpc-tls-enabled (0.01s)
        tls_integration_test.go:566:
            	Error Trace:	/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:566
            	            				/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:162
            	Error:      	"rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: x509: “server” certificate is not trusted\"" does not contain "x509: certificate signed by unknown authority"
            	Test:       	TestServerWithLocalhostCertNoClientCertAuth/GRPC/grpc-tls-enabled
time="2022-11-10T11:52:57+11:00" level=info msg="server listening on addresses" grpc="[::]:52924" http="[::]:52925"
2022/11/10 11:52:57 http: TLS handshake error from [::1]:52926: remote error: tls: bad certificate
2022/11/10 11:52:57 http: TLS handshake error from [::1]:52928: remote error: tls: bad certificate
2022/11/10 11:52:57 http: TLS handshake error from [::1]:52930: remote error: tls: bad certificate
--- FAIL: TestServerWithoutLocalhostCertNoClientCertAuth (0.41s)
    --- FAIL: TestServerWithoutLocalhostCertNoClientCertAuth/HTTP/no-config (0.02s)
        tls_integration_test.go:566:
            	Error Trace:	/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:566
            	            				/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:125
            	Error:      	"Get \"https://localhost:52925/hello\": x509: “server-no-localhost” certificate is not trusted" does not contain "x509: certificate is valid for my-other-name, not localhost"
            	Test:       	TestServerWithoutLocalhostCertNoClientCertAuth/HTTP/no-config
    --- FAIL: TestServerWithoutLocalhostCertNoClientCertAuth/HTTP/grpc-tls-enabled (0.01s)
        tls_integration_test.go:566:
            	Error Trace:	/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:566
            	            				/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:125
            	Error:      	"Get \"https://localhost:52925/hello\": x509: “server-no-localhost” certificate is not trusted" does not contain "x509: certificate is valid for my-other-name, not localhost"
            	Test:       	TestServerWithoutLocalhostCertNoClientCertAuth/HTTP/grpc-tls-enabled
    --- FAIL: TestServerWithoutLocalhostCertNoClientCertAuth/GRPC/grpc-tls-enabled (0.01s)
        tls_integration_test.go:566:
            	Error Trace:	/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:566
            	            				/Users/charleskorn/Repositories/Grafana/dskit/crypto/tls/test/tls_integration_test.go:162
            	Error:      	"rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: x509: “server-no-localhost” certificate is not trusted\"" does not contain "x509: certificate is valid for my-other-name, not localhost"
            	Test:       	TestServerWithoutLocalhostCertNoClientCertAuth/GRPC/grpc-tls-enabled
time="2022-11-10T11:52:57+11:00" level=info msg="server listening on addresses" grpc="[::]:52944" http="[::]:52945"
2022/11/10 11:52:57 http: TLS handshake error from [::1]:52946: tls: client didn't provide a certificate
2022/11/10 11:52:57 http: TLS handshake error from [::1]:52948: tls: client didn't provide a certificate
2022/11/10 11:52:58 http: TLS handshake error from [::1]:52969: tls: client didn't provide a certificate
time="2022-11-10T11:52:58+11:00" level=info msg="server listening on addresses" grpc="[::]:52981" http="[::]:52982"
FAIL
FAIL	github.com/grafana/dskit/crypto/tls/test	4.308s
```

These test failures are caused by the fact that error messages returned by the `crypto/x509` package vary depending on the OS, but the tests only expect one error message.

I'm not super happy with the change - very open to feedback. (I also considered adding a `errorContainsAnyOfStrings(...)` method, but felt that being specific about what message we expect in what situations is best, rather than accepting anything from a list of possibilities.)

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
