### PR TITLE
Added missing methods to InstrumentedMockCache

### DIFF
--- a/cache/mock.go
+++ b/cache/mock.go
@@ -120,6 +120,14 @@ func (m *InstrumentedMockCache) Delete(ctx context.Context, key string) error {
 	return m.cache.Delete(ctx, key)
 }
 
+func (m *InstrumentedMockCache) GetItems() map[string]Item {
+	return m.cache.GetItems()
+}
+
+func (m *InstrumentedMockCache) Flush() {
+	m.cache.Flush()
+}
+
 func (m *InstrumentedMockCache) CountStoreCalls() int {
 	return int(m.storeCount.Load())
 }


### PR DESCRIPTION
**What this PR does**:
`InstrumentedMockCache` is intended to be a wrapper of `MockCache`, but it's not exposing a couple of methods useful in tests. This PR fixes it.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
