### PR TITLE
Remove context argument from cache.Cache.Store method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [CHANGE] Memberlist: cluster label verification feature (`-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled`) is now marked as stable. #222
 * [CHANGE] Cache: Switch Memcached backend to use `github.com/grafana/gomemcache` repository instead of `github.com/bradfitz/gomemcache`. #248
 * [CHANGE] Multierror: Implement `Is(error) bool`. This allows to use `multierror.MultiError` with `errors.Is()`. `MultiError` will in turn call `errors.Is()` on every error value. #254
+* [CHANGE] Cache: Remove the `context.Context` argument from the `Cache.Store` method and rename the method to `Cache.StoreAsync`. #273
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,7 +20,7 @@ type RemoteCacheClient interface {
 	// SetAsync enqueues an asynchronous operation to store a key into memcached.
 	// Returns an error in case it fails to enqueue the operation. In case the
 	// underlying async operation will fail, the error will be tracked/logged.
-	SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error
+	SetAsync(key string, value []byte, ttl time.Duration) error
 
 	// Delete deletes a key from memcached.
 	// This is a synchronous operation. If an asynchronous set operation for key is still
@@ -33,20 +33,20 @@ type RemoteCacheClient interface {
 
 // Cache is a generic interface.
 type Cache interface {
-	// Store data into the cache.
+	// StoreAsync writes data into the cache asynchronously.
 	//
 	// Note that individual byte buffers may be retained by the cache!
-	Store(ctx context.Context, data map[string][]byte, ttl time.Duration)
+	StoreAsync(data map[string][]byte, ttl time.Duration)
 
 	// Fetch multiple keys from cache. Returns map of input keys to data.
 	// If key isn't in the map, data for given key was not found. One or more
 	// Option instances may be passed to modify the behavior of this Fetch call.
 	Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte
 
-	Name() string
-
 	// Delete cache entry with the given key if it exists.
 	Delete(ctx context.Context, key string) error
+
+	Name() string
 }
 
 // Options are used to modify the behavior of an individual call to get results

--- a/cache/client.go
+++ b/cache/client.go
@@ -114,7 +114,7 @@ func newBaseClient(
 	}
 }
 
-func (c *baseClient) setAsync(ctx context.Context, key string, value []byte, ttl time.Duration, f func(ctx context.Context, key string, buf []byte, ttl time.Duration) error) error {
+func (c *baseClient) setAsync(key string, value []byte, ttl time.Duration, f func(key string, buf []byte, ttl time.Duration) error) error {
 	if c.maxItemSize > 0 && uint64(len(value)) > c.maxItemSize {
 		c.metrics.skipped.WithLabelValues(opSet, reasonMaxItemSize).Inc()
 		return nil
@@ -124,7 +124,7 @@ func (c *baseClient) setAsync(ctx context.Context, key string, value []byte, ttl
 		start := time.Now()
 		c.metrics.operations.WithLabelValues(opSet).Inc()
 
-		err := f(ctx, key, value, ttl)
+		err := f(key, value, ttl)
 		if err != nil {
 			level.Debug(c.logger).Log(
 				"msg", "failed to store item to cache",

--- a/cache/compression.go
+++ b/cache/compression.go
@@ -67,14 +67,14 @@ func NewSnappy(next Cache, logger log.Logger) Cache {
 	}
 }
 
-// Store implements Cache.
-func (s *snappyCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+// StoreAsync implements Cache.
+func (s *snappyCache) StoreAsync(data map[string][]byte, ttl time.Duration) {
 	encoded := make(map[string][]byte, len(data))
 	for key, value := range data {
 		encoded[key] = snappy.Encode(nil, value)
 	}
 
-	s.next.Store(ctx, encoded, ttl)
+	s.next.StoreAsync(encoded, ttl)
 }
 
 // Fetch implements Cache.

--- a/cache/compression_test.go
+++ b/cache/compression_test.go
@@ -52,13 +52,13 @@ func TestSnappyCache(t *testing.T) {
 			"b": []byte("value-b"),
 		}
 
-		c.Store(ctx, expected, time.Hour)
+		c.StoreAsync(expected, time.Hour)
 		assert.Equal(t, expected, c.Fetch(ctx, []string{"a", "b", "c"}))
 	})
 
 	t.Run("Fetch() should skip entries failing to decode", func(t *testing.T) {
-		c.Store(ctx, map[string][]byte{"a": []byte("value-a")}, time.Hour)
-		backend.Store(ctx, map[string][]byte{"b": []byte("value-b")}, time.Hour)
+		c.StoreAsync(map[string][]byte{"a": []byte("value-a")}, time.Hour)
+		backend.StoreAsync(map[string][]byte{"b": []byte("value-b")}, time.Hour)
 
 		expected := map[string][]byte{
 			"a": []byte("value-a"),

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -37,14 +37,14 @@ type Item struct {
 // The LRU cache is limited in number of items using `lruSize`. This means this cache is not tailored for large items or items that have a big
 // variation in size.
 func WrapWithLRUCache(c Cache, name string, reg prometheus.Registerer, lruSize int, defaultTTL time.Duration) (*LRUCache, error) {
-	lru, err := lru.NewLRU(lruSize, nil)
+	l, err := lru.NewLRU(lruSize, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	cache := &LRUCache{
 		c:          c,
-		lru:        lru,
+		lru:        l,
 		name:       name,
 		defaultTTL: defaultTTL,
 
@@ -74,9 +74,9 @@ func WrapWithLRUCache(c Cache, name string, reg prometheus.Registerer, lruSize i
 	return cache, nil
 }
 
-func (l *LRUCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+func (l *LRUCache) StoreAsync(data map[string][]byte, ttl time.Duration) {
 	// store the data in the shared cache.
-	l.c.Store(ctx, data, ttl)
+	l.c.StoreAsync(data, ttl)
 
 	l.mtx.Lock()
 	defer l.mtx.Unlock()

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -17,18 +17,18 @@ func TestLRUCache_StoreFetchDelete(t *testing.T) {
 		ctx  = context.Background()
 	)
 	// This entry is only known by our underlying cache.
-	mock.Store(ctx, map[string][]byte{"buzz": []byte("buzz")}, time.Hour)
+	mock.StoreAsync(map[string][]byte{"buzz": []byte("buzz")}, time.Hour)
 
 	reg := prometheus.NewPedanticRegistry()
 	lru, err := WrapWithLRUCache(mock, "test", reg, 10000, 2*time.Hour)
 	require.NoError(t, err)
 
-	lru.Store(ctx, map[string][]byte{
+	lru.StoreAsync(map[string][]byte{
 		"foo": []byte("bar"),
 		"bar": []byte("baz"),
 	}, time.Minute)
 
-	lru.Store(ctx, map[string][]byte{
+	lru.StoreAsync(map[string][]byte{
 		"expired": []byte("expired"),
 	}, -time.Minute)
 
@@ -82,7 +82,7 @@ func TestLRUCache_Evictions(t *testing.T) {
 	lru, err := WrapWithLRUCache(NewMockCache(), "test", reg, maxItems, 2*time.Hour)
 	require.NoError(t, err)
 
-	lru.Store(context.Background(), map[string][]byte{
+	lru.StoreAsync(map[string][]byte{
 		"key_1": []byte("value_1"),
 		"key_2": []byte("value_2"),
 		"key_3": []byte("value_3"),

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -260,8 +260,8 @@ func (c *memcachedClient) Stop() {
 	c.client.Close()
 }
 
-func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
-	return c.setAsync(ctx, key, value, ttl, func(ctx context.Context, key string, buf []byte, ttl time.Duration) error {
+func (c *memcachedClient) SetAsync(key string, value []byte, ttl time.Duration) error {
+	return c.setAsync(key, value, ttl, func(key string, buf []byte, ttl time.Duration) error {
 		return c.client.Set(&memcache.Item{
 			Key:        key,
 			Value:      value,

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -35,7 +35,7 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 	t.Run("no allocator", func(t *testing.T) {
 		client, backend, err := setup()
 		require.NoError(t, err)
-		require.NoError(t, client.SetAsync(context.Background(), "foo", []byte("bar"), 10*time.Second))
+		require.NoError(t, client.SetAsync("foo", []byte("bar"), 10*time.Second))
 		require.NoError(t, client.wait())
 
 		ctx := context.Background()
@@ -47,7 +47,7 @@ func TestMemcachedClient_GetMulti(t *testing.T) {
 	t.Run("with allocator", func(t *testing.T) {
 		client, backend, err := setup()
 		require.NoError(t, err)
-		require.NoError(t, client.SetAsync(context.Background(), "foo", []byte("bar"), 10*time.Second))
+		require.NoError(t, client.SetAsync("foo", []byte("bar"), 10*time.Second))
 		require.NoError(t, client.wait())
 
 		res := client.GetMulti(context.Background(), []string{"foo"}, WithAllocator(&nopAllocator{}))

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -24,7 +24,7 @@ func NewMockCache() *MockCache {
 	return c
 }
 
-func (m *MockCache) Store(_ context.Context, data map[string][]byte, ttl time.Duration) {
+func (m *MockCache) StoreAsync(data map[string][]byte, ttl time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -98,9 +98,9 @@ func NewInstrumentedMockCache() *InstrumentedMockCache {
 	}
 }
 
-func (m *InstrumentedMockCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+func (m *InstrumentedMockCache) StoreAsync(data map[string][]byte, ttl time.Duration) {
 	m.storeCount.Inc()
-	m.cache.Store(ctx, data, ttl)
+	m.cache.StoreAsync(data, ttl)
 }
 
 func (m *InstrumentedMockCache) Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte {

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -215,9 +215,9 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 }
 
 // SetAsync implement RemoteCacheClient.
-func (c *redisClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
-	return c.setAsync(ctx, key, value, ttl, func(ctx context.Context, key string, buf []byte, ttl time.Duration) error {
-		_, err := c.Set(ctx, key, value, ttl).Result()
+func (c *redisClient) SetAsync(key string, value []byte, ttl time.Duration) error {
+	return c.setAsync(key, value, ttl, func(key string, buf []byte, ttl time.Duration) error {
+		_, err := c.Set(context.Background(), key, value, ttl).Result()
 		return err
 	})
 }

--- a/cache/redis_client_test.go
+++ b/cache/redis_client_test.go
@@ -142,9 +142,8 @@ func TestRedisClient(t *testing.T) {
 
 					defer c.Stop()
 					defer s.FlushAll()
-					ctx := context.Background()
 					for k, v := range tt.args.data {
-						_ = c.SetAsync(ctx, k, v, time.Hour)
+						_ = c.SetAsync(k, v, time.Hour)
 					}
 
 					test.Poll(t, time.Second, true, func() interface{} {
@@ -174,7 +173,7 @@ func TestRedisClientDelete(t *testing.T) {
 	key1 := "key1"
 	value1 := []byte{1}
 
-	_ = c.SetAsync(context.Background(), key1, value1, time.Hour)
+	_ = c.SetAsync(key1, value1, time.Hour)
 
 	test.Poll(t, time.Second, true, func() interface{} {
 		hits := c.GetMulti(context.Background(), []string{key1})

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -103,17 +103,17 @@ func newRemoteCache(name string, logger log.Logger, remoteClient RemoteCacheClie
 	return c
 }
 
-// Store data identified by keys.
+// StoreAsync data identified by keys asynchronously using a job queue.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
-func (c *remoteCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+func (c *remoteCache) StoreAsync(data map[string][]byte, ttl time.Duration) {
 	var (
 		firstErr error
 		failed   int
 	)
 
 	for key, val := range data {
-		if err := c.remoteClient.SetAsync(ctx, key, val, ttl); err != nil {
+		if err := c.remoteClient.SetAsync(key, val, ttl); err != nil {
 			failed++
 			if firstErr == nil {
 				firstErr = err

--- a/cache/tracing.go
+++ b/cache/tracing.go
@@ -23,8 +23,8 @@ func NewSpanlessTracingCache(cache Cache, logger log.Logger, resolver spanlogger
 	return SpanlessTracingCache{c: cache, resolver: resolver, logger: logger}
 }
 
-func (t SpanlessTracingCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
-	t.c.Store(ctx, data, ttl)
+func (t SpanlessTracingCache) StoreAsync(data map[string][]byte, ttl time.Duration) {
+	t.c.StoreAsync(data, ttl)
 }
 
 func (t SpanlessTracingCache) Fetch(ctx context.Context, keys []string, opts ...Option) (result map[string][]byte) {

--- a/cache/versioned.go
+++ b/cache/versioned.go
@@ -24,12 +24,12 @@ func NewVersioned(c Cache, version uint) Versioned {
 	}
 }
 
-func (c Versioned) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+func (c Versioned) StoreAsync(data map[string][]byte, ttl time.Duration) {
 	versioned := make(map[string][]byte, len(data))
 	for k, v := range data {
 		versioned[c.addVersion(k)] = v
 	}
-	c.cache.Store(ctx, versioned, ttl)
+	c.cache.StoreAsync(versioned, ttl)
 }
 
 func (c Versioned) Fetch(ctx context.Context, keys []string, opts ...Option) map[string][]byte {

--- a/cache/versioned_test.go
+++ b/cache/versioned_test.go
@@ -15,7 +15,7 @@ func TestVersioned(t *testing.T) {
 		cache := NewMockCache()
 		v1 := NewVersioned(cache, 1)
 		data := map[string][]byte{"hit": []byte(`data`)}
-		v1.Store(context.Background(), data, time.Minute)
+		v1.StoreAsync(data, time.Minute)
 		res := v1.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, data, res)
 		err := v1.Delete(context.Background(), "hit")
@@ -28,10 +28,10 @@ func TestVersioned(t *testing.T) {
 		cache := NewMockCache()
 		v1 := NewVersioned(cache, 1)
 		v1Data := map[string][]byte{"hit": []byte(`first version`)}
-		v1.Store(context.Background(), v1Data, time.Minute)
+		v1.StoreAsync(v1Data, time.Minute)
 		v2 := NewVersioned(cache, 2)
 		v2Data := map[string][]byte{"hit": []byte(`second version`)}
-		v2.Store(context.Background(), v2Data, time.Minute)
+		v2.StoreAsync(v2Data, time.Minute)
 
 		resV1 := v1.Fetch(context.Background(), []string{"hit", "miss"})
 		assert.Equal(t, v1Data, resV1)


### PR DESCRIPTION
**What this PR does**:

The Redis and Memcached implementations of the `Cache` interface use a job queue to perform writes in the background after the `Store` method has already returned. Including a context argument creates the possibility of the writes being cancelled after the originating request finishes while the writes are still being run in the background. Removing the context makes it harder to misuse the cache like this.

This change also renames the `Store` method to `StoreAsync` to make this behavior more obvious.

**Which issue(s) this PR fixes**:

See grafana/mimir#4341
See grafana/mimir#4342

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
