### PR TITLE
Add config for connect params for the gRPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [CHANGE] Cache: Remove the `context.Context` argument from the `Cache.Store` method and rename the method to `Cache.StoreAsync`. #273
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
+* [ENHANCEMENT] Add configuration for ConnectParams for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * [CHANGE] Cache: Remove the `context.Context` argument from the `Cache.Store` method and rename the method to `Cache.StoreAsync`. #273
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
-* [ENHANCEMENT] Add configuration for ConnectParams for the gRPC clients.
+* [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38
 * [ENHANCEMENT] Add the ring package #45

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	grpcbackoff "google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 
@@ -28,6 +29,10 @@ type Config struct {
 
 	TLSEnabled bool             `yaml:"tls_enabled" category:"advanced"`
 	TLS        tls.ClientConfig `yaml:",inline"`
+
+	ConnectTimeout          time.Duration `yaml:"connect_timeout" category:"advanced"`
+	ConnectBackoffBaseDelay time.Duration `yaml:"connect_backoff_base_delay" category:"advanced"`
+	ConnectBackoffMaxDelay  time.Duration `yaml:"connect_backoff_max_delay" category:"advanced"`
 }
 
 // RegisterFlags registers flags.
@@ -44,6 +49,10 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")
 	f.BoolVar(&cfg.BackoffOnRatelimits, prefix+".backoff-on-ratelimits", false, "Enable backoff and retry when we hit ratelimits.")
 	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
+
+	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 0, "The maximum amount of time to establish a connection. A value of 0 means default connect gRPC connect timeout and backoff.")
+	f.DurationVar(&cfg.ConnectBackoffBaseDelay, prefix+".connect-backoff-base-delay", time.Second, "Initial backoff delay after first connect failure.")
+	f.DurationVar(&cfg.ConnectBackoffMaxDelay, prefix+".connect-backoff-max-delay", 5*time.Second, "Maximum backoff delay when establishing a connection.")
 
 	cfg.BackoffConfig.RegisterFlagsWithPrefix(prefix, f)
 
@@ -86,6 +95,19 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 
 	if cfg.RateLimit > 0 {
 		unaryClientInterceptors = append([]grpc.UnaryClientInterceptor{NewRateLimiter(cfg)}, unaryClientInterceptors...)
+	}
+
+	if cfg.ConnectTimeout > 0 {
+		opts = append(
+			opts,
+			grpc.WithConnectParams(grpc.ConnectParams{
+				Backoff: grpcbackoff.Config{
+					BaseDelay: cfg.ConnectBackoffBaseDelay,
+					MaxDelay:  cfg.ConnectBackoffMaxDelay,
+				},
+				MinConnectTimeout: cfg.ConnectTimeout,
+			}),
+		)
 	}
 
 	return append(

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -99,13 +99,20 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 	}
 
 	if cfg.ConnectTimeout > 0 {
+		defaultCfg := grpcbackoff.DefaultConfig
+
+		if cfg.ConnectBackoffBaseDelay > 0 {
+			defaultCfg.BaseDelay = cfg.ConnectBackoffBaseDelay
+		}
+
+		if cfg.ConnectBackoffMaxDelay > 0 {
+			defaultCfg.MaxDelay = cfg.ConnectBackoffMaxDelay
+		}
+
 		opts = append(
 			opts,
 			grpc.WithConnectParams(grpc.ConnectParams{
-				Backoff: grpcbackoff.Config{
-					BaseDelay: cfg.ConnectBackoffBaseDelay,
-					MaxDelay:  cfg.ConnectBackoffMaxDelay,
-				},
+				Backoff:           defaultCfg,
 				MinConnectTimeout: cfg.ConnectTimeout,
 			}),
 		)

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -30,7 +30,8 @@ type Config struct {
 	TLSEnabled bool             `yaml:"tls_enabled" category:"advanced"`
 	TLS        tls.ClientConfig `yaml:",inline"`
 
-	ConnectTimeout          time.Duration `yaml:"connect_timeout" category:"advanced"`
+	ConnectTimeout time.Duration `yaml:"connect_timeout" category:"advanced"`
+	// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
 	ConnectBackoffBaseDelay time.Duration `yaml:"connect_backoff_base_delay" category:"advanced"`
 	ConnectBackoffMaxDelay  time.Duration `yaml:"connect_backoff_max_delay" category:"advanced"`
 }
@@ -50,9 +51,9 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.BackoffOnRatelimits, prefix+".backoff-on-ratelimits", false, "Enable backoff and retry when we hit ratelimits.")
 	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
 
-	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 0, "The maximum amount of time to establish a connection. A value of 0 means default connect gRPC connect timeout and backoff.")
-	f.DurationVar(&cfg.ConnectBackoffBaseDelay, prefix+".connect-backoff-base-delay", time.Second, "Initial backoff delay after first connect failure.")
-	f.DurationVar(&cfg.ConnectBackoffMaxDelay, prefix+".connect-backoff-max-delay", 5*time.Second, "Maximum backoff delay when establishing a connection.")
+	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 0, "The maximum amount of time to establish a connection. A value of 0 means default gRPC connect timeout and backoff.")
+	f.DurationVar(&cfg.ConnectBackoffBaseDelay, prefix+".connect-backoff-base-delay", time.Second, "Initial backoff delay after first connection failure. Only relevant if ConnectTimeout > 0.")
+	f.DurationVar(&cfg.ConnectBackoffMaxDelay, prefix+".connect-backoff-max-delay", 5*time.Second, "Maximum backoff delay when establishing a connection. Only relevant if ConnectTimeout > 0.")
 
 	cfg.BackoffConfig.RegisterFlagsWithPrefix(prefix, f)
 


### PR DESCRIPTION
**What this PR does**:

This PR adds configuration options for the gRPC client, namely the connect connect timeout, and backoff delays.

In Loki we observed that the default gRPC connect timeout caused tail latency when the client is used in a client pool for the ring, e.g. index-gateway clients. In case a server is unexpectedly restarted (e.g. due to OOMing) the server still remains in the ring even though it is may be unavailable or not ready (during startup). However, the client pool still create the client for the address of the server and tries to connect. A long timeout when establishing a connection introduces the latency until the next server is tried.

https://github.com/grafana/loki/blob/main/pkg/storage/stores/indexshipper/gatewayclient/gateway_client.go#L327-L357

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
