### PR TITLE
Add option to make user invisible modules targetable

### DIFF
--- a/modules/modules.go
+++ b/modules/modules.go
@@ -180,7 +180,7 @@ func (m *Manager) IsUserVisibleModule(mod string) bool {
 }
 
 // IsTargetableModule check if given module is targetable or not. Returns true
-// if and only if the given module is registered and is target.
+// if and only if the given module is registered and is targetable.
 func (m *Manager) IsTargetableModule(mod string) bool {
 	val, ok := m.modules[mod]
 

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -20,6 +20,9 @@ type module struct {
 
 	// is this module user visible (i.e. intended to be passed to `InitModuleServices`)
 	userVisible bool
+
+	// is the module allowed to be selected as a target
+	targetable bool
 }
 
 // Manager is a component that initialises modules of the application
@@ -32,6 +35,15 @@ type Manager struct {
 // UserInvisibleModule is an option for `RegisterModule` that marks module not visible to user. Modules are user visible by default.
 func UserInvisibleModule(m *module) {
 	m.userVisible = false
+
+	// by default invisible modules should not be targetable.
+	m.targetable = false
+}
+
+// TargetableModule is an option for `RegisterModule` that marks module targetable.
+// Modules are targetable by default, except those that are user invisible.
+func TargetableModule(m *module) {
+	m.targetable = true
 }
 
 // NewManager creates a new Manager
@@ -49,6 +61,7 @@ func (m *Manager) RegisterModule(name string, initFn func() (services.Service, e
 	m.modules[name] = &module{
 		initFn:      initFn,
 		userVisible: true,
+		targetable:  true,
 	}
 
 	for _, o := range options {
@@ -161,6 +174,18 @@ func (m *Manager) IsUserVisibleModule(mod string) bool {
 
 	if ok {
 		return val.userVisible
+	}
+
+	return false
+}
+
+// IsTargetableModule check if given module is targetable or not. Returns true
+// if and only if the given module is registered and is target.
+func (m *Manager) IsTargetableModule(mod string) bool {
+	val, ok := m.modules[mod]
+
+	if ok {
+		return val.targetable
 	}
 
 	return false

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -18,7 +18,7 @@ type module struct {
 	// initFn for this module (can return nil)
 	initFn func() (services.Service, error)
 
-	// is this module user visible (i.e. intended to be passed to `InitModuleServices`)
+	// is this module user visible
 	userVisible bool
 
 	// is the module allowed to be selected as a target
@@ -40,9 +40,12 @@ func UserInvisibleModule(m *module) {
 	m.targetable = false
 }
 
-// TargetableModule is an option for `RegisterModule` that marks module targetable.
-// Modules are targetable by default, except those that are user invisible.
-func TargetableModule(m *module) {
+// UserInvisibleTargetableModule is an option for `RegisterModule` that marks module not visible to user, but still keeps it targetable.
+// Modules are visible and targetable by default.
+func UserInvisibleTargetableModule(m *module) {
+	m.userVisible = false
+
+	// ensure that the module is still targetable.
 	m.targetable = true
 }
 

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -232,7 +232,7 @@ func TestIsTargetableModule(t *testing.T) {
 	invisibleModName := "invisible"
 	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule(defaultModName, mockInitFunc)
-	sut.RegisterModule(invisibleModName, mockInitFunc, UserInvisibleModule, TargetableModule)
+	sut.RegisterModule(invisibleModName, mockInitFunc, UserInvisibleTargetableModule)
 
 	var result = sut.IsUserVisibleModule(defaultModName)
 	assert.True(t, result, "module '%v' should be user visible", defaultModName)

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -206,10 +206,10 @@ func TestGetEmptyListWhenThereIsNoUserVisibleModule(t *testing.T) {
 
 func TestIsUserVisibleModule(t *testing.T) {
 	userVisibleModName := "userVisible"
-	internalModName := "invisible"
+	invisibleModName := "invisible"
 	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule(userVisibleModName, mockInitFunc)
-	sut.RegisterModule(internalModName, mockInitFunc, UserInvisibleModule)
+	sut.RegisterModule(invisibleModName, mockInitFunc, UserInvisibleModule)
 
 	var result = sut.IsUserVisibleModule(userVisibleModName)
 	assert.True(t, result, "module '%v' should be user visible", userVisibleModName)
@@ -217,11 +217,11 @@ func TestIsUserVisibleModule(t *testing.T) {
 	result = sut.IsTargetableModule(userVisibleModName)
 	assert.True(t, result, "module '%v' should be targetable", userVisibleModName)
 
-	result = sut.IsUserVisibleModule(internalModName)
-	assert.False(t, result, "module '%v' should be invisible", internalModName)
+	result = sut.IsUserVisibleModule(invisibleModName)
+	assert.False(t, result, "module '%v' should be invisible", invisibleModName)
 
-	result = sut.IsTargetableModule(internalModName)
-	assert.False(t, result, "module '%v' should not be targetable", internalModName)
+	result = sut.IsTargetableModule(invisibleModName)
+	assert.False(t, result, "module '%v' should not be targetable", invisibleModName)
 
 	result = sut.IsUserVisibleModule("ghost")
 	assert.False(t, result, "expects result be false when module does not exist")

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -206,7 +206,7 @@ func TestGetEmptyListWhenThereIsNoUserVisibleModule(t *testing.T) {
 
 func TestIsUserVisibleModule(t *testing.T) {
 	userVisibleModName := "userVisible"
-	internalModName := "internal"
+	internalModName := "invisible"
 	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule(userVisibleModName, mockInitFunc)
 	sut.RegisterModule(internalModName, mockInitFunc, UserInvisibleModule)
@@ -214,10 +214,39 @@ func TestIsUserVisibleModule(t *testing.T) {
 	var result = sut.IsUserVisibleModule(userVisibleModName)
 	assert.True(t, result, "module '%v' should be user visible", userVisibleModName)
 
+	result = sut.IsTargetableModule(userVisibleModName)
+	assert.True(t, result, "module '%v' should be targetable", userVisibleModName)
+
 	result = sut.IsUserVisibleModule(internalModName)
-	assert.False(t, result, "module '%v' should be internal", internalModName)
+	assert.False(t, result, "module '%v' should be invisible", internalModName)
+
+	result = sut.IsTargetableModule(internalModName)
+	assert.False(t, result, "module '%v' should not be targetable", internalModName)
 
 	result = sut.IsUserVisibleModule("ghost")
+	assert.False(t, result, "expects result be false when module does not exist")
+}
+
+func TestIsTargetableModule(t *testing.T) {
+	defaultModName := "userVisible"
+	invisibleModName := "invisible"
+	sut := NewManager(log.NewNopLogger())
+	sut.RegisterModule(defaultModName, mockInitFunc)
+	sut.RegisterModule(invisibleModName, mockInitFunc, UserInvisibleModule, TargetableModule)
+
+	var result = sut.IsUserVisibleModule(defaultModName)
+	assert.True(t, result, "module '%v' should be user visible", defaultModName)
+
+	result = sut.IsTargetableModule(defaultModName)
+	assert.True(t, result, "module '%v' should be targetable", defaultModName)
+
+	result = sut.IsUserVisibleModule(invisibleModName)
+	assert.False(t, result, "module '%v' should be invisible", invisibleModName)
+
+	result = sut.IsTargetableModule(invisibleModName)
+	assert.True(t, result, "module '%v' should be targetable", invisibleModName)
+
+	result = sut.IsTargetableModule("ghost")
 	assert.False(t, result, "expects result be false when module does not exist")
 }
 


### PR DESCRIPTION
This makes it possible to define a user invisible module which is still targetable by the user.