### PR TITLE
ring: make it harder to leak contexts when using DoUntilQuorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [CHANGE] Cache: Switch Memcached backend to use `github.com/grafana/gomemcache` repository instead of `github.com/bradfitz/gomemcache`. #248
 * [CHANGE] Multierror: Implement `Is(error) bool`. This allows to use `multierror.MultiError` with `errors.Is()`. `MultiError` will in turn call `errors.Is()` on every error value. #254
 * [CHANGE] Cache: Remove the `context.Context` argument from the `Cache.Store` method and rename the method to `Cache.StoreAsync`. #273
+* [CHANGE] ring: make it harder to leak contexts when using `DoUntilQuorum`. #319
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -89,49 +89,49 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	return results, nil
 }
 
-// DoUntilQuorum runs function f in parallel for all replicas in r.
+// DoUntilQuorumWithoutSuccessfulContextCancellation runs function f in parallel for all replicas in r.
 //
 // If r.MaxUnavailableZones is greater than zero:
-//   - DoUntilQuorum returns an error if calls to f for instances in more than r.MaxUnavailableZones zones return errors
-//   - Otherwise, DoUntilQuorum returns all results from all replicas in the first zones for which f succeeds
-//     for every instance in that zone (eg. if there are 3 zones and r.MaxUnavailableZones is 1, DoUntilQuorum will
+//   - DoUntilQuorumWithoutSuccessfulContextCancellation returns an error if calls to f for instances in more than r.MaxUnavailableZones zones return errors
+//   - Otherwise, DoUntilQuorumWithoutSuccessfulContextCancellation returns all results from all replicas in the first zones for which f succeeds
+//     for every instance in that zone (eg. if there are 3 zones and r.MaxUnavailableZones is 1, DoUntilQuorumWithoutSuccessfulContextCancellation will
 //     return the results from all instances in 2 zones, even if all calls to f succeed).
 //
 // Otherwise:
-//   - DoUntilQuorum returns an error if more than r.MaxErrors calls to f return errors
-//   - Otherwise, DoUntilQuorum returns all results from the first len(r.Instances) - r.MaxErrors instances
-//     (eg. if there are 6 replicas and r.MaxErrors is 2, DoUntilQuorum will return the results from the first 4
+//   - DoUntilQuorumWithoutSuccessfulContextCancellation returns an error if more than r.MaxErrors calls to f return errors
+//   - Otherwise, DoUntilQuorumWithoutSuccessfulContextCancellation returns all results from the first len(r.Instances) - r.MaxErrors instances
+//     (eg. if there are 6 replicas and r.MaxErrors is 2, DoUntilQuorumWithoutSuccessfulContextCancellation will return the results from the first 4
 //     successful calls to f, even if all 6 calls to f succeed).
 //
-// If minimizeRequests is false, DoUntilQuorum will call f for each instance in r.
+// If minimizeRequests is false, DoUntilQuorumWithoutSuccessfulContextCancellation will call f for each instance in r.
 //
-// If minimizeRequests is true, DoUntilQuorum will initially call f for the minimum number of instances needed to reach
+// If minimizeRequests is true, DoUntilQuorumWithoutSuccessfulContextCancellation will initially call f for the minimum number of instances needed to reach
 // the termination conditions above, and later call f for further instances if required. For example, if
-// r.MaxUnavailableZones is 1 and there are three zones, DoUntilQuorum will initially only call f for instances in two
+// r.MaxUnavailableZones is 1 and there are three zones, DoUntilQuorumWithoutSuccessfulContextCancellation will initially only call f for instances in two
 // zones, and only call f for instances in the remaining zone if a request in the initial two zones fails.
 //
-// If minimizeRequests is true, DoUntilQuorum will randomly select available zones / instances such that calling
-// DoUntilQuorum multiple times with the same ReplicationSet should evenly distribute requests across all zones /
+// If minimizeRequests is true, DoUntilQuorumWithoutSuccessfulContextCancellation will randomly select available zones / instances such that calling
+// DoUntilQuorumWithoutSuccessfulContextCancellation multiple times with the same ReplicationSet should evenly distribute requests across all zones /
 // instances.
 //
 // Regardless of the value of minimizeRequests, if one of the termination conditions above is satisfied or ctx is
 // cancelled before f is called for an instance, f may not be called for that instance at all.
 //
-// Any results from successful calls to f that are not returned by DoUntilQuorum will be passed to cleanupFunc,
-// including when DoUntilQuorum returns an error or only returns a subset of successful results. cleanupFunc may
-// be called both before and after DoUntilQuorum returns.
+// Any results from successful calls to f that are not returned by DoUntilQuorumWithoutSuccessfulContextCancellation will be passed to cleanupFunc,
+// including when DoUntilQuorumWithoutSuccessfulContextCancellation returns an error or only returns a subset of successful results. cleanupFunc may
+// be called both before and after DoUntilQuorumWithoutSuccessfulContextCancellation returns.
 //
 // A call to f is considered successful if it returns a nil error.
 //
