### PR TITLE
Add flagext.ParseFlagsAndArguments() and flagext.ParseFlagsWithoutArguments() utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338
+* [FEATURE] Add `flagext.ParseFlagsAndArguments()` and `flagext.ParseFlagsWithoutArguments()` utilities. #341
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38

--- a/flagext/parse.go
+++ b/flagext/parse.go
@@ -1,0 +1,28 @@
+package flagext
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ParseFlagsAndArguments calls Parse() on the input flag.FlagSet and returns the parsed arguments.
+func ParseFlagsAndArguments(f *flag.FlagSet) ([]string, error) {
+	err := f.Parse(os.Args[1:])
+	return f.Args(), err
+}
+
+// ParseFlagsWithoutArguments calls Parse() on the input flag.FlagSet and enforces no arguments have been parsed.
+// This utility should be called whenever we only expect CLI flags but no arguments.
+func ParseFlagsWithoutArguments(f *flag.FlagSet) error {
+	if err := f.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+
+	if f.NArg() > 0 {
+		return fmt.Errorf("the command does not support any argument, but some were provided: %s", strings.Join(f.Args(), " "))
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does**:
In Mimir we've been hit by a golang quirk when parsing boolean CLI flags (see [details here](https://github.com/grafana/mimir/pull/5627)). We would like to stop using `flag.Parse()`, `flag.NArg()`, `flag.Arg()` and `flag.Args()` at all, replacing the parsing with a couple of utilities that then call `flag.Parse()` so that we have a better way to make a command fail if some arguments have been parsed, but the command doesn't expect any argument.

We think that, even if simple, these utilities may be of general usage, so proposing them in dskit.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
