### PR TITLE
Allow TokenGenerator.GenerateTokens() to return error

### DIFF
--- a/ring/basic_lifecycler_delegates_test.go
+++ b/ring/basic_lifecycler_delegates_test.go
@@ -322,7 +322,7 @@ func TestInstanceRegisterDelegate_OnRingInstanceRegister(t *testing.T) {
 		desc := NewDesc()
 		desc.AddIngester("other-instance", "addr", "zone", otherIngesterTokens, ACTIVE, time.Now())
 
-		state, tokens := delegate.OnRingInstanceRegister(lifecycler, *desc, false, "test-instance", InstanceDesc{})
+		state, tokens, _ := delegate.OnRingInstanceRegister(lifecycler, *desc, false, "test-instance", InstanceDesc{})
 		require.Equal(t, JOINING, state)
 		require.Equal(t, tokenCount, len(tokens))
 		for _, tok := range otherIngesterTokens {
@@ -346,7 +346,7 @@ func TestInstanceRegisterDelegate_OnRingInstanceRegister(t *testing.T) {
 		prevTokens := []uint32{10, 20, 30}
 		desc.AddIngester("test-instance", "test-addr", "zone", prevTokens, JOINING, time.Now())
 
-		state, tokens := delegate.OnRingInstanceRegister(lifecycler, *desc, true, "test-instance", desc.GetIngesters()["test-instance"])
+		state, tokens, _ := delegate.OnRingInstanceRegister(lifecycler, *desc, true, "test-instance", desc.GetIngesters()["test-instance"])
 		require.Equal(t, ACTIVE, state)
 		require.Equal(t, tokenCount, len(tokens))
 

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -519,12 +519,13 @@ type mockDelegate struct {
 	onHeartbeat     func(lifecycler *BasicLifecycler, ringDesc *Desc, instanceDesc *InstanceDesc)
 }
 
-func (m *mockDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc InstanceDesc) (InstanceState, Tokens) {
+func (m *mockDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc InstanceDesc) (InstanceState, Tokens, error) {
 	if m.onRegister == nil {
-		return PENDING, Tokens{}
+		return PENDING, Tokens{}, nil
 	}
 
-	return m.onRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+	instanceState, tokens := m.onRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+	return instanceState, tokens, nil
 }
 
 func (m *mockDelegate) OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens Tokens) {

--- a/ring/token_generator.go
+++ b/ring/token_generator.go
@@ -9,7 +9,7 @@ import (
 type TokenGenerator interface {
 	// GenerateTokens generates unique tokensCount tokens, none of which clash
 	// with the given takenTokens. Generated tokens are sorted.
-	GenerateTokens(tokensCount int, takenTokens []uint32) Tokens
+	GenerateTokens(tokensCount int, takenTokens []uint32) (Tokens, error)
 }
 
 type RandomTokenGenerator struct{}
@@ -20,9 +20,9 @@ func NewRandomTokenGenerator() *RandomTokenGenerator {
 
 // GenerateTokens generates unique tokensCount random tokens, none of which clash
 // with takenTokens. Generated tokens are sorted.
-func (t *RandomTokenGenerator) GenerateTokens(tokensCount int, takenTokens []uint32) Tokens {
+func (t *RandomTokenGenerator) GenerateTokens(tokensCount int, takenTokens []uint32) (Tokens, error) {
 	if tokensCount <= 0 {
-		return []uint32{}
+		return []uint32{}, nil
 	}
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -48,5 +48,5 @@ func (t *RandomTokenGenerator) GenerateTokens(tokensCount int, takenTokens []uin
 		return tokens[i] < tokens[j]
 	})
 
-	return tokens
+	return tokens, nil
 }

--- a/ring/token_generator_test.go
+++ b/ring/token_generator_test.go
@@ -1,10 +1,14 @@
 package ring
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestRandomTokenGenerator_GenerateTokens(t *testing.T) {
 	tokenGenerator := NewRandomTokenGenerator()
-	tokens := tokenGenerator.GenerateTokens(1000000, nil)
+	tokens, _ := tokenGenerator.GenerateTokens(1000000, nil)
 
 	dups := make(map[uint32]int)
 
@@ -19,8 +23,10 @@ func TestRandomTokenGenerator_GenerateTokens(t *testing.T) {
 
 func TestRandomTokenGenerator_IgnoresOldTokens(t *testing.T) {
 	tokenGenerator := NewRandomTokenGenerator()
-	first := tokenGenerator.GenerateTokens(1000000, nil)
-	second := tokenGenerator.GenerateTokens(1000000, first)
+	first, err := tokenGenerator.GenerateTokens(1000000, nil)
+	require.NoError(t, err)
+	second, err := tokenGenerator.GenerateTokens(1000000, first)
+	require.NoError(t, err)
 
 	dups := make(map[uint32]bool)
 
@@ -37,5 +43,9 @@ func TestRandomTokenGenerator_IgnoresOldTokens(t *testing.T) {
 
 // GenerateTokens generates numTokens unique, random and sorted tokens for testing purposes.
 func GenerateTokens(tokensCount int, takenTokens []uint32) Tokens {
-	return NewRandomTokenGenerator().GenerateTokens(tokensCount, takenTokens)
+	tokens, err := NewRandomTokenGenerator().GenerateTokens(tokensCount, takenTokens)
+	if err != nil {
+		return nil
+	}
+	return tokens
 }


### PR DESCRIPTION
**What this PR does**:
This PR modifies the signature of `TokenGenerator.GenerateTokens()` method in such a way that it, beside a set of tokens, returns also an error in the case something went wrong during the token generation.

Additionally, the signature of `BasicLifecyclerDelegate.OnRingInstanceRegister` was modified in a similar way: beside the instance state and the set of tokens assigned to the registered instance, it also returns an error in the case it was not possible to obtain the set of tokens to assign to the instance.
 
**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/mimir/issues/4736

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
