### PR TITLE
ring: modify `DoUntilQuorum` to optionally only send the minimum number of requests required to reach quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 * [ENHANCEMENT] BasicLifecycler: functions `ShouldKeepInstanceInTheRingOnShutdown` and `SetKeepInstanceInTheRingOnShutdown` for checking and setting whether instances should be kept in the ring or unregistered on shutdown have been added. #290
 * [ENHANCEMENT] Ring: add `DoUntilQuorum` method. #293
 * [ENHANCEMENT] Ring: add `ReplicationSet.ZoneCount()` method. #298
+* [ENHANCEMENT] Ring: add request minimization to `DoUntilQuorum` method. #306
 * [ENHANCEMENT] grpcclient: add `<prefix>.initial-stream-window-size` and `<prefix>.initial-connection-window-size` configuration flags to alter HTTP flow control options for a gRPC client. #312
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -2,6 +2,7 @@ package ring
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"time"
 )
@@ -89,6 +90,8 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	return results, nil
 }
 
+var errResultNotNeeded = errors.New("result from this instance is not needed and so f has not been called")
+
 // DoUntilQuorum runs function f in parallel for all replicas in r.
 //
 // If r.MaxUnavailableZones is greater than zero:
@@ -103,6 +106,17 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 //     (eg. if there are 6 replicas and r.MaxErrors is 2, DoUntilQuorum will return the results from the first 4
 //     successful calls to f, even if all 6 calls to f succeed).
 //
+// If minimizeRequests is false, DoUntilQuorum will call f for each instance in r.
+//
+// If minimizeRequests is true, DoUntilQuorum will call f for the minimum number of instances needed to reach
+// the termination conditions above. For example, if r.MaxUnavailableZones is 1 and there are three zones, DoUntilQuorum
+// will initially only call f for instances in two zones, and only call f for instances in the remaining zone if a
+// request in the initial two zones fails.
+//
+// If minimizeRequests is true, DoUntilQuorum will randomly select available zones / instances such that calling
+// DoUntilQuorum multiple times with the same ReplicationSet should evenly distribute requests across all zones /
+// instances.
+//
 // Any results from successful calls to f that are not returned by DoUntilQuorum will be passed to cleanupFunc,
 // including when DoUntilQuorum returns an error or only returns a subset of successful results. cleanupFunc may
 // be called both before and after DoUntilQuorum returns.
@@ -113,7 +127,7 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 // f will not be returned. If the result of that invocation of f will be returned, the context.Context passed
 // to that invocation of f will not be cancelled by DoUntilQuorum, but the context.Context is a child of ctx
 // passed to DoUntilQuorum and so will be cancelled if ctx is cancelled.
