### PR TITLE
Impose SpreadMinimizingTokenGenerator to register instances in ascending order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 * [ENHANCEMENT] Lifecycler: Added `RingTokenGenerator` configuration that specifies the `TokenGenerator` implementation that is used for token generation. Default value is nil, meaning that `RandomTokenGenerator` is used. #323
 * [ENHANCEMENT] BasicLifecycler: Added `RingTokenGenerator` configuration that specifies the `TokenGenerator` implementation that is used for token generation. Default value is nil, meaning that `RandomTokenGenerator` is used. #323
 * [ENHANCEMENT] Ring: add support for hedging to `DoUntilQuorum` when request minimization is enabled. #330
+* [ENHANCEMENT] Lifecycler: allow instances to register in ascending order of ids in case of spread minimizing token generation strategy. #326
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -25,7 +25,7 @@ const (
 func TestBasicLifecycler_GetTokenGenerator(t *testing.T) {
 	cfg := prepareBasicLifecyclerConfig()
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, 0, log.NewNopLogger())
 	require.NoError(t, err)
 
 	tests := []TokenGenerator{nil, NewRandomTokenGenerator(), spreadMinimizingTokenGenerator}

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -25,7 +25,7 @@ const (
 func TestBasicLifecycler_GetTokenGenerator(t *testing.T) {
 	cfg := prepareBasicLifecyclerConfig()
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, 0, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, log.NewNopLogger())
 	require.NoError(t, err)
 
 	tests := []TokenGenerator{nil, NewRandomTokenGenerator(), spreadMinimizingTokenGenerator}

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -64,7 +64,7 @@ func TestLifecyclerConfig_Validate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, pathToTokens, cfg.TokensFilePath)
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, 0, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, log.NewNopLogger())
 	require.NoError(t, err)
 
 	cfg.RingTokenGenerator = spreadMinimizingTokenGenerator
@@ -82,7 +82,7 @@ func TestLifecycler_TokenGenerator(t *testing.T) {
 
 	cfg := testLifecyclerConfig(ringConfig, "instance-1")
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, 0, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, log.NewNopLogger())
 	require.NoError(t, err)
 
 	tests := []TokenGenerator{nil, NewRandomTokenGenerator(), spreadMinimizingTokenGenerator}
@@ -1308,7 +1308,7 @@ func TestAutoJoinWithSpreadMinimizingTokenGenerator(t *testing.T) {
 	targetInstanceID := instanceName(2, 1)
 	targetZone := zone(1)
 	spreadMinimizingZones := []string{zone(1), zone(2), zone(3)}
-	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(targetInstanceID, targetZone, spreadMinimizingZones, true, 0, log.NewNopLogger())
+	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(targetInstanceID, targetZone, spreadMinimizingZones, true, log.NewNopLogger())
 	require.NoError(t, err)
 	tokensByInstanceID := tokenGenerator.generateTokensByInstanceID()
 	cfg := testLifecyclerConfig(ringConfig, targetInstanceID)
@@ -1352,7 +1352,7 @@ func TestAutoJoinWithSpreadMinimizingTokenGenerator(t *testing.T) {
 	})
 
 	outOfOrderInstanceID := instanceName(4, 1)
-	tokenGenerator, err = NewSpreadMinimizingTokenGenerator(outOfOrderInstanceID, targetZone, spreadMinimizingZones, true, 0, log.NewNopLogger())
+	tokenGenerator, err = NewSpreadMinimizingTokenGenerator(outOfOrderInstanceID, targetZone, spreadMinimizingZones, true, log.NewNopLogger())
 	require.NoError(t, err)
 	tokensByInstanceID = tokenGenerator.generateTokensByInstanceID()
 	outOfORderCfg := testLifecyclerConfig(ringConfig, outOfOrderInstanceID)

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -60,18 +60,16 @@ func TestLifecyclerConfig_Validate(t *testing.T) {
 	cfg := testLifecyclerConfig(ringConfig, "instance-1")
 	cfg.TokensFilePath = pathToTokens
 
-	logger := log.NewNopLogger()
-	err := cfg.Validate(logger)
+	err := cfg.Validate()
 	require.NoError(t, err)
 	require.Equal(t, pathToTokens, cfg.TokensFilePath)
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, 0, log.NewNopLogger())
 	require.NoError(t, err)
 
 	cfg.RingTokenGenerator = spreadMinimizingTokenGenerator
