### PR TITLE
Fix issue where successful streaming requests are not always captured in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,4 +147,4 @@
 * [BUGFIX] grpcclient: fix missing `.` in flag name for initial connection window size flag. #314
 * [BUGFIX] ring.Lifecycler: Handle when previous ring state is leaving and the number of tokens has changed. #79
 * [BUGFIX] memberlist metrics: fix registration of `memberlist_client_kv_store_count` metric and disable expiration of metrics exposed by memberlist library. #327
-* [BUGFIX] middleware: fix issue where successful streaming requests are not always captured in metrics. #344
+* [BUGFIX] middleware: fix issue where successful gRPC streaming requests are not always captured in metrics. #344

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,3 +147,4 @@
 * [BUGFIX] grpcclient: fix missing `.` in flag name for initial connection window size flag. #314
 * [BUGFIX] ring.Lifecycler: Handle when previous ring state is leaving and the number of tokens has changed. #79
 * [BUGFIX] memberlist metrics: fix registration of `memberlist_client_kv_store_count` metric and disable expiration of metrics exposed by memberlist library. #327
+* [BUGFIX] middleware: fix issue where successful streaming requests are not always captured in metrics. #344

--- a/middleware/grpc_instrumentation.go
+++ b/middleware/grpc_instrumentation.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	grpcUtils "github.com/grafana/dskit/grpcutil"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/instrument"
 )
@@ -24,7 +25,7 @@ func observe(ctx context.Context, hist *prometheus.HistogramVec, method string, 
 	if err != nil {
 		if errResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
 			respStatus = strconv.Itoa(int(errResp.Code))
-		} else if grpcUtils.IsCanceled(err) {
+		} else if grpcutil.IsCanceled(err) {
 			respStatus = "cancel"
 		} else {
 			respStatus = "error"
@@ -70,20 +71,50 @@ func StreamClientInstrumentInterceptor(metric *prometheus.HistogramVec) grpc.Str
 	) (grpc.ClientStream, error) {
 		start := time.Now()
 		stream, err := streamer(ctx, desc, cc, method, opts...)
-		return &instrumentedClientStream{
-			metric:       metric,
-			start:        start,
-			method:       method,
-			ClientStream: stream,
-		}, err
+		s := &instrumentedClientStream{
+			metric:        metric,
+			start:         start,
+			method:        method,
+			serverStreams: desc.ServerStreams,
+			finished:      atomic.NewBool(false),
+			finishedChan:  make(chan struct{}),
+			ClientStream:  stream,
+		}
+		s.awaitCompletion(ctx)
+		return s, err
 	}
 }
 
