### PR TITLE
Add `ReplicationSet.ZoneCount` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 * [ENHANCEMENT] Ring: cache results of shuffle sharding with lookback where possible. #283 #295
 * [ENHANCEMENT] BasicLifecycler: functions `ShouldKeepInstanceInTheRingOnShutdown` and `SetKeepInstanceInTheRingOnShutdown` for checking and setting whether instances should be kept in the ring or unregistered on shutdown have been added. #290
 * [ENHANCEMENT] Ring: add `DoUntilQuorum` method. #293
+* [ENHANCEMENT] Ring: add `ReplicationSet.ZoneCount()` method. #298
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -243,6 +243,17 @@ func (r ReplicationSet) GetAddressesWithout(exclude string) []string {
 	return addrs
 }
 
+// ZoneCount returns the number of unique zones represented by instances within this replication set.
+func (r *ReplicationSet) ZoneCount() int {
+	zones := map[string]struct{}{}
+
+	for _, i := range r.Instances {
+		zones[i.Zone] = struct{}{}
+	}
+
+	return len(zones)
+}
+
 // HasReplicationSetChanged returns true if two replications sets are the same (with possibly different timestamps),
 // false if they differ in any way (number of instances, instance states, tokens, zones, ...).
 func HasReplicationSetChanged(before, after ReplicationSet) bool {

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -245,10 +245,22 @@ func (r ReplicationSet) GetAddressesWithout(exclude string) []string {
 
 // ZoneCount returns the number of unique zones represented by instances within this replication set.
 func (r *ReplicationSet) ZoneCount() int {
-	zones := map[string]struct{}{}
+	// Why not use a map here? Using a slice is faster for the small number of zones we expect to typically use.
+	zones := []string{}
 
 	for _, i := range r.Instances {
-		zones[i.Zone] = struct{}{}
+		sawZone := false
+
+		for _, z := range zones {
+			if z == i.Zone {
+				sawZone = true
+				break
+			}
+		}
+
+		if !sawZone {
+			zones = append(zones, i.Zone)
+		}
 	}
 
 	return len(zones)

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -876,3 +876,74 @@ func TestHasReplicationSetChangedWithoutState_IgnoresTimeStampAndState(t *testin
 		})
 	}
 }
+
+func TestReplicationSet_ZoneCount(t *testing.T) {
+	testCases := map[string]struct {
+		instances         []InstanceDesc
+		expectedZoneCount int
+	}{
+		"empty ring": {
+			instances:         []InstanceDesc{},
+			expectedZoneCount: 0,
+		},
+		"ring with single instance without a zone": {
+			instances: []InstanceDesc{
+				{Addr: "instance-1"},
+			},
+			expectedZoneCount: 1,
+		},
+		"ring with many instances without a zone": {
+			instances: []InstanceDesc{
+				{Addr: "instance-1"},
+				{Addr: "instance-2"},
+				{Addr: "instance-3"},
+			},
+			expectedZoneCount: 1,
+		},
+		"ring with single instance with a zone": {
+			instances: []InstanceDesc{
+				{Addr: "instance-1", Zone: "zone-a"},
+			},
+			expectedZoneCount: 1,
+		},
+		"ring with many instances in one zone": {
+			instances: []InstanceDesc{
+				{Addr: "instance-1", Zone: "zone-a"},
+				{Addr: "instance-2", Zone: "zone-a"},
+				{Addr: "instance-3", Zone: "zone-a"},
+			},
+			expectedZoneCount: 1,
+		},
+		"ring with many instances, each in their own zone": {
+			instances: []InstanceDesc{
+				{Addr: "instance-1", Zone: "zone-a"},
+				{Addr: "instance-2", Zone: "zone-b"},
+				{Addr: "instance-3", Zone: "zone-c"},
+			},
+			expectedZoneCount: 3,
+		},
+		"ring with many instances in each zone": {
+			instances: []InstanceDesc{
+				{Addr: "zone-a-instance-1", Zone: "zone-a"},
+				{Addr: "zone-a-instance-2", Zone: "zone-a"},
+				{Addr: "zone-a-instance-3", Zone: "zone-a"},
+				{Addr: "zone-b-instance-1", Zone: "zone-b"},
+				{Addr: "zone-b-instance-2", Zone: "zone-b"},
+				{Addr: "zone-b-instance-3", Zone: "zone-b"},
+				{Addr: "zone-c-instance-1", Zone: "zone-c"},
+				{Addr: "zone-c-instance-2", Zone: "zone-c"},
+				{Addr: "zone-c-instance-3", Zone: "zone-c"},
+			},
+			expectedZoneCount: 3,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := ReplicationSet{Instances: testCase.instances}
+
+			actual := r.ZoneCount()
+			require.Equal(t, testCase.expectedZoneCount, actual)
+		})
+	}
+}

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -947,3 +947,32 @@ func TestReplicationSet_ZoneCount(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkReplicationSetZoneCount(b *testing.B) {
+	for _, instancesPerZone := range []int{1, 2, 5, 10, 100, 300} {
+		for _, zones := range []int{1, 2, 3} {
+			instances := make([]InstanceDesc, 0, instancesPerZone*zones)
+
+			for zoneIdx := 0; zoneIdx < zones; zoneIdx++ {
+				zoneName := fmt.Sprintf("zone-%v", string(rune('a'+zoneIdx)))
+
+				for instanceIdx := 0; instanceIdx < instancesPerZone; instanceIdx++ {
+					instance := InstanceDesc{
+						Addr: fmt.Sprintf("%v-instance-%v", zoneName, instanceIdx+1),
+						Zone: zoneName,
+					}
+
+					instances = append(instances, instance)
+				}
+			}
+
+			r := ReplicationSet{Instances: instances}
+
+			b.Run(fmt.Sprintf("%v instances per zone, %v zones", instancesPerZone, zones), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					r.ZoneCount()
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does**:

This PR adds a `ZoneCount` method to `ReplicationSet`. This is useful for consumers that need to allocate a slice or map with enough space for an entry per zone.

This is an initial naïve implementation. A more complex implementation could take advantage of the fact that many places that create a `ReplicationSet` know how many zones it contains and so this could be stored in the `ReplicationSet`. I'm open to feedback on whether this is worth implementing.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
