### PR TITLE
Add "redis" as allowed cache backend value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * [CHANGE] Memberlist: cluster label verification feature (`-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled`) is now marked as stable. #222
 * [CHANGE] Cache: Switch Memcached backend to use `github.com/grafana/gomemcache` repository instead of `github.com/bradfitz/gomemcache`. #248
 * [CHANGE] Multierror: Implement `Is(error) bool`. This allows to use `multierror.MultiError` with `errors.Is()`. `MultiError` will in turn call `errors.Is()` on every error value. #254
-* [FEATURE] Cache: Add support for configuring a Redis cache backend. #268
+* [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45
 * [ENHANCEMENT] Add limiter package. #41

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -94,7 +94,7 @@ type BackendConfig struct {
 
 // Validate the config.
 func (cfg *BackendConfig) Validate() error {
-	if cfg.Backend != "" && cfg.Backend != BackendMemcached {
+	if cfg.Backend != "" && cfg.Backend != BackendMemcached && cfg.Backend != BackendRedis {
 		return fmt.Errorf("unsupported cache backend: %s", cfg.Backend)
 	}
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBackendConfig_Validate(t *testing.T) {
+	t.Run("empty backend", func(t *testing.T) {
+		cfg := BackendConfig{}
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("invalid backend", func(t *testing.T) {
+		cfg := BackendConfig{
+			Backend: "invalid",
+		}
+
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("memcached backend valid", func(t *testing.T) {
+		cfg := BackendConfig{
+			Backend: BackendMemcached,
+			Memcached: MemcachedClientConfig{
+				Addresses:           []string{"localhost:11211"},
+				MaxAsyncConcurrency: 1,
+			},
+		}
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("memcached backend invalid", func(t *testing.T) {
+		cfg := BackendConfig{
+			Backend:   BackendMemcached,
+			Memcached: MemcachedClientConfig{},
+		}
+
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("redis backend valid", func(t *testing.T) {
+		cfg := BackendConfig{
+			Backend: BackendRedis,
+			Redis: RedisClientConfig{
+				Endpoint:            []string{"localhost:6379"},
+				MaxAsyncConcurrency: 1,
+			},
+		}
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("redis backend invalid", func(t *testing.T) {
+		cfg := BackendConfig{
+			Backend: BackendRedis,
+			Redis:   RedisClientConfig{},
+		}
+
+		require.Error(t, cfg.Validate())
+	})
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,8 +1,9 @@
 package cache
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackendConfig_Validate(t *testing.T) {

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -192,7 +192,7 @@ func newMemcachedClient(
 ) (*memcachedClient, error) {
 	legacyRegister := prometheus.WrapRegistererWithPrefix(legacyMemcachedPrefix, reg)
 	reg = prometheus.WrapRegistererWith(
-		prometheus.Labels{labelCacheBackend: backendMemcached},
+		prometheus.Labels{labelCacheBackend: backendValueMemcached},
 		prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
 
 	backwardCompatibleRegs := promregistry.TeeRegisterer{legacyRegister, reg}

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -176,7 +176,7 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 	}
 
 	reg = prometheus.WrapRegistererWith(
-		prometheus.Labels{labelCacheName: name, labelCacheBackend: backendRedis},
+		prometheus.Labels{labelCacheName: name, labelCacheBackend: backendValueRedis},
 		prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
 
 	metrics := newClientMetrics(reg)

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -20,8 +20,8 @@ var (
 const (
 	labelCacheName           = "name"
 	labelCacheBackend        = "backend"
-	backendRedis             = "redis"
-	backendMemcached         = "memcached"
+	backendValueRedis        = "redis"
+	backendValueMemcached    = "memcached"
 	cacheMetricNamePrefix    = "cache_"
 	getMultiMetricNamePrefix = "getmulti_"
 	legacyMemcachedPrefix    = "memcached_"
@@ -43,7 +43,7 @@ func NewMemcachedCache(name string, logger log.Logger, memcachedClient RemoteCac
 			promregistry.TeeRegisterer{
 				prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix+legacyMemcachedPrefix, reg),
 				prometheus.WrapRegistererWith(
-					prometheus.Labels{labelCacheBackend: backendMemcached},
+					prometheus.Labels{labelCacheBackend: backendValueMemcached},
 					prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg)),
 			},
 		),
@@ -63,7 +63,7 @@ func NewRedisCache(name string, logger log.Logger, redisClient RemoteCacheClient
 			logger,
 			redisClient,
 			prometheus.WrapRegistererWith(
-				prometheus.Labels{labelCacheBackend: backendRedis},
+				prometheus.Labels{labelCacheBackend: backendValueRedis},
 				prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg)),
 		),
 	}


### PR DESCRIPTION
Support for Redis in #268 was added but configuration validation was not updated to reflect this.

See grafana/mimir#4236

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
