### PR TITLE
Add Delete method to cache.Cache interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,26 @@
 * [ENHANCEMENT] Add the metrics package to support per tenant metric aggregation. #258
 * [ENHANCEMENT] Cache: Add Delete method to cache.Cache interface. #255
 * [ENHANCEMENT] Cache: Add backward compatible metrics exposition for cache. #255
+  * `<prefix>_cache_client_info{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_dns_failures_total{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_dns_lookups_total{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_dns_provider_results{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_getmulti_gate_duration_seconds_bucket{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_getmulti_gate_duration_seconds_count{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_getmulti_gate_duration_seconds_sum{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_getmulti_gate_queries_concurrent_max{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_getmulti_gate_queries_in_flight{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_hits_total{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_data_size_bytes_bucket{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_data_size_bytes_count{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_data_size_bytes_sum{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_duration_seconds_bucket{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_duration_seconds_count{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_duration_seconds_sum{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_failures_total{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operation_skipped_total{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_operations_total{backend="[memcached|redis]",...}`
+  * `<prefix>_cache_requests_total{backend="[memcached|redis]",...}`
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 * [ENHANCEMENT] Cache: Add the ability to use a custom memory allocator for cache results. #249
 * [ENHANCEMENT] Add the metrics package to support per tenant metric aggregation. #258
 * [ENHANCEMENT] Cache: Add Delete method to cache.Cache interface. #255
-* [ENHANCEMENT] Cache: Add backward compatible metrics exposition for cache. #260
+* [ENHANCEMENT] Cache: Add backward compatible metrics exposition for cache. #255
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * [ENHANCEMENT] Cache: Add the ability to use a custom memory allocator for cache results. #249
 * [ENHANCEMENT] Add the metrics package to support per tenant metric aggregation. #258
 * [ENHANCEMENT] Cache: Add Delete method to cache.Cache interface. #255
+* [ENHANCEMENT] Cache: Add backward compatible metrics exposition for cache. #260
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * [ENHANCEMENT] Execute health checks in ring client pool concurrently. #237
 * [ENHANCEMENT] Cache: Add the ability to use a custom memory allocator for cache results. #249
 * [ENHANCEMENT] Add the metrics package to support per tenant metric aggregation. #258
+* [ENHANCEMENT] Cache: Add Delete method to cache.Cache interface. #255
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -43,14 +43,10 @@ type Cache interface {
 	// Option instances may be passed to modify the behavior of this Fetch call.
 	Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte
 
-	Name() string
-}
-
-// DeletableCache is cache that can delete its key.
-type DeletableCache interface {
-	Cache
 	// Delete cache entry with the given key if it exists.
 	Delete(ctx context.Context, key string) error
+
+	Name() string
 }
 
 // Options are used to modify the behavior of an individual call to get results
@@ -132,17 +128,4 @@ func CreateClient(cacheName string, cfg BackendConfig, logger log.Logger, reg pr
 	default:
 		return nil, errors.Errorf("unsupported cache type for cache %s: %s", cacheName, cfg.Backend)
 	}
