### PR TITLE
Reduce level of log on nil check in consul WatchKey()

### DIFF
--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -252,7 +252,6 @@ func (c *Client) WatchKey(ctx context.Context, key string, f func(interface{}) b
 		}
 
 		if kvp == nil {
-			level.Info(c.logger).Log("msg", "value is nil", "key", key, "index", index)
 			continue
 		}
 

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -252,6 +252,7 @@ func (c *Client) WatchKey(ctx context.Context, key string, f func(interface{}) b
 		}
 
 		if kvp == nil {
+			level.Debug(c.logger).Log("msg", "value is nil", "key", key, "index", index)
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does**:
Consul is the only client that will log anything if the watched for key does not exist. This is causing some [log spam](https://github.com/grafana/tempo/issues/2048) in Tempo under certain configurations. Fixing it on Tempo's side cleanly is surprisingly difficult due to the way config is loaded independently by various services.

Given that this is unlogged by other clients I'm hoping this change is acceptable. I'd also be willing to remove the line entirely.