### PR TITLE
[Chore] Updated minimum required Go version to 1.19 to ensure compatibility with OpenTelemetry version 1.14.0

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,5 +1,4 @@
 local supported_golang_versions = [
-  '1.18.4',
   '1.19.3',
   '1.20.4',
 ];

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -27,16 +27,6 @@
          "depends_on": [
             "make-lint"
          ],
-         "image": "golang:1.18.4",
-         "name": "make-test (go 1.18.4)"
-      },
-      {
-         "commands": [
-            "make test"
-         ],
-         "depends_on": [
-            "make-lint"
-         ],
          "image": "golang:1.19.3",
          "name": "make-test (go 1.19.3)"
       },
@@ -66,6 +56,6 @@
 }
 ---
 kind: signature
-hmac: ba2e91169a3cbf382b561c4dacfb5919852c86b5af7614d9621f260228164234
+hmac: ee344abb0ee88da8a963ac73a95cbdb417f8612b23e6d329cb5ab55da16a6a46
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Updated the minimum required Go version to 1.19 to ensure compatibility with OpenTelemetry version 1.14.0. #350
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178
 * [CHANGE] Flagext: `DayValue` now always uses UTC when parsing or displaying dates. #71

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/dskit
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -154,7 +154,7 @@ func NewClient(address string) (*Client, error) {
 
 // HTTPRequest wraps an ordinary HTTPRequest with a gRPC one
 func HTTPRequest(r *http.Request) (*httpgrpc.HTTPRequest, error) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Because of opentelemetry 1.14.0, we need to update minimum go version to 1.19, related [PR](https://github.com/grafana/dskit/pull/345)
**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