-}
-
-func CreateClientWithDelete(cacheName string, cfg BackendConfig, logger log.Logger, reg prometheus.Registerer) (DeletableCache, error) {
-	client, err := CreateClient(cacheName, cfg, logger, reg)
-	if err != nil {
-		return nil, err
-	}
-
-	clientCacheWithDelete, ok := client.(DeletableCache)
-	if !ok {
-		return nil, fmt.Errorf("client is not DeletableCache type")
-	}
-	return clientCacheWithDelete, nil
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -109,7 +109,7 @@ func (cfg *BackendConfig) Validate() error {
 	return nil
 }
 
-func CreateClient(cacheName string, cfg BackendConfig, logger log.Logger, reg prometheus.Registerer) (DeletableCache, error) {
+func CreateClient(cacheName string, cfg BackendConfig, logger log.Logger, reg prometheus.Registerer) (Cache, error) {
 	switch cfg.Backend {
 	case "":
 		// No caching.
@@ -132,4 +132,17 @@ func CreateClient(cacheName string, cfg BackendConfig, logger log.Logger, reg pr
 	default:
 		return nil, errors.Errorf("unsupported cache type for cache %s: %s", cacheName, cfg.Backend)
 	}
+}
+
+func CreateClientWithDelete(cacheName string, cfg BackendConfig, logger log.Logger, reg prometheus.Registerer) (DeletableCache, error) {
+	client, err := CreateClient(cacheName, cfg, logger, reg)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCacheWithDelete, ok := client.(DeletableCache)
+	if !ok {
+		return nil, fmt.Errorf("client is not DeletableCache type")
+	}
+	return clientCacheWithDelete, nil
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -43,10 +43,10 @@ type Cache interface {
 	// Option instances may be passed to modify the behavior of this Fetch call.
 	Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte
 
+	Name() string
+
 	// Delete cache entry with the given key if it exists.
 	Delete(ctx context.Context, key string) error
-
-	Name() string
 }
 
 // Options are used to modify the behavior of an individual call to get results

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -87,9 +87,8 @@ const (
 )
 
 type BackendConfig struct {
-	Backend   string            `yaml:"backend"`
-	Memcached MemcachedConfig   `yaml:"memcached"`
-	Redis     RedisClientConfig `yaml:"redis" category:"experimental"`
+	Backend   string          `yaml:"backend"`
+	Memcached MemcachedConfig `yaml:"memcached"`
 }
 
 // Validate the config.
@@ -117,13 +116,6 @@ func CreateClient(cacheName string, cfg BackendConfig, logger log.Logger, reg pr
 			return nil, errors.Wrapf(err, "failed to create memcached client")
 		}
 		return NewMemcachedCache(cacheName, logger, client, reg), nil
-
-	case BackendRedis:
-		client, err := NewRedisClient(logger, cacheName, cfg.Redis, reg)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create redis client")
-		}
-		return NewRedisCache(cacheName, logger, client, reg), nil
 
 	default:
 		return nil, errors.Errorf("unsupported cache type for cache %s: %s", cacheName, cfg.Backend)

--- a/cache/compression.go
+++ b/cache/compression.go
@@ -98,3 +98,8 @@ func (s *snappyCache) Fetch(ctx context.Context, keys []string, opts ...Option) 
 func (s *snappyCache) Name() string {
 	return s.next.Name()
 }
+
+func (s *snappyCache) Delete(_ context.Context, _ string) error {
+	// no-op
+	return nil
+}

--- a/cache/compression.go
+++ b/cache/compression.go
@@ -99,7 +99,6 @@ func (s *snappyCache) Name() string {
 	return s.next.Name()
 }
 
-func (s *snappyCache) Delete(_ context.Context, _ string) error {
-	// no-op
-	return nil
+func (s *snappyCache) Delete(ctx context.Context, key string) error {
+	return s.next.Delete(ctx, key)
 }

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -135,8 +135,7 @@ func (l *LRUCache) Name() string {
 	return "in-memory-" + l.name
 }
 
-func (l *LRUCache) Delete(_ context.Context, key string) error {
+func (l *LRUCache) Delete(ctx context.Context, key string) error {
 	l.lru.Remove(key)
-	// even if key to be deleted not found then just considered as non-error
-	return nil
+	return l.c.Delete(ctx, key)
 }

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -136,6 +136,8 @@ func (l *LRUCache) Name() string {
 }
 
 func (l *LRUCache) Delete(ctx context.Context, key string) error {
+	l.mtx.Lock()
 	l.lru.Remove(key)
+	l.mtx.Unlock()
 	return l.c.Delete(ctx, key)
 }

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -134,3 +134,8 @@ func (l *LRUCache) Fetch(ctx context.Context, keys []string, opts ...Option) (re
 func (l *LRUCache) Name() string {
 	return "in-memory-" + l.name
 }
+
+func (l *LRUCache) Delete(_ context.Context, _ string) error {
+	// no-op
+	return nil
+}

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -135,7 +135,8 @@ func (l *LRUCache) Name() string {
 	return "in-memory-" + l.name
 }
 
-func (l *LRUCache) Delete(_ context.Context, _ string) error {
-	// no-op
+func (l *LRUCache) Delete(_ context.Context, key string) error {
+	l.lru.Remove(key)
+	// even if key to be deleted not found then just considered as non-error
 	return nil
 }

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -56,6 +56,11 @@ func TestLRUCache_StoreFetch(t *testing.T) {
 		# TYPE cache_memory_requests_total counter
 		cache_memory_requests_total{name="test"} 4
 	`)))
+
+	lru.Delete(context.Background(), "buzz")
+	value, ok := lru.lru.Get("buzz")
+	require.False(t, ok)
+	require.Equal(t, nil, value)
 }
 
 func TestLRUCache_Evictions(t *testing.T) {

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -59,9 +59,8 @@ func TestLRUCache_StoreFetch(t *testing.T) {
 
 	err = lru.Delete(context.Background(), "buzz")
 	require.NoError(t, err)
-	value, ok := lru.lru.Get("buzz")
-	require.False(t, ok)
-	require.Equal(t, nil, value)
+	value := lru.Fetch(context.Background(), []string{"buzz"})
+	require.Equal(t, map[string][]uint8{}, value)
 }
 
 func TestLRUCache_Evictions(t *testing.T) {

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -57,7 +57,8 @@ func TestLRUCache_StoreFetch(t *testing.T) {
 		cache_memory_requests_total{name="test"} 4
 	`)))
 
-	lru.Delete(context.Background(), "buzz")
+	err = lru.Delete(context.Background(), "buzz")
+	require.NoError(t, err)
 	value, ok := lru.lru.Get("buzz")
 	require.False(t, ok)
 	require.Equal(t, nil, value)

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLRUCache_StoreFetch(t *testing.T) {
+func TestLRUCache_StoreFetchDelete(t *testing.T) {
 	var (
 		mock = NewMockCache()
 		ctx  = context.Background()
@@ -61,6 +61,18 @@ func TestLRUCache_StoreFetch(t *testing.T) {
 	require.NoError(t, err)
 	value := lru.Fetch(context.Background(), []string{"buzz"})
 	require.Equal(t, map[string][]uint8{}, value)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cache_memory_items_count Total number of items currently in the in-memory cache.
+		# TYPE cache_memory_items_count gauge
+		cache_memory_items_count{name="test"} 2
+		# HELP cache_memory_hits_total Total number of requests to the in-memory cache that were a hit.
+		# TYPE cache_memory_hits_total counter
+		cache_memory_hits_total{name="test"} 2
+		# HELP cache_memory_requests_total Total number of requests to the in-memory cache.
+		# TYPE cache_memory_requests_total counter
+		cache_memory_requests_total{name="test"} 5
+	`)))
 }
 
 func TestLRUCache_Evictions(t *testing.T) {

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -181,7 +181,7 @@ func newMemcachedClient(
 ) (*memcachedClient, error) {
 	newRegisterer := prometheus.WrapRegistererWith(
 		prometheus.Labels{labelCacheBackend: backendMemcached},
-		prometheus.WrapRegistererWithPrefix(cachePrefix, reg))
+		prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
 	reg = prometheus.WrapRegistererWithPrefix(legacyMemcachedPrefix, reg)
 
 	backwardCompatibleRegs := promregistry.TeeRegisterer{reg, newRegisterer}

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -166,7 +166,7 @@ func NewMemcachedClientWithConfig(logger log.Logger, name string, config Memcach
 	client.MaxIdleConns = config.MaxIdleConnections
 
 	if reg != nil {
-		reg = prometheus.WrapRegistererWith(prometheus.Labels{labelName: name}, reg)
+		reg = prometheus.WrapRegistererWith(prometheus.Labels{labelCacheName: name}, reg)
 	}
 	return newMemcachedClient(logger, client, selector, config, reg, name)
 }
@@ -180,7 +180,7 @@ func newMemcachedClient(
 	name string,
 ) (*memcachedClient, error) {
 	newRegisterer := prometheus.WrapRegistererWith(
-		prometheus.Labels{labelBackend: backendMemcached},
+		prometheus.Labels{labelCacheBackend: backendMemcached},
 		prometheus.WrapRegistererWithPrefix(cachePrefix, reg))
 	reg = prometheus.WrapRegistererWithPrefix(legacyMemcachedPrefix, reg)
 

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/dskit/dns"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/gate"
+	"github.com/grafana/dskit/promregistry"
 )
 
 var (
@@ -165,7 +166,7 @@ func NewMemcachedClientWithConfig(logger log.Logger, name string, config Memcach
 	client.MaxIdleConns = config.MaxIdleConnections
 
 	if reg != nil {
-		reg = prometheus.WrapRegistererWith(prometheus.Labels{"name": name}, reg)
+		reg = prometheus.WrapRegistererWith(prometheus.Labels{labelName: name}, reg)
 	}
 	return newMemcachedClient(logger, client, selector, config, reg, name)
 }
@@ -178,15 +179,21 @@ func newMemcachedClient(
 	reg prometheus.Registerer,
 	name string,
 ) (*memcachedClient, error) {
+	newRegisterer := prometheus.WrapRegistererWith(
+		prometheus.Labels{labelBackend: backendMemcached},
+		prometheus.WrapRegistererWithPrefix(cachePrefix, reg))
+	reg = prometheus.WrapRegistererWithPrefix(legacyMemcachedPrefix, reg)
+
+	backwardCompatibleRegs := promregistry.TeeRegisterer{reg, newRegisterer}
+
 	addressProvider := dns.NewProvider(
 		logger,
-		prometheus.WrapRegistererWithPrefix("memcached_", reg),
+		backwardCompatibleRegs,
 		dns.MiekgdnsResolverType,
 	)
 
-	metrics := newClientMetrics(
-		prometheus.WrapRegistererWithPrefix("memcached_", reg),
-	)
+	metrics := newClientMetrics(backwardCompatibleRegs)
+
 	c := &memcachedClient{
 		baseClient:      newBaseClient(logger, uint64(config.MaxItemSize), config.MaxAsyncBufferSize, config.MaxAsyncConcurrency, metrics),
 		logger:          log.With(logger, "name", name),
@@ -196,13 +203,16 @@ func newMemcachedClient(
 		addressProvider: addressProvider,
 		stop:            make(chan struct{}, 1),
 		getMultiGate: gate.New(
-			prometheus.WrapRegistererWithPrefix("memcached_getmulti_", reg),
+			promregistry.TeeRegisterer{
+				prometheus.WrapRegistererWithPrefix(getMultiPrefix, reg),
+				prometheus.WrapRegistererWithPrefix(getMultiPrefix, newRegisterer),
+			},
 			config.MaxGetMultiConcurrency,
 		),
 	}
 
 	c.clientInfo = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "memcached_client_info",
+		Name: "client_info",
 		Help: "A metric with a constant '1' value labeled by configuration options from which memcached client was configured.",
 		ConstLabels: prometheus.Labels{
 			"timeout":                      config.Timeout.String(),

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -204,15 +204,15 @@ func newMemcachedClient(
 		stop:            make(chan struct{}, 1),
 		getMultiGate: gate.New(
 			promregistry.TeeRegisterer{
-				prometheus.WrapRegistererWithPrefix(getMultiPrefix, legacyRegister),
-				prometheus.WrapRegistererWithPrefix(getMultiPrefix, reg),
+				prometheus.WrapRegistererWithPrefix(getMultiMetricNamePrefix, legacyRegister),
+				prometheus.WrapRegistererWithPrefix(getMultiMetricNamePrefix, reg),
 			},
 			config.MaxGetMultiConcurrency,
 		),
 	}
 
-	c.clientInfo = promauto.With(legacyRegister).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "client_info",
+	c.clientInfo = promauto.With(backwardCompatibleRegs).NewGaugeFunc(prometheus.GaugeOpts{
+		Name: clientInfoMetricName,
 		Help: "A metric with a constant '1' value labeled by configuration options from which memcached client was configured.",
 		ConstLabels: prometheus.Labels{
 			"timeout":                      config.Timeout.String(),

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -176,13 +176,13 @@ func newMemcachedClient(
 	client memcachedClientBackend,
 	selector updatableServerSelector,
 	config MemcachedClientConfig,
-	legacyRegister prometheus.Registerer,
+	reg prometheus.Registerer,
 	name string,
 ) (*memcachedClient, error) {
-	reg := prometheus.WrapRegistererWith(
+	legacyRegister := prometheus.WrapRegistererWithPrefix(legacyMemcachedPrefix, reg)
+	reg = prometheus.WrapRegistererWith(
 		prometheus.Labels{labelCacheBackend: backendMemcached},
-		prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, legacyRegister))
-	legacyRegister = prometheus.WrapRegistererWithPrefix(legacyMemcachedPrefix, legacyRegister)
+		prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
 
 	backwardCompatibleRegs := promregistry.TeeRegisterer{legacyRegister, reg}
 

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -85,9 +85,10 @@ func (m *MockCache) Flush() {
 // InstrumentedMockCache is a mocked cache implementation which also tracks the number
 // of times its functions are called.
 type InstrumentedMockCache struct {
-	cache      *MockCache
-	storeCount atomic.Int32
-	fetchCount atomic.Int32
+	cache       *MockCache
+	storeCount  atomic.Int32
+	fetchCount  atomic.Int32
+	deleteCount atomic.Int32
 }
 
 // NewInstrumentedMockCache makes a new InstrumentedMockCache.
@@ -112,6 +113,7 @@ func (m *InstrumentedMockCache) Name() string {
 }
 
 func (m *InstrumentedMockCache) Delete(ctx context.Context, key string) error {
+	m.deleteCount.Inc()
 	return m.cache.Delete(ctx, key)
 }
 
@@ -121,4 +123,8 @@ func (m *InstrumentedMockCache) CountStoreCalls() int {
 
 func (m *InstrumentedMockCache) CountFetchCalls() int {
 	return int(m.fetchCount.Load())
+}
+
+func (m *InstrumentedMockCache) CountDeleteCalls() int {
+	return int(m.deleteCount.Load())
 }

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -67,18 +67,19 @@ func (m *MockCache) Name() string {
 	return "mock"
 }
 
+func (m *MockCache) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.cache, key)
+	return nil
+}
+
 func (m *MockCache) Flush() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.cache = map[string]Item{}
-}
-
-func (m *MockCache) Delete(key string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	delete(m.cache, key)
 }
 
 // InstrumentedMockCache is a mocked cache implementation which also tracks the number
@@ -108,6 +109,11 @@ func (m *InstrumentedMockCache) Fetch(ctx context.Context, keys []string, opts .
 
 func (m *InstrumentedMockCache) Name() string {
 	return m.cache.Name()
+}
+
+func (m *InstrumentedMockCache) Delete(_ context.Context, _ string) error {
+	// no-op
+	return nil
 }
 
 func (m *InstrumentedMockCache) CountStoreCalls() int {

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -111,9 +111,8 @@ func (m *InstrumentedMockCache) Name() string {
 	return m.cache.Name()
 }
 
-func (m *InstrumentedMockCache) Delete(_ context.Context, _ string) error {
-	// no-op
-	return nil
+func (m *InstrumentedMockCache) Delete(ctx context.Context, key string) error {
+	return m.cache.Delete(ctx, key)
 }
 
 func (m *InstrumentedMockCache) CountStoreCalls() int {

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -177,11 +177,9 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 		opts.TLSConfig = tlsClientConfig
 	}
 
-	if reg != nil {
-		reg = prometheus.WrapRegistererWith(
-			prometheus.Labels{labelCacheName: name, labelCacheBackend: backendRedis},
-			prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
-	}
+	reg = prometheus.WrapRegistererWith(
+		prometheus.Labels{labelCacheName: name, labelCacheBackend: backendRedis},
+		prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
 
 	metrics := newClientMetrics(reg)
 

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -179,7 +179,7 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 
 	if reg != nil {
 		reg = prometheus.WrapRegistererWith(
-			prometheus.Labels{labelName: name, labelBackend: backendRedis},
+			prometheus.Labels{labelCacheName: name, labelCacheBackend: backendRedis},
 			prometheus.WrapRegistererWithPrefix(cachePrefix, reg))
 	}
 

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -191,13 +191,13 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 	}
 	if config.MaxGetMultiConcurrency > 0 {
 		c.getMultiGate = gate.New(
-			prometheus.WrapRegistererWithPrefix(getMultiPrefix, reg),
+			prometheus.WrapRegistererWithPrefix(getMultiMetricNamePrefix, reg),
 			config.MaxGetMultiConcurrency,
 		)
 	}
 
 	c.clientInfo = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "redis_client_info",
+		Name: clientInfoMetricName,
 		Help: "A metric with a constant '1' value labeled by configuration options from which redis client was configured.",
 		ConstLabels: prometheus.Labels{
 			"dial_timeout":              config.DialTimeout.String(),

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -180,7 +180,7 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 	if reg != nil {
 		reg = prometheus.WrapRegistererWith(
 			prometheus.Labels{labelCacheName: name, labelCacheBackend: backendRedis},
-			prometheus.WrapRegistererWithPrefix(cachePrefix, reg))
+			prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
 	}
 
 	metrics := newClientMetrics(reg)

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -89,8 +89,8 @@ type RedisClientConfig struct {
 	// If set to 0, concurrency is unlimited.
 	MaxGetMultiConcurrency int `yaml:"max_get_multi_concurrency" category:"advanced"`
 
-	// GetMultiBatchSize specifies the maximum size per batch for mget.
-	GetMultiBatchSize int `yaml:"get_multi_batch_size" category:"advanced"`
+	// MaxGetMultiBatchSize specifies the maximum size per batch for mget.
+	MaxGetMultiBatchSize int `yaml:"max_get_multi_batch_size" category:"advanced"`
 
 	// TLSEnabled enable TLS for Redis connection.
 	TLSEnabled bool `yaml:"tls_enabled" category:"advanced"`
@@ -117,7 +117,7 @@ func (c *RedisClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagS
 	f.IntVar(&c.MaxAsyncConcurrency, prefix+".max-async-concurrency", 50, "The maximum number of concurrent asynchronous operations can occur.")
 	f.IntVar(&c.MaxAsyncBufferSize, prefix+".max-async-buffer-size", 25000, "The maximum number of enqueued asynchronous operations allowed.")
 	f.IntVar(&c.MaxGetMultiConcurrency, prefix+".max-get-multi-concurrency", 100, "The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited.")
-	f.IntVar(&c.GetMultiBatchSize, prefix+".max-get-multi-batch-size", 100, "The maximum size per batch for mget operations.")
+	f.IntVar(&c.MaxGetMultiBatchSize, prefix+".max-get-multi-batch-size", 100, "The maximum size per batch for mget operations.")
 	f.IntVar(&c.MaxItemSize, prefix+".max-item-size", 16*1024*1024, "The maximum size of an item stored in Redis. Bigger items are not stored. If set to 0, no maximum size is enforced.")
 
 	f.BoolVar(&c.TLSEnabled, prefix+".tls-enabled", false, "Enable connecting to Redis with TLS.")
@@ -208,7 +208,7 @@ func (c *redisClient) GetMulti(ctx context.Context, keys []string, _ ...Option) 
 	var mu sync.Mutex
 	results := make(map[string][]byte, len(keys))
 
-	err := doWithBatch(ctx, len(keys), c.config.GetMultiBatchSize, c.getMultiGate, func(startIndex, endIndex int) error {
+	err := doWithBatch(ctx, len(keys), c.config.MaxGetMultiBatchSize, c.getMultiGate, func(startIndex, endIndex int) error {
 		start := time.Now()
 		c.metrics.operations.WithLabelValues(opGetMulti).Inc()
 

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	dstls "github.com/grafana/dskit/crypto/tls"
 	"github.com/grafana/dskit/flagext"
@@ -145,6 +147,9 @@ type redisClient struct {
 	getMultiGate gate.Gate
 
 	logger log.Logger
+
+	// Tracked metrics.
+	clientInfo prometheus.GaugeFunc
 }
 
 // NewRedisClient makes a new RedisClient.
@@ -172,11 +177,14 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 		opts.TLSConfig = tlsClientConfig
 	}
 
-	reg = prometheus.WrapRegistererWith(prometheus.Labels{"name": name}, reg)
+	if reg != nil {
+		reg = prometheus.WrapRegistererWith(
+			prometheus.Labels{labelName: name, labelBackend: backendRedis},
+			prometheus.WrapRegistererWithPrefix(cachePrefix, reg))
+	}
 
-	metrics := newClientMetrics(
-		prometheus.WrapRegistererWithPrefix("redis_", reg),
-	)
+	metrics := newClientMetrics(reg)
+
 	c := &redisClient{
 		baseClient:      newBaseClient(logger, uint64(config.MaxItemSize), config.MaxAsyncBufferSize, config.MaxAsyncConcurrency, metrics),
 		UniversalClient: redis.NewUniversalClient(opts),
@@ -185,10 +193,28 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 	}
 	if config.MaxGetMultiConcurrency > 0 {
 		c.getMultiGate = gate.New(
-			prometheus.WrapRegistererWithPrefix("redis_getmulti_", reg),
+			prometheus.WrapRegistererWithPrefix(getMultiPrefix, reg),
 			config.MaxGetMultiConcurrency,
 		)
 	}
+
+	c.clientInfo = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "redis_client_info",
+		Help: "A metric with a constant '1' value labeled by configuration options from which redis client was configured.",
+		ConstLabels: prometheus.Labels{
+			"dial_timeout":              config.DialTimeout.String(),
+			"read_timeout":              config.ReadTimeout.String(),
+			"write_timeout":             config.WriteTimeout.String(),
+			"connection_pool_size":      strconv.Itoa(config.ConnectionPoolSize),
+			"max_async_concurrency":     strconv.Itoa(config.MaxAsyncConcurrency),
+			"max_async_buffer_size":     strconv.Itoa(config.MaxAsyncBufferSize),
+			"max_item_size":             strconv.FormatUint(uint64(config.MaxItemSize), 10),
+			"max_get_multi_concurrency": strconv.Itoa(config.MaxGetMultiConcurrency),
+			"max_get_multi_batch_size":  strconv.Itoa(config.MaxGetMultiBatchSize),
+		},
+	},
+		func() float64 { return 1 },
+	)
 	return c, nil
 }
 

--- a/cache/redis_client_test.go
+++ b/cache/redis_client_test.go
@@ -26,7 +26,7 @@ var (
 		MinIdleConnections:     10,
 		IdleTimeout:            time.Minute * 5,
 		MaxGetMultiConcurrency: 100,
-		GetMultiBatchSize:      100,
+		MaxGetMultiBatchSize:   100,
 		MaxItemSize:            16 * 1024 * 1024,
 		MaxAsyncConcurrency:    50,
 		MaxAsyncBufferSize:     25000,
@@ -110,22 +110,22 @@ func TestRedisClient(t *testing.T) {
 		redisConfig func() RedisClientConfig
 	}{
 		{
-			name: "MaxConcurrency and GetMultiBatchSize set to a value > 0",
+			name: "MaxConcurrency and MaxGetMultiBatchSize set to a value > 0",
 			redisConfig: func() RedisClientConfig {
 				cfg := defaultRedisClientConfig
 				cfg.Endpoint = flagext.StringSliceCSV{s.Addr()}
 				cfg.MaxGetMultiConcurrency = 2
-				cfg.GetMultiBatchSize = 2
+				cfg.MaxGetMultiBatchSize = 2
 				return cfg
 			},
 		},
 		{
-			name: "MaxConcurrency and GetMultiBatchSize set to 0",
+			name: "MaxConcurrency and MaxGetMultiBatchSize set to 0",
 			redisConfig: func() RedisClientConfig {
 				cfg := defaultRedisClientConfig
 				cfg.Endpoint = flagext.StringSliceCSV{s.Addr()}
 				cfg.MaxGetMultiConcurrency = 0
-				cfg.GetMultiBatchSize = 0
+				cfg.MaxGetMultiBatchSize = 0
 				return cfg
 			},
 		},

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -86,14 +86,14 @@ func newRemoteCache(name string, logger log.Logger, remoteClient RemoteCacheClie
 // Store data identified by keys.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
-func (c *remoteCache) Store(_ context.Context, data map[string][]byte, ttl time.Duration) {
+func (c *remoteCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
 	var (
 		firstErr error
 		failed   int
 	)
 
 	for key, val := range data {
-		if err := c.remoteClient.SetAsync(context.Background(), key, val, ttl); err != nil {
+		if err := c.remoteClient.SetAsync(ctx, key, val, ttl); err != nil {
 			failed++
 			if firstErr == nil {
 				firstErr = err

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -23,7 +23,7 @@ const (
 	backendRedis          = "redis"
 	backendMemcached      = "memcached"
 	cacheMetricNamePrefix = "cache_"
-	getMultiPrefix        = "getMulti_"
+	getMultiPrefix        = "getmulti_"
 	legacyMemcachedPrefix = "memcached_"
 )
 

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -86,14 +86,14 @@ func newRemoteCache(name string, logger log.Logger, remoteClient RemoteCacheClie
 // Store data identified by keys.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
-func (c *remoteCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+func (c *remoteCache) Store(_ context.Context, data map[string][]byte, ttl time.Duration) {
 	var (
 		firstErr error
 		failed   int
 	)
 
 	for key, val := range data {
-		if err := c.remoteClient.SetAsync(ctx, key, val, ttl); err != nil {
+		if err := c.remoteClient.SetAsync(context.Background(), key, val, ttl); err != nil {
 			failed++
 			if firstErr == nil {
 				firstErr = err

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -18,8 +18,8 @@ var (
 )
 
 const (
-	labelName             = "name"
-	labelBackend          = "backend"
+	labelCacheName        = "name"
+	labelCacheBackend     = "backend"
 	backendRedis          = "redis"
 	backendMemcached      = "memcached"
 	cachePrefix           = "cache_"
@@ -42,7 +42,7 @@ func NewMemcachedCache(name string, logger log.Logger, memcachedClient RemoteCac
 			promregistry.TeeRegisterer{
 				prometheus.WrapRegistererWithPrefix(cachePrefix+legacyMemcachedPrefix, reg),
 				prometheus.WrapRegistererWith(
-					prometheus.Labels{labelBackend: backendMemcached},
+					prometheus.Labels{labelCacheBackend: backendMemcached},
 					prometheus.WrapRegistererWithPrefix(cachePrefix, reg)),
 			},
 		),
@@ -62,7 +62,7 @@ func NewRedisCache(name string, logger log.Logger, redisClient RemoteCacheClient
 			logger,
 			redisClient,
 			prometheus.WrapRegistererWith(
-				prometheus.Labels{labelBackend: backendRedis},
+				prometheus.Labels{labelCacheBackend: backendRedis},
 				prometheus.WrapRegistererWithPrefix(cachePrefix, reg)),
 		),
 	}
@@ -88,13 +88,13 @@ func newRemoteCache(name string, logger log.Logger, remoteClient RemoteCacheClie
 	c.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name:        "requests_total",
 		Help:        "Total number of items requests to cache.",
-		ConstLabels: prometheus.Labels{labelName: name},
+		ConstLabels: prometheus.Labels{labelCacheName: name},
 	})
 
 	c.hits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name:        "hits_total",
 		Help:        "Total number of items requests to the cache that were a hit.",
-		ConstLabels: prometheus.Labels{labelName: name},
+		ConstLabels: prometheus.Labels{labelCacheName: name},
 	})
 
 	level.Info(logger).Log("msg", "created remote cache")

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -116,6 +116,11 @@ func (c *remoteCache) Fetch(ctx context.Context, keys []string, opts ...Option) 
 	return results
 }
 
+// Delete data with the given key from cache.
+func (c *remoteCache) Delete(ctx context.Context, key string) error {
+	return c.remoteClient.Delete(ctx, key)
+}
+
 func (c *remoteCache) Name() string {
 	return c.name
 }

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -22,7 +22,7 @@ const (
 	labelCacheBackend     = "backend"
 	backendRedis          = "redis"
 	backendMemcached      = "memcached"
-	cachePrefix           = "cache_"
+	cacheMetricNamePrefix = "cache_"
 	getMultiPrefix        = "getMulti_"
 	legacyMemcachedPrefix = "memcached_"
 )
@@ -40,10 +40,10 @@ func NewMemcachedCache(name string, logger log.Logger, memcachedClient RemoteCac
 			logger,
 			memcachedClient,
 			promregistry.TeeRegisterer{
-				prometheus.WrapRegistererWithPrefix(cachePrefix+legacyMemcachedPrefix, reg),
+				prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix+legacyMemcachedPrefix, reg),
 				prometheus.WrapRegistererWith(
 					prometheus.Labels{labelCacheBackend: backendMemcached},
-					prometheus.WrapRegistererWithPrefix(cachePrefix, reg)),
+					prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg)),
 			},
 		),
 	}
@@ -63,7 +63,7 @@ func NewRedisCache(name string, logger log.Logger, redisClient RemoteCacheClient
 			redisClient,
 			prometheus.WrapRegistererWith(
 				prometheus.Labels{labelCacheBackend: backendRedis},
-				prometheus.WrapRegistererWithPrefix(cachePrefix, reg)),
+				prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg)),
 		),
 	}
 }

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -18,13 +18,14 @@ var (
 )
 
 const (
-	labelCacheName        = "name"
-	labelCacheBackend     = "backend"
-	backendRedis          = "redis"
-	backendMemcached      = "memcached"
-	cacheMetricNamePrefix = "cache_"
-	getMultiPrefix        = "getmulti_"
-	legacyMemcachedPrefix = "memcached_"
+	labelCacheName           = "name"
+	labelCacheBackend        = "backend"
+	backendRedis             = "redis"
+	backendMemcached         = "memcached"
+	cacheMetricNamePrefix    = "cache_"
+	getMultiMetricNamePrefix = "getmulti_"
+	legacyMemcachedPrefix    = "memcached_"
+	clientInfoMetricName     = "client_info"
 )
 
 // MemcachedCache is a memcached-based cache.

--- a/cache/tracing.go
+++ b/cache/tracing.go
@@ -46,7 +46,6 @@ func (t SpanlessTracingCache) Name() string {
 	return t.c.Name()
 }
 
-func (t SpanlessTracingCache) Delete(_ context.Context, _ string) error {
-	// no-op
-	return nil
+func (t SpanlessTracingCache) Delete(ctx context.Context, key string) error {
+	return t.c.Delete(ctx, key)
 }

--- a/cache/tracing.go
+++ b/cache/tracing.go
@@ -45,3 +45,8 @@ func (t SpanlessTracingCache) Fetch(ctx context.Context, keys []string, opts ...
 func (t SpanlessTracingCache) Name() string {
 	return t.c.Name()
 }
+
+func (t SpanlessTracingCache) Delete(_ context.Context, _ string) error {
+	// no-op
+	return nil
+}

--- a/cache/versioned.go
+++ b/cache/versioned.go
@@ -49,9 +49,8 @@ func (c Versioned) Name() string {
 	return c.cache.Name()
 }
 
-func (c Versioned) Delete(_ context.Context, _ string) error {
-	// no-op
-	return nil
+func (c Versioned) Delete(ctx context.Context, key string) error {
+	return c.cache.Delete(ctx, c.addVersion(key))
 }
 
 func (c Versioned) addVersion(k string) string {

--- a/cache/versioned.go
+++ b/cache/versioned.go
@@ -49,6 +49,11 @@ func (c Versioned) Name() string {
 	return c.cache.Name()
 }
 
+func (c Versioned) Delete(_ context.Context, _ string) error {
+	// no-op
+	return nil
+}
+
 func (c Versioned) addVersion(k string) string {
 	return c.versionPrefix + k
 }

--- a/cache/versioned_test.go
+++ b/cache/versioned_test.go
@@ -42,6 +42,8 @@ func TestVersioned(t *testing.T) {
 		require.NoError(t, err)
 		resV1 = v1.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, map[string][]uint8{}, resV1)
+		resV2 = v2.Fetch(context.Background(), []string{"hit", "miss"})
+		assert.Equal(t, v2Data, resV2, "v2 cached data should still retain the data")
 		err = v2.Delete(context.Background(), "hit")
 		require.NoError(t, err)
 		resV2 = v2.Fetch(context.Background(), []string{"hit", "miss"})

--- a/cache/versioned_test.go
+++ b/cache/versioned_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +18,8 @@ func TestVersioned(t *testing.T) {
 		v1.Store(context.Background(), data, time.Minute)
 		res := v1.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, data, res)
-		v1.Delete(context.Background(), "hit")
+		err := v1.Delete(context.Background(), "hit")
+		require.NoError(t, err)
 		res = v1.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, map[string][]uint8{}, res)
 	})
@@ -35,10 +38,12 @@ func TestVersioned(t *testing.T) {
 		resV2 := v2.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, v2Data, resV2)
 
-		v1.Delete(context.Background(), "hit")
+		err := v1.Delete(context.Background(), "hit")
+		require.NoError(t, err)
 		resV1 = v1.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, map[string][]uint8{}, resV1)
-		v2.Delete(context.Background(), "hit")
+		err = v2.Delete(context.Background(), "hit")
+		require.NoError(t, err)
 		resV2 = v2.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, map[string][]uint8{}, resV2)
 	})

--- a/cache/versioned_test.go
+++ b/cache/versioned_test.go
@@ -9,13 +9,16 @@ import (
 )
 
 func TestVersioned(t *testing.T) {
-	t.Run("happy case: can store and retrieve", func(t *testing.T) {
+	t.Run("happy case: can store, retrieve and delete", func(t *testing.T) {
 		cache := NewMockCache()
 		v1 := NewVersioned(cache, 1)
 		data := map[string][]byte{"hit": []byte(`data`)}
 		v1.Store(context.Background(), data, time.Minute)
 		res := v1.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, data, res)
+		v1.Delete(context.Background(), "hit")
+		res = v1.Fetch(context.Background(), []string{"hit", "miss"})
+		assert.Equal(t, map[string][]uint8{}, res)
 	})
 
 	t.Run("different versions use different datasets", func(t *testing.T) {
@@ -31,5 +34,12 @@ func TestVersioned(t *testing.T) {
 		assert.Equal(t, v1Data, resV1)
 		resV2 := v2.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, v2Data, resV2)
+
+		v1.Delete(context.Background(), "hit")
+		resV1 = v1.Fetch(context.Background(), []string{"hit", "miss"})
+		assert.Equal(t, map[string][]uint8{}, resV1)
+		v2.Delete(context.Background(), "hit")
+		resV2 = v2.Fetch(context.Background(), []string{"hit", "miss"})
+		assert.Equal(t, map[string][]uint8{}, resV2)
 	})
 }

--- a/gate/gate.go
+++ b/gate/gate.go
@@ -70,6 +70,7 @@ func NewInstrumented(reg prometheus.Registerer, maxConcurrent int, gate Gate) Ga
 			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
 		}),
 	}
+
 	g.max.Set(float64(maxConcurrent))
 	return g
 }

--- a/gate/gate.go
+++ b/gate/gate.go
@@ -70,7 +70,6 @@ func NewInstrumented(reg prometheus.Registerer, maxConcurrent int, gate Gate) Ga
 			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
 		}),
 	}
-
 	g.max.Set(float64(maxConcurrent))
 	return g
 }

--- a/promregistry/registry.go
+++ b/promregistry/registry.go
@@ -1,0 +1,32 @@
+package promregistry
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// TeeRegisterer is a slice of Registerers. It implements Registerer itself and
+// forward registrations to all Registerers in the slice.
+type TeeRegisterer []prometheus.Registerer
+
+func (t TeeRegisterer) Register(c prometheus.Collector) error {
+	for _, reg := range t {
+		if err := reg.Register(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t TeeRegisterer) MustRegister(cs ...prometheus.Collector) {
+	for _, reg := range t {
+		reg.MustRegister(cs...)
+	}
+}
+
+func (t TeeRegisterer) Unregister(c prometheus.Collector) bool {
+	result := false
+	for _, reg := range t {
+		if reg.Unregister(c) {
+			result = true
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

- Refactor and simplify cache interfaces in dskit. We are adding the Delete method in the cache.Cache interface so that it can cover the use case on where cache items can be deleted.
- Implement backward compatible cache metrics exposition by moving backend type (e.g. redis/memcached) as label instead of part of metric name. Was part of #260

More context: ([internal link](https://github.com/grafana/backend-enterprise/pull/4030#issuecomment-1379944449)).

Dependency to be updated (will do once this PR merged):
* Backend Enterprise: https://github.com/grafana/backend-enterprise/pull/4113
* Mimir: https://github.com/grafana/mimir/pull/4078

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
