### PR TITLE
[modules]: add test for ordered shutdown

### DIFF
--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -332,6 +332,8 @@ func TestModuleWaitsForAllDependencies(t *testing.T) {
 
 	expectedStopOrder := []string{"c", "a"}
 
+	close(stopChanOrder)
+
 	for i, stopID := range <-stopChanOrder {
 		assert.Equal(t, expectedStopOrder[i], string(stopID))
 	}


### PR DESCRIPTION
**What this PR does**:

I had some questions about the shutdown process with regard to ordering.  I see some of the code is ordering by name, and so here I included a test that checks the shutdown order of the various services.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
