### PR TITLE
Sar/ring stuck in leaving issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,3 +125,4 @@
 * [BUGFIX] Memberlist: fix crash when methods from `memberlist.Delegate` interface are called on `*memberlist.KV` before the service is fully started. #244
 * [BUGFIX] runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery from bad config with exact same config hash as before. #262
 * [BUGFIX] Ring status page: fixed the owned tokens percentage value displayed. #282
+* [BUGFIX] ring.Lifecycler: Handle when previous ring state is leaving and the number of tokens has changed. #79

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -1422,6 +1422,6 @@ func GenerateTokenJSONFile(tokens int) string {
 		}
 		tokens--
 	}
-	token, _ := json.Marshal(&tokenFile)
-	return string(token)
+	tokenFileJSON, _ := json.Marshal(&tokenFile)
+	return string(tokenFileJSON)
 }

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -2,8 +2,11 @@ package ring
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -235,6 +238,242 @@ func TestLifecycler_InstancesInZoneCount(t *testing.T) {
 		require.Equal(t, instance.expectedHealthyInstancesCount, lifecycler.HealthyInstancesCount())
 		require.Equal(t, instance.expectedZonesCount, lifecycler.ZonesCount())
 	}
+}
+
+// Test Lifecycler when increasing tokens and instance is already in the ring in leaving state.
+func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
+	ctx := context.Background()
+
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = ringStore
+	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+	})
+
+	tokenDir := t.TempDir()
+	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
+	// Make sure changes are applied instantly
+	lifecyclerConfig.HeartbeatPeriod = 0
+	lifecyclerConfig.NumTokens = 128
+	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
+
+	// Simulate ingester with 64 tokens left the ring in LEAVING state
+	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := NewDesc()
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
+		if err != nil {
+			return nil, false, err
+		}
+
+		ringDesc.AddIngester("ing1", addr, lifecyclerConfig.Zone, GenerateTokens(64, nil), LEAVING, time.Now())
+		return ringDesc, true, nil
+	})
+	require.NoError(t, err)
+
+	// Start ingester with increased number of tokens
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, l))
+	})
+
+	// Verify ingester joined, is active, and has 128 tokens
+	test.Poll(t, time.Second, true, func() interface{} {
+		d, err := r.KVClient.Get(ctx, ringKey)
+		require.NoError(t, err)
+
+		desc, ok := d.(*Desc)
+		require.True(t, ok)
+		ingDesc := desc.Ingesters["ing1"]
+		t.Log("Polling for new ingester to have become active with 128 tokens", "state", ingDesc.State, "tokens", len(ingDesc.Tokens))
+		return ingDesc.State == ACTIVE && len(ingDesc.Tokens) == 128
+	})
+}
+
+// Test Lifecycler when decreasing tokens and instance is already in the ring in leaving state.
+func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
+	ctx := context.Background()
+
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = ringStore
+	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+	})
+
+	tokenDir := t.TempDir()
+	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
+	// Make sure changes are applied instantly
+	lifecyclerConfig.HeartbeatPeriod = 0
+	lifecyclerConfig.NumTokens = 64
+	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
+
+	// Simulate ingester with 128 tokens left the ring in LEAVING state
+	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := NewDesc()
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
+		if err != nil {
+			return nil, false, err
+		}
+
+		ringDesc.AddIngester("ing1", addr, lifecyclerConfig.Zone, GenerateTokens(128, nil), LEAVING, time.Now())
+		return ringDesc, true, nil
+	})
+	require.NoError(t, err)
+
+	// Start ingester with decreased number of tokens
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, l))
+	})
+
+	// Verify ingester joined, is active, and has 64 tokens
+	test.Poll(t, time.Second, true, func() interface{} {
+		d, err := r.KVClient.Get(ctx, ringKey)
+		require.NoError(t, err)
+
+		desc, ok := d.(*Desc)
+		require.True(t, ok)
+		ingDesc := desc.Ingesters["ing1"]
+		t.Log("Polling for new ingester to have become active with 64 tokens", "state", ingDesc.State, "tokens", len(ingDesc.Tokens))
+		return ingDesc.State == ACTIVE && len(ingDesc.Tokens) == 64
+	})
+}
+
+// Test Lifecycler when increasing tokens and instance is already in the ring in leaving state and tokensFromFile is not empty.
+func TestLifecycler_IncreasingTokensLeavingInstanceInTheRingAndTokensFromFileNotEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = ringStore
+	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+	})
+
+	tokenDir := t.TempDir()
+	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
+	// Make sure changes are applied instantly
+	lifecyclerConfig.HeartbeatPeriod = 0
+	lifecyclerConfig.NumTokens = 128
+	f, err := os.Create(filepath.Join(tokenDir, "/tokens"))
+	f.WriteString(GenerateTokenJsonFile(64))
+	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
+
+	// Simulate ingester with 64 tokens left the ring in LEAVING state
+	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := NewDesc()
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
+		if err != nil {
+			return nil, false, err
+		}
+
+		ringDesc.AddIngester("ing1", addr, lifecyclerConfig.Zone, GenerateTokens(64, nil), LEAVING, time.Now())
+		return ringDesc, true, nil
+	})
+	require.NoError(t, err)
+
+	// Start ingester with increased number of tokens
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, l))
+	})
+
+	// Verify ingester joined, is active, and has 128 tokens
+	test.Poll(t, time.Second, true, func() interface{} {
+		d, err := r.KVClient.Get(ctx, ringKey)
+		require.NoError(t, err)
+
+		desc, ok := d.(*Desc)
+		require.True(t, ok)
+		ingDesc := desc.Ingesters["ing1"]
+		t.Log("Polling for new ingester to have become active with 128 tokens", "state", ingDesc.State, "tokens", len(ingDesc.Tokens))
+		return ingDesc.State == ACTIVE && len(ingDesc.Tokens) == 128
+	})
+}
+
+// Test Lifecycler when decreasing tokens and instance is already in the ring in leaving state.
+func TestLifecycler_DecreasingTokensLeavingInstanceInTheRingAndTokensFromFileNotEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = ringStore
+	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, r))
+	})
+
+	tokenDir := t.TempDir()
+	lifecyclerConfig := testLifecyclerConfig(ringConfig, "ing1")
+	// Make sure changes are applied instantly
+	lifecyclerConfig.HeartbeatPeriod = 0
+	lifecyclerConfig.NumTokens = 64
+	f, err := os.Create(filepath.Join(tokenDir, "/tokens"))
+	f.WriteString(GenerateTokenJsonFile(128))
+	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
+
+	// Simulate ingester with 128 tokens left the ring in LEAVING state
+	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := NewDesc()
+		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
+		if err != nil {
+			return nil, false, err
+		}
+
+		ringDesc.AddIngester("ing1", addr, lifecyclerConfig.Zone, GenerateTokens(64, nil), LEAVING, time.Now())
+		return ringDesc, true, nil
+	})
+	require.NoError(t, err)
+
+	// Start ingester with decreased number of tokens
+	l, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, l))
+	t.Cleanup(func() {
+		assert.NoError(t, services.StopAndAwaitTerminated(ctx, l))
+	})
+
+	// Verify ingester joined, is active, and has 64 tokens
+	test.Poll(t, time.Second, true, func() interface{} {
+		d, err := r.KVClient.Get(ctx, ringKey)
+		require.NoError(t, err)
+
+		desc, ok := d.(*Desc)
+		require.True(t, ok)
+		ingDesc := desc.Ingesters["ing1"]
+		t.Log("Polling for new ingester to have become active with 64 tokens", "state", ingDesc.State, "tokens", len(ingDesc.Tokens))
+		return ingDesc.State == ACTIVE && len(ingDesc.Tokens) == 64
+	})
 }
 
 func TestLifecycler_ZonesCount(t *testing.T) {
@@ -1163,4 +1402,26 @@ func TestDefaultFinalSleepValue(t *testing.T) {
 		flagext.DefaultValues(cfg)
 		assert.Equal(t, time.Minute, cfg.FinalSleep)
 	})
