### PR TITLE
Improve performance of `Ring.shuffleShard()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 * [ENHANCEMENT] Lifecycler: Added `InstancesInZoneCount` and `InstancesCount` functions returning respectively the total number of instances in the ring and the number of instances in the ring that are registered in lifecycler's zone, updated during the last heartbeat period. #270
 * [ENHANCEMENT] Memcached: add `MinIdleConnectionsHeadroomPercentage` support. It configures the minimum number of idle connections to keep open as a percentage of the number of recently used idle connections. If negative (default), idle connections are kept open indefinitely. #269
 * [ENHANCEMENT] Memcached: Add support for using TLS or mTLS with Memcached based caching. #278
+* [ENHANCEMENT] Ring: improve performance of shuffle sharding computation. #281
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/goleak v1.2.0
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/sync v0.1.0
 	golang.org/x/time v0.1.0
 	google.golang.org/grpc v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -530,6 +530,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/loser/loser.go
+++ b/loser/loser.go
@@ -1,0 +1,166 @@
+// Loser tree, from https://en.wikipedia.org/wiki/K-way_merge_algorithm#Tournament_Tree
+
+package loser
+
+type Sequence interface {
+	Next() bool // Advances and returns true if there is a value at this new position.
+}
+
+func New[E any, S Sequence](sequences []S, maxVal E, at func(S) E, less func(E, E) bool, close func(S)) *Tree[E, S] {
+	nSequences := len(sequences)
+	t := Tree[E, S]{
+		maxVal: maxVal,
+		at:     at,
+		less:   less,
+		close:  close,
+		nodes:  make([]node[E, S], nSequences*2),
+	}
+	for i, s := range sequences {
+		t.nodes[i+nSequences].items = s
+		t.moveNext(i + nSequences) // Must call Next on each item so that At() has a value.
+	}
+	if nSequences > 0 {
+		t.nodes[0].index = -1 // flag to be initialized on first call to Next().
+	}
+	return &t
+}
+
+// Call the close function on all sequences that are still open.
+func (t *Tree[E, S]) Close() {
+	for _, e := range t.nodes[len(t.nodes)/2 : len(t.nodes)] {
+		if e.index == -1 {
+			continue
+		}
+		t.close(e.items)
+	}
+}
+
+// A loser tree is a binary tree laid out such that nodes N and N+1 have parent N/2.
+// We store M leaf nodes in positions M...2M-1, and M-1 internal nodes in positions 1..M-1.
+// Node 0 is a special node, containing the winner of the contest.
+type Tree[E any, S Sequence] struct {
+	maxVal E
+	at     func(S) E
+	less   func(E, E) bool
+	close  func(S) // Called when Next() returns false.
+	nodes  []node[E, S]
+}
+
+type node[E any, S Sequence] struct {
+	index int // This is the loser for all nodes except the 0th, where it is the winner.
+	value E   // Value copied from the loser node, or winner for node 0.
+	items S   // Only populated for leaf nodes.
+}
+
+func (t *Tree[E, S]) moveNext(index int) bool {
+	n := &t.nodes[index]
+	if n.items.Next() {
+		n.value = t.at(n.items)
+		return true
+	}
+	t.close(n.items) // Next() returned false; close it and mark as finished.
+	n.value = t.maxVal
+	n.index = -1
+	return false
+}
+
+func (t *Tree[E, S]) Winner() S {
+	return t.nodes[t.nodes[0].index].items
+}
+
+func (t *Tree[E, S]) Next() bool {
+	if len(t.nodes) == 0 {
+		return false
+	}
+	if t.nodes[0].index == -1 { // If tree has not been initialized yet, do that.
+		t.initialize()
+		return t.nodes[t.nodes[0].index].index != -1
+	}
+	if t.nodes[t.nodes[0].index].index == -1 { // already exhausted
+		return false
+	}
+	t.moveNext(t.nodes[0].index)
+	t.replayGames(t.nodes[0].index)
+	return t.nodes[t.nodes[0].index].index != -1
+}
+
+func (t *Tree[E, S]) initialize() {
+	winners := make([]int, len(t.nodes))
+	// Initialize leaf nodes as winners to start.
+	for i := len(t.nodes) / 2; i < len(t.nodes); i++ {
+		winners[i] = i
+	}
+	for i := len(t.nodes) - 2; i > 0; i -= 2 {
+		// At each stage the winners play each other, and we record the loser in the node.
+		loser, winner := t.playGame(winners[i], winners[i+1])
+		p := parent(i)
+		t.nodes[p].index = loser
+		t.nodes[p].value = t.nodes[loser].value
+		winners[p] = winner
+	}
+	t.nodes[0].index = winners[1]
+	t.nodes[0].value = t.nodes[winners[1]].value
+}
+
+// Starting at pos, re-consider all values up to the root.
+func (t *Tree[E, S]) replayGames(pos int) {
+	// At the start, pos is a leaf node, and is the winner at that level.
+	n := parent(pos)
+	for n != 0 {
+		if t.less(t.nodes[n].value, t.nodes[pos].value) {
+			loser := pos
+			// Record pos as the loser here, and the old loser is the new winner.
+			pos = t.nodes[n].index
+			t.nodes[n].index = loser
+			t.nodes[n].value = t.nodes[loser].value
+		}
+		n = parent(n)
+	}
+	// pos is now the winner; store it in node 0.
+	t.nodes[0].index = pos
+	t.nodes[0].value = t.nodes[pos].value
+}
+
+func (t *Tree[E, S]) playGame(a, b int) (loser, winner int) {
+	if t.less(t.nodes[a].value, t.nodes[b].value) {
+		return b, a
+	}
+	return a, b
+}
+
+func parent(i int) int { return i / 2 }
+
+// Add a new sequence to the merge set
+func (t *Tree[E, S]) Push(sequence S) {
+	// First, see if we can replace one that was previously finished.
+	for newPos := len(t.nodes) / 2; newPos < len(t.nodes); newPos++ {
+		if t.nodes[newPos].index == -1 {
+			t.nodes[newPos].index = newPos
+			t.nodes[newPos].items = sequence
+			t.moveNext(newPos)
+			t.nodes[0].index = -1 // flag for re-initialize on next call to Next()
+			return
+		}
+	}
+	// We need to expand the tree. Pick the next biggest power of 2 to amortise resizing cost.
+	size := 1
+	for ; size <= len(t.nodes)/2; size *= 2 {
+	}
+	newPos := size + len(t.nodes)/2
+	newNodes := make([]node[E, S], size*2)
+	// Copy data over and fix up the indexes.
+	for i, n := range t.nodes[len(t.nodes)/2:] {
+		newNodes[i+size] = n
+		newNodes[i+size].index = i + size
+	}
+	t.nodes = newNodes
+	t.nodes[newPos].index = newPos
+	t.nodes[newPos].items = sequence
+	// Mark all the empty nodes we have added as finished.
+	for i := newPos + 1; i < len(t.nodes); i++ {
+		t.nodes[i].index = -1
+		t.nodes[i].value = t.maxVal
+	}
+	t.moveNext(newPos)
+	t.nodes[0].index = -1 // flag for re-initialize on next call to Next()
+}

--- a/loser/loser.go
+++ b/loser/loser.go
@@ -89,7 +89,7 @@ func (t *Tree[E]) replayGames(pos int) {
 	// At the start, pos is a leaf node, and is the winner at that level.
 	n := parent(pos)
 	for n != 0 {
-		if t.nodes[n].value < t.nodes[pos].value {
+		if t.nodes[n].value <= t.nodes[pos].value {
 			loser := pos
 			// Record pos as the loser here, and the old loser is the new winner.
 			pos = t.nodes[n].index
@@ -104,7 +104,7 @@ func (t *Tree[E]) replayGames(pos int) {
 }
 
 func (t *Tree[E]) playGame(a, b int) (loser, winner int) {
-	if t.nodes[a].value < t.nodes[b].value {
+	if t.nodes[a].value <= t.nodes[b].value {
 		return b, a
 	}
 	return a, b

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -64,6 +64,16 @@ var testCases = []struct {
 		args: [][]uint64{{1, 3}, {2, 4}, {5}},
 		want: []uint64{1, 2, 3, 4, 5},
 	},
+	{
+		name: "two lists, largest value equal to one less than maximum",
+		args: [][]uint64{{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 3}, {(math.MaxUint64 / 4) * 2, math.MaxUint64 - 1}},
+		want: []uint64{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 2, (math.MaxUint64 / 4) * 3, math.MaxUint64 - 1},
+	},
+	{
+		name: "two lists, largest value equal to maximum",
+		args: [][]uint64{{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 3}, {(math.MaxUint64 / 4) * 2, math.MaxUint64}},
+		want: []uint64{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 2, (math.MaxUint64 / 4) * 3, math.MaxUint64},
+	},
 }
 
 func TestMerge(t *testing.T) {

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -2,12 +2,13 @@ package loser_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
 	"math"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
 
 	"github.com/grafana/dskit/loser"
 )

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -1,0 +1,143 @@
+package loser_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/grafana/dskit/loser"
+)
+
+type List struct {
+	list []uint64
+	cur  uint64
+}
+
+func NewList(list ...uint64) *List {
+	return &List{list: list}
+}
+
+func (it *List) At() uint64 {
+	return it.cur
+}
+
+func (it *List) Next() bool {
+	if len(it.list) > 0 {
+		it.cur = it.list[0]
+		it.list = it.list[1:]
+		return true
+	}
+	it.cur = 0
+	return false
+}
+
+func (it *List) Seek(val uint64) bool {
+	for it.cur < val && len(it.list) > 0 {
+		it.cur = it.list[0]
+		it.list = it.list[1:]
+	}
+	return len(it.list) > 0
+}
+
+func checkIterablesEqual[E any, S1 loser.Sequence, S2 loser.Sequence](t *testing.T, a S1, b S2, at1 func(S1) E, at2 func(S2) E, less func(E, E) bool) {
+	t.Helper()
+	count := 0
+	for a.Next() {
+		count++
+		if !b.Next() {
+			t.Fatalf("b ended before a after %d elements", count)
+		}
+		if less(at1(a), at2(b)) || less(at2(b), at1(a)) {
+			t.Fatalf("position %d: %v != %v", count, at1(a), at2(b))
+		}
+	}
+	if b.Next() {
+		t.Fatalf("a ended before b after %d elements", count)
+	}
+}
+
+var testCases = []struct {
+	name string
+	args []*List
+	want *List
+}{
+	{
+		name: "empty input",
+		want: NewList(),
+	},
+	{
+		name: "one list",
+		args: []*List{NewList(1, 2, 3, 4)},
+		want: NewList(1, 2, 3, 4),
+	},
+	{
+		name: "two lists",
+		args: []*List{NewList(3, 4, 5), NewList(1, 2)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+	{
+		name: "two lists, first empty",
+		args: []*List{NewList(), NewList(1, 2)},
+		want: NewList(1, 2),
+	},
+	{
+		name: "two lists, second empty",
+		args: []*List{NewList(1, 2), NewList()},
+		want: NewList(1, 2),
+	},
+	{
+		name: "two lists b",
+		args: []*List{NewList(1, 2), NewList(3, 4, 5)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+	{
+		name: "two lists c",
+		args: []*List{NewList(1, 3), NewList(2, 4, 5)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+	{
+		name: "three lists",
+		args: []*List{NewList(1, 3), NewList(2, 4), NewList(5)},
+		want: NewList(1, 2, 3, 4, 5),
+	},
+}
+
+func TestMerge(t *testing.T) {
+	at := func(s *List) uint64 { return s.At() }
+	less := func(a, b uint64) bool { return a < b }
+	at2 := func(s *loser.Tree[uint64, *List]) uint64 { return s.Winner().At() }
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			numCloses := 0
+			close := func(s *List) {
+				numCloses++
+			}
+			lt := loser.New(tt.args, math.MaxUint64, at, less, close)
+			checkIterablesEqual(t, tt.want, lt, at, at2, less)
+			if numCloses != len(tt.args) {
+				t.Errorf("Expected %d closes, got %d", len(tt.args), numCloses)
+			}
+		})
+	}
+}
+
+func TestPush(t *testing.T) {
+	at := func(s *List) uint64 { return s.At() }
+	less := func(a, b uint64) bool { return a < b }
+	at2 := func(s *loser.Tree[uint64, *List]) uint64 { return s.Winner().At() }
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			numCloses := 0
+			close := func(s *List) {
+				numCloses++
+			}
+			lt := loser.New(nil, math.MaxUint64, at, less, close)
+			for _, s := range tt.args {
+				lt.Push(s)
+			}
+			checkIterablesEqual(t, tt.want, lt, at, at2, less)
+			if numCloses != len(tt.args) {
+				t.Errorf("Expected %d closes, got %d", len(tt.args), numCloses)
+			}
+		})
+	}
+}

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -30,14 +30,6 @@ func (it *List) Next() bool {
 	return false
 }
 
-func (it *List) Seek(val uint64) bool {
-	for it.cur < val && len(it.list) > 0 {
-		it.cur = it.list[0]
-		it.list = it.list[1:]
-	}
-	return len(it.list) > 0
-}
-
 func checkIterablesEqual[E any, S1 loser.Sequence, S2 loser.Sequence](t *testing.T, a S1, b S2, at1 func(S1) E, at2 func(S2) E, less func(E, E) bool) {
 	t.Helper()
 	count := 0

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -1,135 +1,88 @@
 package loser_test
 
 import (
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/constraints"
 	"math"
 	"testing"
 
 	"github.com/grafana/dskit/loser"
 )
 
-type List struct {
-	list []uint64
-	cur  uint64
-}
-
-func NewList(list ...uint64) *List {
-	return &List{list: list}
-}
-
-func (it *List) At() uint64 {
-	return it.cur
-}
-
-func (it *List) Next() bool {
-	if len(it.list) > 0 {
-		it.cur = it.list[0]
-		it.list = it.list[1:]
-		return true
-	}
-	it.cur = 0
-	return false
-}
-
-func checkIterablesEqual[E any, S1 loser.Sequence, S2 loser.Sequence](t *testing.T, a S1, b S2, at1 func(S1) E, at2 func(S2) E, less func(E, E) bool) {
+func checkTreeEqual[E constraints.Ordered](t *testing.T, tree *loser.Tree[E], expected []E) {
 	t.Helper()
-	count := 0
-	for a.Next() {
-		count++
-		if !b.Next() {
-			t.Fatalf("b ended before a after %d elements", count)
-		}
-		if less(at1(a), at2(b)) || less(at2(b), at1(a)) {
-			t.Fatalf("position %d: %v != %v", count, at1(a), at2(b))
-		}
+	actual := []E{}
+
+	for tree.Next() {
+		actual = append(actual, tree.Winner())
 	}
-	if b.Next() {
-		t.Fatalf("a ended before b after %d elements", count)
-	}
+
+	require.Equal(t, expected, actual)
 }
 
 var testCases = []struct {
 	name string
-	args []*List
-	want *List
+	args [][]uint64
+	want []uint64
 }{
 	{
 		name: "empty input",
-		want: NewList(),
+		want: []uint64{},
 	},
 	{
 		name: "one list",
-		args: []*List{NewList(1, 2, 3, 4)},
-		want: NewList(1, 2, 3, 4),
+		args: [][]uint64{{1, 2, 3, 4}},
+		want: []uint64{1, 2, 3, 4},
 	},
 	{
 		name: "two lists",
-		args: []*List{NewList(3, 4, 5), NewList(1, 2)},
-		want: NewList(1, 2, 3, 4, 5),
+		args: [][]uint64{{3, 4, 5}, {1, 2}},
+		want: []uint64{1, 2, 3, 4, 5},
 	},
 	{
 		name: "two lists, first empty",
-		args: []*List{NewList(), NewList(1, 2)},
-		want: NewList(1, 2),
+		args: [][]uint64{{}, {1, 2}},
+		want: []uint64{1, 2},
 	},
 	{
 		name: "two lists, second empty",
-		args: []*List{NewList(1, 2), NewList()},
-		want: NewList(1, 2),
+		args: [][]uint64{{1, 2}, {}},
+		want: []uint64{1, 2},
 	},
 	{
 		name: "two lists b",
-		args: []*List{NewList(1, 2), NewList(3, 4, 5)},
-		want: NewList(1, 2, 3, 4, 5),
+		args: [][]uint64{{1, 2}, {3, 4, 5}},
+		want: []uint64{1, 2, 3, 4, 5},
 	},
 	{
 		name: "two lists c",
-		args: []*List{NewList(1, 3), NewList(2, 4, 5)},
-		want: NewList(1, 2, 3, 4, 5),
+		args: [][]uint64{{1, 3}, {2, 4, 5}},
+		want: []uint64{1, 2, 3, 4, 5},
 	},
 	{
 		name: "three lists",
-		args: []*List{NewList(1, 3), NewList(2, 4), NewList(5)},
-		want: NewList(1, 2, 3, 4, 5),
+		args: [][]uint64{{1, 3}, {2, 4}, {5}},
+		want: []uint64{1, 2, 3, 4, 5},
 	},
 }
 
 func TestMerge(t *testing.T) {
-	at := func(s *List) uint64 { return s.At() }
-	less := func(a, b uint64) bool { return a < b }
-	at2 := func(s *loser.Tree[uint64, *List]) uint64 { return s.Winner().At() }
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			numCloses := 0
-			close := func(s *List) {
-				numCloses++
-			}
-			lt := loser.New(tt.args, math.MaxUint64, at, less, close)
-			checkIterablesEqual(t, tt.want, lt, at, at2, less)
-			if numCloses != len(tt.args) {
-				t.Errorf("Expected %d closes, got %d", len(tt.args), numCloses)
-			}
+			lt := loser.New(tt.args, math.MaxUint64)
+			checkTreeEqual(t, lt, tt.want)
 		})
 	}
 }
 
 func TestPush(t *testing.T) {
-	at := func(s *List) uint64 { return s.At() }
-	less := func(a, b uint64) bool { return a < b }
-	at2 := func(s *loser.Tree[uint64, *List]) uint64 { return s.Winner().At() }
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			numCloses := 0
-			close := func(s *List) {
-				numCloses++
-			}
-			lt := loser.New(nil, math.MaxUint64, at, less, close)
+			lt := loser.New[uint64](nil, math.MaxUint64)
 			for _, s := range tt.args {
 				lt.Push(s)
 			}
-			checkIterablesEqual(t, tt.want, lt, at, at2, less)
-			if numCloses != len(tt.args) {
-				t.Errorf("Expected %d closes, got %d", len(tt.args), numCloses)
-			}
+			checkTreeEqual(t, lt, tt.want)
 		})
 	}
 }

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -69,23 +69,23 @@ var testCases = []struct {
 	},
 	{
 		name: "two lists, largest value equal to one less than maximum",
-		args: [][]uint64{{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 3}, {(math.MaxUint64 / 4) * 2, math.MaxUint64 - 1}},
-		want: []uint64{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 2, (math.MaxUint64 / 4) * 3, math.MaxUint64 - 1},
+		args: [][]uint64{{1, 3}, {2, math.MaxUint64 - 1}},
+		want: []uint64{1, 2, 3, math.MaxUint64 - 1},
 	},
 	{
 		name: "two lists, largest value in first list equal to maximum",
-		args: [][]uint64{{math.MaxUint64 / 4, math.MaxUint64}, {(math.MaxUint64 / 4) * 2, (math.MaxUint64 / 4) * 3}},
-		want: []uint64{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 2, (math.MaxUint64 / 4) * 3, math.MaxUint64},
+		args: [][]uint64{{1, math.MaxUint64}, {2, 3}},
+		want: []uint64{1, 2, 3, math.MaxUint64},
 	},
 	{
 		name: "two lists, largest value in second list equal to maximum",
-		args: [][]uint64{{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 3}, {(math.MaxUint64 / 4) * 2, math.MaxUint64}},
-		want: []uint64{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 2, (math.MaxUint64 / 4) * 3, math.MaxUint64},
+		args: [][]uint64{{1, 3}, {2, math.MaxUint64}},
+		want: []uint64{1, 2, 3, math.MaxUint64},
 	},
 	{
 		name: "two lists, largest value in both lists equal to maximum",
-		args: [][]uint64{{math.MaxUint64 / 4, math.MaxUint64}, {(math.MaxUint64 / 4) * 2, math.MaxUint64}},
-		want: []uint64{math.MaxUint64 / 4, (math.MaxUint64 / 4) * 2, math.MaxUint64, math.MaxUint64},
+		args: [][]uint64{{1, math.MaxUint64}, {2, math.MaxUint64}},
+		want: []uint64{1, 2, math.MaxUint64, math.MaxUint64},
 	},
 }
 

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -78,8 +78,18 @@ var testCases = []struct {
 		want: []uint64{1, 2, 3, math.MaxUint64},
 	},
 	{
+		name: "two lists, first straddles second and has largest value equal to maximum",
+		args: [][]uint64{{1, 3, math.MaxUint64}, {2}},
+		want: []uint64{1, 2, 3, math.MaxUint64},
+	},
+	{
 		name: "two lists, largest value in second list equal to maximum",
 		args: [][]uint64{{1, 3}, {2, math.MaxUint64}},
+		want: []uint64{1, 2, 3, math.MaxUint64},
+	},
+	{
+		name: "two lists, second straddles first and has largest value equal to maximum",
+		args: [][]uint64{{2}, {1, 3, math.MaxUint64}},
 		want: []uint64{1, 2, 3, math.MaxUint64},
 	},
 	{

--- a/ring/model.go
+++ b/ring/model.go
@@ -591,54 +591,21 @@ func GetOrCreateRingDesc(d interface{}) *Desc {
 	return d.(*Desc)
 }
 
-type tokenList struct {
-	list []uint32
-	cur  uint32
-}
-
-func newTokenList(list ...uint32) *tokenList {
-	return &tokenList{list: list}
-}
-
-func (it *tokenList) At() uint32 {
-	return it.cur
-}
-
-func (it *tokenList) Next() bool {
-	if len(it.list) > 0 {
-		it.cur = it.list[0]
-		it.list = it.list[1:]
-		return true
-	}
-	it.cur = 0
-	return false
-}
-
 // MergeTokens takes in input multiple lists of tokens and returns a single list
 // containing all tokens merged and sorted. Each input single list is required
 // to have tokens already sorted.
 func MergeTokens(instances [][]uint32) []uint32 {
 	numTokens := 0
-	lists := make([]*tokenList, len(instances))
 
-	for i, tokens := range instances {
-		if len(tokens) == 0 {
-			continue
-		}
-
+	for _, tokens := range instances {
 		numTokens += len(tokens)
-		lists[i] = newTokenList(tokens...)
 	}
 
-	at := func(s *tokenList) uint32 { return s.At() }
-	less := func(a, b uint32) bool { return a < b }
-	close := func(s *tokenList) {}
-	tree := loser.New(lists, math.MaxUint32, at, less, close)
-
+	tree := loser.New(instances, math.MaxUint32)
 	out := make([]uint32, 0, numTokens)
 
 	for tree.Next() {
-		out = append(out, tree.Winner().At())
+		out = append(out, tree.Winner())
 	}
 
 	return out

--- a/ring/model.go
+++ b/ring/model.go
@@ -2,11 +2,12 @@ package ring
 
 import (
 	"fmt"
-	"github.com/grafana/dskit/loser"
 	"math"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/grafana/dskit/loser"
 
 	"github.com/gogo/protobuf/proto"
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -756,9 +756,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 // mergeTokenGroups returns a sorted list of all tokens in each entry in groupsByName.
 // Each element of groupsByName is assumed to already be sorted.
 func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
-	tokenCount := 0
-	groupsByIndex := make([][]uint32, 0, len(groupsByName))
-	nextIndex := make([]int, 0, len(groupsByName))
+	groupsList := make([][]uint32, 0, len(groupsByName))
 
 	for _, group := range groupsByName {
 		// If there's only one group, there's nothing to merge.
@@ -766,42 +764,10 @@ func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
 			return group
 		}
 
-		tokenCount += len(group)
-		groupsByIndex = append(groupsByIndex, group)
-		nextIndex = append(nextIndex, 0)
+		groupsList = append(groupsList, group)
 	}
 
-	merged := make([]uint32, 0, tokenCount)
-
-	for i := 0; i < tokenCount; i++ {
-		haveSeenGroupWithRemainingToken := false
-		lowestToken := uint32(0)
-		lowestTokenGroupIndex := 0
-
-		for groupIndex, group := range groupsByIndex {
-			nextIndexInGroup := nextIndex[groupIndex]
-
-			if nextIndexInGroup >= len(group) {
-				continue
-			}
-
-			if group[nextIndexInGroup] < lowestToken || !haveSeenGroupWithRemainingToken {
-				lowestToken = group[nextIndexInGroup]
-				lowestTokenGroupIndex = groupIndex
-			}
-
-			haveSeenGroupWithRemainingToken = true
-		}
-
-		if !haveSeenGroupWithRemainingToken {
-			return merged
-		}
-
-		merged = append(merged, lowestToken)
-		nextIndex[lowestTokenGroupIndex]++
-	}
-
-	return merged
+	return MergeTokens(groupsList)
 }
 
 // GetInstanceState returns the current state of an instance or an error if the

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -756,7 +756,9 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 // mergeTokenGroups returns a sorted list of all tokens in each entry in groupsByName.
 // Each element of groupsByName is assumed to already be sorted.
 func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
-	groupsList := make([][]uint32, 0, len(groupsByName))
+	tokenCount := 0
+	groupsByIndex := make([][]uint32, 0, len(groupsByName))
+	nextIndex := make([]int, 0, len(groupsByName))
 
 	for _, group := range groupsByName {
 		// If there's only one group, there's nothing to merge.
@@ -764,10 +766,42 @@ func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
 			return group
 		}
 
-		groupsList = append(groupsList, group)
+		tokenCount += len(group)
+		groupsByIndex = append(groupsByIndex, group)
+		nextIndex = append(nextIndex, 0)
 	}
 
-	return MergeTokens(groupsList)
+	merged := make([]uint32, 0, tokenCount)
+
+	for i := 0; i < tokenCount; i++ {
+		haveSeenGroupWithRemainingToken := false
+		lowestToken := uint32(0)
+		lowestTokenGroupIndex := 0
+
+		for groupIndex, group := range groupsByIndex {
+			nextIndexInGroup := nextIndex[groupIndex]
+
+			if nextIndexInGroup >= len(group) {
+				continue
+			}
+
+			if group[nextIndexInGroup] < lowestToken || !haveSeenGroupWithRemainingToken {
+				lowestToken = group[nextIndexInGroup]
+				lowestTokenGroupIndex = groupIndex
+			}
+
+			haveSeenGroupWithRemainingToken = true
+		}
+
+		if !haveSeenGroupWithRemainingToken {
+			return merged
+		}
+
+		merged = append(merged, lowestToken)
+		nextIndex[lowestTokenGroupIndex]++
+	}
+
+	return merged
 }
 
 // GetInstanceState returns the current state of an instance or an error if the

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -731,12 +731,13 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 	// Build a read-only ring for the shard.
 	shardDesc := &Desc{Ingesters: shard}
 	shardTokensByZone := shardDesc.getTokensByZone()
+	shardTokens := mergeTokenGroups(shardTokensByZone)
 
 	return &Ring{
 		cfg:              r.cfg,
 		strategy:         r.strategy,
 		ringDesc:         shardDesc,
-		ringTokens:       shardDesc.GetTokens(),
+		ringTokens:       shardTokens,
 		ringTokensByZone: shardTokensByZone,
 		ringZones:        getZones(shardTokensByZone),
 
@@ -750,6 +751,57 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 		// For caching to work, remember these values.
 		lastTopologyChange: r.lastTopologyChange,
 	}
+}
+
+// mergeTokenGroups returns a sorted list of all tokens in each entry in groupsByName.
+// Each element of groupsByName is assumed to already be sorted.
+func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
+	tokenCount := 0
+	groupsByIndex := make([][]uint32, 0, len(groupsByName))
+	nextIndex := make([]int, 0, len(groupsByName))
+
+	for _, group := range groupsByName {
+		// If there's only one group, there's nothing to merge.
+		if len(groupsByName) == 1 {
+			return group
+		}
+
+		tokenCount += len(group)
+		groupsByIndex = append(groupsByIndex, group)
+		nextIndex = append(nextIndex, 0)
+	}
+
+	merged := make([]uint32, 0, tokenCount)
+
+	for i := 0; i < tokenCount; i++ {
+		haveSeenGroupWithRemainingToken := false
+		lowestToken := uint32(0)
+		lowestTokenGroupIndex := 0
+
+		for groupIndex, group := range groupsByIndex {
+			nextIndexInGroup := nextIndex[groupIndex]
+
+			if nextIndexInGroup >= len(group) {
+				continue
+			}
+
+			if group[nextIndexInGroup] < lowestToken || !haveSeenGroupWithRemainingToken {
+				lowestToken = group[nextIndexInGroup]
+				lowestTokenGroupIndex = groupIndex
+			}
+
+			haveSeenGroupWithRemainingToken = true
+		}
+
+		if !haveSeenGroupWithRemainingToken {
+			return merged
+		}
+
+		merged = append(merged, lowestToken)
+		nextIndex[lowestTokenGroupIndex] += 1
+	}
+
+	return merged
 }
 
 // GetInstanceState returns the current state of an instance or an error if the

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -788,9 +788,8 @@ func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
 			if group[nextIndexInGroup] < lowestToken || !haveSeenGroupWithRemainingToken {
 				lowestToken = group[nextIndexInGroup]
 				lowestTokenGroupIndex = groupIndex
+				haveSeenGroupWithRemainingToken = true
 			}
-
-			haveSeenGroupWithRemainingToken = true
 		}
 
 		if !haveSeenGroupWithRemainingToken {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -798,7 +798,7 @@ func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
 		}
 
 		merged = append(merged, lowestToken)
-		nextIndex[lowestTokenGroupIndex] += 1
+		nextIndex[lowestTokenGroupIndex]++
 	}
 
 	return merged

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2004,7 +2004,7 @@ func BenchmarkRing_ShuffleShard_512Tokens(b *testing.B) {
 	benchmarkShuffleSharding(b, numInstances, numZones, numTokens, shardSize, cacheEnabled)
 }
 
-func BenchmarkRing_ShuffleShard_512Tokens_100Instances_3Zones(b *testing.B) {
+func BenchmarkRing_ShuffleShard_LargeShardSize(b *testing.B) {
 	const (
 		numInstances = 300 // = 100 per zone
 		numZones     = 3

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2517,3 +2517,75 @@ func TestUpdateMetricsWithRemoval(t *testing.T) {
 	`))
 	assert.NoError(t, err)
 }
