### PR TITLE
Make ring.CountTokens() take into account instances zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [CHANGE] Multierror: Implement `Is(error) bool`. This allows to use `multierror.MultiError` with `errors.Is()`. `MultiError` will in turn call `errors.Is()` on every error value. #254
 * [CHANGE] Cache: Remove the `context.Context` argument from the `Cache.Store` method and rename the method to `Cache.StoreAsync`. #273
 * [CHANGE] ring: make it harder to leak contexts when using `DoUntilQuorum`. #319
+* [CHANGE] ring: `CountTokens()`, used for the calculation of ownership in the ring page has been changed in such a way that when zone-awareness is enabled, it calculates the ownership per-zone. Previously zones were not taken into account. #325
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.


### PR DESCRIPTION
**What this PR does**:
This PR fixes a bug that was present in the calculation of instance ownership. `ring.CountTokens()`.
Namely, the previous implementation did not take into account the zone different instances belong to, and was calculating, for each instance, the sum of distances between its token and the first token preceding the former. That is wrong, because only the tokens belonging to the instances of the same zone should be taken into account.

For example, suppose we have the following tokens in 2 zones belonging to 2 instances:
- `instance-zone-a-1` with tokens `1000`, `20000`, `300000` 
- `instance-zone-b-1` with tokens `1001`, `20001`, `300001`

It is clear that the ownership of both instances is $2^{32}$, since they belong to different zones. Nevertheless, the previous implementation would return ownership $2^{32}-3$ for `instance-zone-a-1` and $3$ for `instance-zone-b-1`, which is wrong.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/mimir/issues/4736

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
