### PR TITLE
ring: Add DoUntilQuorum method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 * [ENHANCEMENT] Add option to enable IPv6 address detection in ring and memberlist handling. #185
 * [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 
 * [ENHANCEMENT] BasicLifecycler: functions `ShouldKeepInstanceInTheRingOnShutdown` and `SetKeepInstanceInTheRingOnShutdown` for checking and setting whether instances should be kept in the ring or unregistered on shutdown have been added. #290
+* [ENHANCEMENT] Ring: add `DoUntilQuorum` method. #293
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -413,6 +413,7 @@ func TestBasicLifecycler_TokensObservePeriod(t *testing.T) {
 
 	lifecycler, delegate, store, err := prepareBasicLifecycler(t, cfg)
 	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
 	delegate.onRegister = func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ InstanceDesc) (InstanceState, Tokens) {
 		return ACTIVE, Tokens{1, 2, 3, 4, 5}

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -363,6 +363,7 @@ func TestLifecycler_ShouldHandleInstanceAbruptlyRestarted(t *testing.T) {
 	l1, err := NewLifecycler(lifecyclerConfig1, &nopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l1))
+	defer services.StopAndAwaitTerminated(context.Background(), l1) //nolint:errcheck
 
 	// Check this ingester joined, is active, and has one token.
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
@@ -382,6 +383,7 @@ func TestLifecycler_ShouldHandleInstanceAbruptlyRestarted(t *testing.T) {
 	l2, err := NewLifecycler(lifecyclerConfig1, &nopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l2))
+	defer services.StopAndAwaitTerminated(context.Background(), l2) //nolint:errcheck
 
 	// Check the new ingester picked up the same tokens and registered timestamp.
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
@@ -695,6 +697,7 @@ func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testi
 	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	// poll function waits for a condition and returning actual state of the ingesters after the condition succeed.
 	poll := func(condition func(*Desc) bool) map[string]InstanceDesc {
@@ -998,6 +1001,7 @@ func TestJoinInLeavingState(t *testing.T) {
 	l1, err := NewLifecycler(cfg, &nopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l1))
+	defer services.StopAndAwaitTerminated(context.Background(), l1) //nolint:errcheck
 
 	// Check that the lifecycler was able to join after coming up in LEAVING
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
@@ -1056,6 +1060,7 @@ func TestJoinInJoiningState(t *testing.T) {
 	l1, err := NewLifecycler(cfg, &nopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l1))
+	defer services.StopAndAwaitTerminated(context.Background(), l1) //nolint:errcheck
 
 	// Check that the lifecycler was able to join after coming up in JOINING
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
@@ -1115,6 +1120,7 @@ func TestRestoreOfZoneWhenOverwritten(t *testing.T) {
 	l1, err := NewLifecycler(cfg, &nopFlushTransferer{}, "ingester", ringKey, true, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l1))
+	defer services.StopAndAwaitTerminated(context.Background(), l1) //nolint:errcheck
 
 	// Check that the lifecycler was able to reset the zone value to the expected setting
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -155,13 +155,6 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, f func(context.
 		}(instance)
 	}
 
-	cancelAllContexts := func() {
-		for i := range r.Instances {
-			instance := &r.Instances[i]
-			tracker.cancelContextFor(instance)
-		}
-	}
-
 	resultsMap := make(map[*InstanceDesc]T, len(r.Instances))
 	cleanupResultsAlreadyReceived := func() {
 		for _, result := range resultsMap {
@@ -183,7 +176,7 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, f func(context.
 			if result.err == nil {
 				resultsMap[result.instance] = result.result
 			} else if tracker.failed() {
-				cancelAllContexts()
+				tracker.cancelAllContexts()
 				cleanupResultsAlreadyReceived()
 				return nil, result.err
 			}

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -33,9 +33,9 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	// Initialise the result tracker, which is use to keep track of successes and failures.
 	var tracker replicationSetResultTracker
 	if r.MaxUnavailableZones > 0 {
-		tracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones)
+		tracker = newZoneAwareResultTracker(ctx, r.Instances, r.MaxUnavailableZones)
 	} else {
-		tracker = newDefaultResultTracker(r.Instances, r.MaxErrors)
+		tracker = newDefaultResultTracker(ctx, r.Instances, r.MaxErrors)
 	}
 
 	var (
@@ -93,6 +93,129 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	}
 
 	return results, nil
+}
+
+// DoUntilQuorum runs function f in parallel for all replicas in r.
+//
+// If r.MaxUnavailableZones is greater than zero:
+//   - DoUntilQuorum returns an error if calls to f for instances in r.MaxUnavailableZones zones return errors
+//   - Otherwise, DoUntilQuorum returns all results from all replicas in the first zones for which f succeeds
+//     for every instance in that zone (eg. if there are 3 zones and r.MaxUnavailableZones is 1, DoUntilQuorum will
+//     return the results from all instances in 2 zones, even if all calls to f succeed).
+//
+// Otherwise:
+//   - DoUntilQuorum returns an error if r.MaxErrors calls to f return errors
+//   - Otherwise, DoUntilQuorum returns all results from the first len(r.Instances) - r.MaxErrors instances
+//     (eg. if there are 6 replicas and r.MaxErrors is 2, DoUntilQuorum will return the results from the first 4
+//     successful calls to f, even if all 6 calls to f succeed).
+//
+// Any results from successful calls to f that are not returned by DoUntilQuorum will be passed to cleanupFunc,
+// including when DoUntilQuorum returns an error or only returns a subset of successful results. cleanupFunc may
+// be called both before and after DoUntilQuorum returns.
+//
+// DoUntilQuorum cancels the context.Context passed to each invocation of f if the result of that invocation of
+// f will not be returned. If the result of that invocation of f will be returned, the context.Context passed
+// to that invocation of f will not be cancelled by DoUntilQuorum, but the context.Context is a child of ctx
+// and so will be cancelled if ctx is cancelled.
+func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, f func(context.Context, *InstanceDesc) (T, error), cleanupFunc func(T)) ([]T, error) {
+	resultsChan := make(chan instanceResult[T], len(r.Instances))
+	resultsRemaining := len(r.Instances)
+
+	defer func() {
+		go func() {
+			for resultsRemaining > 0 {
+				result := <-resultsChan
+				resultsRemaining--
+
+				if result.err == nil {
+					cleanupFunc(result.result)
+				}
+			}
+		}()
+	}()
+
+	var tracker replicationSetResultTracker
+	if r.MaxUnavailableZones > 0 {
+		tracker = newZoneAwareResultTracker(ctx, r.Instances, r.MaxUnavailableZones)
+	} else {
+		tracker = newDefaultResultTracker(ctx, r.Instances, r.MaxErrors)
+	}
+
+	for i := range r.Instances {
+		instance := &r.Instances[i]
+		instanceCtx := tracker.contextFor(instance)
+
+		go func(desc *InstanceDesc) {
+			result, err := f(instanceCtx, desc)
+			resultsChan <- instanceResult[T]{
+				result:   result,
+				err:      err,
+				instance: desc,
+			}
+		}(instance)
+	}
+
+	cancelAllContexts := func() {
+		for i := range r.Instances {
+			instance := &r.Instances[i]
+			tracker.cancelContextFor(instance)
+		}
+	}
+
+	resultsMap := make(map[*InstanceDesc]T, len(r.Instances))
+	cleanupResultsAlreadyReceived := func() {
+		for _, result := range resultsMap {
+			cleanupFunc(result)
+		}
+	}
+
+	for !tracker.succeeded() {
+		select {
+		case <-ctx.Done():
+			// No need to cancel individual instance contexts, as they inherit the cancellation from ctx.
+			cleanupResultsAlreadyReceived()
+
+			return nil, ctx.Err()
+		case result := <-resultsChan:
+			resultsRemaining--
+			tracker.done(result.instance, result.err)
+
+			if result.err == nil {
+				resultsMap[result.instance] = result.result
+			} else if tracker.failed() {
+				cancelAllContexts()
+				cleanupResultsAlreadyReceived()
+				return nil, result.err
+			}
+		}
+	}
+
+	results := make([]T, 0, len(r.Instances))
+
+	for i := range r.Instances {
+		instance := &r.Instances[i]
+		result, haveResult := resultsMap[instance]
+
+		if haveResult {
+			if tracker.shouldIncludeResultFrom(instance) {
+				results = append(results, result)
+			} else {
+				tracker.cancelContextFor(instance)
+				cleanupFunc(result)
+			}
+		} else {
+			// Nothing to clean up (yet) - this will be handled by deferred call above.
+			tracker.cancelContextFor(instance)
+		}
+	}
+
+	return results, nil
+}
+
+type instanceResult[T any] struct {
+	result   T
+	err      error
+	instance *InstanceDesc
 }
 
 // Includes returns whether the replication set includes the replica with the provided addr.

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -107,6 +107,8 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 // including when DoUntilQuorum returns an error or only returns a subset of successful results. cleanupFunc may
 // be called both before and after DoUntilQuorum returns.
 //
+// A call to f is considered successful if it returns a nil error.
+//
 // DoUntilQuorum cancels the context.Context passed to each invocation of f if the result of that invocation of
 // f will not be returned. If the result of that invocation of f will be returned, the context.Context passed
 // to that invocation of f will not be cancelled by DoUntilQuorum, but the context.Context is a child of ctx

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -98,13 +98,13 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 // DoUntilQuorum runs function f in parallel for all replicas in r.
 //
 // If r.MaxUnavailableZones is greater than zero:
-//   - DoUntilQuorum returns an error if calls to f for instances in r.MaxUnavailableZones zones return errors
+//   - DoUntilQuorum returns an error if calls to f for instances in more than r.MaxUnavailableZones zones return errors
 //   - Otherwise, DoUntilQuorum returns all results from all replicas in the first zones for which f succeeds
 //     for every instance in that zone (eg. if there are 3 zones and r.MaxUnavailableZones is 1, DoUntilQuorum will
 //     return the results from all instances in 2 zones, even if all calls to f succeed).
 //
 // Otherwise:
-//   - DoUntilQuorum returns an error if r.MaxErrors calls to f return errors
+//   - DoUntilQuorum returns an error if more than r.MaxErrors calls to f return errors
 //   - Otherwise, DoUntilQuorum returns all results from the first len(r.Instances) - r.MaxErrors instances
 //     (eg. if there are 6 replicas and r.MaxErrors is 2, DoUntilQuorum will return the results from the first 4
 //     successful calls to f, even if all 6 calls to f succeed).
@@ -116,7 +116,7 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 // DoUntilQuorum cancels the context.Context passed to each invocation of f if the result of that invocation of
 // f will not be returned. If the result of that invocation of f will be returned, the context.Context passed
 // to that invocation of f will not be cancelled by DoUntilQuorum, but the context.Context is a child of ctx
-// and so will be cancelled if ctx is cancelled.
+// passed to DoUntilQuorum and so will be cancelled if ctx is cancelled.
 func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, f func(context.Context, *InstanceDesc) (T, error), cleanupFunc func(T)) ([]T, error) {
 	resultsChan := make(chan instanceResult[T], len(r.Instances))
 	resultsRemaining := len(r.Instances)

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -3,12 +3,17 @@ package ring
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+
+	"github.com/grafana/dskit/internal/slices"
 )
 
 func TestReplicationSet_GetAddresses(t *testing.T) {
@@ -240,6 +245,555 @@ func TestReplicationSet_Do(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestDoUntilQuorum(t *testing.T) {
+	successfulF := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		return desc.Addr, nil
+	}
+
+	failingF := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		return "", fmt.Errorf("this is the error for %v", desc.Addr)
+	}
+
+	oneFailingInstance := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		if desc.Addr == "zone-b-replica-2" {
+			return "", fmt.Errorf("this is the error for %v", desc.Addr)
+		}
+
+		return desc.Addr, nil
+	}
+
+	failingZoneB := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		if desc.Zone == "zone-b" {
+			return "", fmt.Errorf("this is the error for %v", desc.Addr)
+		}
+
+		return desc.Addr, nil
+	}
+
+	failingReplica1 := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		if strings.HasSuffix(desc.Addr, "replica-1") {
+			return "", errors.New("error from a replica-1 instance")
+		}
+
+		return desc.Addr, nil
+	}
+
+	testCases := map[string]struct {
+		replicationSet  ReplicationSet
+		f               func(context.Context, *InstanceDesc) (string, error)
+		expectedResults []string
+		expectedError   error
+		expectedCleanup []string
+	}{
+		"no replicas, max errors = 0, max unavailable zones = 0": {
+			replicationSet:  ReplicationSet{},
+			f:               successfulF,
+			expectedResults: []string{},
+			expectedError:   nil,
+			expectedCleanup: nil,
+		},
+		"no replicas, max errors = 1": {
+			replicationSet: ReplicationSet{
+				MaxErrors: 1,
+			},
+			f:               successfulF,
+			expectedResults: []string{},
+			expectedError:   nil,
+			expectedCleanup: nil,
+		},
+		"no replicas, max unavailable zones = 1": {
+			replicationSet: ReplicationSet{
+				MaxUnavailableZones: 1,
+			},
+			f:               successfulF,
+			expectedResults: []string{},
+			expectedError:   nil,
+			expectedCleanup: nil,
+		},
+		"one replica, max errors = 0, max unavailable zones = 0, call succeeds": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "replica-1", Zone: "zone-1"},
+				},
+			},
+			f:               successfulF,
+			expectedResults: []string{"replica-1"},
+			expectedError:   nil,
+			expectedCleanup: nil,
+		},
+		"one replica, max errors = 0, max unavailable zones = 0, call fails": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "replica-1", Zone: "zone-1"},
+				},
+			},
+			f:               failingF,
+			expectedResults: nil,
+			expectedError:   errors.New("this is the error for replica-1"),
+			expectedCleanup: nil,
+		},
+		"one replica, max errors = 1, call succeeds": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "replica-1", Zone: "zone-1"},
+				},
+				MaxErrors: 1,
+			},
+			f:               successfulF,
+			expectedResults: []string{}, // We don't need any results.
+			expectedError:   nil,
+			expectedCleanup: []string{"replica-1"},
+		},
+		"one replica, max errors = 1, call fails": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "replica-1", Zone: "zone-1"},
+				},
+				MaxErrors: 1,
+			},
+			f:               failingF,
+			expectedResults: []string{},
+			expectedError:   nil,
+			expectedCleanup: nil,
+		},
+		"one replica, max unavailable zones = 1, call succeeds": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "replica-1", Zone: "zone-1"},
+				},
+				MaxUnavailableZones: 1,
+			},
+			f:               successfulF,
+			expectedResults: []string{}, // We don't need any results.
+			expectedError:   nil,
+			expectedCleanup: []string{"replica-1"},
+		},
+		"one replica, max unavailable zones = 1, call fails": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "replica-1", Zone: "zone-1"},
+				},
+				MaxUnavailableZones: 1,
+			},
+			f:               failingF,
+			expectedResults: []string{},
+			expectedError:   nil,
+			expectedCleanup: nil,
+		},
+		"partial zone failure with many replicas, max unavailable zones = 1": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "zone-a-replica-1", Zone: "zone-a"},
+					{Addr: "zone-a-replica-2", Zone: "zone-a"},
+					{Addr: "zone-b-replica-1", Zone: "zone-b"},
+					{Addr: "zone-b-replica-2", Zone: "zone-b"},
+					{Addr: "zone-c-replica-1", Zone: "zone-c"},
+					{Addr: "zone-c-replica-2", Zone: "zone-c"},
+				},
+				MaxUnavailableZones: 1,
+			},
+			f:               oneFailingInstance,
+			expectedResults: []string{"zone-a-replica-1", "zone-a-replica-2", "zone-c-replica-1", "zone-c-replica-2"},
+			expectedError:   nil,
+			expectedCleanup: []string{"zone-b-replica-1"},
+		},
+		"total zone failure with many replicas, max unavailable zones = 1": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "zone-a-replica-1", Zone: "zone-a"},
+					{Addr: "zone-a-replica-2", Zone: "zone-a"},
+					{Addr: "zone-b-replica-1", Zone: "zone-b"},
+					{Addr: "zone-b-replica-2", Zone: "zone-b"},
+					{Addr: "zone-c-replica-1", Zone: "zone-c"},
+					{Addr: "zone-c-replica-2", Zone: "zone-c"},
+				},
+				MaxUnavailableZones: 1,
+			},
+			f:               failingZoneB,
+			expectedResults: []string{"zone-a-replica-1", "zone-a-replica-2", "zone-c-replica-1", "zone-c-replica-2"},
+			expectedError:   nil,
+			expectedCleanup: nil,
+		},
+		"multiple unavailable zones": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "zone-a-replica-1", Zone: "zone-a"},
+					{Addr: "zone-a-replica-2", Zone: "zone-a"},
+					{Addr: "zone-b-replica-1", Zone: "zone-b"},
+					{Addr: "zone-b-replica-2", Zone: "zone-b"},
+					{Addr: "zone-c-replica-1", Zone: "zone-c"},
+					{Addr: "zone-c-replica-2", Zone: "zone-c"},
+				},
+				MaxUnavailableZones: 1,
+			},
+			f:               failingReplica1,
+			expectedResults: nil,
+			expectedError:   errors.New("error from a replica-1 instance"),
+			expectedCleanup: []string{"zone-a-replica-2", "zone-b-replica-2", "zone-c-replica-2"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			cleanupTracker := newCleanupTracker(t, len(testCase.expectedCleanup))
+
+			wrappedF := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+				cleanupTracker.trackInstanceContext(ctx, desc)
+				return testCase.f(ctx, desc)
+			}
+
+			actualResults, actualError := DoUntilQuorum(ctx, testCase.replicationSet, wrappedF, cleanupTracker.cleanup)
+			require.ElementsMatch(t, testCase.expectedResults, actualResults)
+			require.Equal(t, testCase.expectedError, actualError)
+
+			cleanupTracker.collectCleanedUpInstances()
+			cleanupTracker.assertCorrectCleanup(testCase.expectedResults, testCase.expectedCleanup)
+		})
+	}
+}
+
+func TestDoUntilQuorum_RunsCallsInParallel(t *testing.T) {
+	ctx := context.Background()
+	replicationSet := ReplicationSet{
+		Instances: []InstanceDesc{
+			{
+				Addr: "replica-1",
+			},
+			{
+				Addr: "replica-2",
+			},
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(replicationSet.Instances))
+
+	f := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		wg.Done()
+
+		// Wait for the other calls to f to start. If this test hangs here, then the calls are not running in parallel.
+		wg.Wait()
+
+		return desc.Addr, nil
+	}
+
+	cleanupFunc := func(_ string) {}
+	results, err := DoUntilQuorum(ctx, replicationSet, f, cleanupFunc)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"replica-1", "replica-2"}, results)
+}
+
+func TestDoUntilQuorum_ReturnsMinimumResultSetForZoneAwareWhenAllSucceed(t *testing.T) {
+	instances := []InstanceDesc{
+		{
+			Addr: "zone-a-replica-1",
+			Zone: "zone-a",
+		},
+		{
+			Addr: "zone-a-replica-2",
+			Zone: "zone-a",
+		},
+		{
+			Addr: "zone-b-replica-1",
+			Zone: "zone-b",
+		},
+		{
+			Addr: "zone-b-replica-2",
+			Zone: "zone-b",
+		},
+		{
+			Addr: "zone-c-replica-1",
+			Zone: "zone-c",
+		},
+		{
+			Addr: "zone-c-replica-2",
+			Zone: "zone-c",
+		},
+	}
+
+	ctx := context.Background()
+	replicationSet := ReplicationSet{
+		Instances:           instances,
+		MaxUnavailableZones: 1,
+	}
+
+	cleanupTracker := newCleanupTracker(t, 2)
+
+	f := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		cleanupTracker.trackInstanceContext(ctx, desc)
+		return desc.Addr, nil
+	}
+
+	results, err := DoUntilQuorum(ctx, replicationSet, f, cleanupTracker.cleanup)
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+
+	zoneAReturned := slices.Contains(results, "zone-a-replica-1") && slices.Contains(results, "zone-a-replica-2")
+	zoneBReturned := slices.Contains(results, "zone-b-replica-1") && slices.Contains(results, "zone-b-replica-2")
+	zoneCReturned := slices.Contains(results, "zone-c-replica-1") && slices.Contains(results, "zone-c-replica-2")
+	zonesReturned := 0
+
+	if zoneAReturned {
+		zonesReturned++
+	}
+
+	if zoneBReturned {
+		zonesReturned++
+	}
+
+	if zoneCReturned {
+		zonesReturned++
+	}
+
+	require.Equalf(t, 2, zonesReturned, "received results from %v, expected results from only two zones", results)
+
+	cleanupTracker.collectCleanedUpInstances()
+
+	switch {
+	case !zoneAReturned:
+		cleanupTracker.assertCorrectCleanup([]string{"zone-b-replica-1", "zone-b-replica-2", "zone-c-replica-1", "zone-c-replica-1"}, []string{"zone-a-replica-1", "zone-a-replica-2"})
+	case !zoneBReturned:
+		cleanupTracker.assertCorrectCleanup([]string{"zone-a-replica-1", "zone-a-replica-2", "zone-c-replica-1", "zone-c-replica-1"}, []string{"zone-b-replica-1", "zone-b-replica-2"})
+	case !zoneCReturned:
+		cleanupTracker.assertCorrectCleanup([]string{"zone-a-replica-1", "zone-a-replica-2", "zone-b-replica-1", "zone-b-replica-1"}, []string{"zone-c-replica-1", "zone-c-replica-2"})
+	default:
+		require.FailNow(t, "this should never happen")
+	}
+}
+
+func TestDoUntilQuorum_ReturnsMinimumResultSetForNonZoneAwareWhenAllSucceed(t *testing.T) {
+	instances := []InstanceDesc{
+		{
+			Addr: "zone-a-replica-1",
+			Zone: "zone-a",
+		},
+		{
+			Addr: "zone-a-replica-2",
+			Zone: "zone-a",
+		},
+		{
+			Addr: "zone-b-replica-1",
+			Zone: "zone-b",
+		},
+		{
+			Addr: "zone-b-replica-2",
+			Zone: "zone-b",
+		},
+		{
+			Addr: "zone-c-replica-1",
+			Zone: "zone-c",
+		},
+		{
+			Addr: "zone-c-replica-2",
+			Zone: "zone-c",
+		},
+	}
+
+	ctx := context.Background()
+	replicationSet := ReplicationSet{
+		Instances: instances,
+		MaxErrors: 1,
+	}
+
+	cleanupTracker := newCleanupTracker(t, 1)
+
+	f := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		cleanupTracker.trackInstanceContext(ctx, desc)
+		return desc.Addr, nil
+	}
+
+	results, err := DoUntilQuorum(ctx, replicationSet, f, cleanupTracker.cleanup)
+	require.NoError(t, err)
+	require.Len(t, results, 5, "should only have results from instances require to meet quorum requirement")
+
+	cleanupTracker.collectCleanedUpInstances()
+	require.Len(t, cleanupTracker.cleanedUpInstances, 1, "should clean up result from instance not used to meet quorum requirement")
+	require.NotContains(t, results, cleanupTracker.cleanedUpInstances, "result from instance cleaned up should not be returned")
+	require.ElementsMatch(t, append(results, cleanupTracker.cleanedUpInstances...), []string{"zone-a-replica-1", "zone-a-replica-2", "zone-b-replica-1", "zone-b-replica-2", "zone-c-replica-1", "zone-c-replica-2"})
+
+	cleanupTracker.assertCorrectCleanup(results, cleanupTracker.cleanedUpInstances)
+}
+
+func TestDoUntilQuorum_DoesNotWaitForUnnecessarySlowResponses(t *testing.T) {
+	testCases := map[string]struct {
+		replicationSet  ReplicationSet
+		expectedResults []string
+		expectedCleanup []string
+	}{
+		"not zone aware": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "instance-1"},
+					{Addr: "instance-2-slow"},
+					{Addr: "instance-3"},
+				},
+				MaxErrors: 1,
+			},
+			expectedResults: []string{"instance-1", "instance-3"},
+			expectedCleanup: []string{"instance-2-slow"},
+		},
+		"zone aware": {
+			replicationSet: ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "zone-a-instance-1", Zone: "zone-a"},
+					{Addr: "zone-a-instance-2-slow", Zone: "zone-a"},
+					{Addr: "zone-b-instance-1", Zone: "zone-b"},
+					{Addr: "zone-b-instance-2", Zone: "zone-b"},
+					{Addr: "zone-c-instance-1", Zone: "zone-c"},
+					{Addr: "zone-c-instance-2", Zone: "zone-c"},
+				},
+				MaxUnavailableZones: 1,
+			},
+			expectedResults: []string{"zone-b-instance-1", "zone-b-instance-2", "zone-c-instance-1", "zone-c-instance-2"},
+			expectedCleanup: []string{"zone-a-instance-1", "zone-a-instance-2-slow"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			waitChan := make(chan struct{})
+			cleanupTracker := newCleanupTracker(t, len(testCase.expectedCleanup))
+
+			f := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+				cleanupTracker.trackInstanceContext(ctx, desc)
+
+				if strings.HasSuffix(desc.Addr, "-slow") {
+					select {
+					case <-waitChan:
+						// Nothing more to do.
+					case <-time.After(time.Second):
+						require.FailNow(t, "DoUntilQuorum waited for unnecessary slow response")
+					}
+				}
+
+				return desc.Addr, nil
+			}
+
+			actualResults, err := DoUntilQuorum(ctx, testCase.replicationSet, f, cleanupTracker.cleanup)
+			require.ElementsMatch(t, testCase.expectedResults, actualResults)
+			require.NoError(t, err)
+
+			close(waitChan)
+			cleanupTracker.collectCleanedUpInstances()
+			cleanupTracker.assertCorrectCleanup(testCase.expectedResults, testCase.expectedCleanup)
+		})
+	}
+}
+
+func TestDoUntilQuorum_ParentContextHandling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent"))
+
+	replicationSet := ReplicationSet{
+		Instances: []InstanceDesc{
+			{Addr: "instance-1"},
+			{Addr: "instance-2"},
+			{Addr: "instance-3"},
+		},
+	}
+
+	cleanupTracker := newCleanupTracker(t, 3)
+
+	f := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+		cleanupTracker.trackInstanceContext(ctx, desc)
+
+		require.Equal(t, "this-is-the-value-from-the-parent", ctx.Value(testContextKey), "expected instance context to inherit from context passed to DoUntilQuorum")
+
+		if desc.Addr == "instance-1" {
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				cancel()
+			}()
+		} else {
+			select {
+			case <-ctx.Done():
+				// Nothing more to do.
+			case <-time.After(time.Second):
+				require.FailNow(t, "expected instance context to be cancelled, but timed out waiting for cancellation")
+			}
+		}
+
+		return desc.Addr, nil
+	}
+
+	results, err := DoUntilQuorum(ctx, replicationSet, f, cleanupTracker.cleanup)
+	require.Empty(t, results)
+	require.Equal(t, context.Canceled, err)
+
+	cleanupTracker.collectCleanedUpInstances()
+	cleanupTracker.assertCorrectCleanup(nil, []string{"instance-1", "instance-2", "instance-3"})
+}
+
+type cleanupTracker struct {
+	t                    *testing.T
+	expectedCleanupCalls int
+	receivedCleanupCalls *atomic.Uint64
+	cleanupChan          chan string
+	cleanedUpInstances   []string
+	instanceContexts     sync.Map
+}
+
+func newCleanupTracker(t *testing.T, expectedCleanupCalls int) *cleanupTracker {
+	return &cleanupTracker{
+		t:                    t,
+		expectedCleanupCalls: expectedCleanupCalls,
+		receivedCleanupCalls: atomic.NewUint64(0),
+		cleanupChan:          make(chan string, expectedCleanupCalls),
+	}
+}
+
+func (c *cleanupTracker) trackInstanceContext(ctx context.Context, instance *InstanceDesc) {
+	c.instanceContexts.Store(instance.Addr, ctx)
+}
+
+func (c *cleanupTracker) cleanup(res string) {
+	cleanupCallsSoFar := c.receivedCleanupCalls.Inc()
+
+	if cleanupCallsSoFar > uint64(c.expectedCleanupCalls) {
+		require.FailNowf(c.t, "received more cleanup calls than expected", "expected %v, but got at least %v", c.expectedCleanupCalls, cleanupCallsSoFar)
+	}
+
+	c.cleanupChan <- res
+}
+
+func (c *cleanupTracker) collectCleanedUpInstances() {
+	c.cleanedUpInstances = make([]string, 0, c.expectedCleanupCalls)
+
+	for len(c.cleanedUpInstances) < c.expectedCleanupCalls {
+		select {
+		case call := <-c.cleanupChan:
+			c.cleanedUpInstances = append(c.cleanedUpInstances, call)
+		case <-time.After(time.Second):
+			require.FailNowf(c.t, "gave up waiting for expected cleanup call", "have received %v so far, expected %v", c.cleanedUpInstances, c.expectedCleanupCalls)
+		}
+	}
+}
+
+func (c *cleanupTracker) assertCorrectCleanup(successfulInstances []string, failedInstances []string) {
+	for _, instance := range successfulInstances {
+		require.NotContainsf(c.t, failedInstances, instance, "invalid test case: instance %v is in list of both successful and failed instances", instance)
+
+		require.NotContainsf(c.t, c.cleanedUpInstances, instance, "result for instance %v was returned, but it was cleaned up", instance)
+
+		instanceContext, ok := c.instanceContexts.Load(instance)
+		require.True(c.t, ok)
+		require.NoErrorf(c.t, instanceContext.(context.Context).Err(), "all returned results should not have their context cancelled, but context for %v is cancelled", instance)
+	}
+
+	for _, instance := range failedInstances {
+		require.Containsf(c.t, c.cleanedUpInstances, instance, "result for instance %v was not returned, but it was not cleaned up", instance)
+
+		instanceContext, ok := c.instanceContexts.Load(instance)
+		require.True(c.t, ok)
+		require.Equalf(c.t, context.Canceled, instanceContext.(context.Context).Err(), "all cleaned up results should have their context cancelled, but context for %v is not cancelled", instance)
+	}
+
+	require.ElementsMatch(c.t, c.cleanedUpInstances, failedInstances)
 }
 
 var (

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -257,7 +257,7 @@ func TestDoUntilQuorum(t *testing.T) {
 		return "", fmt.Errorf("this is the error for %v", desc.Addr)
 	}
 
-	oneFailingInstance := func(ctx context.Context, desc *InstanceDesc) (string, error) {
+	failingZoneBReplica2 := func(ctx context.Context, desc *InstanceDesc) (string, error) {
 		if desc.Addr == "zone-b-replica-2" {
 			return "", fmt.Errorf("this is the error for %v", desc.Addr)
 		}
@@ -395,7 +395,7 @@ func TestDoUntilQuorum(t *testing.T) {
 				},
 				MaxUnavailableZones: 1,
 			},
-			f:               oneFailingInstance,
+			f:               failingZoneBReplica2,
 			expectedResults: []string{"zone-a-replica-1", "zone-a-replica-2", "zone-c-replica-1", "zone-c-replica-2"},
 			expectedError:   nil,
 			expectedCleanup: []string{"zone-b-replica-1"},

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+	"go.uber.org/goleak"
 
 	"github.com/grafana/dskit/internal/slices"
 )
@@ -438,6 +439,8 @@ func TestDoUntilQuorum(t *testing.T) {
 	for name, testCase := range testCases {
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
 			ctx := context.Background()
 			cleanupTracker := newCleanupTracker(t, len(testCase.expectedCleanup))
 
@@ -457,6 +460,8 @@ func TestDoUntilQuorum(t *testing.T) {
 }
 
 func TestDoUntilQuorum_RunsCallsInParallel(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	ctx := context.Background()
 	replicationSet := ReplicationSet{
 		Instances: []InstanceDesc{
@@ -488,6 +493,8 @@ func TestDoUntilQuorum_RunsCallsInParallel(t *testing.T) {
 }
 
 func TestDoUntilQuorum_ReturnsMinimumResultSetForZoneAwareWhenAllSucceed(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	instances := []InstanceDesc{
 		{
 			Addr: "zone-a-replica-1",
@@ -566,6 +573,8 @@ func TestDoUntilQuorum_ReturnsMinimumResultSetForZoneAwareWhenAllSucceed(t *test
 }
 
 func TestDoUntilQuorum_ReturnsMinimumResultSetForNonZoneAwareWhenAllSucceed(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	instances := []InstanceDesc{
 		{
 			Addr: "zone-a-replica-1",
@@ -656,6 +665,8 @@ func TestDoUntilQuorum_DoesNotWaitForUnnecessarySlowResponses(t *testing.T) {
 	for name, testCase := range testCases {
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
 			ctx := context.Background()
 			waitChan := make(chan struct{})
 			cleanupTracker := newCleanupTracker(t, len(testCase.expectedCleanup))
@@ -687,6 +698,8 @@ func TestDoUntilQuorum_DoesNotWaitForUnnecessarySlowResponses(t *testing.T) {
 }
 
 func TestDoUntilQuorum_ParentContextHandling(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent"))
 
 	replicationSet := ReplicationSet{

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -80,12 +80,16 @@ func (t *defaultResultTracker) contextFor(instance *InstanceDesc) context.Contex
 }
 
 func (t *defaultResultTracker) cancelContextFor(instance *InstanceDesc) {
-	t.instanceContextCancelFuncs[instance]()
+	if cancel, ok := t.instanceContextCancelFuncs[instance]; ok {
+		cancel()
+		delete(t.instanceContextCancelFuncs, instance)
+	}
 }
 
 func (t *defaultResultTracker) cancelAllContexts() {
-	for _, cancel := range t.instanceContextCancelFuncs {
+	for instance, cancel := range t.instanceContextCancelFuncs {
 		cancel()
+		delete(t.instanceContextCancelFuncs, instance)
 	}
 }
 

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -1,5 +1,7 @@
 package ring
 
+import "context"
+
 type replicationSetResultTracker interface {
 	// Signals an instance has done the execution, either successful (no error)
 	// or failed (with error).
@@ -10,21 +12,41 @@ type replicationSetResultTracker interface {
 
 	// Returns true if the maximum number of failed executions have been reached.
 	failed() bool
+
+	// Returns true if the result returned by instance is part of the minimal set of all results
+	// required to meet the quorum requirements of this tracker.
+	// This method should only be called for instances that have returned a successful result,
+	// calling this method for an instance that returned an error may return unpredictable results.
+	// This method should only be called after succeeded returns true for the first time and before
+	// calling done any further times.
+	shouldIncludeResultFrom(instance *InstanceDesc) bool
+
+	// Returns a context.Context for instance.
+	contextFor(instance *InstanceDesc) context.Context
+
+	// Cancels the context for instance previously obtained with contextFor.
+	// This method may cancel the context for other instances if those other instances are part of
+	// the same zone and this tracker is zone-aware.
+	cancelContextFor(instance *InstanceDesc)
 }
 
 type defaultResultTracker struct {
-	minSucceeded int
-	numSucceeded int
-	numErrors    int
-	maxErrors    int
+	ctx                        context.Context
+	minSucceeded               int
+	numSucceeded               int
+	numErrors                  int
+	maxErrors                  int
+	instanceContextCancelFuncs map[*InstanceDesc]context.CancelFunc
 }
 
-func newDefaultResultTracker(instances []InstanceDesc, maxErrors int) *defaultResultTracker {
+func newDefaultResultTracker(ctx context.Context, instances []InstanceDesc, maxErrors int) *defaultResultTracker {
 	return &defaultResultTracker{
-		minSucceeded: len(instances) - maxErrors,
-		numSucceeded: 0,
-		numErrors:    0,
-		maxErrors:    maxErrors,
+		ctx:                        ctx,
+		minSucceeded:               len(instances) - maxErrors,
+		numSucceeded:               0,
+		numErrors:                  0,
+		maxErrors:                  maxErrors,
+		instanceContextCancelFuncs: make(map[*InstanceDesc]context.CancelFunc, len(instances)),
 	}
 }
 
@@ -44,16 +66,34 @@ func (t *defaultResultTracker) failed() bool {
 	return t.numErrors > t.maxErrors
 }
 
+func (t *defaultResultTracker) shouldIncludeResultFrom(_ *InstanceDesc) bool {
+	// This method should only be called for instances that succeeded, and immediately
+	// after we've returned succeeded()==true for the first time.
+	return true
+}
+
+func (t *defaultResultTracker) contextFor(instance *InstanceDesc) context.Context {
+	ctx, cancel := context.WithCancel(t.ctx)
+	t.instanceContextCancelFuncs[instance] = cancel
+	return ctx
+}
+
+func (t *defaultResultTracker) cancelContextFor(instance *InstanceDesc) {
+	t.instanceContextCancelFuncs[instance]()
+}
+
 // zoneAwareResultTracker tracks the results per zone.
 // All instances in a zone must succeed in order for the zone to succeed.
 type zoneAwareResultTracker struct {
-	waitingByZone       map[string]int
-	failuresByZone      map[string]int
-	minSuccessfulZones  int
-	maxUnavailableZones int
+	waitingByZone          map[string]int
+	failuresByZone         map[string]int
+	minSuccessfulZones     int
+	maxUnavailableZones    int
+	zoneContexts           map[string]context.Context
+	zoneContextCancelFuncs map[string]context.CancelFunc
 }
 
-func newZoneAwareResultTracker(instances []InstanceDesc, maxUnavailableZones int) *zoneAwareResultTracker {
+func newZoneAwareResultTracker(ctx context.Context, instances []InstanceDesc, maxUnavailableZones int) *zoneAwareResultTracker {
 	t := &zoneAwareResultTracker{
 		waitingByZone:       make(map[string]int),
 		failuresByZone:      make(map[string]int),
@@ -63,7 +103,17 @@ func newZoneAwareResultTracker(instances []InstanceDesc, maxUnavailableZones int
 	for _, instance := range instances {
 		t.waitingByZone[instance.Zone]++
 	}
+
 	t.minSuccessfulZones = len(t.waitingByZone) - maxUnavailableZones
+
+	t.zoneContexts = make(map[string]context.Context, len(t.waitingByZone))
+	t.zoneContextCancelFuncs = make(map[string]context.CancelFunc, len(t.waitingByZone))
+
+	for zone := range t.waitingByZone {
+		zoneCtx, cancel := context.WithCancel(ctx)
+		t.zoneContexts[zone] = zoneCtx
+		t.zoneContextCancelFuncs[zone] = cancel
+	}
 
 	return t
 }
@@ -93,4 +143,16 @@ func (t *zoneAwareResultTracker) succeeded() bool {
 func (t *zoneAwareResultTracker) failed() bool {
 	failedZones := len(t.failuresByZone)
 	return failedZones > t.maxUnavailableZones
+}
+
+func (t *zoneAwareResultTracker) shouldIncludeResultFrom(instance *InstanceDesc) bool {
+	return t.failuresByZone[instance.Zone] == 0 && t.waitingByZone[instance.Zone] == 0
+}
+
+func (t *zoneAwareResultTracker) contextFor(instance *InstanceDesc) context.Context {
+	return t.zoneContexts[instance.Zone]
+}
+
+func (t *zoneAwareResultTracker) cancelContextFor(instance *InstanceDesc) {
+	t.zoneContextCancelFuncs[instance.Zone]()
 }

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -165,11 +165,15 @@ func (t *zoneAwareResultTracker) contextFor(instance *InstanceDesc) context.Cont
 }
 
 func (t *zoneAwareResultTracker) cancelContextFor(instance *InstanceDesc) {
-	t.zoneContextCancelFuncs[instance.Zone]()
+	if cancel, ok := t.zoneContextCancelFuncs[instance.Zone]; ok {
+		cancel()
+		delete(t.zoneContextCancelFuncs, instance.Zone)
+	}
 }
 
 func (t *zoneAwareResultTracker) cancelAllContexts() {
-	for _, cancel := range t.zoneContextCancelFuncs {
+	for zone, cancel := range t.zoneContextCancelFuncs {
 		cancel()
+		delete(t.zoneContextCancelFuncs, zone)
 	}
 }

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -28,6 +28,9 @@ type replicationSetResultTracker interface {
 	// This method may cancel the context for other instances if those other instances are part of
 	// the same zone and this tracker is zone-aware.
 	cancelContextFor(instance *InstanceDesc)
+
+	// Cancels all contexts previously obtained with contextFor.
+	cancelAllContexts()
 }
 
 type defaultResultTracker struct {
@@ -80,6 +83,12 @@ func (t *defaultResultTracker) contextFor(instance *InstanceDesc) context.Contex
 
 func (t *defaultResultTracker) cancelContextFor(instance *InstanceDesc) {
 	t.instanceContextCancelFuncs[instance]()
+}
+
+func (t *defaultResultTracker) cancelAllContexts() {
+	for _, cancel := range t.instanceContextCancelFuncs {
+		cancel()
+	}
 }
 
 // zoneAwareResultTracker tracks the results per zone.
@@ -155,4 +164,10 @@ func (t *zoneAwareResultTracker) contextFor(instance *InstanceDesc) context.Cont
 
 func (t *zoneAwareResultTracker) cancelContextFor(instance *InstanceDesc) {
 	t.zoneContextCancelFuncs[instance.Zone]()
+}
+
+func (t *zoneAwareResultTracker) cancelAllContexts() {
+	for _, cancel := range t.zoneContextCancelFuncs {
+		cancel()
+	}
 }

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -70,8 +70,6 @@ func (t *defaultResultTracker) failed() bool {
 }
 
 func (t *defaultResultTracker) shouldIncludeResultFrom(_ *InstanceDesc) bool {
-	// This method should only be called for instances that succeeded, and immediately
-	// after we've returned succeeded()==true for the first time.
 	return true
 }
 

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -154,14 +154,12 @@ func TestDefaultResultTracker(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			parentCtx := context.Background()
-
-			testCase.run(t, newDefaultResultTracker(parentCtx, testCase.instances, testCase.maxErrors))
+			testCase.run(t, newDefaultResultTracker(testCase.instances, testCase.maxErrors))
 		})
 	}
 }
 
-func TestDefaultResultTracker_ContextHandling(t *testing.T) {
+func TestDefaultContextTracker(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3"}
@@ -169,7 +167,7 @@ func TestDefaultResultTracker_ContextHandling(t *testing.T) {
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	parentCtx := context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent")
-	tracker := newDefaultResultTracker(parentCtx, instances, 0)
+	tracker := newDefaultContextTracker(parentCtx, instances)
 
 	instance1Ctx := tracker.contextFor(&instance1)
 	instance2Ctx := tracker.contextFor(&instance2)
@@ -367,12 +365,12 @@ func TestZoneAwareResultTracker(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			testCase.run(t, newZoneAwareResultTracker(context.Background(), testCase.instances, testCase.maxUnavailableZones))
+			testCase.run(t, newZoneAwareResultTracker(testCase.instances, testCase.maxUnavailableZones))
 		})
 	}
 }
 
-func TestZoneAwareResultTracker_ContextHandling(t *testing.T) {
+func TestZoneAwareContextTracker(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
@@ -382,7 +380,7 @@ func TestZoneAwareResultTracker_ContextHandling(t *testing.T) {
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6}
 
 	parentCtx := context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent")
-	tracker := newZoneAwareResultTracker(parentCtx, instances, 0)
+	tracker := newZoneAwareContextTracker(parentCtx, instances)
 
 	instance1Ctx := tracker.contextFor(&instance1)
 	instance2Ctx := tracker.contextFor(&instance2)

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -1,11 +1,17 @@
 package ring
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type contextKey int
+
+const testContextKey contextKey = iota
 
 func TestDefaultResultTracker(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
@@ -48,6 +54,40 @@ func TestDefaultResultTracker(t *testing.T) {
 				tracker.done(&instance4, nil)
 				assert.True(t, tracker.succeeded())
 				assert.False(t, tracker.failed())
+
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance1))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance2))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance3))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance4))
+			},
+		},
+		"should succeed with 1 failing instance on max errors = 1": {
+			instances: []InstanceDesc{instance1, instance2, instance3, instance4},
+			maxErrors: 1,
+			run: func(t *testing.T, tracker *defaultResultTracker) {
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance2, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance3, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance4, nil)
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance1))
+				// Instance 2 failed, and so shouldIncludeResultFrom won't be called by DoUntilQuorum.
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance3))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance4))
 			},
 		},
 		"should fail on 1st failing instance on max errors = 0": {
@@ -114,8 +154,38 @@ func TestDefaultResultTracker(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			testCase.run(t, newDefaultResultTracker(testCase.instances, testCase.maxErrors))
+			parentCtx := context.Background()
+
+			testCase.run(t, newDefaultResultTracker(parentCtx, testCase.instances, testCase.maxErrors))
 		})
+	}
+}
+
+func TestDefaultResultTracker_ContextHandling(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
+
+	parentCtx := context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent")
+	tracker := newDefaultResultTracker(parentCtx, instances, 0)
+
+	instance1Ctx := tracker.contextFor(&instance1)
+	instance2Ctx := tracker.contextFor(&instance2)
+	instance3Ctx := tracker.contextFor(&instance3)
+	instance4Ctx := tracker.contextFor(&instance4)
+
+	for _, ctx := range []context.Context{instance1Ctx, instance2Ctx, instance3Ctx, instance4Ctx} {
+		require.Equal(t, "this-is-the-value-from-the-parent", ctx.Value(testContextKey), "context for instance should inherit from provided parent context")
+		require.NoError(t, ctx.Err(), "context for instance should not be cancelled")
+	}
+
+	// Cancel a context for one instance and check that the others are not cancelled.
+	tracker.cancelContextFor(&instance1)
+	require.Equal(t, context.Canceled, instance1Ctx.Err(), "instance context should be cancelled")
+	for _, ctx := range []context.Context{instance2Ctx, instance3Ctx, instance4Ctx} {
+		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
 	}
 }
 
@@ -158,6 +228,10 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				tracker.done(&instance3, nil)
 				assert.True(t, tracker.succeeded())
 				assert.False(t, tracker.failed())
+
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance1))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance2))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance3))
 			},
 		},
 		"should fail on 1st failing instance on max unavailable zones = 0": {
@@ -197,6 +271,13 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				tracker.done(&instance6, nil)
 				assert.True(t, tracker.succeeded())
 				assert.False(t, tracker.failed())
+
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance1))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance2))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance3))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance4))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance5))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance6))
 			},
 		},
 		"should succeed as soon as the response has been successfully received from 'all zones - 1' on max unavailable zones = 1": {
@@ -213,6 +294,13 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				tracker.done(&instance4, nil)
 				assert.True(t, tracker.succeeded())
 				assert.False(t, tracker.failed())
+
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance1))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance2))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance3))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance4))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance5))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance6))
 			},
 		},
 		"should succeed on failing instances within 2 zones on max unavailable zones = 2": {
@@ -234,6 +322,13 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				tracker.done(&instance6, nil)
 				assert.True(t, tracker.succeeded())
 				assert.False(t, tracker.failed())
+
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance1))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance2))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance3))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance4))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance5))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance6))
 			},
 		},
 		"should succeed as soon as the response has been successfully received from 'all zones - 2' on max unavailable zones = 2": {
@@ -254,13 +349,54 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				tracker.done(&instance2, nil)
 				assert.True(t, tracker.succeeded())
 				assert.False(t, tracker.failed())
+
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance1))
+				assert.True(t, tracker.shouldIncludeResultFrom(&instance2))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance3))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance4))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance5))
+				assert.False(t, tracker.shouldIncludeResultFrom(&instance6))
 			},
 		},
 	}
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			testCase.run(t, newZoneAwareResultTracker(testCase.instances, testCase.maxUnavailableZones))
+			testCase.run(t, newZoneAwareResultTracker(context.Background(), testCase.instances, testCase.maxUnavailableZones))
 		})