+
+func TestMergeTokenGroups(t *testing.T) {
+	scenarios := map[string]struct {
+		groups   map[string][]uint32
+		expected []uint32
+	}{
+		"no groups": {
+			groups:   map[string][]uint32{},
+			expected: []uint32{},
+		},
+		"empty group": {
+			groups: map[string][]uint32{
+				"group-1": {},
+			},
+			expected: []uint32{},
+		},
+		"single group with one value": {
+			groups: map[string][]uint32{
+				"group-1": {1},
+			},
+			expected: []uint32{1},
+		},
+		"single group with many values": {
+			groups: map[string][]uint32{
+				"group-1": {1, 2, 3},
+			},
+			expected: []uint32{1, 2, 3},
+		},
+		"single group with repeated value": {
+			groups: map[string][]uint32{
+				"group-1": {1, 2, 2},
+			},
+			expected: []uint32{1, 2, 2},
+		},
+		"two groups with one value each": {
+			groups: map[string][]uint32{
+				"group-1": {1},
+				"group-2": {2},
+			},
+			expected: []uint32{1, 2},
+		},
+		"two groups with many values": {
+			groups: map[string][]uint32{
+				"group-1": {1, 3, 4, 7},
+				"group-2": {2, 5, 6},
+			},
+			expected: []uint32{1, 2, 3, 4, 5, 6, 7},
+		},
+		"two groups with common values": {
+			groups: map[string][]uint32{
+				"group-1": {1, 4, 6},
+				"group-2": {2, 4, 5},
+			},
+			expected: []uint32{1, 2, 4, 4, 5, 6},
+		},
+		"many groups": {
+			groups: map[string][]uint32{
+				"group-1": {1, 4, 7},
+				"group-2": {2, 5, 8},
+				"group-3": {3, 6, 9},
+			},
+			expected: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			actual := mergeTokenGroups(scenario.groups)
+			require.Equal(t, scenario.expected, actual)
+		})
+	}
+}

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2004,6 +2004,18 @@ func BenchmarkRing_ShuffleShard_512Tokens(b *testing.B) {
 	benchmarkShuffleSharding(b, numInstances, numZones, numTokens, shardSize, cacheEnabled)
 }
 
