### PR TITLE
ring.Lifecycler: Ingester stuck in LEAVING state when ring tokens are increased.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@
 * [ENHANCEMENT] Memcached: Add support for using TLS or mTLS with Memcached based caching. #278
 * [ENHANCEMENT] Ring: improve performance of shuffle sharding computation. #281
 * [ENHANCEMENT] Add option to enable IPv6 address detection in ring and memberlist handling. #185
-* [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 
+* [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109
@@ -125,3 +125,4 @@
 * [BUGFIX] Memberlist: fix crash when methods from `memberlist.Delegate` interface are called on `*memberlist.KV` before the service is fully started. #244
 * [BUGFIX] runtimeconfig: Fix `runtime_config_last_reload_successful` metric after recovery from bad config with exact same config hash as before. #262
 * [BUGFIX] Ring status page: fixed the owned tokens percentage value displayed. #282
+* [BUGFIX] ring.Lifecycler: Handle when previous ring state is leaving and the number of tokens has changed. #79

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -616,6 +616,12 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			return ringDesc, true, nil
 		}
 
+		// If the ingester fails to clean its ring entry up, it can end up in LEAVING state, we need to bring the state of
+		// the ingester to ACTIVE, but there are a couple of cases we need to handle.
+		// 1. Generate tokens if number of new tokens is more than old tokens.
+		// 2. Assign tokens to old token count if old tokens are more in number than number of new tokens.
+		// 3. Assign a subset of tokens from instanceDesc if token file is empty.
+		// After we have assigned the desginated tokens we need to set the state of ingester to active.
 		if instanceDesc.State == LEAVING {
 			var tokens Tokens = instanceDesc.Tokens // way of forcing tokens to be of type Tokens instead of []uint32.
 			setIsActive := true

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -621,7 +621,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 		// 1. Generate tokens if number of new tokens is more than old tokens.
 		// 2. Assign tokens to old token count if old tokens are more in number than number of new tokens.
 		// 3. Assign a subset of tokens from instanceDesc if token file is empty.
-		// After we have assigned the desginated tokens we need to set the state of ingester to active.
+		// After we have assigned the designated tokens we need to set the state of ingester to active.
 		if instanceDesc.State == LEAVING {
 			var tokens Tokens = instanceDesc.Tokens // way of forcing tokens to be of type Tokens instead of []uint32.
 			setIsActive := true

--- a/runutil/runutil.go
+++ b/runutil/runutil.go
@@ -7,7 +7,6 @@ package runutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +58,7 @@ func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ..
 // dir except for the ignoreDirs directories.
 // NOTE: DeleteAll is not idempotent.
 func DeleteAll(dir string, ignoreDirs ...string) error {
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil
 	}


### PR DESCRIPTION
What this PR does:
When starting a ring.Lifecycler, handle when previous ingester state is found in ring, its state is leaving and the number of tokens has changed. Tests are included.

What Changed?
1. Old code was only check if number of tokens before and number of tokens after ingester is in LEAVING state is equal to allow it to transition to ACTIVE state. This PR works on the similar logic used by @DylanGuedes to add or remove tokens if there is a increase or decrease tokens.
2. Also in the tests we weren't testing against number of tokens in the token file in the Dylan's PR, I have added a logic to add tokens in the temp file which is created to test the logic and test it against the tokens from the file.
3. Updated the runutil.go file to update the deprecated io.ioutil package.

The PR is based on the work done in this PR https://github.com/grafana/dskit/pull/79.  


Which issue(s) this PR fixes:

Fixes https://github.com/grafana/dskit/issues/73

Checklist

Tests updated
CHANGELOG.md updated - the order of entries should be [CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX]