### PR TITLE
Change init of consul client to respect TLS

### DIFF
--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"time"
 
 	"github.com/go-kit/log"
@@ -84,16 +83,16 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 
 // NewClient returns a new Client.
 func NewClient(cfg Config, codec codec.Codec, logger log.Logger, registerer prometheus.Registerer) (*Client, error) {
-	client, err := consul.NewClient(&consul.Config{
-		Address: cfg.Host,
-		Token:   cfg.ACLToken.String(),
-		Scheme:  "http",
-		HttpClient: &http.Client{
-			Transport: cleanhttp.DefaultPooledTransport(),
-			// See https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
-			Timeout: cfg.HTTPClientTimeout,
-		},
-	})
+	config := &consul.Config{
+		Address:   cfg.Host,
+		Token:     cfg.ACLToken.String(),
+		Scheme:    "http",
+		Transport: cleanhttp.DefaultPooledTransport(),
+	}
+	client, err := consul.NewClient(config)
+	// See https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
+	config.HttpClient.Timeout = cfg.HTTPClientTimeout
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

This PR changes the initialisation of the consul client.

As during the creation of a new consul client a lot of environment variables are taken as fallback default configs, passing in a own HttpClient prevents on picking the consul specific TLS environment variables.

Instead of passing in the complete new HttpClient it only passes the transport and sets the timeout on the HttpClient afterwards


Fixes #346

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