+	}
+}
+
+func TestZoneAwareResultTracker_ContextHandling(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := InstanceDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := InstanceDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6}
+
+	parentCtx := context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent")
+	tracker := newZoneAwareResultTracker(parentCtx, instances, 0)
+
+	instance1Ctx := tracker.contextFor(&instance1)
+	instance2Ctx := tracker.contextFor(&instance2)
+	instance3Ctx := tracker.contextFor(&instance3)
+	instance4Ctx := tracker.contextFor(&instance4)
+	instance5Ctx := tracker.contextFor(&instance5)
+	instance6Ctx := tracker.contextFor(&instance6)
+
+	for _, ctx := range []context.Context{instance1Ctx, instance2Ctx, instance3Ctx, instance4Ctx, instance5Ctx, instance6Ctx} {
+		require.Equal(t, "this-is-the-value-from-the-parent", ctx.Value(testContextKey), "context for instance should inherit from provided parent context")
+		require.NoError(t, ctx.Err(), "context for instance should not be cancelled")
+	}
+
+	// Cancel a context for one instance and check that the other context in its zone is cancelled, but others are
+	// unaffected.
+	tracker.cancelContextFor(&instance1)
+	require.Equal(t, context.Canceled, instance1Ctx.Err(), "instance context should be cancelled")
+	require.Equal(t, context.Canceled, instance2Ctx.Err(), "context for instance in same zone as cancelled instance should also be cancelled")
+	for _, ctx := range []context.Context{instance3Ctx, instance4Ctx, instance5Ctx, instance6Ctx} {
+		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
 	}
 }

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -187,6 +187,11 @@ func TestDefaultResultTracker_ContextHandling(t *testing.T) {
 	for _, ctx := range []context.Context{instance2Ctx, instance3Ctx, instance4Ctx} {
 		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
 	}
+
+	tracker.cancelAllContexts()
+	for _, ctx := range []context.Context{instance1Ctx, instance2Ctx, instance3Ctx, instance4Ctx} {
+		require.Equal(t, context.Canceled, ctx.Err(), "context for instance should be cancelled after cancelling all contexts")
+	}
 }
 
 func TestZoneAwareResultTracker(t *testing.T) {
@@ -398,5 +403,10 @@ func TestZoneAwareResultTracker_ContextHandling(t *testing.T) {
 	require.Equal(t, context.Canceled, instance2Ctx.Err(), "context for instance in same zone as cancelled instance should also be cancelled")
 	for _, ctx := range []context.Context{instance3Ctx, instance4Ctx, instance5Ctx, instance6Ctx} {
 		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
+	}
+
+	tracker.cancelAllContexts()
+	for _, ctx := range []context.Context{instance1Ctx, instance2Ctx, instance3Ctx, instance4Ctx, instance5Ctx, instance6Ctx} {
+		require.Equal(t, context.Canceled, ctx.Err(), "context for instance should be cancelled after cancelling all contexts")
 	}
 }

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2735,7 +2735,7 @@ func TestRing_ShuffleShard_Caching(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ring))
 	t.Cleanup(func() {
-		_ = services.StartAndAwaitRunning(context.Background(), ring)
+		_ = services.StopAndAwaitTerminated(context.Background(), ring)
 	})
 
 	// We will stop <number of zones> instances later, to see that subring is recomputed.