-func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, f func(context.Context, *InstanceDesc) (T, error), cleanupFunc func(T)) ([]T, error) {
+func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, minimizeRequests bool, f func(context.Context, *InstanceDesc) (T, error), cleanupFunc func(T)) ([]T, error) {
 	resultsChan := make(chan instanceResult[T], len(r.Instances))
 	resultsRemaining := len(r.Instances)
 
@@ -140,11 +154,27 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, f func(context.
 		contextTracker = newDefaultContextTracker(ctx, r.Instances)
 	}
 
+	if minimizeRequests {
+		resultTracker.releaseMinimumRequests()
+	} else {
+		resultTracker.releaseAllRequests()
+	}
+
 	for i := range r.Instances {
 		instance := &r.Instances[i]
 		instanceCtx := contextTracker.contextFor(instance)
 
 		go func(desc *InstanceDesc) {
+			if !resultTracker.awaitRelease(desc) {
+				// Post to resultsChan so that the deferred cleanup handler above eventually terminates.
+				resultsChan <- instanceResult[T]{
+					err:      errResultNotNeeded, // This will never be returned from this method.
+					instance: desc,
+				}
+
+				return
+			}
+
 			result, err := f(instanceCtx, desc)
 			resultsChan <- instanceResult[T]{
 				result:   result,

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -155,9 +155,9 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, minimizeRequest
 	}
 
 	if minimizeRequests {
-		resultTracker.releaseMinimumRequests()
+		resultTracker.startMinimumRequests()
 	} else {
-		resultTracker.releaseAllRequests()
+		resultTracker.startAllRequests()
 	}
 
 	for i := range r.Instances {
@@ -165,7 +165,7 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, minimizeRequest
 		instanceCtx := contextTracker.contextFor(instance)
 
 		go func(desc *InstanceDesc) {
-			if !resultTracker.awaitRelease(desc) {
+			if !resultTracker.awaitStart(desc) {
 				// Post to resultsChan so that the deferred cleanup handler above eventually terminates.
 				resultsChan <- instanceResult[T]{
 					err:      errResultNotNeeded, // This will never be returned from this method.

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -105,14 +105,17 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 //
 // If minimizeRequests is false, DoUntilQuorum will call f for each instance in r.
 //
-// If minimizeRequests is true, DoUntilQuorum will call f for the minimum number of instances needed to reach
-// the termination conditions above. For example, if r.MaxUnavailableZones is 1 and there are three zones, DoUntilQuorum
-// will initially only call f for instances in two zones, and only call f for instances in the remaining zone if a
-// request in the initial two zones fails.
+// If minimizeRequests is true, DoUntilQuorum will initially call f for the minimum number of instances needed to reach
+// the termination conditions above, and later call f for further instances if required. For example, if
+// r.MaxUnavailableZones is 1 and there are three zones, DoUntilQuorum will initially only call f for instances in two
+// zones, and only call f for instances in the remaining zone if a request in the initial two zones fails.
 //
 // If minimizeRequests is true, DoUntilQuorum will randomly select available zones / instances such that calling
 // DoUntilQuorum multiple times with the same ReplicationSet should evenly distribute requests across all zones /
 // instances.
+//
+// Regardless of the value of minimizeRequests, if one of the termination conditions above is satisfied or ctx is
+// cancelled before f is called for an instance, f may not be called for that instance at all.
 //
 // Any results from successful calls to f that are not returned by DoUntilQuorum will be passed to cleanupFunc,
 // including when DoUntilQuorum returns an error or only returns a subset of successful results. cleanupFunc may

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -508,9 +508,9 @@ func TestDoUntilQuorum_PartialZoneFailure(t *testing.T) {
 					cleanupTracker.assertCorrectCleanup(expectedResults, []string{})
 				}
 			} else {
-				require.True(t, zoneBCalled.Load(), "calls should be made for all instances when minimizeRequests=false")
 				cleanupTracker.collectCleanedUpInstances()
 				cleanupTracker.assertCorrectCleanup(expectedResults, []string{"zone-b-replica-1"})
+				require.True(t, zoneBCalled.Load(), "calls should be made for all instances when minimizeRequests=false")
 			}
 		})
 	}

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -650,7 +650,6 @@ func TestDoUntilQuorum_ReturnsMinimumResultSetForZoneAwareWhenAllSucceed(t *test
 	}
 }
 
-// TODO: minimizeRequests = true
 func TestDoUntilQuorum_ReturnsMinimumResultSetForNonZoneAwareWhenAllSucceed(t *testing.T) {
 	defer goleak.VerifyNone(t)
 

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -201,7 +201,6 @@ type zoneAwareResultTracker struct {
 	failuresByZone      map[string]int
 	minSuccessfulZones  int
 	maxUnavailableZones int
-	instances           []InstanceDesc
 	zoneRelease         map[string]chan struct{}
 	zoneShouldStart     map[string]*atomic.Bool
 	pendingZones        []string

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -162,7 +162,7 @@ func TestDefaultResultTracker(t *testing.T) {
 	}
 }
 
-func TestDefaultResultTracker_ReleaseAllRequests(t *testing.T) {
+func TestDefaultResultTracker_StartAllRequests(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3"}
@@ -170,15 +170,15 @@ func TestDefaultResultTracker_ReleaseAllRequests(t *testing.T) {
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 	tracker := newDefaultResultTracker(instances, 1)
 
-	tracker.releaseAllRequests()
+	tracker.startAllRequests()
 
 	for i := range instances {
 		instance := &instances[i]
-		require.True(t, tracker.awaitRelease(instance), "requests for all instances should be released immediately")
+		require.True(t, tracker.awaitStart(instance), "requests for all instances should be released immediately")
 	}
 }
 
-func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testing.T) {
+func TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3"}
@@ -189,7 +189,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testin
 
 	for testIteration := 0; testIteration < 1000; testIteration++ {
 		tracker := newDefaultResultTracker(instances, 1)
-		tracker.releaseMinimumRequests()
+		tracker.startMinimumRequests()
 
 		mtx := sync.RWMutex{}
 		instancesAwaitReleaseResults := make([]bool, len(instances))
@@ -199,7 +199,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testin
 			instanceIdx := instanceIdx
 			instance := &instances[instanceIdx]
 			go func() {
-				released := tracker.awaitRelease(instance)
+				released := tracker.awaitStart(instance)
 
 				mtx.Lock()
 				defer mtx.Unlock()
@@ -245,7 +245,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testin
 	}
 }
 
-func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsBelowMaximumAllowed(t *testing.T) {
+func TestDefaultResultTracker_StartMinimumRequests_FailingRequestsBelowMaximumAllowed(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3"}
@@ -253,7 +253,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsBelowMaximum
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	tracker := newDefaultResultTracker(instances, 2)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
 	countInstancesReleased := 0
@@ -262,7 +262,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsBelowMaximum
 	for instanceIdx := range instances {
 		instance := &instances[instanceIdx]
 		go func() {
-			released := tracker.awaitRelease(instance)
+			released := tracker.awaitStart(instance)
 
 			mtx.Lock()
 			defer mtx.Unlock()
@@ -303,7 +303,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsBelowMaximum
 	require.True(t, tracker.succeeded(), "overall request should succeed")
 }
 
-func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsEqualToMaximumAllowed(t *testing.T) {
+func TestDefaultResultTracker_StartMinimumRequests_FailingRequestsEqualToMaximumAllowed(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3"}
@@ -311,7 +311,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsEqualToMaxim
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	tracker := newDefaultResultTracker(instances, 2)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
 	countInstancesReleased := 0
@@ -321,7 +321,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsEqualToMaxim
 		instanceIdx := instanceIdx
 		instance := &instances[instanceIdx]
 		go func() {
-			released := tracker.awaitRelease(instance)
+			released := tracker.awaitStart(instance)
 
 			mtx.Lock()
 			defer mtx.Unlock()
@@ -353,7 +353,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_FailingRequestsEqualToMaxim
 	require.True(t, tracker.succeeded(), "overall request should succeed")
 }
 
-func TestDefaultResultTracker_ReleaseMinimumRequests_MoreFailingRequestsThanMaximumAllowed(t *testing.T) {
+func TestDefaultResultTracker_StartMinimumRequests_MoreFailingRequestsThanMaximumAllowed(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3"}
@@ -361,7 +361,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_MoreFailingRequestsThanMaxi
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	tracker := newDefaultResultTracker(instances, 1)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
 	countInstancesReleased := 0
@@ -371,7 +371,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_MoreFailingRequestsThanMaxi
 		instanceIdx := instanceIdx
 		instance := &instances[instanceIdx]
 		go func() {
-			released := tracker.awaitRelease(instance)
+			released := tracker.awaitStart(instance)
 
 			mtx.Lock()
 			defer mtx.Unlock()
@@ -403,20 +403,20 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_MoreFailingRequestsThanMaxi
 	require.True(t, tracker.failed(), "overall request should fail")
 }
 
-func TestDefaultResultTracker_ReleaseMinimumRequests_MaxErrorsIsNumberOfInstances(t *testing.T) {
+func TestDefaultResultTracker_StartMinimumRequests_MaxErrorsIsNumberOfInstances(t *testing.T) {
 	// This scenario should never happen in the real world, but if we were to get into this situation,
 	// we need to make sure we don't end up blocking forever, which could lead to leaking a goroutine in DoUntilQuorum.
 
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instances := []InstanceDesc{instance1}
 	tracker := newDefaultResultTracker(instances, 1)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	requestStarted := false
 	released := make(chan struct{})
 
 	go func() {
-		requestStarted = tracker.awaitRelease(&instances[0])
+		requestStarted = tracker.awaitStart(&instances[0])
 		close(released)
 	}()
 
@@ -639,7 +639,7 @@ func TestZoneAwareResultTracker(t *testing.T) {
 	}
 }
 
-func TestZoneAwareResultTracker_ReleaseAllRequests(t *testing.T) {
+func TestZoneAwareResultTracker_StartAllRequests(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
@@ -649,15 +649,15 @@ func TestZoneAwareResultTracker_ReleaseAllRequests(t *testing.T) {
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6}
 	tracker := newZoneAwareResultTracker(instances, 1)
 
-	tracker.releaseAllRequests()
+	tracker.startAllRequests()
 
 	for i := range instances {
 		instance := &instances[i]
-		require.True(t, tracker.awaitRelease(instance), "requests for all instances should be released immediately")
+		require.True(t, tracker.awaitStart(instance), "requests for all instances should be released immediately")
 	}
 }
 
-func TestZoneAwareResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testing.T) {
+func TestZoneAwareResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
@@ -670,7 +670,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *test
 
 	for testIteration := 0; testIteration < 900; testIteration++ {
 		tracker := newZoneAwareResultTracker(instances, 1)
-		tracker.releaseMinimumRequests()
+		tracker.startMinimumRequests()
 
 		mtx := sync.RWMutex{}
 		instancesAwaitReleaseResults := make([]bool, len(instances))
@@ -680,7 +680,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *test
 			instanceIdx := instanceIdx
 			instance := &instances[instanceIdx]
 			go func() {
-				released := tracker.awaitRelease(instance)
+				released := tracker.awaitStart(instance)
 
 				mtx.Lock()
 				defer mtx.Unlock()
@@ -740,7 +740,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *test
 	}
 }
 
-func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaximumAllowed_SingleFailingRequestInZone(t *testing.T) {
+func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximumAllowed_SingleFailingRequestInZone(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
@@ -752,7 +752,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaxim
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
 	tracker := newZoneAwareResultTracker(instances, 2)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
 	instancesAwaitReleaseResults := make([]bool, len(instances))
@@ -761,7 +761,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaxim
 		instanceIdx := instanceIdx
 		instance := &instances[instanceIdx]
 		go func() {
-			released := tracker.awaitRelease(instance)
+			released := tracker.awaitStart(instance)
 
 			mtx.Lock()
 			defer mtx.Unlock()
@@ -808,7 +808,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaxim
 	require.Equal(t, 6, trueCount(instancesAwaitReleaseResults), "expected remaining instances to not be signalled to start")
 }
 
-func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaximumAllowed_MultipleFailingRequestsInSingleZone(t *testing.T) {
+func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximumAllowed_MultipleFailingRequestsInSingleZone(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
@@ -820,7 +820,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaxim
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
 	tracker := newZoneAwareResultTracker(instances, 2)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
 	instancesAwaitReleaseResults := make([]bool, len(instances))
@@ -832,7 +832,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaxim
 		instanceIdx := instanceIdx
 		instance := &instances[instanceIdx]
 		go func() {
-			released := tracker.awaitRelease(instance)
+			released := tracker.awaitStart(instance)
 
 			mtx.Lock()
 			defer mtx.Unlock()
@@ -913,7 +913,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaxim
 	require.Equal(t, 6, trueCount(instancesAwaitReleaseResults), "expected remaining instances to not be signalled to start")
 }
 
-func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesEqualToMaximumAllowed(t *testing.T) {
+func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesEqualToMaximumAllowed(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
@@ -925,7 +925,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesEqualToMaximu
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
 	tracker := newZoneAwareResultTracker(instances, 2)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
 	instancesAwaitReleaseResults := make([]bool, len(instances))
@@ -934,7 +934,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesEqualToMaximu
 		instanceIdx := instanceIdx
 		instance := &instances[instanceIdx]
 		go func() {
-			released := tracker.awaitRelease(instance)
+			released := tracker.awaitStart(instance)
 
 			mtx.Lock()
 			defer mtx.Unlock()
@@ -984,7 +984,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesEqualToMaximu
 	require.Equal(t, 4, uniqueZoneCount(instancesReleased), "expected four zones to be released after two failed")
 }
 
-func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesGreaterThanMaximumAllowed(t *testing.T) {
+func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesGreaterThanMaximumAllowed(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
@@ -996,7 +996,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesGreaterThanMa
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
 	tracker := newZoneAwareResultTracker(instances, 2)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
 	instancesAwaitReleaseResults := make([]bool, len(instances))
@@ -1005,7 +1005,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesGreaterThanMa
 		instanceIdx := instanceIdx
 		instance := &instances[instanceIdx]
 		go func() {
-			released := tracker.awaitRelease(instance)
+			released := tracker.awaitStart(instance)
 
 			mtx.Lock()
 			defer mtx.Unlock()
@@ -1044,7 +1044,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesGreaterThanMa
 	require.True(t, tracker.failed())
 }
 
-func TestZoneAwareResultTracker_ReleaseMinimumRequests_MaxUnavailableZonesIsNumberOfZones(t *testing.T) {
+func TestZoneAwareResultTracker_StartMinimumRequests_MaxUnavailableZonesIsNumberOfZones(t *testing.T) {
 	// This scenario should never happen in the real world, but if we were to get into this situation,
 	// we need to make sure we don't end up blocking forever, which could lead to leaking a goroutine in DoUntilQuorum.
 
@@ -1052,7 +1052,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_MaxUnavailableZonesIsNumb
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instances := []InstanceDesc{instance1, instance2}
 	tracker := newZoneAwareResultTracker(instances, 1)
-	tracker.releaseMinimumRequests()
+	tracker.startMinimumRequests()
 
 	requestsStarted := []bool{false, false}
 	wg := sync.WaitGroup{}
@@ -1063,7 +1063,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_MaxUnavailableZonesIsNumb
 		i := i
 		instance := &instances[i]
 		go func() {
-			requestsStarted[i] = tracker.awaitRelease(instance)
+			requestsStarted[i] = tracker.awaitStart(instance)
 			wg.Done()
 		}()
 	}

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -216,12 +216,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testin
 			mtx.RLock()
 			defer mtx.RUnlock()
 
-			countSignalledToStart := 0
-			for _, start := range instancesAwaitReleaseResults {
-				if start {
-					countSignalledToStart++
-				}
-			}
+			countSignalledToStart := trueCount(instancesAwaitReleaseResults)
 
 			return countInstancesReleased == 3 && countSignalledToStart == 3
 		}, 1*time.Second, 10*time.Millisecond, "expected three of the four requests to be released and signalled to start immediately")
@@ -235,12 +230,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testin
 			mtx.RLock()
 			defer mtx.RUnlock()
 
-			countSignalledToStart := 0
-			for _, start := range instancesAwaitReleaseResults {
-				if start {
-					countSignalledToStart++
-				}
-			}
+			countSignalledToStart := trueCount(instancesAwaitReleaseResults)
 
 			return countInstancesReleased == 4 && countSignalledToStart == 3
 		}, 1*time.Second, 10*time.Millisecond, "expected the final request to be released but not signalled to start")
@@ -248,7 +238,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testin
 		require.True(t, tracker.succeeded())
 	}
 
-	// With 1000 iterations, 4 instances and 1 max error, we'd expect each instance to receive
+	// With 1000 iterations, 4 instances and max 1 error, we'd expect each instance to receive
 	// 750 calls each (each instance has a 3-in-4 chance of being called in each iteration).
 	for _, instanceRequestCount := range instanceRequestCounts {
 		require.InDeltaf(t, 750, instanceRequestCount.Load(), 30, "expected roughly even distribution of requests across all instances, but got %v", instanceRequestCounts)
@@ -624,6 +614,414 @@ func TestZoneAwareResultTracker(t *testing.T) {
 	}
 }
 
+func TestZoneAwareResultTracker_ReleaseAllRequests(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := InstanceDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := InstanceDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6}
+	tracker := newZoneAwareResultTracker(instances, 1)
+
+	tracker.releaseAllRequests()
+
+	for i := range instances {
+		instance := &instances[i]
+		require.True(t, tracker.awaitRelease(instance), "requests for all instances should be released immediately")
+	}
+}
+
+func TestZoneAwareResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := InstanceDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := InstanceDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6}
+
+	zoneRequestCounts := map[string]int{"zone-a": 0, "zone-b": 0, "zone-c": 0}
+
+	for testIteration := 0; testIteration < 900; testIteration++ {
+		tracker := newZoneAwareResultTracker(instances, 1)
+		tracker.releaseMinimumRequests()
+
+		mtx := sync.RWMutex{}
+		instancesAwaitReleaseResults := make([]bool, len(instances))
+		countInstancesReleased := 0
+		for instanceIdx := range instances {
+			instanceIdx := instanceIdx
+			instance := &instances[instanceIdx]
+			go func() {
+				released := tracker.awaitRelease(instance)
+
+				mtx.Lock()
+				defer mtx.Unlock()
+				instancesAwaitReleaseResults[instanceIdx] = released
+				countInstancesReleased++
+			}()
+		}
+
+		require.Eventually(t, func() bool {
+			mtx.RLock()
+			defer mtx.RUnlock()
+
+			countSignalledToStart := trueCount(instancesAwaitReleaseResults)
+
+			return countInstancesReleased == 4 && countSignalledToStart == 4
+		}, 1*time.Second, 10*time.Millisecond, "expected four instances to be released and signalled to start immediately")
+
+		require.Equal(t, instancesAwaitReleaseResults[0], instancesAwaitReleaseResults[1], "expected both zone A instances to either be started or not started")
+		require.Equal(t, instancesAwaitReleaseResults[2], instancesAwaitReleaseResults[3], "expected both zone B instances to either be started or not started")
+		require.Equal(t, instancesAwaitReleaseResults[4], instancesAwaitReleaseResults[5], "expected both zone C instances to either be started or not started")
+
+		zoneAReleased := instancesAwaitReleaseResults[0]
+		zoneBReleased := instancesAwaitReleaseResults[2]
+		zoneCReleased := instancesAwaitReleaseResults[4]
+
+		if zoneAReleased {
+			zoneRequestCounts["zone-a"]++
+			tracker.done(&instance1, nil)
+			tracker.done(&instance2, nil)
+		}
+
+		if zoneBReleased {
+			zoneRequestCounts["zone-b"]++
+			tracker.done(&instance3, nil)
+			tracker.done(&instance4, nil)
+		}
+
+		if zoneCReleased {
+			zoneRequestCounts["zone-c"]++
+			tracker.done(&instance5, nil)
+			tracker.done(&instance6, nil)
+		}
+
+		require.True(t, tracker.succeeded())
+
+		require.Eventually(t, func() bool {
+			mtx.RLock()
+			defer mtx.RUnlock()
+
+			countSignalledToStart := trueCount(instancesAwaitReleaseResults)
+
+			return countInstancesReleased == 6 && countSignalledToStart == 4
+		}, 1*time.Second, 10*time.Millisecond, "expected the final requests to be released but not signalled to start")
+
+	}
+
+	// With 900 iterations, 3 zones and max 1 failing zone, we'd expect each zone to receive
+	// 600 calls each (each zone has a 2-in-3 chance of being called in each iteration).
+	for _, zoneRequestCount := range zoneRequestCounts {
+		require.InDeltaf(t, 600, zoneRequestCount, 30, "expected roughly even distribution of requests across all zones, but got %v", zoneRequestCount)
+	}
+}
+
+func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaximumAllowed_SingleFailingRequestInZone(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := InstanceDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := InstanceDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+	instance7 := InstanceDesc{Addr: "127.0.0.7", Zone: "zone-d"}
+	instance8 := InstanceDesc{Addr: "127.0.0.8", Zone: "zone-d"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
+
+	tracker := newZoneAwareResultTracker(instances, 2)
+	tracker.releaseMinimumRequests()
+
+	mtx := sync.RWMutex{}
+	instancesAwaitReleaseResults := make([]bool, len(instances))
+	instancesReleased := make([]*InstanceDesc, 0, len(instances))
+	for instanceIdx := range instances {
+		instanceIdx := instanceIdx
+		instance := &instances[instanceIdx]
+		go func() {
+			released := tracker.awaitRelease(instance)
+
+			mtx.Lock()
+			defer mtx.Unlock()
+			instancesAwaitReleaseResults[instanceIdx] = released
+			instancesReleased = append(instancesReleased, instance)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+
+		return len(instancesReleased) == 4
+	}, 1*time.Second, 10*time.Millisecond, "expected four instances to be released initially")
+
+	require.Equal(t, 4, trueCount(instancesAwaitReleaseResults), "expected all four instances to be signalled to start")
+	require.Equal(t, 2, uniqueZoneCount(instancesReleased), "expected two zones to be released initially")
+
+	// Simulate one request failing and check that another zone is released.
+	tracker.done(instancesReleased[0], errors.New("something went wrong"))
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+		return len(instancesReleased) == 6
+	}, 1*time.Second, 10*time.Millisecond, "expected an additional two instances to be released after a failed request in one zone")
+
+	require.Equal(t, 6, trueCount(instancesAwaitReleaseResults), "expected all six instances to be signalled to start")
+	require.Equal(t, 3, uniqueZoneCount(instancesReleased), "expected three zones to be released after one failed")
+
+	// Simulate the remaining requests succeeding and check that the last zone is signalled not to start.
+	for _, i := range instancesReleased[1:] {
+		tracker.done(i, nil)
+	}
+
+	require.True(t, tracker.succeeded())
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+		return len(instancesReleased) == 8
+	}, 1*time.Second, 10*time.Millisecond, "expected remaining instances to be released")
+
+	require.Equal(t, 6, trueCount(instancesAwaitReleaseResults), "expected remaining instances to not be signalled to start")
+}
+
+func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesLessThanMaximumAllowed_MultipleFailingRequestsInSingleZone(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := InstanceDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := InstanceDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+	instance7 := InstanceDesc{Addr: "127.0.0.7", Zone: "zone-d"}
+	instance8 := InstanceDesc{Addr: "127.0.0.8", Zone: "zone-d"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
+
+	tracker := newZoneAwareResultTracker(instances, 2)
+	tracker.releaseMinimumRequests()
+
+	mtx := sync.RWMutex{}
+	instancesAwaitReleaseResults := make([]bool, len(instances))
+	instancesReleased := make([]*InstanceDesc, 0, len(instances))
+	reportingSecondFailure := false
+	instanceReleasedWhileReportingSecondFailure := false
+
+	for instanceIdx := range instances {
+		instanceIdx := instanceIdx
+		instance := &instances[instanceIdx]
+		go func() {
+			released := tracker.awaitRelease(instance)
+
+			mtx.Lock()
+			defer mtx.Unlock()
+			instancesAwaitReleaseResults[instanceIdx] = released
+			instancesReleased = append(instancesReleased, instance)
+
+			if reportingSecondFailure {
+				instanceReleasedWhileReportingSecondFailure = true
+			}
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+
+		return len(instancesReleased) == 4
+	}, 1*time.Second, 10*time.Millisecond, "expected four instances to be released initially")
+
+	require.Equal(t, 4, trueCount(instancesAwaitReleaseResults), "expected all four instances to be signalled to start")
+	require.Equal(t, 2, uniqueZoneCount(instancesReleased), "expected two zones to be released initially")
+
+	// Simulate one request failing and check that another zone is released.
+	failingInstance := instancesReleased[0]
+	tracker.done(failingInstance, errors.New("something went wrong"))
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+		return len(instancesReleased) == 6
+	}, 1*time.Second, 10*time.Millisecond, "expected an additional two instances to be released after a failed request in one zone")
+
+	require.Equal(t, 6, trueCount(instancesAwaitReleaseResults), "expected all six instances to be signalled to start")
+	require.Equal(t, 3, uniqueZoneCount(instancesReleased), "expected three zones to be released after one failed")
+
+	// Simulate the other request in the same zone as the previous failing request also failing, and check that no further zones are released.
+	var otherInstanceInFailingZone *InstanceDesc
+
+	for _, i := range instancesReleased[1:] {
+		if i.Zone == failingInstance.Zone {
+			otherInstanceInFailingZone = i
+			break
+		}
+	}
+
+	mtx.Lock()
+	reportingSecondFailure = true
+	mtx.Unlock()
+	tracker.done(otherInstanceInFailingZone, errors.New("something else went wrong"))
+
+	// Wait a little to make sure no more requests were released.
+	require.Never(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+
+		return instanceReleasedWhileReportingSecondFailure
+	}, 500*time.Millisecond, 10*time.Millisecond, "expected no instances to be released after reporting a second failure in the same zone")
+
+	mtx.Lock()
+	reportingSecondFailure = false
+	mtx.Unlock()
+
+	// Simulate the remaining requests succeeding and check that the last zone is signalled not to start.
+	for _, i := range instancesReleased {
+		if i != failingInstance && i != otherInstanceInFailingZone {
+			tracker.done(i, nil)
+		}
+	}
+
+	require.True(t, tracker.succeeded())
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+		return len(instancesReleased) == 8
+	}, 1*time.Second, 10*time.Millisecond, "expected remaining instances to be released")
+
+	require.Equal(t, 6, trueCount(instancesAwaitReleaseResults), "expected remaining instances to not be signalled to start")
+}
+
+func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesEqualToMaximumAllowed(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := InstanceDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := InstanceDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+	instance7 := InstanceDesc{Addr: "127.0.0.7", Zone: "zone-d"}
+	instance8 := InstanceDesc{Addr: "127.0.0.8", Zone: "zone-d"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
+
+	tracker := newZoneAwareResultTracker(instances, 2)
+	tracker.releaseMinimumRequests()
+
+	mtx := sync.RWMutex{}
+	instancesAwaitReleaseResults := make([]bool, len(instances))
+	instancesReleased := make([]*InstanceDesc, 0, len(instances))
+	for instanceIdx := range instances {
+		instanceIdx := instanceIdx
+		instance := &instances[instanceIdx]
+		go func() {
+			released := tracker.awaitRelease(instance)
+
+			mtx.Lock()
+			defer mtx.Unlock()
+			instancesAwaitReleaseResults[instanceIdx] = released
+			instancesReleased = append(instancesReleased, instance)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+
+		return len(instancesReleased) == 4
+	}, 1*time.Second, 10*time.Millisecond, "expected four instances to be released initially")
+
+	require.Equal(t, 4, trueCount(instancesAwaitReleaseResults), "expected all four instances to be signalled to start")
+	require.Equal(t, 2, uniqueZoneCount(instancesReleased), "expected two zones to be released initially")
+
+	// Simulate one request failing and check that another zone is released.
+	firstFailingInstance := instancesReleased[0]
+	tracker.done(firstFailingInstance, errors.New("something went wrong"))
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+		return len(instancesReleased) == 6
+	}, 1*time.Second, 10*time.Millisecond, "expected an additional two instances to be released after a failed request in one zone")
+
+	require.Equal(t, 6, trueCount(instancesAwaitReleaseResults), "expected all six instances to be signalled to start")
+	require.Equal(t, 3, uniqueZoneCount(instancesReleased), "expected three zones to be released after one failed")
+
+	// Simulate another request from another zone failing and check that another zone is released.
+	for _, i := range instancesReleased {
+		if i.Zone != firstFailingInstance.Zone {
+			tracker.done(i, errors.New("something else went wrong"))
+			break
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+		return len(instancesReleased) == 8
+	}, 1*time.Second, 10*time.Millisecond, "expected an additional two instances to be released after a failed request in a second zone")
+
+	require.Equal(t, 8, trueCount(instancesAwaitReleaseResults), "expected all eight instances to be signalled to start")
+	require.Equal(t, 4, uniqueZoneCount(instancesReleased), "expected four zones to be released after two failed")
+}
+
+func TestZoneAwareResultTracker_ReleaseMinimumRequests_FailingZonesGreaterThanMaximumAllowed(t *testing.T) {
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := InstanceDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := InstanceDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+	instance7 := InstanceDesc{Addr: "127.0.0.7", Zone: "zone-d"}
+	instance8 := InstanceDesc{Addr: "127.0.0.8", Zone: "zone-d"}
+	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
+
+	tracker := newZoneAwareResultTracker(instances, 2)
+	tracker.releaseMinimumRequests()
+
+	mtx := sync.RWMutex{}
+	instancesAwaitReleaseResults := make([]bool, len(instances))
+	instancesReleased := make([]*InstanceDesc, 0, len(instances))
+	for instanceIdx := range instances {
+		instanceIdx := instanceIdx
+		instance := &instances[instanceIdx]
+		go func() {
+			released := tracker.awaitRelease(instance)
+
+			mtx.Lock()
+			defer mtx.Unlock()
+			instancesAwaitReleaseResults[instanceIdx] = released
+			instancesReleased = append(instancesReleased, instance)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+
+		return len(instancesReleased) == 4
+	}, 1*time.Second, 10*time.Millisecond, "expected four instances to be released initially")
+
+	require.Equal(t, 4, trueCount(instancesAwaitReleaseResults), "expected all four instances to be signalled to start")
+	require.Equal(t, 2, uniqueZoneCount(instancesReleased), "expected two zones to be released initially")
+
+	// Simulate both initial zones failing and check that the remaining two zones are released.
+	for _, i := range instancesReleased {
+		tracker.done(i, errors.New("something went wrong"))
+	}
+
+	require.Eventually(t, func() bool {
+		mtx.RLock()
+		defer mtx.RUnlock()
+
+		return len(instancesReleased) == 8
+	}, 1*time.Second, 10*time.Millisecond, "expected all instances to be released after initial two zone failures")
+
+	require.Equal(t, 8, trueCount(instancesAwaitReleaseResults), "expected all instances to be signalled to start")
+
+	// Simulate one more zone failing.
+	tracker.done(instancesReleased[4], errors.New("something else went wrong"))
+
+	require.True(t, tracker.failed())
+}
+
 func TestZoneAwareContextTracker(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
@@ -661,4 +1059,26 @@ func TestZoneAwareContextTracker(t *testing.T) {
 	for _, ctx := range []context.Context{instance1Ctx, instance2Ctx, instance3Ctx, instance4Ctx, instance5Ctx, instance6Ctx} {
 		require.Equal(t, context.Canceled, ctx.Err(), "context for instance should be cancelled after cancelling all contexts")
 	}
+}
+
+func uniqueZoneCount(instances []*InstanceDesc) int {
+	zones := map[string]struct{}{}
+
+	for _, i := range instances {
+		zones[i.Zone] = struct{}{}
+	}
+
+	return len(zones)
+}
+
+func trueCount(l []bool) int {
+	count := 0
+
+	for _, v := range l {
+		if v {
+			count++
+		}
+	}
+
+	return count
 }

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -241,7 +241,7 @@ func TestDefaultResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *testin
 	// With 1000 iterations, 4 instances and max 1 error, we'd expect each instance to receive
 	// 750 calls each (each instance has a 3-in-4 chance of being called in each iteration).
 	for _, instanceRequestCount := range instanceRequestCounts {
-		require.InDeltaf(t, 750, instanceRequestCount.Load(), 30, "expected roughly even distribution of requests across all instances, but got %v", instanceRequestCounts)
+		require.InDeltaf(t, 750, instanceRequestCount.Load(), 50, "expected roughly even distribution of requests across all instances, but got %v", instanceRequestCounts)
 	}
 }
 
@@ -736,7 +736,7 @@ func TestZoneAwareResultTracker_ReleaseMinimumRequests_NoFailingRequests(t *test
 	// With 900 iterations, 3 zones and max 1 failing zone, we'd expect each zone to receive
 	// 600 calls each (each zone has a 2-in-3 chance of being called in each iteration).
 	for _, zoneRequestCount := range zoneRequestCounts {
-		require.InDeltaf(t, 600, zoneRequestCount, 30, "expected roughly even distribution of requests across all zones, but got %v", zoneRequestCount)
+		require.InDeltaf(t, 600, zoneRequestCount, 50, "expected roughly even distribution of requests across all zones, but got %v", zoneRequestCount)
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

This PR modifies `DoUntilQuorum` to optionally only send the minimum number of requests required to reach quorum. 

For example, assume zone-awareness is enabled, the replication set contains three zones and one zone failure is tolerated:

* With request minimization disabled, `DoUntilQuorum` behaves as it does currently: it calls `f` for all instances in the replication set immediately, but only returns the results from the calls required to reach quorum and cancels any outstanding calls once quorum is reached.

* With request minimization enabled, `DoUntilQuorum` would initially only call `f` for instances in two of the three zones. If those calls all succeed, then `DoUntilQuorum` returns those results and ignores the remaining zone. If any call fails, then `DoUntilQuorum` calls `f` for the instances in the remaining zone. The set of results returned only includes results from instances in successful zones, as before.

Enabling request minimization is expected to reduce the number of calls made in the happy case (all requests succeed) at the cost of additional latency in the event that one or more of the initial calls fails.

This is a breaking change to the signature for `DoUntilQuorum`. As far as I can see, `DoUntilQuorum` is only used in two places, once in Mimir ([source](https://github.com/grafana/mimir/blob/bea4bd616c42c5ea42b3cbc7e350e3ebf2a291f0/pkg/distributor/query.go#L306)) and once in Phlare ([source](https://github.com/grafana/phlare/blob/d9eb816015a8d255c8faa4c58a4f4f169a3cabc1/pkg/querier/replication.go#L29)), so the small impact seems worthwhile over introducing a second method to maintain backwards compatibility.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
