### PR TITLE
Cache subrings returned by `Ring.ShuffleShardWithLookback()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 * [ENHANCEMENT] Memcached: add `MinIdleConnectionsHeadroomPercentage` support. It configures the minimum number of idle connections to keep open as a percentage of the number of recently used idle connections. If negative (default), idle connections are kept open indefinitely. #269
 * [ENHANCEMENT] Memcached: Add support for using TLS or mTLS with Memcached based caching. #278
 * [ENHANCEMENT] Ring: improve performance of shuffle sharding computation. #281
+* [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -195,8 +195,9 @@ type Ring struct {
 }
 
 type subringCacheKey struct {
-	identifier string
-	shardSize  int
+	identifier     string
+	shardSize      int
+	lookbackPeriod time.Duration
 }
 
 type cachedSubringWithLookback struct {
@@ -906,7 +907,7 @@ func (r *Ring) getCachedShuffledSubringWithLookback(identifier string, size int,
 		return nil
 	}
 
-	cached, ok := r.shuffledSubringWithLookbackCache[subringCacheKey{identifier: identifier, shardSize: size}]
+	cached, ok := r.shuffledSubringWithLookbackCache[subringCacheKey{identifier: identifier, shardSize: size, lookbackPeriod: lookbackPeriod}]
 	if !ok {
 		return nil
 	}
@@ -969,7 +970,7 @@ func (r *Ring) setCachedShuffledSubringWithLookback(identifier string, size int,
 	// Only update cache if subring's lookback window starts later than the previously cached subring for this identifier,
 	// if there is one. This prevents cache thrashing due to different calls competing if their lookback windows start
 	// before and after the time of an instance registering.
-	key := subringCacheKey{identifier: identifier, shardSize: size}
+	key := subringCacheKey{identifier: identifier, shardSize: size, lookbackPeriod: lookbackPeriod}
 
 	if existingEntry, haveCached := r.shuffledSubringWithLookbackCache[key]; !haveCached || existingEntry.validForLookbackWindowsStartingAt < lookbackStart {
 		r.shuffledSubringWithLookbackCache[key] = cachedSubringWithLookback{

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -185,7 +185,8 @@ type Ring struct {
 
 	// Cache of shuffle-sharded subrings per identifier. Invalidated when topology changes.
 	// If set to nil, no caching is done (used by tests, and subrings).
-	shuffledSubringCache map[subringCacheKey]*Ring
+	shuffledSubringCache             map[subringCacheKey]*Ring
+	shuffledSubringWithLookbackCache map[subringCacheKey]cachedSubringWithLookback
 
 	numMembersGaugeVec      *prometheus.GaugeVec
 	totalTokensGauge        prometheus.Gauge
@@ -197,6 +198,12 @@ type Ring struct {
 type subringCacheKey struct {
 	identifier string
 	shardSize  int
+}
+
+type cachedSubringWithLookback struct {
+	subring               *Ring
+	validForLookbackFrom  int64
+	validForLookbackUntil int64
 }
 
 // New creates a new Ring. Being a service, Ring needs to be started to do anything.
@@ -222,12 +229,13 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 	}
 
 	r := &Ring{
-		key:                  key,
-		cfg:                  cfg,
-		KVClient:             store,
-		strategy:             strategy,
-		ringDesc:             &Desc{},
-		shuffledSubringCache: map[subringCacheKey]*Ring{},
+		key:                              key,
+		cfg:                              cfg,
+		KVClient:                         store,
+		strategy:                         strategy,
+		ringDesc:                         &Desc{},
+		shuffledSubringCache:             map[subringCacheKey]*Ring{},
+		shuffledSubringWithLookbackCache: map[subringCacheKey]cachedSubringWithLookback{},
 		numMembersGaugeVec: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "ring_members",
 			Help:        "Number of members in the ring",
@@ -325,10 +333,15 @@ func (r *Ring) updateRingState(ringDesc *Desc) {
 	r.ringZones = ringZones
 	r.oldestRegisteredTimestamp = oldestRegisteredTimestamp
 	r.lastTopologyChange = now
+
+	// Invalidate all cached subrings.
 	if r.shuffledSubringCache != nil {
-		// Invalidate all cached subrings.
 		r.shuffledSubringCache = make(map[subringCacheKey]*Ring)
 	}
+	if r.shuffledSubringWithLookbackCache != nil {
+		r.shuffledSubringWithLookbackCache = make(map[subringCacheKey]cachedSubringWithLookback)
+	}
+
 	r.updateRingMetrics(rc)
 }
 
@@ -623,14 +636,25 @@ func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 // The returned subring may be unbalanced with regard to zones and should never be used for write
 // operations (read only).
 //
-// This function doesn't support caching.
+// This function supports caching, but the cache will only be effective if successive calls for the
+// same identifier are for increasing values of (now-lookbackPeriod).
 func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ReadRing {
 	// Nothing to do if the shard size is not smaller then the actual ring.
 	if size <= 0 || r.InstancesCount() <= size {
 		return r
 	}
 
-	return r.shuffleShard(identifier, size, lookbackPeriod, now)
+	if cached := r.getCachedShuffledSubringWithLookback(identifier, size, lookbackPeriod, now); cached != nil {
+		return cached
+	}
+
+	result := r.shuffleShard(identifier, size, lookbackPeriod, now)
+
+	if result != r {
+		r.setCachedShuffledSubringWithLookback(identifier, size, lookbackPeriod, now, result)
+	}
+
+	return result
 }
 
 func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Duration, now time.Time) *Ring {
@@ -877,6 +901,85 @@ func (r *Ring) setCachedShuffledSubring(identifier string, size int, subring *Ri
 	}
 }
 
+func (r *Ring) getCachedShuffledSubringWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) *Ring {
+	if r.cfg.SubringCacheDisabled {
+		return nil
+	}
+
+	cached, ok := r.shuffledSubringWithLookbackCache[subringCacheKey{identifier: identifier, shardSize: size}]
+	if !ok {
+		return nil
+	}
+
+	lookbackStart := now.Add(-lookbackPeriod).Unix()
+	if lookbackStart < cached.validForLookbackFrom || lookbackStart > cached.validForLookbackUntil {
+		return nil
+	}
+
+	cachedSubring := cached.subring
+	if r == cachedSubring {
+		return cachedSubring
+	}
+
+	cachedSubring.mtx.Lock()
+	defer cachedSubring.mtx.Unlock()
+
+	// Update instance states and timestamps. We know that the topology is the same,
+	// so zones and tokens are equal.
+	for name, cachedIng := range cachedSubring.ringDesc.Ingesters {
+		ing := r.ringDesc.Ingesters[name]
+		cachedIng.State = ing.State
+		cachedIng.Timestamp = ing.Timestamp
+		cachedSubring.ringDesc.Ingesters[name] = cachedIng
+	}
+
+	return cachedSubring
+}
+
+func (r *Ring) setCachedShuffledSubringWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time, subring *Ring) {
+	if subring == nil || r.cfg.SubringCacheDisabled {
+		return
+	}
+
+	lookbackStart := now.Add(-lookbackPeriod).Unix()
+	validForLookbackUntil := int64(math.MaxInt64)
+
+	for _, instance := range subring.ringDesc.Ingesters {
+		registeredDuringLookbackWindow := instance.RegisteredTimestamp >= lookbackStart
+
+		if registeredDuringLookbackWindow && instance.RegisteredTimestamp < validForLookbackUntil {
+			validForLookbackUntil = instance.RegisteredTimestamp
+		}
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	// Only cache if *this* ring hasn't changed since computing result
+	// (which can happen between releasing the read lock and getting read-write lock).
+	// Note that shuffledSubringCache can be only nil when set by test.
+	if r.shuffledSubringWithLookbackCache == nil {
+		return
+	}
+
+	if !r.lastTopologyChange.Equal(subring.lastTopologyChange) {
+		return
+	}
+
+	// Only update cache if subring's lookback window starts later than the previously cached subring for this identifier,
+	// if there is one. This prevents cache thrashing due to different calls competing if their lookback windows start
+	// before and after the time of an instance registering.
+	key := subringCacheKey{identifier: identifier, shardSize: size}
+
+	if existingEntry, haveCached := r.shuffledSubringWithLookbackCache[key]; !haveCached || existingEntry.validForLookbackFrom < lookbackStart {
+		r.shuffledSubringWithLookbackCache[key] = cachedSubringWithLookback{
+			subring:               subring,
+			validForLookbackFrom:  lookbackStart,
+			validForLookbackUntil: validForLookbackUntil,
+		}
+	}
+}
+
 func (r *Ring) CleanupShuffleShardCache(identifier string) {
 	if r.cfg.SubringCacheDisabled {
 		return
@@ -888,6 +991,12 @@ func (r *Ring) CleanupShuffleShardCache(identifier string) {
 	for k := range r.shuffledSubringCache {
 		if k.identifier == identifier {
 			delete(r.shuffledSubringCache, k)
+		}
+	}
+
+	for k := range r.shuffledSubringWithLookbackCache {
+		if k.identifier == identifier {
+			delete(r.shuffledSubringWithLookbackCache, k)
 		}
 	}
 }

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2032,7 +2032,7 @@ func TestRing_ShuffleShardWithLookback_Caching(t *testing.T) {
 			},
 			test: func(t *testing.T, ring *Ring) {
 				first := ring.ShuffleShardWithLookback(userID, subringSize, time.Hour, now)
-				second := ring.ShuffleShardWithLookback(userID, subringSize*2, time.Hour, now)
+				second := ring.ShuffleShardWithLookback(userID, subringSize+1, time.Hour, now)
 				require.NotSame(t, first, second)
 
 				firstReplicationSet, err := first.GetAllHealthy(Read)

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2279,7 +2279,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
-func TestShuffleShardWithCaching(t *testing.T) {
+func TestRing_ShuffleShard_Caching(t *testing.T) {
 	inmem, closer := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
 		MaxCasRetries: 20,
 		CasRetryDelay: 500 * time.Millisecond,


### PR DESCRIPTION
**What this PR does**:

This PR adds caching for `Ring.ShuffleShardWithLookback()`. `ShuffleShardWithLookback` is a potentially expensive operation (see benchmarks in #281), and the results are cacheable.

As far as I can tell, the only system that uses `ShuffleShardWithLookback` is Mimir - I couldn't find any references in Loki, Tempo or Phlare. So I've implemented a cache that suits Mimir's access pattern, namely that we only request subrings with lookback windows later than previous lookback windows. For example, if we request a subring for `user-1` with lookback window starting at $T_1$, then subsequent requests for `user-1` will have a lookback window starting at or after $T_1$. 

`ShuffleShardWithLookback` will still return correct results if this access pattern is not followed, but the cache will not be effective.

Cached subrings are returned if no members of the subring registered between the beginning of the cached lookback window and the beginning of the requested lookback window. This is best illustrated visually:

![ShuffleShardWithLookback caching explanation](https://user-images.githubusercontent.com/4017646/231942250-1c604ad0-dd56-4c7e-a248-a4a2d82cc042.png)

Explanation:
* Imagine the first request to this ring is for lookback window A. The cache is empty, so we compute the subring $R_1$, store it in the cache and return it to the caller.
* Next, another request is made for lookback window B. No instances in $R_1$ registered between the start of window A and the start of window B, so we can return the cached $R_1$.
* Finally, a third request is made, this time for lookback window C. An instance in $R_1$ registered between the start of window A and the start of window C, so we can't reuse $R_1$ and instead must compute a new subring, $R_2$, store it in the cache and return it to the caller.

(Please check my logic carefully here: I'm not super familiar with the ring implementation and may have missed some edge cases.)

The cache implementation follows a similar pattern to the caching implemented for `Ring.ShuffleShard()`, and all cached subrings are discarded when the ring topology changes.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
