### PR TITLE
server: correctly route PATCH requests when using RouteHTTPToGRPC

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -259,7 +259,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	if cfg.RouteHTTPToGRPC {
 		grpchttpmux = cmux.New(httpListener)
 
-		httpListener = grpchttpmux.Match(cmux.HTTP1Fast())
+		httpListener = grpchttpmux.Match(cmux.HTTP1Fast("PATCH"))
 		grpcOnHTTPListener = grpchttpmux.Match(cmux.HTTP2())
 	}
 


### PR DESCRIPTION
**What this PR does**:

Tempo relies on the `RouteHTTPToGRPC` option in `server` to handle HTTP and gRPC requests from a single endpoint. This options configures a multiplexer ([soheilhy/cmux](https://github.com/soheilhy/cmux)) to match and route HTTP and gRPC requests to their respective listener.

For HTTP matching it uses `cmux.HTTP1Fast` which matches the method of the request with a predefined set of methods. This change adds `PATCH` to the list to ensure PATCH requests are also sent to the HTTP listener.

More details here: https://github.com/grafana/tempo/issues/2756
For context, this configuration option was added a couple of months ago to support Tempo: https://github.com/weaveworks/common/pull/288

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/2756

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
