### PR TITLE
Lifecycler: return the number of instances in lifecycler's zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@
   * `<prefix>_cache_operation_skipped_total{backend="[memcached|redis]",...}`
   * `<prefix>_cache_operations_total{backend="[memcached|redis]",...}`
   * `<prefix>_cache_requests_total{backend="[memcached|redis]",...}`
-* [ENHANCEMENT] Lifecycler: Added `InstancesInZoneCount` method returning the number of instances in the ring that are registered in lifecycler's zone, updated during the last heartbeat period. #266
+* [ENHANCEMENT] Lifecycler: Added `HealthyInstancesInZoneCount` method returning the number of healthy instances in the ring that are registered in lifecycler's zone, updated during the last heartbeat period. #266
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
   * `<prefix>_cache_operation_skipped_total{backend="[memcached|redis]",...}`
   * `<prefix>_cache_operations_total{backend="[memcached|redis]",...}`
   * `<prefix>_cache_requests_total{backend="[memcached|redis]",...}`
+* [ENHANCEMENT] Lifecycler: Added `InstancesInZoneCount` method returning the number of instances in the ring that are registered in lifecycler's zone, updated during the last heartbeat period. #266
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -130,6 +130,7 @@ type Lifecycler struct {
 	// Keeps stats updated at every heartbeat period
 	countersLock          sync.RWMutex
 	healthyInstancesCount int
+	instancesInZoneCount  int
 	zonesCount            int
 
 	lifecyclerMetrics *LifecyclerMetrics
@@ -381,6 +382,15 @@ func (i *Lifecycler) HealthyInstancesCount() int {
 	defer i.countersLock.RUnlock()
 
 	return i.healthyInstancesCount
+}
+
+// InstancesInZoneCount returns the number of instances in the ring that are registered in
+// this lifecycler's zone, updated during the last heartbeat period.
+func (i *Lifecycler) InstancesInZoneCount() int {
+	i.countersLock.RLock()
+	defer i.countersLock.RUnlock()
+
+	return i.instancesInZoneCount
 }
 
 // ZonesCount returns the number of zones for which there's at least 1 instance registered
@@ -795,13 +805,13 @@ func (i *Lifecycler) changeState(ctx context.Context, state InstanceState) error
 
 func (i *Lifecycler) updateCounters(ringDesc *Desc) {
 	healthyInstancesCount := 0
-	zones := map[string]struct{}{}
+	zones := map[string]int{}
 
 	if ringDesc != nil {
 		now := time.Now()
 
 		for _, ingester := range ringDesc.Ingesters {
-			zones[ingester.Zone] = struct{}{}
+			zones[ingester.Zone]++
 
 			// Count the number of healthy instances for Write operation.
 			if ingester.IsHealthy(Write, i.cfg.RingConfig.HeartbeatTimeout, now) {
@@ -813,6 +823,7 @@ func (i *Lifecycler) updateCounters(ringDesc *Desc) {
 	// Update counters
 	i.countersLock.Lock()
 	i.healthyInstancesCount = healthyInstancesCount
+	i.instancesInZoneCount = zones[i.cfg.Zone]
 	i.zonesCount = len(zones)
 	i.countersLock.Unlock()
 }

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -106,39 +106,102 @@ func TestLifecycler_InstancesInZoneCount(t *testing.T) {
 	flagext.DefaultValues(&ringConfig)
 	ringConfig.KVStore.Mock = ringStore
 
-	events := []struct {
-		zone                         string
-		expectedInstancesInZoneCount int
+	instances := []struct {
+		zone                                string
+		healthy                             bool
+		expectedHealthyInstancesInZoneCount int
+		expectedHealthyInstancesCount       int
 	}{
-		{"zone-a", 1},
-		{"zone-b", 1},
-		{"zone-a", 2},
-		{"zone-c", 1},
-		{"zone-b", 2},
+		{
+			zone:    "zone-a",
+			healthy: true,
+			// after adding a healthy instance in zone-a, expectedHealthyInstancesInZoneCount in zone-a becomes 1
+			expectedHealthyInstancesInZoneCount: 1,
+			// after adding a healthy instance in zone-a, expectedHealthyInstancesCount is 1
+			expectedHealthyInstancesCount: 1,
+		},
+		{
+			zone:    "zone-a",
+			healthy: false,
+			// after adding an unhealthy instance in zone-a, expectedHealthyInstancesInZoneCount in zone-a remains 1
+			expectedHealthyInstancesInZoneCount: 1,
+			// zone-a was already added, so expectedHealthyInstancesCount remains 1
+			expectedHealthyInstancesCount: 1,
+		},
+		{
+			zone:    "zone-a",
+			healthy: true,
+			// after adding a healthy instance in zone-a, expectedHealthyInstancesInZoneCount in zone-a becomes 2
+			expectedHealthyInstancesInZoneCount: 2,
+			// zone-a was already added, so expectedHealthyInstancesCount remains 1
+			expectedHealthyInstancesCount: 1,
+		},
+		{
+			zone:    "zone-b",
+			healthy: true,
+			// after adding a healthy instance in zone-b, expectedHealthyInstancesInZoneCount in zone-b becomes 1
+			expectedHealthyInstancesInZoneCount: 1,
+			// after adding a healthy instance in zone-b, expectedHealthyInstancesCount becomes 2
+			expectedHealthyInstancesCount: 2,
+		},
+		{
+			zone:    "zone-c",
+			healthy: false,
+			// after adding an unhealthy instance in zone-c, expectedHealthyInstancesInZoneCount in zone-c remains 0
+			expectedHealthyInstancesInZoneCount: 0,
+			// after adding an unhealthy instance in zone-c, expectedHealthyInstancesCount becomes 3
+			expectedHealthyInstancesCount: 3,
+		},
+		{
+			zone:    "zone-c",
+			healthy: true,
+			// after adding a healthy instance in zone-c, expectedHealthyInstancesInZoneCount in zone-c becomes 1
+			expectedHealthyInstancesInZoneCount: 1,
+			// zone-c was already added, so expectedHealthyInstancesCount remains 3
+			expectedHealthyInstancesCount: 3,
+		},
+		{
+			zone:    "zone-b",
+			healthy: true,
+			// after adding a healthy instance in zone-b, expectedHealthyInstancesInZoneCount in zone-b becomes 2
+			expectedHealthyInstancesInZoneCount: 2,
+			// zone-b was already added, so expectedHealthyInstancesCount remains 3
+			expectedHealthyInstancesCount: 3,
+		},
 	}
 
-	for idx, event := range events {
+	expectedHealthInstancesCounter := 0
+	for idx, instance := range instances {
 		ctx := context.Background()
 
-		// Register an ingester to the ring.
+		// Register an instance to the ring.
 		cfg := testLifecyclerConfig(ringConfig, fmt.Sprintf("instance-%d", idx))
 		cfg.HeartbeatPeriod = 100 * time.Millisecond
-		cfg.JoinAfter = 100 * time.Millisecond
-		cfg.Zone = event.zone
+		joinTimeoutMs := 1000
+		// unhealthy instances join after 2000ms, which exceeds the 1000ms timeout
+		joinAfterMs := 2000
+		if instance.healthy {
+			expectedHealthInstancesCounter++
+			// healthy instances join after 100ms, which is within the 1000ms timeout
+			joinAfterMs = 100
+		}
+		cfg.JoinAfter = time.Duration(joinAfterMs) * time.Millisecond
+		cfg.Zone = instance.zone
 
-		lifecycler, err := NewLifecycler(cfg, &nopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
+		lifecycler, err := NewLifecycler(cfg, &nopFlushTransferer{}, "instance", ringKey, true, log.NewNopLogger(), nil)
 		require.NoError(t, err)
-		assert.Equal(t, 0, lifecycler.InstancesInZoneCount())
+		assert.Equal(t, 0, lifecycler.HealthyInstancesInZoneCount())
 
 		require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
 		defer services.StopAndAwaitTerminated(ctx, lifecycler) // nolint:errcheck
 
 		// Wait until joined.
-		test.Poll(t, time.Second, idx+1, func() interface{} {
+		test.Poll(t, time.Duration(joinTimeoutMs)*time.Millisecond, expectedHealthInstancesCounter, func() interface{} {
 			return lifecycler.HealthyInstancesCount()
 		})
 
-		require.Equal(t, event.expectedInstancesInZoneCount, lifecycler.InstancesInZoneCount())
+		require.Equal(t, instance.expectedHealthyInstancesInZoneCount, lifecycler.HealthyInstancesInZoneCount())
+		require.Equal(t, instance.expectedHealthyInstancesCount, lifecycler.ZonesCount())
 	}
 }
 

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -110,63 +110,63 @@ func TestLifecycler_InstancesInZoneCount(t *testing.T) {
 		zone                                string
 		healthy                             bool
 		expectedHealthyInstancesInZoneCount int
-		expectedHealthyInstancesCount       int
+		expectedZonesCount                  int
 	}{
 		{
 			zone:    "zone-a",
 			healthy: true,
 			// after adding a healthy instance in zone-a, expectedHealthyInstancesInZoneCount in zone-a becomes 1
 			expectedHealthyInstancesInZoneCount: 1,
-			// after adding a healthy instance in zone-a, expectedHealthyInstancesCount is 1
-			expectedHealthyInstancesCount: 1,
+			// after adding a healthy instance in zone-a, expectedZonesCount is 1
+			expectedZonesCount: 1,
 		},
 		{
 			zone:    "zone-a",
 			healthy: false,
 			// after adding an unhealthy instance in zone-a, expectedHealthyInstancesInZoneCount in zone-a remains 1
 			expectedHealthyInstancesInZoneCount: 1,
-			// zone-a was already added, so expectedHealthyInstancesCount remains 1
-			expectedHealthyInstancesCount: 1,
+			// zone-a was already added, so expectedZonesCount remains 1
+			expectedZonesCount: 1,
 		},
 		{
 			zone:    "zone-a",
 			healthy: true,
 			// after adding a healthy instance in zone-a, expectedHealthyInstancesInZoneCount in zone-a becomes 2
 			expectedHealthyInstancesInZoneCount: 2,
-			// zone-a was already added, so expectedHealthyInstancesCount remains 1
-			expectedHealthyInstancesCount: 1,
+			// zone-a was already added, so expectedZonesCount remains 1
+			expectedZonesCount: 1,
 		},
 		{
 			zone:    "zone-b",
 			healthy: true,
 			// after adding a healthy instance in zone-b, expectedHealthyInstancesInZoneCount in zone-b becomes 1
 			expectedHealthyInstancesInZoneCount: 1,
-			// after adding a healthy instance in zone-b, expectedHealthyInstancesCount becomes 2
-			expectedHealthyInstancesCount: 2,
+			// after adding a healthy instance in zone-b, expectedZonesCount becomes 2
+			expectedZonesCount: 2,
 		},
 		{
 			zone:    "zone-c",
 			healthy: false,
 			// after adding an unhealthy instance in zone-c, expectedHealthyInstancesInZoneCount in zone-c remains 0
 			expectedHealthyInstancesInZoneCount: 0,
-			// after adding an unhealthy instance in zone-c, expectedHealthyInstancesCount becomes 3
-			expectedHealthyInstancesCount: 3,
+			// after adding an unhealthy instance in zone-c, expectedZonesCount becomes 3
+			expectedZonesCount: 3,
 		},
 		{
 			zone:    "zone-c",
 			healthy: true,
 			// after adding a healthy instance in zone-c, expectedHealthyInstancesInZoneCount in zone-c becomes 1
 			expectedHealthyInstancesInZoneCount: 1,
-			// zone-c was already added, so expectedHealthyInstancesCount remains 3
-			expectedHealthyInstancesCount: 3,
+			// zone-c was already added, so expectedZonesCount remains 3
+			expectedZonesCount: 3,
 		},
 		{
 			zone:    "zone-b",
 			healthy: true,
 			// after adding a healthy instance in zone-b, expectedHealthyInstancesInZoneCount in zone-b becomes 2
 			expectedHealthyInstancesInZoneCount: 2,
-			// zone-b was already added, so expectedHealthyInstancesCount remains 3
-			expectedHealthyInstancesCount: 3,
+			// zone-b was already added, so expectedZonesCount remains 3
+			expectedZonesCount: 3,
 		},
 	}
 
@@ -177,9 +177,9 @@ func TestLifecycler_InstancesInZoneCount(t *testing.T) {
 		// Register an instance to the ring.
 		cfg := testLifecyclerConfig(ringConfig, fmt.Sprintf("instance-%d", idx))
 		cfg.HeartbeatPeriod = 100 * time.Millisecond
-		joinTimeoutMs := 1000
-		// unhealthy instances join after 2000ms, which exceeds the 1000ms timeout
-		joinAfterMs := 2000
+		joinWaitMs := 1000
+		// unhealthy instances join the ring after 1min (60000ms), which exceeds the 1000ms waiting time
+		joinAfterMs := 60000
 		if instance.healthy {
 			expectedHealthInstancesCounter++
 			// healthy instances join after 100ms, which is within the 1000ms timeout
@@ -196,12 +196,12 @@ func TestLifecycler_InstancesInZoneCount(t *testing.T) {
 		defer services.StopAndAwaitTerminated(ctx, lifecycler) // nolint:errcheck
 
 		// Wait until joined.
-		test.Poll(t, time.Duration(joinTimeoutMs)*time.Millisecond, expectedHealthInstancesCounter, func() interface{} {
+		test.Poll(t, time.Duration(joinWaitMs)*time.Millisecond, expectedHealthInstancesCounter, func() interface{} {
 			return lifecycler.HealthyInstancesCount()
 		})
 
 		require.Equal(t, instance.expectedHealthyInstancesInZoneCount, lifecycler.HealthyInstancesInZoneCount())
-		require.Equal(t, instance.expectedHealthyInstancesCount, lifecycler.ZonesCount())
+		require.Equal(t, instance.expectedZonesCount, lifecycler.ZonesCount())
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
This PR enriches `Lifecycler` with the `InstancesInZoneCount()` method, that returns the number of instances in ring belonging to the lifecycler's zone, updated during the last heartbeat period. 
A test (`TestLifecycler_InstancesInZoneCount`) showing the expected behaviour of `InstancesInZoneCount()` has been added.

**Which issue(s) this PR fixes**:
This PR is a pre-requisite for fixing the issue [4208](https://github.com/grafana/mimir/issues/4208).

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
