### PR TITLE
Re-export ring.GenerateTokens()

### DIFF
--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -93,7 +93,7 @@ type BasicLifecycler struct {
 
 // NewBasicLifecycler makes a new BasicLifecycler.
 func NewBasicLifecycler(cfg BasicLifecyclerConfig, ringName, ringKey string, store kv.Client, delegate BasicLifecyclerDelegate, logger log.Logger, reg prometheus.Registerer) (*BasicLifecycler, error) {
-	tokenGenerator := newRandomTokenGenerator()
+	tokenGenerator := NewRandomTokenGenerator()
 	l := &BasicLifecycler{
 		cfg:                             cfg,
 		ringName:                        ringName,

--- a/ring/bench/ring_memberlist_test.go
+++ b/ring/bench/ring_memberlist_test.go
@@ -47,9 +47,9 @@ func encodeMessage(b *testing.B, key string, d *ring.Desc) []byte {
 }
 
 func generateUniqueTokens(ingester, numTokens int) []uint32 {
-	// Generate unique tokens without using ring.generateRandomTokens in order to not
+	// Generate unique tokens without using ring.GenerateTokens in order to not
 	// rely on random number generation. Also, because generating unique tokens
-	// with generateRandomTokens can be quite expensive, it pollutes the CPU profile
+	// with GenerateTokens can be quite expensive, it pollutes the CPU profile
 	// to the point of being useless.
 	tokens := make([]uint32, numTokens)
 	for i := range tokens {

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -170,7 +170,7 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 		flushTransferer = NewNoopFlushTransferer()
 	}
 
-	tokenGenerator := newRandomTokenGenerator()
+	tokenGenerator := NewRandomTokenGenerator()
 	l := &Lifecycler{
 		cfg:                   cfg,
 		flushTransferer:       flushTransferer,

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -482,7 +482,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	lifecyclerConfig.NumTokens = numTokens
 
 	// Simulate ingester with 64 tokens left the ring in LEAVING state
-	origTokens := generateRandomTokens(64, nil)
+	origTokens := GenerateTokens(64, nil)
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
@@ -558,7 +558,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	lifecyclerConfig.NumTokens = numTokens
 
 	// Simulate ingester with 128 tokens left the ring in LEAVING state
-	origTokens := generateRandomTokens(128, nil)
+	origTokens := GenerateTokens(128, nil)
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
@@ -952,7 +952,7 @@ func TestRestartIngester_NoUnregister_LongHeartbeat(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	origTokens := generateRandomTokens(100, nil)
+	origTokens := GenerateTokens(100, nil)
 
 	const id = "test"
 	registeredAt := time.Now().Add(-1 * time.Hour)

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -53,7 +53,7 @@ func benchmarkBatch(b *testing.B, numInstances, numKeys int) {
 	desc := NewDesc()
 	takenTokens := []uint32{}
 	for i := 0; i < numInstances; i++ {
-		tokens := generateRandomTokens(numTokens, takenTokens)
+		tokens := GenerateTokens(numTokens, takenTokens)
 		takenTokens = append(takenTokens, tokens...)
 		desc.AddIngester(fmt.Sprintf("%d", i), fmt.Sprintf("instance-%d", i), strconv.Itoa(i), tokens, ACTIVE, time.Now())
 	}
@@ -121,13 +121,13 @@ func benchmarkUpdateRingState(b *testing.B, numInstances, numTokens int, updateT
 	takenTokens := []uint32{}
 	otherTakenTokens := []uint32{}
 	for i := 0; i < numInstances; i++ {
-		tokens := generateRandomTokens(numTokens, takenTokens)
+		tokens := GenerateTokens(numTokens, takenTokens)
 		takenTokens = append(takenTokens, tokens...)
 		now := time.Now()
 		id := fmt.Sprintf("%d", i)
 		desc.AddIngester(id, fmt.Sprintf("instance-%d", i), strconv.Itoa(i), tokens, ACTIVE, now)
 		if updateTokens {
-			otherTokens := generateRandomTokens(numTokens, otherTakenTokens)
+			otherTokens := GenerateTokens(numTokens, otherTakenTokens)
 			otherTakenTokens = append(otherTakenTokens, otherTokens...)
 			otherDesc.AddIngester(id, fmt.Sprintf("instance-%d", i), strconv.Itoa(i), otherTokens, ACTIVE, now)
 		} else {
@@ -179,7 +179,7 @@ func TestDoBatch_QuorumError(t *testing.T) {
 	instanceReturnErrors := [3]error{nil, nil, nil}
 	desc := NewDesc()
 	for address := range instanceReturnErrors {
-		instTokens := generateRandomTokens(128, nil)
+		instTokens := GenerateTokens(128, nil)
 		instanceID := fmt.Sprintf("%d", address)
 		desc.AddIngester(instanceID, instanceID, "", instTokens, ACTIVE, time.Now())
 	}
@@ -277,7 +277,7 @@ func TestAddIngester(t *testing.T) {
 	const ingName = "ing1"
 
 	now := time.Now()
-	ing1Tokens := generateRandomTokens(128, nil)
+	ing1Tokens := GenerateTokens(128, nil)
 
 	r.AddIngester(ingName, "addr", "1", ing1Tokens, ACTIVE, now)
 
@@ -297,7 +297,7 @@ func TestAddIngesterReplacesExistingTokens(t *testing.T) {
 		Tokens: []uint32{11111, 22222, 33333},
 	}
 
-	newTokens := generateRandomTokens(128, nil)
+	newTokens := GenerateTokens(128, nil)
 
 	r.AddIngester(ing1Name, "addr", "1", newTokens, ACTIVE, time.Now())
 
@@ -337,7 +337,7 @@ func TestRing_Get_ZoneAwarenessWithIngesterLeaving(t *testing.T) {
 			}
 			var prevTokens []uint32
 			for id, instance := range instances {
-				ingTokens := generateRandomTokens(128, prevTokens)
+				ingTokens := GenerateTokens(128, prevTokens)
 				r.AddIngester(id, instance.Addr, instance.Zone, ingTokens, instance.State, time.Now())
 				prevTokens = append(prevTokens, ingTokens...)
 			}
@@ -362,8 +362,8 @@ func TestRing_Get_ZoneAwarenessWithIngesterLeaving(t *testing.T) {
 
 			_, bufHosts, bufZones := MakeBuffersForGet()
 
-			// Use the generateRandomTokens to get an array of random uint32 values.
-			testValues := generateRandomTokens(testCount, nil)
+			// Use the GenerateTokens to get an array of random uint32 values.
+			testValues := GenerateTokens(testCount, nil)
 
 			for i := 0; i < testCount; i++ {
 				set, err := ring.Get(testValues[i], Write, instancesList, bufHosts, bufZones)
@@ -430,7 +430,7 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 			var prevTokens []uint32
 			for i := 0; i < testData.numInstances; i++ {
 				name := fmt.Sprintf("ing%v", i)
-				ingTokens := generateRandomTokens(128, prevTokens)
+				ingTokens := GenerateTokens(128, prevTokens)
 
 				r.AddIngester(name, fmt.Sprintf("127.0.0.%d", i), fmt.Sprintf("zone-%v", i%testData.numZones), ingTokens, ACTIVE, time.Now())
 
@@ -459,8 +459,8 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 
 			_, bufHosts, bufZones := MakeBuffersForGet()
 
-			// Use the generateRandomTokens to get an array of random uint32 values.
-			testValues := generateRandomTokens(testCount, nil)
+			// Use the GenerateTokens to get an array of random uint32 values.
+			testValues := GenerateTokens(testCount, nil)
 
 			var set ReplicationSet
 			var err error
@@ -585,11 +585,11 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 		},
 		"should succeed on all healthy instances and RF=1": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-30 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-40 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-30 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-40 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
 			},
 			ringHeartbeatTimeout:    time.Minute,
 			ringReplicationFactor:   1,
@@ -599,11 +599,11 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 		},
 		"should succeed on instances with old timestamps but heartbeat timeout disabled": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
 			},
 			ringHeartbeatTimeout:    0,
 			ringReplicationFactor:   1,
@@ -613,11 +613,11 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 		},
 		"should fail on 1 unhealthy instance and RF=1": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-30 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-30 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
 			},
 			ringHeartbeatTimeout:    time.Minute,
 			ringReplicationFactor:   1,
@@ -627,11 +627,11 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 		},
 		"should succeed on 1 unhealthy instances and RF=3": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-30 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-30 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
 			},
 			ringHeartbeatTimeout:    time.Minute,
 			ringReplicationFactor:   3,
@@ -641,11 +641,11 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 		},
 		"should fail on 2 unhealthy instances and RF=3": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: now.Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", State: ACTIVE, Timestamp: now.Add(-10 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", State: ACTIVE, Timestamp: now.Add(-20 * time.Second).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix(), Tokens: GenerateTokens(128, nil)},
 			},
 			ringHeartbeatTimeout:    time.Minute,
 			ringReplicationFactor:   3,
@@ -707,8 +707,8 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=1, 1 zone": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
 			replicationFactor:           1,
@@ -717,9 +717,9 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=1, 1 zone, one unhealthy instance": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
 			unhealthyInstances: []string{"instance-2"},
 			replicationFactor:  1,
@@ -727,9 +727,9 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=1, 3 zones, one unhealthy instance": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			unhealthyInstances: []string{"instance-3"},
 			replicationFactor:  1,
@@ -737,8 +737,8 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=2, 2 zones": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
 			replicationFactor:           2,
@@ -746,8 +746,8 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=2, 2 zones, one unhealthy instance": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:  []string{"127.0.0.1"},
 			unhealthyInstances: []string{"instance-2"},
@@ -755,9 +755,9 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, 3 zones, one instance per zone": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
 			replicationFactor:           3,
@@ -766,9 +766,9 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, 3 zones, one instance per zone, one instance unhealthy": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.2", "127.0.0.3"},
 			unhealthyInstances:          []string{"instance-1"},
@@ -778,9 +778,9 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, 3 zones, one instance per zone, two instances unhealthy in separate zones": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			unhealthyInstances: []string{"instance-1", "instance-2"},
 			replicationFactor:  3,
@@ -788,9 +788,9 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, 3 zones, one instance per zone, all instances unhealthy": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			unhealthyInstances: []string{"instance-1", "instance-2", "instance-3"},
 			replicationFactor:  3,
@@ -798,12 +798,12 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, 3 zones, two instances per zone": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5", "127.0.0.6"},
 			replicationFactor:           3,
@@ -812,12 +812,12 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, 3 zones, two instances per zone, two instances unhealthy in same zone": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.5", "127.0.0.6"},
 			unhealthyInstances:          []string{"instance-3", "instance-4"},
@@ -827,15 +827,15 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, 3 zones, three instances per zone, two instances unhealthy in same zone": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-6": {Addr: "127.0.0.6", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-7": {Addr: "127.0.0.7", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-8": {Addr: "127.0.0.8", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-9": {Addr: "127.0.0.9", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-7": {Addr: "127.0.0.7", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-8": {Addr: "127.0.0.8", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-9": {Addr: "127.0.0.9", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.7", "127.0.0.8", "127.0.0.9"},
 			unhealthyInstances:          []string{"instance-4", "instance-6"},
@@ -845,10 +845,10 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, only 2 zones, two instances per zone": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"},
 			replicationFactor:           3,
@@ -857,10 +857,10 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, only 2 zones, two instances per zone, one instance unhealthy": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
 			unhealthyInstances:          []string{"instance-4"},
@@ -870,8 +870,8 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, only 1 zone, two instances per zone": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
 			replicationFactor:           3,
@@ -880,8 +880,8 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=3, only 1 zone, two instances per zone, one instance unhealthy": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
 			unhealthyInstances: []string{"instance-2"},
 			replicationFactor:  3,
@@ -889,17 +889,17 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=5, 5 zones, two instances per zone except for one zone which has three": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: generateRandomTokens(128, nil)},
-				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: generateRandomTokens(128, nil)},
-				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
-				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
-				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
+				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5",
 				"127.0.0.6", "127.0.0.7", "127.0.0.8", "127.0.0.9", "127.0.0.10", "127.0.0.11"},
@@ -909,17 +909,17 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=5, 5 zones, two instances per zone except for one zone which has three, 2 unhealthy nodes in same zones": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: generateRandomTokens(128, nil)},
-				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: generateRandomTokens(128, nil)},
-				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
-				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
-				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
+				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.5", "127.0.0.6", "127.0.0.7", "127.0.0.8", "127.0.0.9", "127.0.0.10", "127.0.0.11"},
 			unhealthyInstances:          []string{"instance-3", "instance-4"},
@@ -929,17 +929,17 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=5, 5 zones, two instances per zone except for one zone which has three, 2 unhealthy nodes in separate zones": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: generateRandomTokens(128, nil)},
-				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: generateRandomTokens(128, nil)},
-				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
-				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
-				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
+				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.7", "127.0.0.8", "127.0.0.9", "127.0.0.10", "127.0.0.11"},
 			unhealthyInstances:          []string{"instance-3", "instance-5"},