+func BenchmarkRing_ShuffleShard_512Tokens_100Instances_3Zones(b *testing.B) {
+	const (
+		numInstances = 300 // = 100 per zone
+		numZones     = 3
+		numTokens    = 512
+		shardSize    = 270 // = 90 per zone
+		cacheEnabled = false
+	)
+
+	benchmarkShuffleSharding(b, numInstances, numZones, numTokens, shardSize, cacheEnabled)
+}
+
 func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, shardSize int, cache bool) {
 	// Initialise the ring.
 	ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones, numTokens)}


### PR DESCRIPTION
**What this PR does**:

This PR improves the performance of `Ring.shuffleShard()`, and specifically the evaluation of the list of all tokens in the shard. It also introduces a new benchmark for shuffle sharding, `BenchmarkRing_ShuffleShard_LargeShardSize`, which better mirrors the worst-case parameters we see in production Mimir cells.

There are two main optimisations:
* to compute the per-zone lists of tokens, use a loser tree rather than a heap to merge per-host lists of tokens
* to compute the overall list of tokens, merge the per-zone lists of tokens rather than merging the per-host lists of tokens, and use a simplified merge algorithm to perform this merge step (benchmarks show that it performs better than using either a heap or a loser tree when merging such a small number of lists)

The loser tree implementation is based on @bboreham's implementation in Loki, which we are relicensing as part of this PR. I've modified it to work on slices directly, rather than `Sequence` interfaces, as this improved overall shuffle shard computation performance by ~15%, and incorporated the fix in https://github.com/grafana/loki/pull/9057.