+}
+
+// GenerateTokenJsonFile generates a temp jsonTokenFile with given number of tokens upto 128
+func GenerateTokenJsonFile(tokens int) string {
+	type TokenFile struct {
+		Tokens []int32 `json:"tokens"`
+	}
+	if tokens < 0 {
+		tokens = 0
+	}
+	if tokens > 128 {
+		tokens = 128
+	}
+	var tokenFile TokenFile
+	for tokens >= 1 {
+		tokenFile = TokenFile{
+			Tokens: append(tokenFile.Tokens, rand.Int31()),
+		}
+		tokens--
+	}
+	file, _ := json.Marshal(&tokenFile)
+	return string(file)
 }

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -1422,6 +1422,6 @@ func GenerateTokenJSONFile(tokens int) string {
 		}
 		tokens--
 	}
-	tokenFileJSON, _ := json.Marshal(&tokenFile)
-	return string(tokenFileJSON)
+	file, _ := json.Marshal(&tokenFile)
+	return string(file)
 }

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -439,7 +439,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRingAndTokensFromFileNot
 	lifecyclerConfig.HeartbeatPeriod = 0
 	lifecyclerConfig.NumTokens = 64
 	f, _ := os.Create(filepath.Join(tokenDir, "/tokens"))
-	_, err = f.WriteString(GenerateTokenJSONFile(128))
+	_, _ = f.WriteString(GenerateTokenJSONFile(128))
 	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
 
 	// Simulate ingester with 128 tokens left the ring in LEAVING state

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -1422,6 +1422,6 @@ func GenerateTokenJSONFile(tokens int) string {
 		}
 		tokens--
 	}