-// DoUntilQuorum cancels the context.Context passed to each invocation of f if the result of that invocation of
+// DoUntilQuorumWithoutSuccessfulContextCancellation cancels the context.Context passed to each invocation of f if the result of that invocation of
 // f will not be returned. If the result of that invocation of f will be returned, the context.Context passed
-// to that invocation of f will not be cancelled by DoUntilQuorum, but the context.Context is a child of ctx
-// passed to DoUntilQuorum and so will be cancelled if ctx is cancelled.
+// to that invocation of f will not be cancelled by DoUntilQuorumWithoutSuccessfulContextCancellation, but the context.Context is a child of ctx
+// passed to DoUntilQuorumWithoutSuccessfulContextCancellation and so will be cancelled if ctx is cancelled.
 //
-// Important: to ensure that no context.Context is leaked, you must ensure that ctx is cancelled after DoUntilQuorum
+// Important: to ensure that no context.Context is leaked, you must ensure that ctx is cancelled after DoUntilQuorumWithoutSuccessfulContextCancellation
 // returns. (Until ctx is cancelled, ctx will retain a reference to each uncancelled child context.Context for each
 // returned invocation of f.)
-func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, minimizeRequests bool, f func(context.Context, *InstanceDesc) (T, error), cleanupFunc func(T)) ([]T, error) {
+func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Context, r ReplicationSet, minimizeRequests bool, f func(context.Context, *InstanceDesc) (T, error), cleanupFunc func(T)) ([]T, error) {
 	resultsChan := make(chan instanceResult[T], len(r.Instances))
 	resultsRemaining := len(r.Instances)
 

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -153,8 +153,9 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, minimizeRequest
 // to establish a set of streams that will be used after DoUntilQuorumWithoutSuccessfulContextCancellation returns.
 //
 // It is the caller's responsibility to ensure that either of the following are eventually true:
-// - ctx is cancelled, or
-// - for all invocations of f that do not return an error, the corresponding context.CancelFunc is called.
+//   - ctx is cancelled, or
+//   - the corresponding context.CancelFunc is called for all invocations of f whose results are returned by
+//     DoUntilQuorumWithoutSuccessfulContextCancellation
 //
 // Failing to do this may result in a memory leak.
 func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Context, r ReplicationSet, minimizeRequests bool, f func(context.Context, *InstanceDesc, context.CancelFunc) (T, error), cleanupFunc func(T)) ([]T, error) {

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -454,20 +454,27 @@ func TestDefaultContextTracker(t *testing.T) {
 	parentCtx := context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent")
 	tracker := newDefaultContextTracker(parentCtx, instances)
 
-	instance1Ctx := tracker.contextFor(&instance1)
-	instance2Ctx := tracker.contextFor(&instance2)
-	instance3Ctx := tracker.contextFor(&instance3)
-	instance4Ctx := tracker.contextFor(&instance4)
+	instance1Ctx, _ := tracker.contextFor(&instance1)
+	instance2Ctx, instance2Cancel := tracker.contextFor(&instance2)
+	instance3Ctx, _ := tracker.contextFor(&instance3)
+	instance4Ctx, _ := tracker.contextFor(&instance4)
 
 	for _, ctx := range []context.Context{instance1Ctx, instance2Ctx, instance3Ctx, instance4Ctx} {
 		require.Equal(t, "this-is-the-value-from-the-parent", ctx.Value(testContextKey), "context for instance should inherit from provided parent context")
 		require.NoError(t, ctx.Err(), "context for instance should not be cancelled")
 	}
 
-	// Cancel a context for one instance and check that the others are not cancelled.
+	// Cancel a context for one instance using cancelContextFor and check that the others are not cancelled.
 	tracker.cancelContextFor(&instance1)
 	require.Equal(t, context.Canceled, instance1Ctx.Err(), "instance context should be cancelled")
 	for _, ctx := range []context.Context{instance2Ctx, instance3Ctx, instance4Ctx} {
+		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
+	}
+
+	// Cancel another context using the cancellation function provided and check that the others are not cancelled.
+	instance2Cancel()
+	require.Equal(t, context.Canceled, instance2Ctx.Err(), "instance context should be cancelled")
+	for _, ctx := range []context.Context{instance3Ctx, instance4Ctx} {
 		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
 	}
 
@@ -1125,24 +1132,30 @@ func TestZoneAwareContextTracker(t *testing.T) {
 	parentCtx := context.WithValue(context.Background(), testContextKey, "this-is-the-value-from-the-parent")
 	tracker := newZoneAwareContextTracker(parentCtx, instances)
 
-	instance1Ctx := tracker.contextFor(&instance1)
-	instance2Ctx := tracker.contextFor(&instance2)
-	instance3Ctx := tracker.contextFor(&instance3)
-	instance4Ctx := tracker.contextFor(&instance4)
-	instance5Ctx := tracker.contextFor(&instance5)
-	instance6Ctx := tracker.contextFor(&instance6)
+	instance1Ctx, _ := tracker.contextFor(&instances[0])
+	instance2Ctx, _ := tracker.contextFor(&instances[1])
+	instance3Ctx, instance3Cancel := tracker.contextFor(&instances[2])
+	instance4Ctx, _ := tracker.contextFor(&instances[3])
+	instance5Ctx, _ := tracker.contextFor(&instances[4])
+	instance6Ctx, _ := tracker.contextFor(&instances[5])
 
 	for _, ctx := range []context.Context{instance1Ctx, instance2Ctx, instance3Ctx, instance4Ctx, instance5Ctx, instance6Ctx} {
 		require.Equal(t, "this-is-the-value-from-the-parent", ctx.Value(testContextKey), "context for instance should inherit from provided parent context")
 		require.NoError(t, ctx.Err(), "context for instance should not be cancelled")
 	}
 
-	// Cancel a context for one instance and check that the other context in its zone is cancelled, but others are
+	// Cancel a context for one instance using cancelContextFor and check that the other context in its zone is cancelled, but others are
 	// unaffected.
 	tracker.cancelContextFor(&instance1)
 	require.Equal(t, context.Canceled, instance1Ctx.Err(), "instance context should be cancelled")
 	require.Equal(t, context.Canceled, instance2Ctx.Err(), "context for instance in same zone as cancelled instance should also be cancelled")
 	for _, ctx := range []context.Context{instance3Ctx, instance4Ctx, instance5Ctx, instance6Ctx} {
+		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
+	}
+
+	// Cancel a context for one instance using the cancellation function provided and check that the other context in its zone is NOT cancelled.
+	instance3Cancel()
+	for _, ctx := range []context.Context{instance4Ctx, instance5Ctx, instance6Ctx} {
 		require.NoError(t, ctx.Err(), "context for instance should not be cancelled after cancelling the context of another instance")
 	}
 

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -88,7 +88,7 @@ func TestDefaultResultTracker(t *testing.T) {
 				assert.False(t, tracker.failed())
 
 				assert.True(t, tracker.shouldIncludeResultFrom(&instance1))
-				// Instance 2 failed, and so shouldIncludeResultFrom won't be called by DoUntilQuorum.
+				// Instance 2 failed, and so shouldIncludeResultFrom won't be called by DoUntilQuorumWithoutSuccessfulContextCancellation.
 				assert.True(t, tracker.shouldIncludeResultFrom(&instance3))
 				assert.True(t, tracker.shouldIncludeResultFrom(&instance4))
 			},
@@ -421,7 +421,7 @@ func TestDefaultResultTracker_StartMinimumRequests_MoreFailingRequestsThanMaximu
 
 func TestDefaultResultTracker_StartMinimumRequests_MaxErrorsIsNumberOfInstances(t *testing.T) {
 	// This scenario should never happen in the real world, but if we were to get into this situation,
-	// we need to make sure we don't end up blocking forever, which could lead to leaking a goroutine in DoUntilQuorum.
+	// we need to make sure we don't end up blocking forever, which could lead to leaking a goroutine in DoUntilQuorumWithoutSuccessfulContextCancellation.
 
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instances := []InstanceDesc{instance1}
@@ -1078,7 +1078,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesGreaterThanMaxi
 
 func TestZoneAwareResultTracker_StartMinimumRequests_MaxUnavailableZonesIsNumberOfZones(t *testing.T) {
 	// This scenario should never happen in the real world, but if we were to get into this situation,
-	// we need to make sure we don't end up blocking forever, which could lead to leaking a goroutine in DoUntilQuorum.
+	// we need to make sure we don't end up blocking forever, which could lead to leaking a goroutine in DoUntilQuorumWithoutSuccessfulContextCancellation.
 
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}


### PR DESCRIPTION
**What this PR does**:

This PR makes two changes to `DoUntilQuorum` to make it harder to accidentally leak `context.Context`s:

* The behaviour of `DoUntilQuorum` has been changed to always cancel all contexts passed to `f`. Previously, if the result of a call to `f` was returned from `DoUntilQuorum`, then the corresponding context was not cancelled.

* A new method has been introduced that behaves the same as `DoUntilQuorum` used to, `DoUntilQuorumWithoutSuccessfulContextCancellation`. In addition to the existing parameters, this method also passes a `context.CancelFunc` to `f` that must be called to avoid leaking any contexts.

Notes to reviewers:

* I'm not wedded to the name `DoUntilQuorumWithoutSuccessfulContextCancellation`, open to other suggestions. I wanted a name that conveyed you were doing something a little unusual and pushes people towards `DoUntilQuorum` by default.

* In the interests of simplicity and ease of maintenance, I haven't duplicated all of the previous tests for both `DoUntilQuorum` and `DoUntilQuorumWithoutSuccessfulContextCancellation`. Open to other opinions though.

Related: https://github.com/grafana/mimir/pull/5199

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
