### PR TITLE
Run tests on Go 1.20.

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,6 +1,7 @@
 local supported_golang_versions = [
   '1.18.4',
   '1.19.3',
+  '1.20.4',
 ];
 
 local images = {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -42,6 +42,16 @@
       },
       {
          "commands": [
+            "make test"
+         ],
+         "depends_on": [
+            "make-lint"
+         ],
+         "image": "golang:1.20.4",
+         "name": "make-test (go 1.20.4)"
+      },
+      {
+         "commands": [
             "apt-get update && apt-get -y install unzip",
             "go mod vendor",
             "make check-protos"
@@ -56,6 +66,6 @@
 }
 ---
 kind: signature
-hmac: 65d6be393627e1bca3cdec3ce103650a49f6460092ff0e6855be0938b9c69267
+hmac: 8d1c99ea3689b8cbf6aea9396160f1db269c4d0e9609924b97a674c585178a0b
 
 ...


### PR DESCRIPTION
**What this PR does**:

This PR adds Go 1.20.4 to the list of supported Go versions used for testing during the CI build.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