### PR DESCRIPTION
**What this PR does**:

This PR adds a `DoUntilQuorum` method to the `ring` package.

In contrast to the existing `ReplicationSet.Do` method, `DoUntilQuorum` has the following behaviour differences:

* `DoUntilQuorum` does not support delaying invocations of `f`
* `DoUntilQuorum` supports cleaning up results that will not be returned, including results that arrive after `DoUntilQuorum` returns, making it easier to ensure that resources are not leaked
* `DoUntilQuorum` immediately cancels the context passed to `f` for any invocations we know will are no longer necessary (eg. because other calls in the same zone have already failed)
* `DoUntilQuorum` does not cancel the context passed to `f` if the result is returned, which is useful for scenarios where `DoUntilQuorum` is used to establish a set of streams that will continue after `DoUntilQuorum` returns
* `DoUntilQuorum` only returns the minimum set of results required for quorum

This last point is best explained with an example. Imagine we have three zones each with two instances, we tolerate one unavailable zone and the results from each instance arrive in this order:

1. zone A, instance 1
2. zone B, instance 1
3. zone C, instance 1
4. zone A, instance 2
5. zone B, instance 2

`ReplicationSet.Do` would return results from all five instances, whereas `DoUntilQuorum` will only return the results from the instances in zones A and B and cleanup the results from zone C, including the result from instance 2 in zone C if it arrives.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
