### PR TITLE
flag: deprecate `DeprecatedFlag`, add `DisabledFlag`, add `DeprecatedVar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
   * `<prefix>_cache_requests_total{backend="[memcached|redis]",...}`
 * [ENHANCEMENT] Lifecycler: Added `InstancesInZoneCount` and `InstancesCount` functions returning respectively the total number of instances in the ring and the number of instances in the ring that are registered in lifecycler's zone, updated during the last heartbeat period. #270
 * [ENHANCEMENT] Memcached: add `MinIdleConnectionsHeadroomPercentage` support. It configures the minimum number of idle connections to keep open as a percentage of the number of recently used idle connections. If negative (default), idle connections are kept open indefinitely. #269
+* [ENHANCEMENT] flag: add `DeprecatedVar` functions for registering flags that are deprecated, but can still be used as usual. Add `DisabledFlag` function. Deprecate `DeprecatedFlag` function, which is actually registering a disabled flag. #277
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/flagext/deprecated.go
+++ b/flagext/deprecated.go
@@ -1,7 +1,6 @@
 package flagext
 
 import (
-	"encoding"
 	"flag"
 	"time"
 
@@ -167,18 +166,6 @@ func DeprecatedFloat64Var(f *flag.FlagSet, val *float64, name string, defaultVal
 func DeprecatedStringVar(f *flag.FlagSet, val *string, name string, defaultVal string, usage string, logger log.Logger) {
 	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
 	delegateSet.StringVar(val, name, defaultVal, usage)
-	f.Var(deprecatedFlag{
-		name:     name,
-		logger:   logger,
-		delegate: delegateSet,
-	}, name, usage)
-}
-
-// DeprecatedTextVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedTextVar will
-// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
-func DeprecatedTextVar(f *flag.FlagSet, val encoding.TextUnmarshaler, name string, defaultVal encoding.TextMarshaler, usage string, logger log.Logger) {
-	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
-	delegateSet.TextVar(val, name, defaultVal, usage)
 	f.Var(deprecatedFlag{
 		name:     name,
 		logger:   logger,

--- a/flagext/deprecated.go
+++ b/flagext/deprecated.go
@@ -1,7 +1,9 @@
 package flagext
 
 import (
+	"encoding"
 	"flag"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -16,22 +18,182 @@ var DeprecatedFlagsUsed = promauto.NewCounter(
 		Help: "The number of deprecated flags currently set.",
 	})
 
-type deprecatedFlag struct {
-	name   string
-	logger log.Logger
+// DisabledFlagsUsed is the metric that counts deprecated flags set.
+var DisabledFlagsUsed = promauto.NewCounter(
+	prometheus.CounterOpts{
+		Name: "disabled_flags_inuse_total",
+		Help: "The number of disabled flags currently set.",
+	})
+
+type disabledFlag struct {
+	name              string
+	countAsDeprecated bool
+	logger            log.Logger
 }
 
-func (deprecatedFlag) String() string {
+func (disabledFlag) String() string {
 	return "deprecated"
 }
 
-func (d deprecatedFlag) Set(string) error {
+func (d disabledFlag) Set(string) error {
 	level.Warn(d.logger).Log("msg", "flag disabled", "flag", d.name)
-	DeprecatedFlagsUsed.Inc()
+	if d.countAsDeprecated {
+		DeprecatedFlagsUsed.Inc()
+	} else {
+		DisabledFlagsUsed.Inc()
+	}
 	return nil
 }
 
-// DeprecatedFlag logs a warning when you try to use it.
+// DeprecatedFlag registers a noop flag and logs a warning when you try to use it and increments the DeprecatedFlagsUsed counter.
+//
+// This function is deprecated and will be removed in the future. Please use DisabledFlag or the DeprecatedVar alternatives.
 func DeprecatedFlag(f *flag.FlagSet, name, message string, logger log.Logger) {
-	f.Var(deprecatedFlag{name: name, logger: logger}, name, message)
+	f.Var(disabledFlag{name: name, logger: logger, countAsDeprecated: true}, name, message)
+}
+
+// DisabledFlag registers a noop flag and logs a warning when you try to use it and increments the DisabledFlagsUsed counter.
+func DisabledFlag(f *flag.FlagSet, name, message string, logger log.Logger) {
+	f.Var(disabledFlag{name: name, logger: logger, countAsDeprecated: false}, name, message)
+}
+
+// deprecatedFlag wraps a flag.FlagSet so we can add behaviour on Set without having to reimplement the parsing.
+type deprecatedFlag struct {
+	name     string
+	logger   log.Logger
+	delegate *flag.FlagSet
+}
+
+func (d deprecatedFlag) String() (s string) {
+	// The delegate should only have a single registered flag.
+	d.delegate.VisitAll(func(f *flag.Flag) {
+		s = f.Value.String()
+	})
+	return
+}
+
+func (d deprecatedFlag) Set(s string) error {
+	level.Warn(d.logger).Log("msg", "flag deprecated", "flag", d.name)
+	DeprecatedFlagsUsed.Inc()
+	return d.delegate.Set(d.name, s)
+}
+
+// DeprecatedIntVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedIntVar will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedIntVar(f *flag.FlagSet, val *int, name string, defaultVal int, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.IntVar(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedInt64Var registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedInt64Var will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedInt64Var(f *flag.FlagSet, val *int64, name string, defaultVal int64, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.Int64Var(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedDurationVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedDurationVar will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedDurationVar(f *flag.FlagSet, val *time.Duration, name string, defaultVal time.Duration, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.DurationVar(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedBoolVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedBoolVar will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedBoolVar(f *flag.FlagSet, val *bool, name string, defaultVal bool, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.BoolVar(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedUintVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedUintVar will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedUintVar(f *flag.FlagSet, val *uint, name string, defaultVal uint, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.UintVar(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedUint64Var registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedUint64Var will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedUint64Var(f *flag.FlagSet, val *uint64, name string, defaultVal uint64, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.Uint64Var(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedFloat64Var registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedFloat64Var will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedFloat64Var(f *flag.FlagSet, val *float64, name string, defaultVal float64, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.Float64Var(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedStringVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedStringVar will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedStringVar(f *flag.FlagSet, val *string, name string, defaultVal string, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.StringVar(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedTextVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedTextVar will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedTextVar(f *flag.FlagSet, val encoding.TextUnmarshaler, name string, defaultVal encoding.TextMarshaler, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.TextVar(val, name, defaultVal, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
+}
+
+// DeprecatedVar registers a flag the same as its stdlib flag counterpart. If the flag is set, DeprecatedVar will
+// log the usage as a warning on the provided logger and will increment DeprecatedFlagsUsed.
+func DeprecatedVar(f *flag.FlagSet, v flag.Value, name string, usage string, logger log.Logger) {
+	delegateSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	delegateSet.Var(v, name, usage)
+	f.Var(deprecatedFlag{
+		name:     name,
+		logger:   logger,
+		delegate: delegateSet,
+	}, name, usage)
 }


### PR DESCRIPTION
### Context

Mimir and Cortex have been using a non-conventional definition of "deprecated flag" meaning
a flag that is not used. Mimir is moving away from this definition towards the
more widely adopted definition of "planned for removal but still usable."

This PR changes and adds utility functions to the `flag` package to that end.

### What this PR does

The existing `DeprecatedFlag` actually registers a disabled flag, not a deprecated one.
This PR proposes to deprecate that function and replace it with `DeprecatedVar`.
The idea is to remove `DeprecatedFlag` when we start doing releases of dskit.
There is one implementation of `Deprecated*Var` for every type that the stdlib
`flag.FlagSet` supports (`DeprecatedIntVar`, `DeprecatedDurationVar`, etc.).

To retain the ability to disable flags, this PR also introduces `DisabledFlag`
and a new `disabled_flags_inuse_total` counter.

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
