### PR TITLE
Ring status page: fix the owned tokens percentage value displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,4 @@
 * [BUGFIX] Ring status page: display 100% ownership as "100%", rather than "1e+02%". #231
 * [BUGFIX] Memberlist: fix crash when methods from `memberlist.Delegate` interface are called on `*memberlist.KV` before the service is fully started. #244
 * [BUGFIX] runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery from bad config with exact same config hash as before. #262
+* [BUGFIX] Ring status page: fixed the owned tokens percentage value displayed. #282

--- a/ring/http.go
+++ b/ring/http.go
@@ -93,7 +93,7 @@ func (h *ringPageHandler) handle(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	ownedTokens := ringDesc.countTokens()
+	ownedTokens := ringDesc.CountTokens()
 
 	var ingesterIDs []string
 	for id := range ringDesc.Ingesters {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -506,8 +506,8 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	}, nil
 }
 
-// countTokens returns the number tokens within the range for each instance.
-func (r *Desc) countTokens() map[string]uint32 {
+// CountTokens returns the number tokens within the range for each instance.
+func (r *Desc) CountTokens() map[string]uint32 {
 	var (
 		owned               = make(map[string]uint32, len(r.Ingesters))
 		ringTokens          = r.GetTokens()

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-
 	"math"
 	"math/rand"
 	"net/http"
@@ -510,7 +509,7 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 // countTokens returns the number tokens within the range for each instance.
 func (r *Desc) countTokens() map[string]uint32 {
 	var (
-		owned               = map[string]uint32{}
+		owned               = make(map[string]uint32, len(r.Ingesters))
 		ringTokens          = r.GetTokens()
 		ringInstanceByToken = r.getTokensInfo()
 	)
@@ -519,10 +518,11 @@ func (r *Desc) countTokens() map[string]uint32 {
 		var diff uint32
 
 		// Compute how many tokens are within the range.
-		if i+1 == len(ringTokens) {
-			diff = (math.MaxUint32 - token) + ringTokens[0]
+		if i == 0 {
+			lastToken := ringTokens[len(ringTokens)-1]
+			diff = token + (math.MaxUint32 - lastToken)
 		} else {
-			diff = ringTokens[i+1] - token
+			diff = token - ringTokens[i-1]
 		}
 
 		info := ringInstanceByToken[token]

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2637,7 +2637,7 @@ func TestCountTokens(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, testData.expected, testData.ring.countTokens())
+			assert.Equal(t, testData.expected, testData.ring.CountTokens())
 		})
 	}
 


### PR DESCRIPTION
**What this PR does**:
I'm unbalanced series between Mimir ingesters. While investigating, I noticed the owned tokens percentage displayed in the ring status page is wrong. This PR fixed it and also expose `ring.Desc.CountTokens()` so that I can re-use it in a ring analysis tool I'm building (instead of copying the code).

What's the bug in `countTokens()` and why this PR fixes it? The tokens in the ring are the end of the range, while `countTokens()` was computing the owned tokens range as if the token is the start of the range.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