+// This implementation is heavily inspired by github.com/opentracing-contrib/go-grpc's openTracingClientStream.
 type instrumentedClientStream struct {
-	metric *prometheus.HistogramVec
-	start  time.Time
-	method string
+	metric        *prometheus.HistogramVec
+	start         time.Time
+	method        string
+	serverStreams bool
+	finished      *atomic.Bool
+	finishedChan  chan struct{}
 	grpc.ClientStream
+}
+
+func (s *instrumentedClientStream) awaitCompletion(ctx context.Context) {
+	go func() {
+		select {
+		case <-s.finishedChan:
+			// Stream has finished for another reason, nothing more to do.
+		case <-ctx.Done():
+			s.finish(ctx.Err())
+		}
+	}()
+}
+
+func (s *instrumentedClientStream) finish(err error) {
+	if !s.finished.CompareAndSwap(false, true) {
+		return
+	}
+
+	close(s.finishedChan)
+
+	s.metric.WithLabelValues(s.method, errorCode(err)).Observe(time.Since(s.start).Seconds())
 }
 
 func (s *instrumentedClientStream) SendMsg(m interface{}) error {
@@ -92,25 +123,25 @@ func (s *instrumentedClientStream) SendMsg(m interface{}) error {
 		return nil
 	}
 
-	if err == io.EOF {
-		s.metric.WithLabelValues(s.method, errorCode(nil)).Observe(time.Since(s.start).Seconds())
-	} else {
-		s.metric.WithLabelValues(s.method, errorCode(err)).Observe(time.Since(s.start).Seconds())
-	}
-
+	s.finish(err)
 	return err
 }
 
 func (s *instrumentedClientStream) RecvMsg(m interface{}) error {
 	err := s.ClientStream.RecvMsg(m)
+	if !s.serverStreams {
+		// Unary server: this is the only message we'll receive, so the stream has ended.
+		s.finish(err)
+	}
+
 	if err == nil {
 		return nil
 	}
 
 	if err == io.EOF {
-		s.metric.WithLabelValues(s.method, errorCode(nil)).Observe(time.Since(s.start).Seconds())
+		s.finish(nil)
 	} else {
-		s.metric.WithLabelValues(s.method, errorCode(err)).Observe(time.Since(s.start).Seconds())
+		s.finish(err)
 	}
 
 	return err
@@ -119,9 +150,17 @@ func (s *instrumentedClientStream) RecvMsg(m interface{}) error {
 func (s *instrumentedClientStream) Header() (metadata.MD, error) {
 	md, err := s.ClientStream.Header()
 	if err != nil {
-		s.metric.WithLabelValues(s.method, errorCode(err)).Observe(time.Since(s.start).Seconds())
+		s.finish(err)
 	}
 	return md, err
+}
+
+func (s *instrumentedClientStream) CloseSend() error {
+	err := s.ClientStream.CloseSend()
+	if err != nil {
+		s.finish(err)
+	}
+	return err
 }
 
 // errorCode converts an error into an error code string.
@@ -133,7 +172,7 @@ func errorCode(err error) string {
 	if errResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
 		statusFamily := int(errResp.Code / 100)
 		return strconv.Itoa(statusFamily) + "xx"
-	} else if grpcUtils.IsCanceled(err) {
+	} else if grpcutil.IsCanceled(err) {
 		return "cancel"
 	} else {
 		return "error"

--- a/middleware/grpc_instrumentation.go
+++ b/middleware/grpc_instrumentation.go
@@ -132,6 +132,7 @@ func (s *instrumentedClientStream) RecvMsg(m interface{}) error {
 	if !s.serverStreams {
 		// Unary server: this is the only message we'll receive, so the stream has ended.
 		s.finish(err)
+		return err
 	}
 
 	if err == nil {

--- a/middleware/grpc_instrumentation.go
+++ b/middleware/grpc_instrumentation.go
@@ -127,8 +127,9 @@ func (s *instrumentedClientStream) finish(err error) {
 
 func (s *instrumentedClientStream) SendMsg(m interface{}) error {
 	err := s.stream.SendMsg(m)
-	if err == nil {
-		return nil
+	if err == nil || err == io.EOF {
+		// If SendMsg returns io.EOF, the true error is available from RecvMsg, so we shouldn't consider the stream failed at this point.
+		return err
 	}
 
 	s.finish(err)

--- a/middleware/grpc_instrumentation_test.go
+++ b/middleware/grpc_instrumentation_test.go
@@ -5,11 +5,23 @@
 package middleware
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/dskit/httpgrpc"
@@ -42,4 +54,261 @@ func TestErrorCode_Unknown(t *testing.T) {
 	err := status.Errorf(codes.Unknown, "Fail")
 	a := errorCode(err)
 	assert.Equal(t, "error", a)
+}
+
+func setUpStreamClientInstrumentInterceptorTest(t *testing.T, serverStreams bool) (grpc.ClientStream, *mockGrpcStream, context.CancelFunc, *prometheus.Registry) {
+	reg := prometheus.NewPedanticRegistry()
+	metric := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name: "client_request_duration_seconds",
+	}, []string{"method", "result"})
+
+	interceptor := StreamClientInstrumentInterceptor(metric)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	t.Cleanup(cancelCtx)
+
+	mockStream := &mockGrpcStream{}
+	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return mockStream, nil
+	}
+	desc := &grpc.StreamDesc{ServerStreams: serverStreams}
+	stream, err := interceptor(ctx, desc, nil, "/thing.Server/DoThing", streamer)
+	require.NoError(t, err)
+
+	return stream, mockStream, cancelCtx, reg
+}
+
+func TestStreamClientInstrumentInterceptor_SendMsg(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	err := stream.SendMsg("message 1")
+	require.NoError(t, err)
+	requireNoRequestMetrics(t, reg)
+
+	mockStream.sendMsgError = errors.New("something went wrong")
+	err = stream.SendMsg("message 2")
+	require.Equal(t, mockStream.sendMsgError, err)
+	requireRequestMetrics(t, reg, "error", 1)
+
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+}
+
+func TestStreamClientInstrumentInterceptor_RecvMsg(t *testing.T) {
+	t.Run("server is streaming", func(t *testing.T) {
+		t.Run("RecvMsg returns an EOF", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+			err := stream.RecvMsg(nil)
+			require.NoError(t, err)
+			requireNoRequestMetrics(t, reg)
+
+			mockStream.recvMsgError = io.EOF
+			err = stream.RecvMsg(nil)
+			require.Equal(t, mockStream.recvMsgError, err)
+			requireRequestMetrics(t, reg, "2xx", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "2xx")
+		})
+
+		t.Run("RecvMsg returns an error", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+			err := stream.RecvMsg(nil)
+			require.NoError(t, err)
+			requireNoRequestMetrics(t, reg)
+
+			mockStream.recvMsgError = errors.New("something went wrong")
+			err = stream.RecvMsg(nil)
+			require.Equal(t, mockStream.recvMsgError, err)
+			requireRequestMetrics(t, reg, "error", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+		})
+	})
+
+	t.Run("server is unary", func(t *testing.T) {
+		t.Run("RecvMsg does not return an error", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, false)
+
+			err := stream.RecvMsg(nil)
+			require.NoError(t, err)
+			requireRequestMetrics(t, reg, "2xx", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "2xx")
+		})
+
+		t.Run("RecvMsg returns an error", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, false)
+
+			mockStream.recvMsgError = errors.New("something went wrong")
+			err := stream.RecvMsg(nil)
+			require.Equal(t, mockStream.recvMsgError, err)
+			requireRequestMetrics(t, reg, "error", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+		})
+	})
+}
+
+func TestStreamClientInstrumentInterceptor_Header(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	_, err := stream.Header()
+	require.NoError(t, err)
+	requireNoRequestMetrics(t, reg)
+
+	mockStream.headerError = errors.New("something went wrong")
+	_, err = stream.Header()
+	require.Equal(t, mockStream.headerError, err)
+	requireRequestMetrics(t, reg, "error", 1)
+
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+}
+
+func TestStreamClientInstrumentInterceptor_CloseSend(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	err := stream.CloseSend()
+	require.NoError(t, err)
+	requireNoRequestMetrics(t, reg)
+
+	mockStream.closeSendError = errors.New("something went wrong")
+	err = stream.CloseSend()
+	require.Equal(t, mockStream.closeSendError, err)
+	requireRequestMetrics(t, reg, "error", 1)
+
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+}
+
+func TestStreamClientInstrumentInterceptor_ContextCancelled(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	cancelCtx()
+
+	require.Eventually(t, func() bool {
+		return gatherRequestMetrics(t, reg) != ""
+	}, time.Second, 10*time.Millisecond, "gave up waiting for the context cancellation to report metrics")
+
+	requireRequestMetrics(t, reg, "cancel", 1)
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "cancel")
+}
+
+func requireDoesNotIncrementMetricsAfterCompletion(t *testing.T, stream grpc.ClientStream, mockStream *mockGrpcStream, cancelCtx context.CancelFunc, reg *prometheus.Registry, result string) {
+	// Should not increment metric, even if Header now returns an error.
+	mockStream.headerError = errors.New("calling Header() failed")
+	_, err := stream.Header()
+	require.Equal(t, mockStream.headerError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if SendMsg now returns an error
+	mockStream.sendMsgError = errors.New("calling SendMsg() failed")
+	err = stream.SendMsg("one last message")
+	require.Equal(t, mockStream.sendMsgError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if RecvMsg now returns an error
+	mockStream.recvMsgError = errors.New("calling RecvMsg() failed")
+	err = stream.RecvMsg(nil)
+	require.Equal(t, mockStream.recvMsgError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if RecvMsg now returns EOF
+	mockStream.recvMsgError = io.EOF
+	err = stream.RecvMsg(nil)
+	require.Equal(t, mockStream.recvMsgError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if CloseSend now returns an error
+	mockStream.closeSendError = errors.New("calling CloseSend() failed")
+	err = stream.CloseSend()
+	require.Equal(t, mockStream.closeSendError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if the context is cancelled
+	cancelCtx()
+	requireRequestMetrics(t, reg, result, 1)
+}
+
+func requireNoRequestMetrics(t *testing.T, g prometheus.Gatherer) {
+	actual := gatherRequestMetrics(t, g)
+	require.Empty(t, actual, "expected no request metrics to be reported")
+}
+
+func requireRequestMetrics(t *testing.T, g prometheus.Gatherer, result string, count int) {
+	expected := fmt.Sprintf(`client_request_duration_seconds_count{method="/thing.Server/DoThing", result="%v"} %v`, result, count)
+	actual := gatherRequestMetrics(t, g)
+
+	require.Equalf(t, expected, actual, "expected count of %v for requests with result '%v'", count, result)
+}
+
+func gatherRequestMetrics(t *testing.T, g prometheus.Gatherer) string {
+	got, err := g.Gather()
+	require.NoError(t, err)
+
+	actual := ""
+
+	for _, mf := range got {
+		require.Equal(t, "client_request_duration_seconds", *mf.Name)
+
+		for _, m := range mf.Metric {
+			require.NotNil(t, m.Histogram)
+			actual += fmt.Sprintf(`%v_count%v %v`, *mf.Name, formatLabelPairs(m.Label), *m.Histogram.SampleCount)
+		}
+	}
+
+	return actual
+}
+
+func formatLabelPairs(pairs []*io_prometheus_client.LabelPair) string {
+	if len(pairs) == 0 {
+		return ""
+	}
+
+	b := strings.Builder{}
+	b.WriteString("{")
+
+	for i, p := range pairs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+
+		b.WriteString(*p.Name)
+		b.WriteString(`="`)
+		b.WriteString(*p.Value)
+		b.WriteString(`"`)
+	}
+
+	b.WriteString("}")
+
+	return b.String()
+}
+
+type mockGrpcStream struct {
+	recvMsgError   error
+	sendMsgError   error
+	headerError    error
+	closeSendError error
+}
+
+func (m *mockGrpcStream) Header() (metadata.MD, error) {
+	return nil, m.headerError
+}
+
+func (m *mockGrpcStream) Trailer() metadata.MD {
+	return nil
+}
+
+func (m *mockGrpcStream) CloseSend() error {
+	return m.closeSendError
+}
+
+func (m *mockGrpcStream) Context() context.Context {
+	return nil
+}
+
+func (m *mockGrpcStream) SendMsg(interface{}) error {
+	return m.sendMsgError
+}
+
+func (m *mockGrpcStream) RecvMsg(interface{}) error {
+	return m.recvMsgError
 }

--- a/middleware/grpc_instrumentation_test.go
+++ b/middleware/grpc_instrumentation_test.go
@@ -84,8 +84,13 @@ func TestStreamClientInstrumentInterceptor_SendMsg(t *testing.T) {
 	require.NoError(t, err)
 	requireNoRequestMetrics(t, reg)
 
-	mockStream.sendMsgError = errors.New("something went wrong")
+	mockStream.sendMsgError = io.EOF
 	err = stream.SendMsg("message 2")
+	require.Equal(t, io.EOF, err)
+	requireNoRequestMetrics(t, reg) // If SendMsg returns io.EOF, the true error is available from RecvMsg, so we shouldn't consider the stream failed at this point.
+
+	mockStream.sendMsgError = errors.New("something went wrong")
+	err = stream.SendMsg("message 3")
 	require.Equal(t, mockStream.sendMsgError, err)
 	requireRequestMetrics(t, reg, "error", 1)
 

--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -52,11 +52,11 @@ func TestGrpcStats(t *testing.T) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
+	grpc_health_v1.RegisterHealthServer(serv, health.NewServer())
+
 	go func() {
 		require.NoError(t, serv.Serve(listener))
 	}()
-
-	grpc_health_v1.RegisterHealthServer(serv, health.NewServer())
 
 	closed := false
 	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -143,11 +143,11 @@ func TestGrpcStatsStreaming(t *testing.T) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
+	middleware_test.RegisterEchoServerServer(serv, &halfEcho{log: t.Log})
+
 	go func() {
 		require.NoError(t, serv.Serve(listener))
 	}()
-
-	middleware_test.RegisterEchoServerServer(serv, &halfEcho{log: t.Log})
 
 	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10e6), grpc.MaxCallSendMsgSize(10e6)))
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:

According to https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream, it's safe to not call `Recv()` on a `grpc.ClientStream` until it's exhausted if you clean up the stream in other ways:

> To ensure resources are not leaked due to the stream returned, one of the following actions must be performed:
> 
> 1. Call Close on the ClientConn.
> 2. Cancel the context provided.
> 3. Call RecvMsg until a non-nil error is returned. A protobuf-generated client-streaming RPC, for instance, might use the helper function CloseAndRecv (note that CloseSend does not Recv, therefore is not guaranteed to release all resources).
> 4. Receive a non-nil, non-io.EOF error from Header or SendMsg.

However, the current implementation of `instrumentedClientStream` does not correctly handle choices 1 and 2: if the `ClientConn` is closed and no further action is taken with the stream, or if the context provided is cancelled, metrics for the request are not recorded.

This PR addresses this issue for choice 2 (context cancellation). The fix is inspired by `opentracing-contrib/go-grpc`'s equivalent implementation: [source](https://github.com/opentracing-contrib/go-grpc/blob/master/client.go)

Fixing the issue for choice 1 (calling `Close` on `ClientConn`) is more involved, so in the interests of keeping this PR small, I've chosen to focus on just the context cancellation case here.

This PR also fixes a flaky test.

This was originally raised as https://github.com/weaveworks/common/pull/295.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
