### PR TITLE
Correct comments for ring.HasReplicationSetChanged* methods

### DIFF
--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -374,17 +374,17 @@ func (r *ReplicationSet) ZoneCount() int {
 	return len(zones)
 }
 
-// HasReplicationSetChanged returns true if two replications sets are the same (with possibly different timestamps),
-// false if they differ in any way (number of instances, instance states, tokens, zones, ...).
+// HasReplicationSetChanged returns false if two replications sets are the same (with possibly different timestamps),
+// true if they differ in any way (number of instances, instance states, tokens, zones, ...).
 func HasReplicationSetChanged(before, after ReplicationSet) bool {
 	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
 		i.Timestamp = 0
 	})
 }
 
-// HasReplicationSetChangedWithoutState returns true if two replications sets
+// HasReplicationSetChangedWithoutState returns false if two replications sets
 // are the same (with possibly different timestamps and instance states),
-// false if they differ in any other way (number of instances, tokens, zones, ...).
+// true if they differ in any other way (number of instances, tokens, zones, ...).
 func HasReplicationSetChangedWithoutState(before, after ReplicationSet) bool {
 	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
 		i.Timestamp = 0


### PR DESCRIPTION
They had the boolean reversed. Identified by community member in slack.

**Checklist**
- [NA] Tests updated
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