@@ -949,11 +949,11 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 		},
 		"RF=5, 5 zones, one instances per zone, three unhealthy instances": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-d", Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", Zone: "zone-e", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
 			},
 			unhealthyInstances: []string{"instance-2", "instance-4", "instance-5"},
 			replicationFactor:  5,
@@ -1034,8 +1034,8 @@ func TestRing_ShuffleShard(t *testing.T) {
 		},
 		"single zone, shard size > num instances": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
 			shardSize:            3,
 			zoneAwarenessEnabled: true,
@@ -1044,9 +1044,9 @@ func TestRing_ShuffleShard(t *testing.T) {
 		},
 		"single zone, shard size < num instances": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
 			shardSize:            2,
 			zoneAwarenessEnabled: true,
@@ -1055,9 +1055,9 @@ func TestRing_ShuffleShard(t *testing.T) {
 		},
 		"multiple zones, shard size < num zones": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			shardSize:            2,
 			zoneAwarenessEnabled: true,
@@ -1066,12 +1066,12 @@ func TestRing_ShuffleShard(t *testing.T) {
 		},
 		"multiple zones, shard size divisible by num zones": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			shardSize:            3,
 			zoneAwarenessEnabled: true,
@@ -1080,12 +1080,12 @@ func TestRing_ShuffleShard(t *testing.T) {
 		},
 		"multiple zones, shard size NOT divisible by num zones": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			shardSize:            4,
 			zoneAwarenessEnabled: true,
