### PR TITLE
Clarify double cache access in client pool.

### DIFF
--- a/ring/client/pool.go
+++ b/ring/client/pool.go
@@ -103,8 +103,11 @@ func (p *Pool) GetClientFor(addr string) (PoolClient, error) {
 		return client, nil
 	}
 
+	// No client in cache so create one
 	p.Lock()
 	defer p.Unlock()
+
+	// Check if a client has been created just after checking the cache and before acquiring the lock.
 	client, ok = p.clients[addr]
 	if ok {
 		return client, nil


### PR DESCRIPTION
**What this PR does**:
I've had to scratch my head a little why we would call `p.readFromCache` and `p.clients[addr]` when I've noticed the different locks. I think this comment will avoid confusing.

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
