### PR TITLE
Add WaitN to the multi-tenant RateLimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Changelog
 
-* [ENHANCEMENT] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71
@@ -46,6 +45,7 @@
 * [CHANGE] Multierror: Implement `Is(error) bool`. This allows to use `multierror.MultiError` with `errors.Is()`. `MultiError` will in turn call `errors.Is()` on every error value. #254
 * [CHANGE] Cache: Remove the `context.Context` argument from the `Cache.Store` method and rename the method to `Cache.StoreAsync`. #273
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
+* [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [ENHANCEMENT] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71

--- a/limiter/rate_limiter.go
+++ b/limiter/rate_limiter.go
@@ -1,6 +1,7 @@
 package limiter
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -45,6 +46,14 @@ func NewRateLimiter(strategy RateLimiterStrategy, recheckPeriod time.Duration) *
 // AllowN reports whether n tokens may be consumed happen at time now.
 func (l *RateLimiter) AllowN(now time.Time, tenantID string, n int) bool {
 	return l.getTenantLimiter(now, tenantID).AllowN(now, n)
+}
+
+// WaitN blocks until n events are allowed to happen.
+// It returns an error if n exceeds the Limiter's burst size, the Context is
+// canceled, or the expected wait time exceeds the Context's Deadline.
+// The burst limit is ignored if the rate limit is Inf.
+func (l *RateLimiter) WaitN(ctx context.Context, tenantID string, n int) error {
+	return l.getTenantLimiter(time.Now(), tenantID).WaitN(ctx, n)
 }
 
 // Limit returns the currently configured maximum overall tokens rate.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds `WaitN` to the multitenant RateLimiter's interface. This is provided by the underlying `rate.Limiter`, so this is as simple as exposing it. See https://pkg.go.dev/golang.org/x/time/rate#Limiter.WaitN . 

Copying the docs from there:

> WaitN blocks until lim permits n events to happen. It returns an error if n exceeds the Limiter's burst size, the Context is canceled, or the expected wait time exceeds the Context's Deadline. The burst limit is ignored if the rate limit is Inf.


So this is useful when we don't want to directly error out and discard the task, but wait to adjust the pace.

**Which issue(s) this PR fixes**:
n/a

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