-	err = cfg.Validate(logger)
-	require.NoError(t, err)
-	require.Empty(t, cfg.TokensFilePath)
+	err = cfg.Validate()
+	require.Error(t, err)
 }
 
 func TestLifecycler_TokenGenerator(t *testing.T) {
@@ -84,7 +82,7 @@ func TestLifecycler_TokenGenerator(t *testing.T) {
 
 	cfg := testLifecyclerConfig(ringConfig, "instance-1")
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, 0, log.NewNopLogger())
 	require.NoError(t, err)
 
 	tests := []TokenGenerator{nil, NewRandomTokenGenerator(), spreadMinimizingTokenGenerator}
@@ -1310,7 +1308,7 @@ func TestAutoJoinWithSpreadMinimizingTokenGenerator(t *testing.T) {
 	targetInstanceID := instanceName(2, 1)
 	targetZone := zone(1)
 	spreadMinimizingZones := []string{zone(1), zone(2), zone(3)}
-	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(targetInstanceID, targetZone, spreadMinimizingZones, log.NewNopLogger())
+	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(targetInstanceID, targetZone, spreadMinimizingZones, true, 0, log.NewNopLogger())
 	require.NoError(t, err)
 	tokensByInstanceID := tokenGenerator.generateTokensByInstanceID()
 	cfg := testLifecyclerConfig(ringConfig, targetInstanceID)
@@ -1354,7 +1352,7 @@ func TestAutoJoinWithSpreadMinimizingTokenGenerator(t *testing.T) {
 	})
 
 	outOfOrderInstanceID := instanceName(4, 1)
-	tokenGenerator, err = NewSpreadMinimizingTokenGenerator(outOfOrderInstanceID, targetZone, spreadMinimizingZones, log.NewNopLogger())
+	tokenGenerator, err = NewSpreadMinimizingTokenGenerator(outOfOrderInstanceID, targetZone, spreadMinimizingZones, true, 0, log.NewNopLogger())
 	require.NoError(t, err)
 	tokensByInstanceID = tokenGenerator.generateTokensByInstanceID()
 	outOfORderCfg := testLifecyclerConfig(ringConfig, outOfOrderInstanceID)

--- a/ring/spread_minimizing_token_generator.go
+++ b/ring/spread_minimizing_token_generator.go
@@ -352,3 +352,7 @@ func (t *SpreadMinimizingTokenGenerator) CanJoin(instances map[string]InstanceDe
 	}
 	return errorPreviousInstance(prevInstance, t.instance)
 }
+
+func (t *SpreadMinimizingTokenGenerator) CanJoinEnabled() bool {
+	return t.canJoinEnabled
+}

--- a/ring/spread_minimizing_token_generator.go
+++ b/ring/spread_minimizing_token_generator.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -55,11 +54,10 @@ type SpreadMinimizingTokenGenerator struct {
 	zoneID                int
 	spreadMinimizingZones []string
 	canJoinEnabled        bool
-	canJoinTimeout        time.Duration
 	logger                log.Logger
 }
 
-func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZones []string, canJoinEnabled bool, canJoinTimeout time.Duration, logger log.Logger) (*SpreadMinimizingTokenGenerator, error) {
+func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZones []string, canJoinEnabled bool, logger log.Logger) (*SpreadMinimizingTokenGenerator, error) {
 	if len(spreadMinimizingZones) <= 0 || len(spreadMinimizingZones) > maxZonesCount {
 		return nil, errorZoneCountOutOfBound(len(spreadMinimizingZones))
 	}
@@ -83,7 +81,6 @@ func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZo
 		zoneID:                zoneID,
 		spreadMinimizingZones: sortedZones,
 		canJoinEnabled:        canJoinEnabled,
-		canJoinTimeout:        canJoinTimeout,
 		logger:                logger,
 	}
 	return tokenGenerator, nil

