### PR TITLE
ring: exit early if there aren't enough zones or instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,4 @@
 * [BUGFIX] Memberlist: fix crash when methods from `memberlist.Delegate` interface are called on `*memberlist.KV` before the service is fully started. #244
 * [BUGFIX] runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery from bad config with exact same config hash as before. #262
 * [BUGFIX] Ring status page: fixed the owned tokens percentage value displayed. #282
+* [BUGFIX] Ring: prevent iterating the whole ring when using `ExcludedZones`. #285

--- a/ring/model.go
+++ b/ring/model.go
@@ -478,7 +478,7 @@ func (d *Desc) GetTokens() []uint32 {
 func (d *Desc) getTokensByZone() map[string][]uint32 {
 	zones := map[string][][]uint32{}
 	for _, instance := range d.Ingesters {
-		// Tokens may not be sorted for an older version which, so we enforce sorting here.
+		// Tokens may not be sorted for an older version, so we enforce sorting here.
 		tokens := instance.Tokens
 		if !sort.IsSorted(Tokens(tokens)) {
 			sort.Sort(Tokens(tokens))

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -340,17 +340,19 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 	}
 
 	var (
-		n          = r.cfg.ReplicationFactor
-		instances  = bufDescs[:0]
-		start      = searchToken(r.ringTokens, key)
-		iterations = 0
+		n            = r.cfg.ReplicationFactor
+		instances    = bufDescs[:0]
+		start        = searchToken(r.ringTokens, key)
+		iterations   = 0
+		maxZones     = len(r.ringTokensByZone)
+		maxInstances = len(r.ringDesc.Ingesters)
 
 		// We use a slice instead of a map because it's faster to search within a
 		// slice than lookup a map for a very low number of items.
 		distinctHosts = bufHosts[:0]
 		distinctZones = bufZones[:0]
 	)
-	for i := start; len(distinctHosts) < n && iterations < len(r.ringTokens); i++ {
+	for i := start; len(distinctHosts) < maxInstances && len(distinctZones) < maxZones && len(distinctHosts) < n && iterations < len(r.ringTokens); i++ {
 		iterations++
 		// Wrap i around in the ring.
 		i %= len(r.ringTokens)

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -352,7 +352,7 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 		distinctHosts = bufHosts[:0]
 		distinctZones = bufZones[:0]
 	)
-	for i := start; len(distinctHosts) < maxInstances && len(distinctZones) < maxZones && len(distinctHosts) < n && iterations < len(r.ringTokens); i++ {
+	for i := start; len(distinctHosts) < dsmath.Min(maxInstances, n) && len(distinctZones) < maxZones && iterations < len(r.ringTokens); i++ {
 		iterations++
 		// Wrap i around in the ring.
 		i %= len(r.ringTokens)

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/dskit/flagext"
+	math2 "github.com/grafana/dskit/internal/math"
 	"github.com/grafana/dskit/internal/slices"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/kv/consul"
@@ -2039,36 +2040,68 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, s
 }
 
 func BenchmarkRing_Get(b *testing.B) {
-	const (
-		numInstances      = 100
-		numZones          = 3
-		replicationFactor = 3
-	)
-
-	// Initialise the ring.
-	ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones, numTokens)}
-	ring := Ring{
-		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: true, ReplicationFactor: replicationFactor},
-		ringDesc:             ringDesc,
-		ringTokens:           ringDesc.GetTokens(),
-		ringTokensByZone:     ringDesc.getTokensByZone(),
-		ringInstanceByToken:  ringDesc.getTokensInfo(),
-		ringZones:            getZones(ringDesc.getTokensByZone()),
-		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		strategy:             NewDefaultReplicationStrategy(),
-		lastTopologyChange:   time.Now(),
+	benchCases := map[string]struct {
+		numInstances      int
+		numZones          int
+		replicationFactor int
+	}{
+		"with zone awareness": {
+			numInstances:      99,
+			numZones:          3,
+			replicationFactor: 3,
+		},
+		"one excluded zone": {
+			numInstances:      66,
+			numZones:          2,
+			replicationFactor: 3,
+		},
+		"without zone awareness": {
+			numInstances:      3,
+			numZones:          1,
+			replicationFactor: 3,
+		},
+		"without zone awareness, not enough instances": {
+			numInstances:      2,
+			numZones:          1,
+			replicationFactor: 3,
+		},
 	}
 
-	buf, bufHosts, bufZones := MakeBuffersForGet()
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		set, err := ring.Get(r.Uint32(), Write, buf, bufHosts, bufZones)
-		if err != nil || len(set.Instances) != replicationFactor {
-			b.Fatal()
+	for benchName, benchCase := range benchCases {
+		// Initialise the ring.
+		ringDesc := &Desc{Ingesters: generateRingInstances(benchCase.numInstances, benchCase.numZones, numTokens)}
+		ring := Ring{
+			cfg: Config{
+				HeartbeatTimeout:     time.Hour,
+				ZoneAwarenessEnabled: benchCase.numZones > 1,
+				SubringCacheDisabled: true,
+				ReplicationFactor:    benchCase.replicationFactor,
+			},
+			ringDesc:             ringDesc,
+			ringTokens:           ringDesc.GetTokens(),
+			ringTokensByZone:     ringDesc.getTokensByZone(),
+			ringInstanceByToken:  ringDesc.getTokensInfo(),
+			ringZones:            getZones(ringDesc.getTokensByZone()),
+			shuffledSubringCache: map[subringCacheKey]*Ring{},
+			strategy:             NewDefaultReplicationStrategy(),
+			lastTopologyChange:   time.Now(),
 		}
+
+		buf, bufHosts, bufZones := MakeBuffersForGet()
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+		expectedInstances := math2.Min(benchCase.numInstances, benchCase.replicationFactor)
+		if ring.cfg.ZoneAwarenessEnabled {
+			expectedInstances = math2.Min(benchCase.numZones, benchCase.replicationFactor)
+		}
+
+		b.Run(benchName, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				set, err := ring.Get(r.Uint32(), Write, buf, bufHosts, bufZones)
+				assert.NoError(b, err)
+				assert.Equal(b, expectedInstances, len(set.Instances))
+			}
+		})
 	}
 }
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/dskit/flagext"
-	math2 "github.com/grafana/dskit/internal/math"
+	dsmath "github.com/grafana/dskit/internal/math"
 	"github.com/grafana/dskit/internal/slices"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/kv/consul"
@@ -2090,9 +2090,9 @@ func BenchmarkRing_Get(b *testing.B) {
 		buf, bufHosts, bufZones := MakeBuffersForGet()
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-		expectedInstances := math2.Min(benchCase.numInstances, benchCase.replicationFactor)
+		expectedInstances := dsmath.Min(benchCase.numInstances, benchCase.replicationFactor)
 		if ring.cfg.ZoneAwarenessEnabled {
-			expectedInstances = math2.Min(benchCase.numZones, benchCase.replicationFactor)
+			expectedInstances = dsmath.Min(benchCase.numZones, benchCase.replicationFactor)
 		}
 
 		b.Run(benchName, func(b *testing.B) {


### PR DESCRIPTION
**What this PR does**:

Fixes a performance regression when there aren't enough instances in the ring to meet the replication factor. This may happen when excluding a zone via `ExcludedZones`.

What used to happen in that case is the `Ring.Get` method iterated over all tokens in the ring before existing. This PR adds a condition to exit early when we know that we can't gather enough instances.

<details>
<summary>Benchmark</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/ring
                                                         │ before-96c85c2.txt │          after-0719614.txt          │
                                                         │       sec/op       │    sec/op     vs base               │
Ring_Get/with_zone_awareness-10                                  795.6n ± 64%   761.6n ± 23%        ~ (p=0.240 n=6)
Ring_Get/one_excluded_zone-10                                1533633.0n ±  9%   570.3n ± 22%  -99.96% (p=0.002 n=6)
Ring_Get/without_zone_awareness-10                               511.2n ±  0%   522.0n ±  1%   +2.11% (p=0.002 n=6)
Ring_Get/without_zone_awareness,_not_enough_instances-10       21114.0n ±  3%   421.7n ±  0%  -98.00% (p=0.002 n=6)
geomean                                                          10.71µ         556.1n        -94.81%

                                                         │ before-96c85c2.txt │         after-0719614.txt          │
                                                         │        B/op        │    B/op     vs base                │
Ring_Get/with_zone_awareness-10                                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Ring_Get/one_excluded_zone-10                                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Ring_Get/without_zone_awareness-10                               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Ring_Get/without_zone_awareness,_not_enough_instances-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                     ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                         │ before-96c85c2.txt │         after-0719614.txt          │
                                                         │     allocs/op      │ allocs/op   vs base                │
Ring_Get/with_zone_awareness-10                                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Ring_Get/one_excluded_zone-10                                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Ring_Get/without_zone_awareness-10                               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Ring_Get/without_zone_awareness,_not_enough_instances-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                     ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```


</details>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
