### PR TITLE
Fix issue where ring status page shows 100% ownership as "1e+02%"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,4 @@
 * [BUGFIX] Lifecycler: if existing ring entry is reused, ring is updated immediately, and not on next heartbeat. #175
 * [BUGFIX] stringslicecsv: handle unmarshalling empty yaml string #206
 * [BUGFIX] Memberlist: retry joining memberlist cluster on startup when no nodes are resolved. #215
+* [BUGFIX] Ring status page: display 100% ownership as "100%", rather than "1e+02%". #231

--- a/ring/http.go
+++ b/ring/http.go
@@ -18,7 +18,7 @@ var defaultPageContent string
 var defaultPageTemplate = template.Must(template.New("webpage").Funcs(template.FuncMap{
 	"mod": func(i, j int) bool { return i%j == 0 },
 	"humanFloat": func(f float64) string {
-		return fmt.Sprintf("%.2g", f)
+		return fmt.Sprintf("%.3g", f)
 	},
 	"timeOrEmptyString": func(t time.Time) string {
 		if t.IsZero() {


### PR DESCRIPTION
**What this PR does**:

Currently, if a ring has a single member, the HTML-formatted ring status page shows that member's ownership as "1e+02%", rather than the more human-friendly "100%".

This PR changes the formatting so that 100% ownership is displayed as "100%".

There don't appear to be any tests covering the ring status page - happy to add some if you'd like.

**Which issue(s) this PR fixes**:

Fixes #231.

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
