### PR TITLE
Fix race condition in Ring.ShuffleShardWithLookback()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@
 * [ENHANCEMENT] Memcached: Add support for using TLS or mTLS with Memcached based caching. #278
 * [ENHANCEMENT] Ring: improve performance of shuffle sharding computation. #281
 * [ENHANCEMENT] Add option to enable IPv6 address detection in ring and memberlist handling. #185
-* [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 
+* [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 295
 * [ENHANCEMENT] BasicLifecycler: functions `ShouldKeepInstanceInTheRingOnShutdown` and `SetKeepInstanceInTheRingOnShutdown` for checking and setting whether instances should be kept in the ring or unregistered on shutdown have been added. #290
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@
 * [ENHANCEMENT] Memcached: Add support for using TLS or mTLS with Memcached based caching. #278
 * [ENHANCEMENT] Ring: improve performance of shuffle sharding computation. #281
 * [ENHANCEMENT] Add option to enable IPv6 address detection in ring and memberlist handling. #185
-* [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 295
+* [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 #295
 * [ENHANCEMENT] BasicLifecycler: functions `ShouldKeepInstanceInTheRingOnShutdown` and `SetKeepInstanceInTheRingOnShutdown` for checking and setting whether instances should be kept in the ring or unregistered on shutdown have been added. #290
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -184,6 +184,7 @@ type Ring struct {
 
 	// Cache of shuffle-sharded subrings per identifier. Invalidated when topology changes.
 	// If set to nil, no caching is done (used by tests, and subrings).
+	// Both maps are protected by mtx.
 	shuffledSubringCache             map[subringCacheKey]*Ring
 	shuffledSubringWithLookbackCache map[subringCacheKey]cachedSubringWithLookback
 
@@ -908,6 +909,9 @@ func (r *Ring) getCachedShuffledSubringWithLookback(identifier string, size int,
 	if r.cfg.SubringCacheDisabled {
 		return nil
 	}
+
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
 
 	cached, ok := r.shuffledSubringWithLookbackCache[subringCacheKey{identifier: identifier, shardSize: size, lookbackPeriod: lookbackPeriod}]
 	if !ok {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -184,7 +184,6 @@ type Ring struct {
 
 	// Cache of shuffle-sharded subrings per identifier. Invalidated when topology changes.
 	// If set to nil, no caching is done (used by tests, and subrings).
-	// Both maps are protected by mtx.
 	shuffledSubringCache             map[subringCacheKey]*Ring
 	shuffledSubringWithLookbackCache map[subringCacheKey]cachedSubringWithLookback
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2413,6 +2413,10 @@ func TestRing_ShuffleShardWithLookback_CachingConcurrency(t *testing.T) {
 			for r := 0; r < numRequestsPerWorker; r++ {
 				actual := ring.ShuffleShardWithLookback(userID, 3, time.Hour, now)
 				require.Equal(t, expected, actual)
+
+				// Get the subring for a new user each time too, in order to stress the setter too
+				// (if we only read from the cache there's no read/write concurrent access).
+				ring.ShuffleShardWithLookback(fmt.Sprintf("stress-%d", r), 3, time.Hour, now)
 			}
 		}(w)
 	}

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2418,7 +2418,7 @@ func TestRing_ShuffleShardWithLookback_CachingConcurrency(t *testing.T) {
 	}
 
 	// Wait until all workers have done.
-	wg.Done()
+	wg.Wait()
 }
 
 func BenchmarkRing_ShuffleShard(b *testing.B) {


### PR DESCRIPTION
**What this PR does**:
This PR fix race condition in `Ring.getCachedShuffledSubringWithLookback()`, specifically the access to `r.shuffledSubringWithLookbackCache` which was not protected by `r.mtx`.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
