### PR TITLE
Fix TestOnFlushCallback

### DIFF
--- a/log/buffered_test.go
+++ b/log/buffered_test.go
@@ -104,8 +104,8 @@ func TestOnFlushCallback(t *testing.T) {
 		flushedEntries += int(entries)
 	}
 
+	// Do NOT specify a flush period because we want to be in control of the flushes done by this test.
 	bufLog := NewBufferedLogger(&buf, 2,
-		WithFlushPeriod(flushPeriod),
 		WithPrellocatedBuffer(bufferSize),
 		WithFlushCallback(callback),
 	)

--- a/log/buffered_test.go
+++ b/log/buffered_test.go
@@ -116,6 +116,9 @@ func TestOnFlushCallback(t *testing.T) {
 	// first flush
 	require.NoError(t, l.Log("line"))
 
+	// pre-condition check: the last Log() call should have flushed previous entries.
+	require.Equal(t, uint32(1), bufLog.Size())
+
 	// force a second
 	require.NoError(t, bufLog.Flush())
 


### PR DESCRIPTION
**What this PR does**:
When I opened https://github.com/grafana/dskit/pull/339, the 1st CI failed because of ([details](https://drone.grafana.net/grafana/dskit/2582/1/6)):

```
--- FAIL: TestOnFlushCallback (0.01s)
    buffered_test.go:122: 
        	Error Trace:	/drone/src/log/buffered_test.go:122
        	Error:      	Not equal: 
        	            	expected: 0x2
        	            	actual  : 0x1
        	Test:       	TestOnFlushCallback
==================
WARNING: DATA RACE
Read at 0x00c000026c9c by goroutine 9:
  github.com/grafana/dskit/log.TestOnFlushCallback.func1()
      /drone/src/log/buffered_test.go:103 +0x44
  github.com/grafana/dskit/log.(*BufferedLogger).Flush()
      /drone/src/log/buffered.go:61 +0xd6
  github.com/grafana/dskit/log.WithFlushPeriod.func1.1()
      /drone/src/log/buffered.go:77 +0xf3
```

I think there's a race in the test because the periodic flush may trigger while the test is executing `Flush()`. For `TestOnFlushCallback` I think we don't want the periodic flush. 

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
