### PR TITLE
Introduce support for per-call memory allocator for caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * [ENHANCEMENT] Add the ability to define custom gRPC health checks. #227
 * [ENHANCEMENT] Import Bytes type, DeleteAll function and DNS package from Thanos. #228
 * [ENHANCEMENT] Execute health checks in ring client pool concurrently. #237
+* [ENHANCEMENT] Cache: Add the ability to use a custom memory allocator for cache results. #249
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -10,17 +10,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type contextKey int
-
-const (
-	contextKeyAllocator contextKey = 0
-)
-
 // RemoteCacheClient is a high level client to interact with remote cache.
 type RemoteCacheClient interface {
 	// GetMulti fetches multiple keys at once from remoteCache. In case of error,
-	// an empty map is returned and the error tracked/logged.
-	GetMulti(ctx context.Context, keys []string) map[string][]byte
+	// an empty map is returned and the error tracked/logged. One or more Option
+	// instances may be passed to modify the behavior of this GetMulti call.
+	GetMulti(ctx context.Context, keys []string, opts ...Option) map[string][]byte
 
 	// SetAsync enqueues an asynchronous operation to store a key into memcached.
 	// Returns an error in case it fails to enqueue the operation. In case the
@@ -44,26 +39,30 @@ type Cache interface {
 	Store(ctx context.Context, data map[string][]byte, ttl time.Duration)
 
 	// Fetch multiple keys from cache. Returns map of input keys to data.
-	// If key isn't in the map, data for given key was not found.
-	Fetch(ctx context.Context, keys []string) map[string][]byte
+	// If key isn't in the map, data for given key was not found. One or more
+	// Option instances may be passed to modify the behavior of this Fetch call.
+	Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte
 
 	Name() string
 }
 
-// WithAllocator returns a Context that makes use of a specific memory Allocator
-// for result values loaded by a cache.
-func WithAllocator(ctx context.Context, alloc Allocator) context.Context {
-	return context.WithValue(ctx, contextKeyAllocator, alloc)
+// Options are used to modify the behavior of an individual call to get results
+// from a cache backend. They are constructed by applying Option callbacks passed
+// to a client method to a default Options instance.
+type Options struct {
+	Alloc Allocator
 }
 
-// GetAllocator returns the Allocator set for this particular context, if any.
-func GetAllocator(ctx context.Context) Allocator {
-	val := ctx.Value(contextKeyAllocator)
-	if val != nil {
-		return val.(Allocator)
-	}
+// Option is a callback used to modify the Options that a particular client
+// method uses.
+type Option func(opts *Options)
 
-	return nil
+// WithAllocator creates a new Option that makes use of a specific memory Allocator
+// for cache result values.
+func WithAllocator(alloc Allocator) Option {
+	return func(opts *Options) {
+		opts.Alloc = alloc
+	}
 }
 
 // Allocator allows memory for cache result values to be managed by callers instead of by

--- a/cache/client.go
+++ b/cache/client.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -144,6 +145,23 @@ func (c *baseClient) setAsync(ctx context.Context, key string, value []byte, ttl
 		return nil
 	}
 	return err
+}
+
+// wait submits an async task and blocks until it completes. This can be used during tests
+// to ensure that async "sets" have completed before attempting to read them.
+func (c *baseClient) wait() error {
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	err := c.asyncQueue.submit(func() {
+		wg.Done()
+	})
+	if err != nil {
+		return err
+	}
+
+	wg.Wait()
+	return nil
 }
 
 func (c *baseClient) delete(ctx context.Context, key string, f func(ctx context.Context, key string) error) error {

--- a/cache/client.go
+++ b/cache/client.go
@@ -147,8 +147,8 @@ func (c *baseClient) setAsync(ctx context.Context, key string, value []byte, ttl
 	return err
 }
 
-// wait submits an async task and blocks until it completes. This can be used during tests
-// to ensure that async "sets" have completed before attempting to read them.
+// wait submits an async task and blocks until it completes. This can be used during
+// tests to ensure that async "sets" have completed before attempting to read them.
 func (c *baseClient) wait() error {
 	var wg sync.WaitGroup
 

--- a/cache/compression.go
+++ b/cache/compression.go
@@ -23,6 +23,8 @@ const (
 var (
 	supportedCompressions     = []string{CompressionSnappy}
 	errUnsupportedCompression = errors.New("unsupported compression")
+
+	_ Cache = (*snappyCache)(nil)
 )
 
 type CompressionConfig struct {
@@ -76,8 +78,8 @@ func (s *snappyCache) Store(ctx context.Context, data map[string][]byte, ttl tim
 }
 
 // Fetch implements Cache.
-func (s *snappyCache) Fetch(ctx context.Context, keys []string) map[string][]byte {
-	found := s.next.Fetch(ctx, keys)
+func (s *snappyCache) Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
+	found := s.next.Fetch(ctx, keys, opts...)
 	decoded := make(map[string][]byte, len(found))
 
 	for key, encodedValue := range found {

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -247,6 +247,10 @@ func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte
 }
 
 func toMemcacheOptions(opts ...Option) []memcache.Option {
+	if len(opts) == 0 {
+		return nil
+	}
+
 	base := &Options{}
 	for _, opt := range opts {
 		opt(base)

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -51,8 +51,7 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 		require.NoError(t, client.SetAsync(context.Background(), "foo", []byte("bar"), 10*time.Second))
 		require.NoError(t, client.wait())
 
-		ctx := WithAllocator(context.Background(), &nopAllocator{})
-		res := client.GetMulti(ctx, []string{"foo"})
+		res := client.GetMulti(context.Background(), []string{"foo"}, WithAllocator(&nopAllocator{}))
 		require.Equal(t, map[string][]byte{"foo": []byte("bar")}, res)
 		require.Equal(t, 1, backend.allocations)
 	})
@@ -115,5 +114,5 @@ func (m mockServerSelector) Each(f func(net.Addr) error) error {
 
 type nopAllocator struct{}
 
-func (n nopAllocator) Get(sz int) *[]byte { return nil }
-func (n nopAllocator) Put(b *[]byte)      {}
+func (n nopAllocator) Get(_ int) *[]byte { return nil }
+func (n nopAllocator) Put(_ *[]byte)     {}

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -76,7 +76,7 @@ func (m *mockMemcachedClientBackend) GetMulti(keys []string, opts ...memcache.Op
 	}
 
 	if options.Alloc != nil {
-		m.allocations += 1
+		m.allocations++
 	}
 
 	out := make(map[string]*memcache.Item)

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -1,0 +1,119 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/gomemcache/memcache"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemcachedClient_GetMulti(t *testing.T) {
+	setup := func() (*memcachedClient, *mockMemcachedClientBackend, error) {
+		backend := newMockMemcachedClientBackend()
+		client, err := newMemcachedClient(
+			log.NewNopLogger(),
+			backend,
+			&mockServerSelector{},
+			MemcachedClientConfig{
+				Addresses:                 []string{"localhost"},
+				MaxAsyncConcurrency:       1,
+				MaxAsyncBufferSize:        10,
+				DNSProviderUpdateInterval: 10 * time.Second,
+			},
+			prometheus.NewPedanticRegistry(),
+			"test",
+		)
+
+		return client, backend, err
+	}
+
+	t.Run("no allocator", func(t *testing.T) {
+		client, backend, err := setup()
+		require.NoError(t, err)
+		require.NoError(t, client.SetAsync(context.Background(), "foo", []byte("bar"), 10*time.Second))
+		require.NoError(t, client.wait())
+
+		ctx := context.Background()
+		res := client.GetMulti(ctx, []string{"foo"})
+		require.Equal(t, map[string][]byte{"foo": []byte("bar")}, res)
+		require.Equal(t, 0, backend.allocations)
+	})
+
+	t.Run("with allocator", func(t *testing.T) {
+		client, backend, err := setup()
+		require.NoError(t, err)
+		require.NoError(t, client.SetAsync(context.Background(), "foo", []byte("bar"), 10*time.Second))
+		require.NoError(t, client.wait())
+
+		ctx := WithAllocator(context.Background(), &nopAllocator{})
+		res := client.GetMulti(ctx, []string{"foo"})
+		require.Equal(t, map[string][]byte{"foo": []byte("bar")}, res)
+		require.Equal(t, 1, backend.allocations)
+	})
+}
+
+type mockMemcachedClientBackend struct {
+	allocations int
+	values      map[string]*memcache.Item
+}
+
+func newMockMemcachedClientBackend() *mockMemcachedClientBackend {
+	return &mockMemcachedClientBackend{
+		values: make(map[string]*memcache.Item),
+	}
+}
+
+func (m *mockMemcachedClientBackend) GetMulti(keys []string, opts ...memcache.Option) (map[string]*memcache.Item, error) {
+	options := &memcache.Options{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.Alloc != nil {
+		m.allocations += 1
+	}
+
+	out := make(map[string]*memcache.Item)
+	for _, k := range keys {
+		if v, ok := m.values[k]; ok {
+			out[k] = v
+		}
+	}
+
+	return out, nil
+}
+
+func (m *mockMemcachedClientBackend) Set(item *memcache.Item) error {
+	m.values[item.Key] = item
+	return nil
+}
+
+func (m *mockMemcachedClientBackend) Delete(key string) error {
+	delete(m.values, key)
+	return nil
+}
+
+type mockServerSelector struct{}
+
+func (m mockServerSelector) SetServers(_ ...string) error {
+	return nil
+}
+
+func (m mockServerSelector) PickServer(key string) (net.Addr, error) {
+	return nil, errors.New("mock server selector")
+}
+
+func (m mockServerSelector) Each(f func(net.Addr) error) error {
+	return nil
+}
+
+type nopAllocator struct{}
+
+func (n nopAllocator) Get(sz int) *[]byte { return nil }
+func (n nopAllocator) Put(b *[]byte)      {}

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -8,6 +8,11 @@ import (
 	"go.uber.org/atomic"
 )
 
+var (
+	_ Cache = (*MockCache)(nil)
+	_ Cache = (*InstrumentedMockCache)(nil)
+)
+
 type MockCache struct {
 	mu    sync.Mutex
 	cache map[string]Item

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -34,7 +34,7 @@ func (m *MockCache) Store(_ context.Context, data map[string][]byte, ttl time.Du
 	}
 }
 
-func (m *MockCache) Fetch(_ context.Context, keys []string) map[string][]byte {
+func (m *MockCache) Fetch(_ context.Context, keys []string, _ ...Option) map[string][]byte {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -101,9 +101,9 @@ func (m *InstrumentedMockCache) Store(ctx context.Context, data map[string][]byt
 	m.cache.Store(ctx, data, ttl)
 }
 
-func (m *InstrumentedMockCache) Fetch(ctx context.Context, keys []string) map[string][]byte {
+func (m *InstrumentedMockCache) Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
 	m.fetchCount.Inc()
-	return m.cache.Fetch(ctx, keys)
+	return m.cache.Fetch(ctx, keys, opts...)
 }
 
 func (m *InstrumentedMockCache) Name() string {

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -201,7 +201,7 @@ func (c *redisClient) SetAsync(ctx context.Context, key string, value []byte, tt
 }
 
 // GetMulti implement RemoteCacheClient.
-func (c *redisClient) GetMulti(ctx context.Context, keys []string) map[string][]byte {
+func (c *redisClient) GetMulti(ctx context.Context, keys []string, _ ...Option) map[string][]byte {
 	if len(keys) == 0 {
 		return nil
 	}

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -23,6 +23,8 @@ import (
 var (
 	errRedisConfigNoEndpoint               = errors.New("no redis endpoint provided")
 	errRedisMaxAsyncConcurrencyNotPositive = errors.New("max async concurrency must be positive")
+
+	_ RemoteCacheClient = (*redisClient)(nil)
 )
 
 // RedisClientConfig is the config accepted by RedisClient.

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -108,10 +108,10 @@ func (c *remoteCache) Store(ctx context.Context, data map[string][]byte, ttl tim
 
 // Fetch fetches multiple keys and returns a map containing cache hits, along with a list of missing keys.
 // In case of error, it logs and return an empty cache hits map.
-func (c *remoteCache) Fetch(ctx context.Context, keys []string) map[string][]byte {
+func (c *remoteCache) Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
 	// Fetch the keys from remote cache in a single request.
 	c.requests.Add(float64(len(keys)))
-	results := c.remoteClient.GetMulti(ctx, keys)
+	results := c.remoteClient.GetMulti(ctx, keys, opts...)
 	c.hits.Add(float64(len(results)))
 	return results
 }

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -10,6 +10,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+var (
+	_ Cache = (*MemcachedCache)(nil)
+	_ Cache = (*RedisCache)(nil)
+)
+
 // MemcachedCache is a memcached-based cache.
 type MemcachedCache struct {
 	*remoteCache

--- a/cache/tracing.go
+++ b/cache/tracing.go
@@ -10,6 +10,8 @@ import (
 	"github.com/grafana/dskit/spanlogger"
 )
 
+var _ Cache = (*SpanlessTracingCache)(nil)
+
 // SpanlessTracingCache wraps a Cache and logs Fetch operation in the parent spans.
 type SpanlessTracingCache struct {
 	c        Cache
@@ -25,12 +27,12 @@ func (t SpanlessTracingCache) Store(ctx context.Context, data map[string][]byte,
 	t.c.Store(ctx, data, ttl)
 }
 
-func (t SpanlessTracingCache) Fetch(ctx context.Context, keys []string) (result map[string][]byte) {
+func (t SpanlessTracingCache) Fetch(ctx context.Context, keys []string, opts ...Option) (result map[string][]byte) {
 	var (
 		bytes  int
 		logger = spanlogger.FromContext(ctx, t.logger, t.resolver)
 	)
-	result = t.c.Fetch(ctx, keys)
+	result = t.c.Fetch(ctx, keys, opts...)
 
 	for _, v := range result {
 		bytes += len(v)

--- a/cache/versioned.go
+++ b/cache/versioned.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+var _ Cache = (*Versioned)(nil)
+
 // Versioned cache adds a version prefix to the keys.
 // This allows cache keys to be changed in a newer version of the code (after a bugfix or a cached data format change).
 type Versioned struct {
@@ -30,12 +32,12 @@ func (c Versioned) Store(ctx context.Context, data map[string][]byte, ttl time.D
 	c.cache.Store(ctx, versioned, ttl)
 }
 
-func (c Versioned) Fetch(ctx context.Context, keys []string) map[string][]byte {
+func (c Versioned) Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
 	versionedKeys := make([]string, len(keys))
 	for i, k := range keys {
 		versionedKeys[i] = c.addVersion(k)
 	}
-	versionedRes := c.cache.Fetch(ctx, versionedKeys)
+	versionedRes := c.cache.Fetch(ctx, versionedKeys, opts...)
 	res := make(map[string][]byte, len(versionedRes))
 	for k, v := range versionedRes {
 		res[c.removeVersion(k)] = v

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.0
 	github.com/golang/snappy v0.0.4
-	github.com/grafana/gomemcache v0.0.0-20230104170548-c1cca813817a
+	github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/hashicorp/consul/api v1.15.3
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/grafana/gomemcache v0.0.0-20230104170548-c1cca813817a h1:q7s1Se3EataEmdPWUtP/PE+UVRxaS0MlprU0jUiYn8A=
-github.com/grafana/gomemcache v0.0.0-20230104170548-c1cca813817a/go.mod h1:6fkC8bkriadatJOc7Pvjcvqr2xh9C79BYRRfE3WWoo0=
+github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f h1:ANwIMe7kOiMNTK88tusoNDb840pWVskI4rCrdoMv5i0=
+github.com/grafana/gomemcache v0.0.0-20230105173749-11f792309e1f/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220708130638-bd88e10a3d91 h1:/NipyHnOmvRsVzj81j2qE0VxsvsqhOB0f4vJIhk2qCQ=
 github.com/grafana/memberlist v0.3.1-0.20220708130638-bd88e10a3d91/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 h1:THDBEeQ9xZ8JEaCLyLQqXMMdRqNr0QAUJTIkQAUtFjg=


### PR DESCRIPTION
**What this PR does**:

This change adds the ability to pass a memory allocator to caching methods using one or more `Option` arguments. This allows the underlying client to use memory allocators better suited to their workloads than GC. This is only used by the Memcached client at the moment.

**Which issue(s) this PR fixes**:

See grafana/mimir#3772
See grafana/gomemcache#8

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