--- a/ring/spread_minimizing_token_generator.go
+++ b/ring/spread_minimizing_token_generator.go
@@ -28,8 +28,8 @@ var (
 	}
 	errorNoPreviousInstance = fmt.Errorf("impossible to find the instance preceding the target instance, because it is the first instance")
 
-	errorPreviousInstance = func(requiredInstanceID, instanceID string) error {
-		return fmt.Errorf("impossible to find instance %q requested by the current instance %q, or %q has no registered tokens", requiredInstanceID, instanceID, requiredInstanceID)
+	errorMissingPreviousInstance = func(requiredInstanceID string) error {
+		return fmt.Errorf("the instance %q has not been registered to the ring or has no tokens yet", requiredInstanceID)
 	}
 	errorZoneCountOutOfBound = func(zonesCount int) error {
 		return fmt.Errorf("number of zones %d is not correct: it must be greater than 0 and less or equal than %d", zonesCount, maxZonesCount)
@@ -350,7 +350,7 @@ func (t *SpreadMinimizingTokenGenerator) CanJoin(instances map[string]InstanceDe
 	if ok && len(instanceDesc.Tokens) != 0 {
 		return nil
 	}
-	return errorPreviousInstance(prevInstance, t.instance)
+	return errorMissingPreviousInstance(prevInstance)
 }
 
 func (t *SpreadMinimizingTokenGenerator) CanJoinEnabled() bool {

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -86,7 +86,7 @@ func TestSpreadMinimizingTokenGenerator_PreviousInstanceID(t *testing.T) {
 		},
 		"instance-zone-0 has no previous instance": {
 			instanceID:    "instance-zone-0",
-			expectedError: errorNoPreviousInstance("instance-zone-0"),
+			expectedError: errorNoPreviousInstance,
 		},
 		"instance-zone-c is not valid": {
 			instanceID:    "instance-zone-c",

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -177,7 +177,7 @@ func TestSpreadMinimizingTokenGenerator_NewSpreadMinimizingTokenGenerator(t *tes
 
 	for _, testData := range tests {
 		instance := fmt.Sprintf("instance-%s-1", testData.zone)
-		tokenGenerator, err := NewSpreadMinimizingTokenGenerator(instance, testData.zone, testData.spreadMinimizingZones, true, 0, log.NewNopLogger())
+		tokenGenerator, err := NewSpreadMinimizingTokenGenerator(instance, testData.zone, testData.spreadMinimizingZones, true, log.NewNopLogger())
 		if testData.expectedError != nil {
 			require.Error(t, err)
 			require.Equal(t, testData.expectedError, err)
@@ -481,14 +481,12 @@ func TestSpreadMinimizingTokenGenerator_CanJoin(t *testing.T) {
 	firstInstance := fmt.Sprintf("instance-%s-%d", zone, 0)
 	tokenGenerator := createSpreadMinimizingTokenGenerator(t, firstInstance, zone, zones)
 	tokenGenerator.canJoinEnabled = true
-	tokenGenerator.canJoinTimeout = 1 * time.Second
 	err := tokenGenerator.CanJoin(nil)
 	require.NoError(t, err)
 
 	instanceID := 128
 	targetInstance := fmt.Sprintf("instance-%s-%d", zone, instanceID)
 	tokenGenerator = createSpreadMinimizingTokenGenerator(t, targetInstance, zone, zones)
-	tokenGenerator.canJoinTimeout = 1 * time.Second
 	// this is the set of all sorted tokens assigned to instance
 	allTokens := tokenGenerator.generateTokensByInstanceID()
 	require.Len(t, allTokens, instanceID+1)
@@ -573,7 +571,7 @@ func createTokensForAllInstancesAndZones(t *testing.T, maxInstanceID, tokensPerI
 }
 
 func createSpreadMinimizingTokenGenerator(t testing.TB, instance, zone string, zones []string) *SpreadMinimizingTokenGenerator {
-	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(instance, zone, zones, true, 0, log.NewLogfmtLogger(os.Stdout))
+	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(instance, zone, zones, true, log.NewLogfmtLogger(os.Stdout))
 	require.NoError(t, err)
 	require.NotNil(t, tokenGenerator)
 	return tokenGenerator

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -524,7 +524,7 @@ func TestSpreadMinimizingTokenGenerator_CanJoin(t *testing.T) {
 	tokenGenerator.canJoinEnabled = true
 	err = tokenGenerator.CanJoin(ringDesc.GetIngesters())
 	require.Error(t, err)
-	require.Equal(t, errorPreviousInstance(pendingInstance, targetInstance), err)
+	require.Equal(t, errorMissingPreviousInstance(pendingInstance), err)
 
 	// if canJoinEnabled is true, the check returns nil all instances have tokens
 	tokenGenerator.canJoinEnabled = true

--- a/ring/token_generator.go
+++ b/ring/token_generator.go
@@ -15,6 +15,10 @@ type TokenGenerator interface {
 	// CanJoin checks whether the instance owning this TokenGenerator can join the set of the given instances satisfies,
 	// and fails if it is not possible.
 	CanJoin(instances map[string]InstanceDesc) error
+
+	// CanJoinEnabled returns true if the instance owning this TokenGenerator should perform the CanJoin check before
+	// it tries to join the ring.
+	CanJoinEnabled() bool
 }
 
 type RandomTokenGenerator struct{}
@@ -59,4 +63,8 @@ func (t *RandomTokenGenerator) GenerateTokens(requestedTokensCount int, allTaken
 
 func (t *RandomTokenGenerator) CanJoin(_ map[string]InstanceDesc) error {
 	return nil
+}
+
+func (t *RandomTokenGenerator) CanJoinEnabled() bool {
+	return false
 }

--- a/ring/token_generator.go
+++ b/ring/token_generator.go
@@ -6,19 +6,15 @@ import (
 	"time"
 )
 
-type ConditionalTokenGenerator interface {
-	TokenGenerator
-
-	// CheckConditions checks whether the given set of instances satisfies a condition provided by a specific
-	// implementation, and fails if the latter is not satisfied.
-	CheckConditions(instances map[string]InstanceDesc) error
-}
-
 type TokenGenerator interface {
 	// GenerateTokens generates at most requestedTokensCount unique tokens, none of which clashes with
 	// the given allTakenTokens, representing the set of all tokens currently present in the ring.
 	// Generated tokens are sorted.
 	GenerateTokens(requestedTokensCount int, allTakenTokens []uint32) Tokens
+
+	// CanJoin checks whether the instance owning this TokenGenerator can join the set of the given instances satisfies,
+	// and fails if it is not possible.
+	CanJoin(instances map[string]InstanceDesc) error
 }
 
 type RandomTokenGenerator struct{}
@@ -59,4 +55,8 @@ func (t *RandomTokenGenerator) GenerateTokens(requestedTokensCount int, allTaken
 	})
 
 	return tokens
+}
+
+func (t *RandomTokenGenerator) CanJoin(_ map[string]InstanceDesc) error {
+	return nil
 }

--- a/ring/token_generator.go
+++ b/ring/token_generator.go
@@ -6,6 +6,14 @@ import (
 	"time"
 )
 
+type ConditionalTokenGenerator interface {
+	TokenGenerator
+
+	// CheckConditions checks whether the given set of instances satisfies a condition provided by a specific
+	// implementation, and fails if the latter is not satisfied.
+	CheckConditions(instances map[string]InstanceDesc) error
+}
+
 type TokenGenerator interface {
 	// GenerateTokens generates at most requestedTokensCount unique tokens, none of which clashes with
 	// the given allTakenTokens, representing the set of all tokens currently present in the ring.


### PR DESCRIPTION
**What this PR does**:
This PR proposes a way of how to impose a Lifecycler to accept registering instances with ids in ascending order in case of spread minimizing token generation strategy.
It also imposes Lifecycler not to load or store tokens to a file in the case of the above mentioned strategy.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/mimir/issues/4736

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
