### PR TITLE
flagext: Add support for using Bytes as a CLI flag

### DIFF
--- a/flagext/bytes.go
+++ b/flagext/bytes.go
@@ -8,18 +8,18 @@ import (
 	"github.com/alecthomas/units"
 )
 
-// Bytes is a data type which supports yaml serialization/deserialization
-// with units.
+// Bytes is a data type which supports use as a flag and yaml
+// serialization/deserialization with units.
 type Bytes uint64
 
-func (b *Bytes) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var value string
-	err := unmarshal(&value)
-	if err != nil {
-		return err
-	}
+// String implements flag.Value
+func (b *Bytes) String() string {
+	return units.Base2Bytes(*b).String()
+}
 
-	bytes, err := units.ParseBase2Bytes(value)
+// Set implements flag.Value
+func (b *Bytes) Set(s string) error {
+	bytes, err := units.ParseBase2Bytes(s)
 	if err != nil {
 		return err
 	}
@@ -28,6 +28,15 @@ func (b *Bytes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+func (b *Bytes) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var value string
+	if err := unmarshal(&value); err != nil {
+		return err
+	}
+
+	return b.Set(value)
+}
+
 func (b *Bytes) MarshalYAML() (interface{}, error) {
-	return units.Base2Bytes(*b).String(), nil
+	return b.String(), nil
 }

--- a/flagext/bytes_test.go
+++ b/flagext/bytes_test.go
@@ -1,0 +1,127 @@
+package flagext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func Test_Bytes_String(t *testing.T) {
+	for _, tcase := range []struct {
+		value uint64
+		str   string
+	}{
+		{
+			value: 1024 * 1024 * 1024,
+			str:   "1GiB",
+		},
+		{
+			value: 1024 * 1024,
+			str:   "1MiB",
+		},
+		{
+			value: 1024,
+			str:   "1KiB",
+		},
+	} {
+		b := Bytes(tcase.value)
+		require.Equal(t, tcase.str, b.String())
+	}
+}
+
+func Test_Bytes_Set(t *testing.T) {
+	for _, tcase := range []struct {
+		value uint64
+		str   string
+	}{
+		{
+			value: 1024 * 1024 * 1024,
+			str:   "1GiB",
+		},
+		{
+			value: 1024 * 1024 * 1024,
+			str:   "1GB",
+		},
+		{
+			value: 1024 * 1024,
+			str:   "1MiB",
+		},
+		{
+			value: 1024 * 1024,
+			str:   "1MB",
+		},
+		{
+			value: 1024,
+			str:   "1KiB",
+		},
+		{
+			value: 1024,
+			str:   "1KB",
+		},
+	} {
+		var b Bytes
+		require.NoError(t, b.Set(tcase.str))
+		require.Equal(t, b, Bytes(tcase.value))
+	}
+}
+func Test_Bytes_MarshalYAML(t *testing.T) {
+	for _, tcase := range []struct {
+		value uint64
+		str   string
+	}{
+		{
+			value: 1024 * 1024 * 1024,
+			str:   "1GiB\n",
+		},
+		{
+			value: 1024 * 1024,
+			str:   "1MiB\n",
+		},
+		{
+			value: 1024,
+			str:   "1KiB\n",
+		},
+	} {
+		b := Bytes(tcase.value)
+		y, err := yaml.Marshal(&b)
+		require.NoError(t, err)
+		require.Equal(t, []byte(tcase.str), y)
+	}
+}
+
+func Test_Bytes_UnmarshalYAML(t *testing.T) {
+	for _, tcase := range []struct {
+		value uint64
+		str   string
+	}{
+		{
+			value: 1024 * 1024 * 1024,
+			str:   "1GiB\n",
+		},
+		{
+			value: 1024 * 1024 * 1024,
+			str:   "1GB\n",
+		},
+		{
+			value: 1024 * 1024,
+			str:   "1MiB\n",
+		},
+		{
+			value: 1024 * 1024,
+			str:   "1MB\n",
+		},
+		{
+			value: 1024,
+			str:   "1KiB\n",
+		},
+		{
+			value: 1024,
+			str:   "1KB\n",
+		},
+	} {
+		var b Bytes
+		require.NoError(t, yaml.Unmarshal([]byte(tcase.str), &b))
+		require.Equal(t, Bytes(tcase.value), b)
+	}
+}

--- a/flagext/bytes_test.go
+++ b/flagext/bytes_test.go
@@ -40,6 +40,14 @@ func Test_Bytes_Set(t *testing.T) {
 		expected uint64
 	}{
 		{
+			input:    "1.5GiB",
+			expected: (1024 + 512) * 1024 * 1024,
+		},
+		{
+			input:    "1.5GB",
+			expected: (1024 + 512) * 1024 * 1024,
+		},
+		{
 			input:    "1536MiB",
 			expected: (1024 + 512) * 1024 * 1024,
 		},
@@ -47,6 +55,7 @@ func Test_Bytes_Set(t *testing.T) {
 			input:    "1536MB",
 			expected: (1024 + 512) * 1024 * 1024,
 		},
+
 		{
 			input:    "1GiB",
 			expected: 1024 * 1024 * 1024,
@@ -111,6 +120,14 @@ func Test_Bytes_UnmarshalYAML(t *testing.T) {
 		input    string
 		expected uint64
 	}{
+		{
+			input:    "1.5GiB\n",
+			expected: (1024 + 512) * 1024 * 1024,
+		},
+		{
+			input:    "1.5GB\n",
+			expected: (1024 + 512) * 1024 * 1024,
+		},
 		{
 			input:    "1536MiB\n",
 			expected: (1024 + 512) * 1024 * 1024,

--- a/flagext/bytes_test.go
+++ b/flagext/bytes_test.go
@@ -9,119 +9,143 @@ import (
 
 func Test_Bytes_String(t *testing.T) {
 	for _, tcase := range []struct {
-		value uint64
-		str   string
+		input    uint64
+		expected string
 	}{
 		{
-			value: 1024 * 1024 * 1024,
-			str:   "1GiB",
+			input:    1024 * 1024 * 1024,
+			expected: "1GiB",
 		},
 		{
-			value: 1024 * 1024,
-			str:   "1MiB",
+			input:    (1024 + 512) * 1024 * 1024,
+			expected: "1GiB512MiB",
 		},
 		{
-			value: 1024,
-			str:   "1KiB",
+			input:    1024 * 1024,
+			expected: "1MiB",
+		},
+		{
+			input:    1024,
+			expected: "1KiB",
 		},
 	} {
-		b := Bytes(tcase.value)
-		require.Equal(t, tcase.str, b.String())
+		b := Bytes(tcase.input)
+		require.Equal(t, tcase.expected, b.String())
 	}
 }
 
 func Test_Bytes_Set(t *testing.T) {
 	for _, tcase := range []struct {
-		value uint64
-		str   string
+		input    string
+		expected uint64
 	}{
 		{
-			value: 1024 * 1024 * 1024,
-			str:   "1GiB",
+			input:    "1536MiB",
+			expected: (1024 + 512) * 1024 * 1024,
 		},
 		{
-			value: 1024 * 1024 * 1024,
-			str:   "1GB",
+			input:    "1536MB",
+			expected: (1024 + 512) * 1024 * 1024,
 		},
 		{
-			value: 1024 * 1024,
-			str:   "1MiB",
+			input:    "1GiB",
+			expected: 1024 * 1024 * 1024,
 		},
 		{
-			value: 1024 * 1024,
-			str:   "1MB",
+			input:    "1GB",
+			expected: 1024 * 1024 * 1024,
 		},
 		{
-			value: 1024,
-			str:   "1KiB",
+			input:    "1MiB",
+			expected: 1024 * 1024,
 		},
 		{
-			value: 1024,
-			str:   "1KB",
+			input:    "1MB",
+			expected: 1024 * 1024,
+		},
+		{
+			input:    "1KiB",
+			expected: 1024,
+		},
+		{
+			input:    "1KB",
+			expected: 1024,
 		},
 	} {
 		var b Bytes
-		require.NoError(t, b.Set(tcase.str))
-		require.Equal(t, b, Bytes(tcase.value))
+		require.NoError(t, b.Set(tcase.input))
+		require.Equal(t, b, Bytes(tcase.expected))
 	}
 }
 func Test_Bytes_MarshalYAML(t *testing.T) {
 	for _, tcase := range []struct {
-		value uint64
-		str   string
+		input    uint64
+		expected string
 	}{
 		{
-			value: 1024 * 1024 * 1024,
-			str:   "1GiB\n",
+			input:    (1024 + 512) * 1024 * 1024,
+			expected: "1GiB512MiB\n",
 		},
 		{
-			value: 1024 * 1024,
-			str:   "1MiB\n",
+			input:    1024 * 1024 * 1024,
+			expected: "1GiB\n",
 		},
 		{
-			value: 1024,
-			str:   "1KiB\n",
+			input:    1024 * 1024,
+			expected: "1MiB\n",
+		},
+		{
+			input:    1024,
+			expected: "1KiB\n",
 		},
 	} {
-		b := Bytes(tcase.value)
+		b := Bytes(tcase.input)
 		y, err := yaml.Marshal(&b)
 		require.NoError(t, err)
-		require.Equal(t, []byte(tcase.str), y)
+		require.Equal(t, []byte(tcase.expected), y)
 	}
 }
 
 func Test_Bytes_UnmarshalYAML(t *testing.T) {
 	for _, tcase := range []struct {
-		value uint64
-		str   string
+		input    string
+		expected uint64
 	}{
 		{
-			value: 1024 * 1024 * 1024,
-			str:   "1GiB\n",
+			input:    "1536MiB\n",
+			expected: (1024 + 512) * 1024 * 1024,
 		},
 		{
-			value: 1024 * 1024 * 1024,
-			str:   "1GB\n",
+			input:    "1536MB\n",
+			expected: (1024 + 512) * 1024 * 1024,
 		},
 		{
-			value: 1024 * 1024,
-			str:   "1MiB\n",
+			input:    "1GiB\n",
+			expected: 1024 * 1024 * 1024,
 		},
 		{
-			value: 1024 * 1024,
-			str:   "1MB\n",
+			input:    "1GB\n",
+			expected: 1024 * 1024 * 1024,
 		},
 		{
-			value: 1024,
-			str:   "1KiB\n",
+			input:    "1MiB\n",
+			expected: 1024 * 1024,
 		},
 		{
-			value: 1024,
-			str:   "1KB\n",
+			input:    "1MB\n",
+			expected: 1024 * 1024,
+		},
+		{
+			input:    "1KiB\n",
+			expected: 1024,
+		},
+		{
+			input:    "1KB\n",
+			expected: 1024,
 		},
 	} {
 		var b Bytes
-		require.NoError(t, yaml.Unmarshal([]byte(tcase.str), &b))
-		require.Equal(t, Bytes(tcase.value), b)
+		require.NoError(t, yaml.Unmarshal([]byte(tcase.input), &b))
+		require.Equal(t, Bytes(tcase.expected), b)
 	}
 }


### PR DESCRIPTION
**What this PR does**:

Adds support for use as a CLI flag in addition to the existing YAML serialization.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [X] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
