### PR TITLE
Ring: Allow for custom strategy while re-using existing key namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [ENHANCEMENT] Import Bytes type, DeleteAll function and DNS package from Thanos. #228
 * [ENHANCEMENT] Execute health checks in ring client pool concurrently. #237
 * [ENHANCEMENT] Cache: Add the ability to use a custom memory allocator for cache results. #249
+* [ENHANCEMENT] Ring: Allow for specifying a custom replication strategy while keeping the same KV client suffix #TBD
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-
 	"math"
 	"math/rand"
 	"net/http"
@@ -201,6 +200,11 @@ type subringCacheKey struct {
 
 // New creates a new Ring. Being a service, Ring needs to be started to do anything.
 func New(cfg Config, name, key string, logger log.Logger, reg prometheus.Registerer) (*Ring, error) {
+	return NewWithStrategy(cfg, name, key, NewDefaultReplicationStrategy(), logger, reg)
+}
+
+// NewWithStrategy creates a new Ring with a custom strategy. Being a service, Ring needs to be started to do anything.
+func NewWithStrategy(cfg Config, name, key string, strategy ReplicationStrategy, logger log.Logger, reg prometheus.Registerer) (*Ring, error) {
 	codec := GetCodec()
 	// Suffix all client names with "-ring" to denote this kv client is used by the ring
 	store, err := kv.NewClient(
@@ -213,7 +217,7 @@ func New(cfg Config, name, key string, logger log.Logger, reg prometheus.Registe
 		return nil, err
 	}
 
-	return NewWithStoreClientAndStrategy(cfg, name, key, store, NewDefaultReplicationStrategy(), reg, logger)
+	return NewWithStoreClientAndStrategy(cfg, name, key, store, strategy, reg, logger)
 }
 
 func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client, strategy ReplicationStrategy, reg prometheus.Registerer, logger log.Logger) (*Ring, error) {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2185,7 +2185,7 @@ func TestRingUpdates(t *testing.T) {
 				ExcludedZones:     flagext.StringSliceCSV(testData.excludedZones),
 			}
 
-			ring, err := New(cfg, "test", "test", log.NewNopLogger(), nil)
+			ring, err := NewWithStrategy(cfg, "test", "test", NewDefaultReplicationStrategy(), log.NewNopLogger(), nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), ring))
 			t.Cleanup(func() {
@@ -2281,7 +2281,7 @@ func TestShuffleShardWithCaching(t *testing.T) {
 		ZoneAwarenessEnabled: true,
 	}
 
-	ring, err := New(cfg, "test", "test", log.NewNopLogger(), nil)
+	ring, err := NewWithStrategy(cfg, "test", "test", NewDefaultReplicationStrategy(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ring))
 	t.Cleanup(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

I'd like to add the ability to Mimir to use the other replication strategy `ignoreUnhealthyInstancesReplicationStrategy` with the ingesters so that we can still (very temporarily) tolerate a two AZ outage and fulfill our realtime monitoring use case. I understand this isn't for everyone but it be worth still allowing customers to opt in to this strategy if they want.

To do this I was thinking that instead of a risky rewrite of switching Mimir to preserve the KV suffix `-ring` that you get for free with `New()` I would extend dskit to allow for specifying a custom strategy while keeping the default KV suffix.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
