### PR TITLE
Ring: Modify methods to use ReadRing interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71
 * [CHANGE] Closer: remove the closer package since it's trivial to just copy/paste. #70

--- a/ring/util.go
+++ b/ring/util.go
@@ -95,7 +95,7 @@ func WaitInstanceState(ctx context.Context, r ReadRing, instanceID string, state
 
 // WaitRingStability monitors the ring topology for the provided operation and waits until it
 // keeps stable for at least minStability.
-func WaitRingStability(ctx context.Context, r *Ring, op Operation, minStability, maxWaiting time.Duration) error {
+func WaitRingStability(ctx context.Context, r ReadRing, op Operation, minStability, maxWaiting time.Duration) error {
 	return waitStability(ctx, r, op, minStability, maxWaiting, HasReplicationSetChanged)
 }
 
@@ -104,11 +104,11 @@ func WaitRingStability(ctx context.Context, r *Ring, op Operation, minStability,
 // allowed states (e.g. JOINING->ACTIVE if allowed by op).
 // This can be used to avoid wasting resources on moving data around
 // due to multiple changes in the Ring.
-func WaitRingTokensStability(ctx context.Context, r *Ring, op Operation, minStability, maxWaiting time.Duration) error {
+func WaitRingTokensStability(ctx context.Context, r ReadRing, op Operation, minStability, maxWaiting time.Duration) error {
 	return waitStability(ctx, r, op, minStability, maxWaiting, HasReplicationSetChangedWithoutState)
 }
 
-func waitStability(ctx context.Context, r *Ring, op Operation, minStability, maxWaiting time.Duration, isChanged func(ReplicationSet, ReplicationSet) bool) error {
+func waitStability(ctx context.Context, r ReadRing, op Operation, minStability, maxWaiting time.Duration, isChanged func(ReplicationSet, ReplicationSet) bool) error {
 	// Configure the max waiting time as a context deadline.
 	ctx, cancel := context.WithTimeout(ctx, maxWaiting)
 	defer cancel()


### PR DESCRIPTION
**What this PR does**:
Modify `WaitRingStability` and `WaitInstanceState` to rely on the `ReadRing` interface instead of the `*Ring` struct. Since `ReadRing` is less strict, by changing the signature we make both methods easier to be used.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
