### PR TITLE
Fix some comment typos

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -552,7 +552,7 @@ heartbeatLoop:
 }
 
 // initRing is the first thing we do when we start. It:
-// - add an ingester entry to the ring
+// - adds an ingester entry to the ring
 // - copies out our state and tokens if they exist
 func (i *Lifecycler) initRing(ctx context.Context) error {
 	var (
@@ -616,7 +616,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			return ringDesc, true, nil
 		}
 
-		// If the ingester failed to clean its ring entry up in can leave its state in LEAVING
+		// If the ingester failed to clean its ring entry up it can leave its state in LEAVING
 		// OR unregister_on_shutdown=false
 		// Move it into ACTIVE to ensure the ingester joins the ring.
 		if instanceDesc.State == LEAVING && len(instanceDesc.Tokens) == i.cfg.NumTokens {
@@ -673,7 +673,7 @@ func (i *Lifecycler) verifyTokens(ctx context.Context) bool {
 		ringTokens, takenTokens := ringDesc.TokensFor(i.ID)
 
 		if !i.compareTokens(ringTokens) {
-			// uh, oh... our tokens are not our anymore. Let's try new ones.
+			// uh, oh... our tokens are not ours anymore. Let's try new ones.
 			needTokens := i.cfg.NumTokens - len(ringTokens)
 
 			level.Info(i.logger).Log("msg", "generating new tokens", "count", needTokens, "ring", i.RingName)

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -764,7 +764,7 @@ func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testi
 	// Simulate ingester2 crash on startup and left the ring with JOINING state
 	err = r.KVClient.CAS(context.Background(), ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc, ok := in.(*Desc)
-		require.Equal(t, true, ok)
+		require.True(t, ok)
 		ingester2Desc := desc.Ingesters["ing2"]
 		ingester2Desc.State = JOINING
 		desc.Ingesters["ing2"] = ingester2Desc
@@ -778,7 +778,7 @@ func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testi
 	// Simulate ingester2 crash on startup and left the ring with PENDING state
 	err = r.KVClient.CAS(context.Background(), ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc, ok := in.(*Desc)
-		require.Equal(t, true, ok)
+		require.True(t, ok)
 		ingester2Desc := desc.Ingesters["ing2"]
 		ingester2Desc.State = PENDING
 		desc.Ingesters["ing2"] = ingester2Desc
@@ -869,7 +869,7 @@ func TestTokensOnDisk(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l1))
 
-	// Check this ingester joined, is active, and has 512 token.
+	// Check this ingester joined, is active, and has 512 tokens.
 	var expTokens []uint32
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
 		d, err := r.KVClient.Get(context.Background(), ringKey)
@@ -894,7 +894,7 @@ func TestTokensOnDisk(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l2))
 	defer services.StopAndAwaitTerminated(context.Background(), l2) //nolint:errcheck
 
-	// Check this ingester joined, is active, and has 512 token.
+	// Check this ingester joined, is active, and has 512 tokens.
 	var actTokens []uint32
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
 		d, err := r.KVClient.Get(context.Background(), ringKey)

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -37,7 +37,6 @@ const (
 
 // ReadRing represents the read interface to the ring.
 type ReadRing interface {
-
 	// Get returns n (or more) instances which form the replicas for the given key.
 	// bufDescs, bufHosts and bufZones are slices to be overwritten for the return value
 	// to avoid memory allocation; can be nil, or created with ring.MakeBuffersForGet().
@@ -171,7 +170,7 @@ type Ring struct {
 	oldestRegisteredTimestamp int64
 
 	// Maps a token with the information of the instance holding it. This map is immutable and
-	// cannot be chanced in place because it's shared "as is" between subrings (the only way to
+	// cannot be changed in place because it's shared "as is" between subrings (the only way to
 	// change it is to create a new one and replace it).
 	ringInstanceByToken map[uint32]instanceInfo
 
@@ -727,7 +726,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 					panic(ErrInconsistentTokensInfo)
 				}
 
-				// Ensure we select an unique instance.
+				// Ensure we select a unique instance.
 				if _, ok := shard[info.InstanceID]; ok {
 					continue
 				}


### PR DESCRIPTION
**What this PR does**:
* Fix some comment typos
* Simplify a couple of test assertions (use `require.True` instead of `require.Equal`)

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