@@ -1094,12 +1094,12 @@ func TestRing_ShuffleShard(t *testing.T) {
 		},
 		"multiple zones, shard size NOT divisible by num zones, but zone awareness is disabled": {
 			ringInstances: map[string]InstanceDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: generateRandomTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: generateRandomTokens(128, nil)},
-				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
-				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: generateRandomTokens(128, nil)},
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
 			shardSize:            4,
 			zoneAwarenessEnabled: false,
@@ -1887,7 +1887,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 							zoneID := fmt.Sprintf("zone-%d", nextInstanceID%numZones)
 							nextInstanceID++
 
-							ringDesc.Ingesters[instanceID] = generateRingInstanceWithInfo(instanceID, zoneID, generateRandomTokens(128, nil), currTime)
+							ringDesc.Ingesters[instanceID] = generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(128, nil), currTime)
 
 							ring.ringTokens = ringDesc.GetTokens()
 							ring.ringTokensByZone = ringDesc.getTokensByZone()
@@ -2386,12 +2386,12 @@ func TestRing_ShuffleShardWithLookback_CachingConcurrency(t *testing.T) {
 
 	// Add some instances to the ring.
 	ringDesc := &Desc{Ingesters: map[string]InstanceDesc{
-		"instance-1": generateRingInstanceWithInfo("instance-1", "zone-a", generateRandomTokens(128, nil), now.Add(-2*time.Hour)),
-		"instance-2": generateRingInstanceWithInfo("instance-2", "zone-a", generateRandomTokens(128, nil), now.Add(-2*time.Hour)),
-		"instance-3": generateRingInstanceWithInfo("instance-3", "zone-b", generateRandomTokens(128, nil), now.Add(-2*time.Hour)),
-		"instance-4": generateRingInstanceWithInfo("instance-4", "zone-b", generateRandomTokens(128, nil), now.Add(-2*time.Hour)),
-		"instance-5": generateRingInstanceWithInfo("instance-5", "zone-c", generateRandomTokens(128, nil), now.Add(-2*time.Hour)),
-		"instance-6": generateRingInstanceWithInfo("instance-6", "zone-c", generateRandomTokens(128, nil), now.Add(-2*time.Hour)),
+		"instance-1": generateRingInstanceWithInfo("instance-1", "zone-a", GenerateTokens(128, nil), now.Add(-2*time.Hour)),
+		"instance-2": generateRingInstanceWithInfo("instance-2", "zone-a", GenerateTokens(128, nil), now.Add(-2*time.Hour)),
+		"instance-3": generateRingInstanceWithInfo("instance-3", "zone-b", GenerateTokens(128, nil), now.Add(-2*time.Hour)),
+		"instance-4": generateRingInstanceWithInfo("instance-4", "zone-b", GenerateTokens(128, nil), now.Add(-2*time.Hour)),
+		"instance-5": generateRingInstanceWithInfo("instance-5", "zone-c", GenerateTokens(128, nil), now.Add(-2*time.Hour)),
+		"instance-6": generateRingInstanceWithInfo("instance-6", "zone-c", GenerateTokens(128, nil), now.Add(-2*time.Hour)),
 	}}
 
 	ring.updateRingState(ringDesc)
@@ -2615,7 +2615,7 @@ func generateRingInstance(id, zone, numTokens int) (string, InstanceDesc) {
 	instanceID := fmt.Sprintf("instance-%d", id)
 	zoneID := fmt.Sprintf("zone-%d", zone)
 
-	return instanceID, generateRingInstanceWithInfo(instanceID, zoneID, generateRandomTokens(numTokens, nil), time.Now())
+	return instanceID, generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(numTokens, nil), time.Now())
 }
 
 func generateRingInstanceWithInfo(addr, zone string, tokens []uint32, registeredAt time.Time) InstanceDesc {

--- a/ring/token_generator.go
+++ b/ring/token_generator.go
@@ -12,15 +12,15 @@ type TokenGenerator interface {
 	GenerateTokens(tokensCount int, takenTokens []uint32) Tokens
 }
 
-type randomTokenGenerator struct{}
+type RandomTokenGenerator struct{}
 
-func newRandomTokenGenerator() *randomTokenGenerator {
-	return &randomTokenGenerator{}
+func NewRandomTokenGenerator() *RandomTokenGenerator {
+	return &RandomTokenGenerator{}
 }
 
 // GenerateTokens generates unique tokensCount random tokens, none of which clash
 // with takenTokens. Generated tokens are sorted.
-func (t *randomTokenGenerator) GenerateTokens(tokensCount int, takenTokens []uint32) Tokens {
+func (t *RandomTokenGenerator) GenerateTokens(tokensCount int, takenTokens []uint32) Tokens {
 	if tokensCount <= 0 {
 		return []uint32{}
 	}

--- a/ring/token_generator_test.go
+++ b/ring/token_generator_test.go
@@ -3,7 +3,7 @@ package ring
 import "testing"
 
 func TestRandomTokenGenerator_GenerateTokens(t *testing.T) {
-	tokenGenerator := newRandomTokenGenerator()
+	tokenGenerator := NewRandomTokenGenerator()
 	tokens := tokenGenerator.GenerateTokens(1000000, nil)
 
 	dups := make(map[uint32]int)
@@ -18,7 +18,7 @@ func TestRandomTokenGenerator_GenerateTokens(t *testing.T) {
 }
 
 func TestRandomTokenGenerator_IgnoresOldTokens(t *testing.T) {
-	tokenGenerator := newRandomTokenGenerator()
+	tokenGenerator := NewRandomTokenGenerator()
 	first := tokenGenerator.GenerateTokens(1000000, nil)
 	second := tokenGenerator.GenerateTokens(1000000, first)
 
@@ -37,5 +37,5 @@ func TestRandomTokenGenerator_IgnoresOldTokens(t *testing.T) {
 
 // GenerateTokens generates numTokens unique, random and sorted tokens for testing purposes.
 func GenerateTokens(tokensCount int, takenTokens []uint32) Tokens {
-	return newRandomTokenGenerator().GenerateTokens(tokensCount, takenTokens)
+	return NewRandomTokenGenerator().GenerateTokens(tokensCount, takenTokens)
 }

--- a/ring/token_generator_test.go
+++ b/ring/token_generator_test.go
@@ -30,12 +30,12 @@ func TestRandomTokenGenerator_IgnoresOldTokens(t *testing.T) {
 
 	for _, v := range second {
 		if dups[v] {
-			t.Fatal("generateRandomTokens returned old token")
+			t.Fatal("GenerateTokens returned old token")
 		}
 	}
 }
 
-// generateRandomTokens generates numTokens unique, random and sorted tokens for testing purposes.
-func generateRandomTokens(numTokens int, takenTokens []uint32) Tokens {
-	return newRandomTokenGenerator().GenerateTokens(numTokens, takenTokens)
+// GenerateTokens generates numTokens unique, random and sorted tokens for testing purposes.
+func GenerateTokens(tokensCount int, takenTokens []uint32) Tokens {
+	return newRandomTokenGenerator().GenerateTokens(tokensCount, takenTokens)
 }


### PR DESCRIPTION
**What this PR does**:
In one of previous [PR](https://github.com/grafana/dskit/pull/318)s we removed `GenerateTokens()` from the `ring` package. This PR re-exports `GenerateTokens()` (for backwards compatibility) because it is used by some tests outside of `dskit`.

Moreover, this PR exports `ring.NewRandomTokenGenerator()`, so that generation of random tokens generation could be done by calling ```ring.NewRandomTokenGenerator().GenerateTokens()``` outside of `dskit`.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
