### PR TITLE
spanlogger: skip formatting if trace is not sampled

### DIFF
--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -34,6 +34,7 @@ var (
 type SpanLogger struct {
 	log.Logger
 	opentracing.Span
+	sampled bool
 }
 
 // New makes a new SpanLogger with a log.Logger to send logs to. The provided context will have the logger attached
@@ -43,9 +44,11 @@ func New(ctx context.Context, logger log.Logger, method string, resolver TenantR
 	if ids, err := resolver.TenantIDs(ctx); err == nil && len(ids) > 0 {
 		span.SetTag(TenantIDsTagName, ids)
 	}
+	lwc, sampled := withContext(ctx, logger, resolver)
 	l := &SpanLogger{
-		Logger: log.With(withContext(ctx, logger, resolver), "method", method),
-		Span:   span,
+		Logger:  log.With(lwc, "method", method),
+		Span:    span,
+		sampled: sampled,
 	}
 	if len(kvps) > 0 {
 		level.Debug(l).Log(kvps...)
@@ -68,9 +71,11 @@ func FromContext(ctx context.Context, fallback log.Logger, resolver TenantResolv
 	if sp == nil {
 		sp = defaultNoopSpan
 	}
+	lwc, sampled := withContext(ctx, logger, resolver)
 	return &SpanLogger{
-		Logger: withContext(ctx, logger, resolver),
-		Span:   sp,
+		Logger:  lwc,
+		Span:    sp,
+		sampled: sampled,
 	}
 }
 
@@ -78,6 +83,9 @@ func FromContext(ctx context.Context, fallback log.Logger, resolver TenantResolv
 // also puts the on the spans.
 func (s *SpanLogger) Log(kvps ...interface{}) error {
 	s.Logger.Log(kvps...)
+	if !s.sampled {
+		return nil
+	}
 	fields, err := otlog.InterleavedKVToFields(kvps...)
 	if err != nil {
 		return err
@@ -88,15 +96,15 @@ func (s *SpanLogger) Log(kvps ...interface{}) error {
 
 // Error sets error flag and logs the error on the span, if non-nil. Returns the err passed in.
 func (s *SpanLogger) Error(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || !s.sampled {
+		return err
 	}
 	ext.Error.Set(s.Span, true)
 	s.Span.LogFields(otlog.Error(err))
 	return err
 }
 
-func withContext(ctx context.Context, logger log.Logger, resolver TenantResolver) log.Logger {
+func withContext(ctx context.Context, logger log.Logger, resolver TenantResolver) (log.Logger, bool) {
 	userID, err := resolver.TenantID(ctx)
 	if err == nil && userID != "" {
 		logger = log.With(logger, "user", userID)
@@ -104,8 +112,8 @@ func withContext(ctx context.Context, logger log.Logger, resolver TenantResolver
 
 	traceID, ok := tracing.ExtractSampledTraceID(ctx)
 	if !ok {
-		return logger
+		return logger, false
 	}
 
-	return log.With(logger, "traceID", traceID)
+	return log.With(logger, "traceID", traceID), true
 }

--- a/spanlogger/spanlogger_test.go
+++ b/spanlogger/spanlogger_test.go
@@ -106,3 +106,14 @@ func (r fakeResolver) TenantIDs(ctx context.Context) ([]string, error) {
 
 	return []string{id}, nil
 }
+
+// Using a no-op logger and no tracing provider, measure the overhead of a small log call.
+func BenchmarkSpanLogger(b *testing.B) {
+	logger := log.NewNopLogger()
+	resolver := fakeResolver{}
+	sl, _ := New(context.Background(), logger, "test", resolver, "bar")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = sl.Log("msg", "foo", "more", "data")
+	}
+}


### PR DESCRIPTION
Motivation for this change is profiles like this from Mimir, where 4% of all memory allocation is in `log.InterleavedKVToFields`.

<img width="373" alt="image" src="https://user-images.githubusercontent.com/8125524/211326032-50d21b98-5ca1-4c14-b1cb-d17cdf702dac.png">

If the span was not sampled (and we sample something like 1 in 1,000 of those) then we don't need to format the output.
Add benchmark to demonstrate.
```
name          old time/op    new time/op    delta
SpanLogger-4     436ns ±26%     230ns ±20%  -47.19%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
SpanLogger-4      288B ± 0%      160B ± 0%  -44.44%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
SpanLogger-4      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```

I considered just setting `SpanLogger.Span` to nil if it's not sampled, rather than adding a boolean, but since the field is exported it could trip up someone using this library who expects there is always a span.

**Checklist**
- NA Tests updated
- NA `CHANGELOG.md` updated

