### PR TITLE
runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [BUGFIX] runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery from bad config with exact same config hash as before. #262
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Changelog
 
-* [BUGFIX] runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery from bad config with exact same config hash as before. #262
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71
@@ -91,3 +90,4 @@
 * [BUGFIX] Memberlist: retry joining memberlist cluster on startup when no nodes are resolved. #215
 * [BUGFIX] Ring status page: display 100% ownership as "100%", rather than "1e+02%". #231
 * [BUGFIX] Memberlist: fix crash when methods from `memberlist.Delegate` interface are called on `*memberlist.KV` before the service is fully started. #244
+* [BUGFIX] runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery from bad config with exact same config hash as before. #262

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -175,6 +175,11 @@ func (om *Manager) loadConfig() error {
 
 	if sameHashes {
 		// No need to rebuild runtime config.
+
+		// NOTE: Need to set load success metric to 1 because there can be the case where
+		// success metric was set to 0 during bad config and may never set back to 1 if bad config
+		// was fixed with good config with same hash as before.
+		om.configLoadSuccess.Set(1)
 		return nil
 	}
 

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -175,10 +175,6 @@ func (om *Manager) loadConfig() error {
 
 	if sameHashes {
 		// No need to rebuild runtime config.
-
-		// NOTE: Need to set load success metric to 1 because there can be the case where
-		// success metric was set to 0 during bad config and may never set back to 1 if bad config
-		// was fixed with good config with same hash as before.
 		om.configLoadSuccess.Set(1)
 		return nil
 	}

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -438,6 +438,83 @@ func TestManager_ShouldFastFailOnInvalidConfigAtStartup(t *testing.T) {
 	require.Error(t, services.StartAndAwaitRunning(context.Background(), m))
 }
 
+func TestManager_ReloadMetricAfterBadConfigRecovery(t *testing.T) {
+	// NOTE: This is to assert whether `runtime_config_last_reload_successful` is set back to 1
+	// after recovery from bad config, provided that after recovery the config hash is exactly same as before bad config failure.
+
+	// Create a valid runtime config file
+	tempFile, err := os.CreateTemp("", "valid-config")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove(tempFile.Name()))
+	})
+
+	validConfig := []byte(`overrides:
+    user1:
+        limit2: 150
+`)
+
+	err = os.WriteFile(tempFile.Name(), validConfig, 0600)
+	require.NoError(t, err)
+
+	managerConfig := Config{
+		ReloadPeriod: 100 * time.Millisecond,
+		LoadPath:     []string{tempFile.Name()},
+		Loader:       testLoadOverrides,
+	}
+
+	reg := prometheus.NewPedanticRegistry()
+
+	manager, err := New(managerConfig, reg, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+
+	validConfigSha256 := sha256.Sum256(validConfig)
+
+	// Now success metric should be 1
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP runtime_config_hash Hash of the currently active runtime configuration, merged from all configured files.
+					# TYPE runtime_config_hash gauge
+					runtime_config_hash{sha256="%s"} 1
+					# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
+					# TYPE runtime_config_last_reload_successful gauge
+					runtime_config_last_reload_successful 1
+				`, fmt.Sprintf("%x", validConfigSha256)))))
+
+	// Make config invalid. Now metrics should be 0
+
+	invalidConfig := []byte("invalid")
+	err = os.WriteFile(tempFile.Name(), invalidConfig, 0600)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP runtime_config_hash Hash of the currently active runtime configuration, merged from all configured files.
+					# TYPE runtime_config_hash gauge
+					runtime_config_hash{sha256="%s"} 1
+					# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
+					# TYPE runtime_config_last_reload_successful gauge
+					runtime_config_last_reload_successful 0
+				`, fmt.Sprintf("%x", validConfigSha256)))))
+
+	// Revert config to good state. Make sure it has same hash as before.
+	err = os.WriteFile(tempFile.Name(), validConfig, 0600)
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	// Now success metric should be back to 1.
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP runtime_config_hash Hash of the currently active runtime configuration, merged from all configured files.
+					# TYPE runtime_config_hash gauge
+					runtime_config_hash{sha256="%s"} 1
+					# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
+					# TYPE runtime_config_last_reload_successful gauge
+					runtime_config_last_reload_successful 1
+				`, fmt.Sprintf("%x", validConfigSha256)))))
+}
+
 func TestManager_UnchangedFileDoesntTriggerReload(t *testing.T) {
 	loadCounter := atomic.NewInt32(0)
 

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -471,7 +471,7 @@ func TestManager_ReloadMetricAfterBadConfigRecovery(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
 
-	assertHashAndSuccessMetric := func(config []byte, successCount int) {
+	assertHashAndSuccessMetric := func(config []byte, lastSuccessful int) {
 		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP runtime_config_hash Hash of the currently active runtime configuration, merged from all configured files.
 					# TYPE runtime_config_hash gauge
@@ -479,7 +479,7 @@ func TestManager_ReloadMetricAfterBadConfigRecovery(t *testing.T) {
 					# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
 					# TYPE runtime_config_last_reload_successful gauge
 					runtime_config_last_reload_successful %d
-				`, fmt.Sprintf("%x", sha256.Sum256(config)), successCount))))
+				`, fmt.Sprintf("%x", sha256.Sum256(config)), lastSuccessful))))
 
 	}
 


### PR DESCRIPTION
Currently, we have some optimization of not actually reloading the config if the new config matches the `hash` with old config. 
But that's not properly handled for metric `runtime_config_last_reload_successful` exposing subtle bug during following scenario.

1. Correct config - hash x, sucess_metric 1
2. Bad config - hash x (NOTE: we just keep last successful config hash), success_metric 0
3. Correct config (exactly as 1) - hash x, success_metric 0

Problem with (3) is, since hash never changed, success_metric is never set back to 1.

This causes problem say if alert is triggered for bad config (during (2)), And even after fixing the bad config, if config hash turns out to be exactly same as before, then alert will never resolve.

Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
