### PR TITLE
ingester health check with zone awareness

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -237,6 +237,15 @@ func (i *Lifecycler) checkRingHealthForReadiness(ctx context.Context) error {
 	}
 
 	if i.cfg.ReadinessCheckRingHealth {
+		if i.Zone != "" {
+			if err := ringDesc.IsReadyZoneAware(time.Now(), i.cfg.RingConfig.HeartbeatTimeout, i.Zone); err != nil {
+				level.Warn(i.logger).Log("msg", "found an existing instance(s) not in the expected zone with a problem in the ring, "+
+					"this instance cannot become ready until this problem is resolved. "+
+					"The /ring http endpoint on the distributor (or single binary) provides visibility into the ring.",
+					"ring", i.RingName, "err", err, "expectedZone", i.Zone)
+				return err
+			}
+		}
 		if err := ringDesc.IsReady(time.Now(), i.cfg.RingConfig.HeartbeatTimeout); err != nil {
 			level.Warn(i.logger).Log("msg", "found an existing instance(s) with a problem in the ring, "+
 				"this instance cannot become ready until this problem is resolved. "+


### PR DESCRIPTION
**What this PR does**:
Modify the ready/health check to accept leaving ingesters if they are in the same zone.

**Which issue(s) this PR fixes**:
Loki team has been investigating some behaviour we only saw during rollouts and we found this PR: https://github.com/grafana/mimir/pull/48

Rather than just reimplement this again in Loki (and then maybe Tempo as well) it makes sense to support similar functionality in dskit. It also felt safer to rather than blanket ignore the healthcheck failing to only ignore it if the inactive ingester is in the same zone.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
