### PR TITLE
Include token 0 in ring.CountTokens()

### DIFF
--- a/ring/ring.go
+++ b/ring/ring.go
@@ -522,24 +522,24 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 }
 
 // CountTokens returns the number tokens within the range for each instance.
-func (r *Desc) CountTokens() map[string]uint32 {
+func (r *Desc) CountTokens() map[string]int {
 	var (
-		owned               = make(map[string]uint32, len(r.Ingesters))
+		owned               = make(map[string]int, len(r.Ingesters))
 		ringTokens          = r.GetTokens()
 		ringInstanceByToken = r.getTokensInfo()
 	)
 
 	for i, token := range ringTokens {
-		var diff uint32
+		var prevToken uint32
 
 		// Compute how many tokens are within the range.
 		if i == 0 {
-			lastToken := ringTokens[len(ringTokens)-1]
-			diff = token + (math.MaxUint32 - lastToken)
+			prevToken = ringTokens[len(ringTokens)-1]
 		} else {
-			diff = token - ringTokens[i-1]
+			prevToken = ringTokens[i-1]
 		}
 
+		diff := getTokenDistance(prevToken, token)
 		info := ringInstanceByToken[token]
 		owned[info.InstanceID] = owned[info.InstanceID] + diff
 	}

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -3080,11 +3080,11 @@ func TestMergeTokenGroups(t *testing.T) {
 func TestCountTokens(t *testing.T) {
 	tests := map[string]struct {
 		ring     *Desc
-		expected map[string]uint32
+		expected map[string]int
 	}{
 		"empty ring": {
 			ring:     &Desc{},
-			expected: map[string]uint32{},
+			expected: map[string]int{},
 		},
 		"1 instance with 1 token in the ring": {
 			ring: &Desc{
@@ -3092,8 +3092,8 @@ func TestCountTokens(t *testing.T) {
 					"ingester-1": {Tokens: []uint32{1000000}},
 				},
 			},
-			expected: map[string]uint32{
-				"ingester-1": math.MaxUint32,
+			expected: map[string]int{
+				"ingester-1": math.MaxUint32 + 1,
 			},
 		},
 		"1 instance with multiple tokens in the ring": {
@@ -3102,8 +3102,8 @@ func TestCountTokens(t *testing.T) {
 					"ingester-1": {Tokens: []uint32{1000000, 2000000, 3000000}},
 				},
 			},
-			expected: map[string]uint32{
-				"ingester-1": math.MaxUint32,
+			expected: map[string]int{
+				"ingester-1": math.MaxUint32 + 1,
 			},
 		},
 		"multiple instances with multiple tokens in the ring": {
@@ -3114,8 +3114,8 @@ func TestCountTokens(t *testing.T) {
 					"ingester-3": {Tokens: []uint32{5000000, 9000000}},
 				},
 			},
-			expected: map[string]uint32{
-				"ingester-1": 3000000 + (math.MaxUint32 - 9000000),
+			expected: map[string]int{
+				"ingester-1": 3000000 + (math.MaxUint32 + 1 - 9000000),
 				"ingester-2": 4000000,
 				"ingester-3": 2000000,
 			},

--- a/ring/util.go
+++ b/ring/util.go
@@ -2,6 +2,7 @@ package ring
 
 import (
 	"context"
+	"math"
 	"math/rand"
 	"sort"
 	"time"
@@ -167,4 +168,14 @@ func searchToken(tokens []uint32, key uint32) int {
 		i = 0
 	}
 	return i
+}
+
+// getTokenDistance returns the distance between the given tokens from and to.
+// The distance between a token and itself is the whole ring, i.e., math.MaxUint32 + 1.
+func getTokenDistance(from, to uint32) int {
+	if from < to {
+		return int(to - from)
+	}
+	// the trailing +1 is needed to ensure that token 0 is counted
+	return math.MaxUint32 - int(from) + int(to) + 1
 }

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -3,6 +3,7 @@ package ring
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -414,4 +415,43 @@ func TestWaitInstanceState_ExitsAfterActualStateEqualsState(t *testing.T) {
 
 	assert.Nil(t, err)
 	ring.AssertNumberOfCalls(t, "GetInstanceState", 1)
+}
+
+func TestGetTokenDistance(t *testing.T) {
+	tests := map[string]struct {
+		from     uint32
+		to       uint32
+		expected int
+	}{
+		"whole ring between token and itself": {
+			from:     10,
+			to:       10,
+			expected: math.MaxUint32 + 1,
+		},
+		"10 tokens from 0 to 10": {
+			from:     0,
+			to:       10,
+			expected: 10,
+		},
+		"10 tokens from math.MaxUint32 - 10 to math.MaxUint32": {
+			from:     math.MaxUint32 - 10,
+			to:       math.MaxUint32,
+			expected: 10,
+		},
+		"1 token from math.MaxUint32 and 0": {
+			from:     math.MaxUint32,
+			to:       0,
+			expected: 1,
+		},
+		"21 tokens from math.MaxUint32 - 10 to 10": {
+			from:     math.MaxUint32 - 10,
+			to:       10,
+			expected: 21,
+		},
+	}
+
+	for _, testData := range tests {
+		distance := getTokenDistance(testData.from, testData.to)
+		require.Equal(t, testData.expected, distance)
+	}
 }


### PR DESCRIPTION
**What this PR does**:
This PR fixes a small bug in `ring.CountTokens()`, that does not count 0 as a valid token.
The logic for counting tokens is moved to a new method `util.getTokenDistance()`, that will be used in the following PRs related to this [issue](https://github.com/grafana/mimir-squad/issues/1042).

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/mimir-squad/issues/1042

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