Benchmark results:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/ring
                                                                          │  before.txt   │             final.txt              │
                                                                          │    sec/op     │   sec/op     vs base               │
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_3-10       28.02µ ±  1%   17.82µ ± 0%  -36.41% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_10-10     105.36µ ±  0%   51.41µ ± 0%  -51.20% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_30-10      418.0µ ±  1%   159.6µ ± 0%  -61.81% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_3-10       48.00µ ±  1%   45.07µ ± 0%   -6.10% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_10-10     134.43µ ±  0%   86.19µ ± 1%  -35.89% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_30-10      381.7µ ±  1%   202.3µ ± 6%  -46.99% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_3-10      29.08µ ±  2%   18.31µ ± 2%  -37.04% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_10-10    106.16µ ±  2%   52.62µ ± 0%  -50.43% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_30-10     423.7µ ±  1%   161.1µ ± 1%  -61.99% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_3-10      48.99µ ±  1%   45.88µ ± 0%   -6.36% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_10-10    136.33µ ±  3%   87.78µ ± 1%  -35.61% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_30-10     385.8µ ±  0%   203.4µ ± 0%  -47.28% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_3-10     26.77µ ±  2%   16.46µ ± 0%  -38.50% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_10-10   103.64µ ±  0%   49.62µ ± 0%  -52.13% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_30-10    418.8µ ± 32%   157.1µ ± 0%  -62.48% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_3-10     45.33µ ±  0%   42.24µ ± 1%   -6.82% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_10-10   131.38µ ±  1%   81.63µ ± 1%  -37.87% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_30-10    378.6µ ±  0%   194.9µ ± 1%  -48.51% (p=0.002 n=6)
Ring_ShuffleShard_512Tokens-10                                               286.6µ ±  0%   170.8µ ± 0%  -40.40% (p=0.002 n=6)
Ring_ShuffleShard_LargeShardSize-10                                         22.624m ±  0%   7.956m ± 1%  -64.83% (p=0.002 n=6)
geomean                                                                      162.9µ         91.56µ       -43.81%

                                                                          │  before.txt   │              final.txt              │
                                                                          │     B/op      │     B/op      vs base               │
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_3-10      11.039Ki ± 0%   9.391Ki ± 0%  -14.93% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_10-10      21.12Ki ± 0%   15.51Ki ± 0%  -26.56% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_30-10      51.46Ki ± 0%   34.21Ki ± 0%  -33.52% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_3-10       21.61Ki ± 0%   21.55Ki ± 0%   -0.25% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_10-10      33.49Ki ± 0%   33.03Ki ± 0%   -1.38% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_30-10      62.54Ki ± 0%   61.41Ki ± 0%   -1.79% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_3-10     11.039Ki ± 0%   9.391Ki ± 0%  -14.93% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_10-10     21.12Ki ± 0%   15.51Ki ± 0%  -26.56% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_30-10     51.46Ki ± 0%   34.21Ki ± 0%  -33.52% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_3-10      21.61Ki ± 0%   21.55Ki ± 0%   -0.25% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_10-10     33.49Ki ± 0%   33.03Ki ± 0%   -1.37% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_30-10     62.53Ki ± 0%   61.42Ki ± 0%   -1.79% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_3-10    11.039Ki ± 0%   9.391Ki ± 0%  -14.93% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_10-10    21.12Ki ± 0%   15.51Ki ± 0%  -26.56% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_30-10    51.46Ki ± 0%   34.21Ki ± 0%  -33.52% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_3-10     21.61Ki ± 0%   21.55Ki ± 0%   -0.25% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_10-10    33.49Ki ± 0%   33.03Ki ± 0%   -1.37% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_30-10    62.54Ki ± 0%   61.42Ki ± 0%   -1.78% (p=0.002 n=6)
Ring_ShuffleShard_512Tokens-10                                               56.92Ki ± 0%   56.56Ki ± 0%   -0.63% (p=0.002 n=6)
Ring_ShuffleShard_LargeShardSize-10                                          1.203Mi ± 0%   1.193Mi ± 0%   -0.80% (p=0.002 n=6)
geomean                                                                      35.69Ki        31.10Ki       -12.86%

                                                                          │ before.txt  │             final.txt             │
                                                                          │  allocs/op  │ allocs/op   vs base               │
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_3-10       32.00 ± 0%   22.00 ± 0%  -31.25% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_10-10      62.00 ± 0%   31.00 ± 0%  -50.00% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_30-10     143.00 ± 0%   52.00 ± 0%  -63.64% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_3-10       44.00 ± 0%   37.00 ± 0%  -15.91% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_10-10      86.00 ± 0%   52.00 ± 0%  -39.53% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_30-10     164.00 ± 0%   76.00 ± 0%  -53.66% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_3-10      32.00 ± 0%   22.00 ± 0%  -31.25% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_10-10     62.00 ± 0%   31.00 ± 0%  -50.00% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_30-10    143.00 ± 0%   52.00 ± 0%  -63.64% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_3-10      44.00 ± 0%   37.00 ± 0%  -15.91% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_10-10     86.00 ± 0%   52.00 ± 0%  -39.53% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_30-10    164.00 ± 0%   76.00 ± 0%  -53.66% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_3-10     32.00 ± 0%   22.00 ± 0%  -31.25% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_10-10    62.00 ± 0%   31.00 ± 0%  -50.00% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_30-10   143.00 ± 0%   52.00 ± 0%  -63.64% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_3-10     44.00 ± 0%   37.00 ± 0%  -15.91% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_10-10    86.00 ± 0%   52.00 ± 0%  -39.53% (p=0.002 n=6)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_30-10   164.00 ± 0%   76.00 ± 0%  -53.66% (p=0.002 n=6)
Ring_ShuffleShard_512Tokens-10                                               74.00 ± 0%   49.00 ± 0%  -33.78% (p=0.002 n=6)
Ring_ShuffleShard_LargeShardSize-10                                         1134.0 ± 0%   326.0 ± 0%  -71.25% (p=0.002 n=6)
geomean                                                                      85.71        46.49       -45.76%

```

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