-	file, _ := json.Marshal(&tokenFile)
-	return string(file)
+	tokenFileJSON, _ := json.Marshal(&tokenFile)
+	return string(tokenFileJSON)
 }

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -378,8 +378,8 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRingAndTokensFromFileNot
 	// Make sure changes are applied instantly
 	lifecyclerConfig.HeartbeatPeriod = 0
 	lifecyclerConfig.NumTokens = 128
-	f, err := os.Create(filepath.Join(tokenDir, "/tokens"))
-	f.WriteString(GenerateTokenJsonFile(64))
+	f, _ := os.Create(filepath.Join(tokenDir, "/tokens"))
+	_, _ = f.WriteString(GenerateTokenJSONFile(64))
 	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
 
 	// Simulate ingester with 64 tokens left the ring in LEAVING state
@@ -438,8 +438,8 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRingAndTokensFromFileNot
 	// Make sure changes are applied instantly
 	lifecyclerConfig.HeartbeatPeriod = 0
 	lifecyclerConfig.NumTokens = 64
-	f, err := os.Create(filepath.Join(tokenDir, "/tokens"))
-	f.WriteString(GenerateTokenJsonFile(128))
+	f, _ := os.Create(filepath.Join(tokenDir, "/tokens"))
+	_, err = f.WriteString(GenerateTokenJSONFile(128))
 	lifecyclerConfig.TokensFilePath = filepath.Join(tokenDir, "/tokens")
 
 	// Simulate ingester with 128 tokens left the ring in LEAVING state
@@ -1405,7 +1405,7 @@ func TestDefaultFinalSleepValue(t *testing.T) {
 }
 
 // GenerateTokenJsonFile generates a temp jsonTokenFile with given number of tokens upto 128
-func GenerateTokenJsonFile(tokens int) string {
+func GenerateTokenJSONFile(tokens int) string {
 	type TokenFile struct {
 		Tokens []int32 `json:"tokens"`
 	}

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -1422,6 +1422,6 @@ func GenerateTokenJSONFile(tokens int) string {
 		}
 		tokens--
 	}
-	tokenFileJSON, _ := json.Marshal(&tokenFile)
-	return string(tokenFileJSON)
+	token, _ := json.Marshal(&tokenFile)
+	return string(token)
 }

--- a/runutil/runutil.go
+++ b/runutil/runutil.go
@@ -7,7 +7,6 @@ package runutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +58,7 @@ func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ..
 // dir except for the ignoreDirs directories.
 // NOTE: DeleteAll is not idempotent.
 func DeleteAll(dir string, ignoreDirs ...string) error {
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil
 	}


### PR DESCRIPTION
What this PR does:
When starting a ring.Lifecycler, handle when previous ingester state is found in ring, its state is leaving and the number of tokens has changed. Tests are included.

Added a couple of tests to check when the tokens file is not empty by generating random tokens and testing it.

The PR is based on the work done in this PR https://github.com/grafana/dskit/pull/79.

Which issue(s) this PR fixes:

Fixes https://github.com/grafana/dskit/issues/73

Checklist

Tests updated
CHANGELOG.md updated - the order of entries should be [CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX]