### PR TITLE
multierror: Add support for errors.Is()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [CHANGE] Services: `FailureWatcher.WatchService()` and `FailureWatcher.WatchManager()` now panic if `FailureWatcher` is `nil`. #219
 * [CHANGE] Memberlist: cluster label verification feature (`-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled`) is now marked as stable. #222
 * [CHANGE] Cache: Switch Memcached backend to use `github.com/grafana/gomemcache` repository instead of `github.com/bradfitz/gomemcache`. #248
+* [CHANGE] Multierror: Implement `Is(error) bool`. This allows to use `multierror.MultiError` with `errors.Is()`. `MultiError` will in turn call `errors.Is()` on every error value. #254
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/multierror/multierror.go
+++ b/multierror/multierror.go
@@ -5,6 +5,7 @@ package multierror
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 )
 
@@ -59,4 +60,16 @@ func (es nonNilMultiError) Error() string {
 	}
 
 	return buf.String()
+}
+
+// Is attempts to match the provided error against errors in the error list.
+//
+// This function allows errors.Is to traverse the values stored in the MultiError.
+func (es nonNilMultiError) Is(target error) bool {
+	for _, err := range es {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/multierror/multierror_test.go
+++ b/multierror/multierror_test.go
@@ -25,12 +25,12 @@ func TestMultiError_Is(t *testing.T) {
 			is:           true,
 		},
 		"adding wrapped context cancellations doesn't lose the information": {
-			sourceErrors: []error{errors.New("some error"), errors.Wrap(context.Canceled, "some mesasge")},
+			sourceErrors: []error{errors.New("some error"), errors.Wrap(context.Canceled, "some message")},
 			target:       context.Canceled,
 			is:           true,
 		},
 		"adding a nil error doesn't lose the information": {
-			sourceErrors: []error{errors.New("some error"), errors.Wrap(context.Canceled, "some mesasge"), nil},
+			sourceErrors: []error{errors.New("some error"), errors.Wrap(context.Canceled, "some message"), nil},
 			target:       context.Canceled,
 			is:           true,
 		},

--- a/multierror/multierror_test.go
+++ b/multierror/multierror_test.go
@@ -1,0 +1,58 @@
+package multierror
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiError_Is(t *testing.T) {
+	testCases := map[string]struct {
+		sourceErrors []error
+		target       error
+		is           bool
+	}{
+		"adding a context cancellation doesn't lose the information": {
+			sourceErrors: []error{context.Canceled},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"adding multiple context cancellations doesn't lose the information": {
+			sourceErrors: []error{context.Canceled, context.Canceled},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"adding wrapped context cancellations doesn't lose the information": {
+			sourceErrors: []error{errors.New("some error"), errors.Wrap(context.Canceled, "some mesasge")},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"adding a nil error doesn't lose the information": {
+			sourceErrors: []error{errors.New("some error"), errors.Wrap(context.Canceled, "some mesasge"), nil},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"no errors are not a context canceled error": {
+			sourceErrors: nil,
+			target:       context.Canceled,
+			is:           false,
+		},
+		"no errors are a nil error": {
+			sourceErrors: nil,
+			target:       nil,
+			is:           true,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			mErr := MultiError{}
+			for _, err := range testCase.sourceErrors {
+				mErr.Add(err)
+			}
+			assert.Equal(t, testCase.is, errors.Is(mErr.Err(), testCase.target))
+		})
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This allows to use `multierror.MultiError` with `errors.Is()`.
`MultiError` will in turn call `errors.Is()` on every error value.


**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
