### PR TITLE
Ring: Add GetTokens to ReadRing interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [FEATURE] Added new `GetTokens` method to `ReadRing` interface. #252
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -77,6 +77,9 @@ type ReadRing interface {
 
 	// CleanupShuffleShardCache should delete cached shuffle-shard subrings for given identifier.
 	CleanupShuffleShardCache(identifier string)
+
+	// GetTokens returns ring instance tokens.
+	GetTokens(ctx context.Context) Tokens
 }
 
 var (
@@ -400,6 +403,14 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 		Instances: healthyInstances,
 		MaxErrors: maxFailure,
 	}, nil
+}
+
+// GetTokens implement ReadRing.
+func (r *Ring) GetTokens(ctx context.Context) Tokens {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	return r.ringTokens
 }
 
 // GetAllHealthy implements ReadRing.

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -59,6 +59,10 @@ func (r *RingMock) ShuffleShardWithLookback(identifier string, size int, lookbac
 	return args.Get(0).(ReadRing)
 }
 
+func (r *RingMock) GetTokens(ctx context.Context) Tokens {
+	return Tokens{}
+}
+
 func (r *RingMock) HasInstance(instanceID string) bool {
 	return true
 }


### PR DESCRIPTION
**What this PR does**:
- Add a new `GetTokens` method to the `ReadRing` interface
- Add `ring.Ring` implementation of `GetTokens`

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
