### PR TITLE
Test against Go 1.21 on CI

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,6 +1,7 @@
 local supported_golang_versions = [
   '1.19.3',
   '1.20.4',
+  '1.21.0',
 ];
 
 local images = {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -7,7 +7,7 @@
          "commands": [
             "make mod-check"
          ],
-         "image": "golang:1.20.4",
+         "image": "golang:1.21.0",
          "name": "make-mod-check"
       },
       {
@@ -17,7 +17,7 @@
          "depends_on": [
             "make-mod-check"
          ],
-         "image": "golang:1.20.4",
+         "image": "golang:1.21.0",
          "name": "make-lint"
       },
       {
@@ -42,6 +42,16 @@
       },
       {
          "commands": [
+            "make test"
+         ],
+         "depends_on": [
+            "make-lint"
+         ],
+         "image": "golang:1.21.0",
+         "name": "make-test (go 1.21.0)"
+      },
+      {
+         "commands": [
             "apt-get update && apt-get -y install unzip",
             "go mod vendor",
             "make check-protos"
@@ -49,13 +59,13 @@
          "depends_on": [
             "make-mod-check"
          ],
-         "image": "golang:1.20.4",
+         "image": "golang:1.21.0",
          "name": "make-check-protos"
       }
    ]
 }
 ---
 kind: signature
-hmac: ee344abb0ee88da8a963ac73a95cbdb417f8612b23e6d329cb5ab55da16a6a46
+hmac: cc85df30ab5ea7fb028057d36dec2fb6676df9343afbac6bdc9ea99b2c913b74
 
 ...

--- a/crypto/tls/test/tls_integration_go_1_20_test.go
+++ b/crypto/tls/test/tls_integration_go_1_20_test.go
@@ -1,0 +1,6 @@
+//go:build !go1.21
+
+package test
+
+// The error message changed in Go 1.21.
+const badCertificateErrorMessage = "remote error: tls: bad certificate"

--- a/crypto/tls/test/tls_integration_go_1_21_test.go
+++ b/crypto/tls/test/tls_integration_go_1_21_test.go
@@ -1,0 +1,6 @@
+//go:build go1.21
+
+package test
+
+// The error message changed in Go 1.21.
+const badCertificateErrorMessage = "remote error: tls: certificate required"

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -355,7 +355,7 @@ func TestTLSServerWithLocalhostCertWithClientCertificateEnforcementUsingClientCA
 	// TODO: Investigate why we don't really receive the error about the
 	// bad certificate from the server side and just see connection
 	// closed/reset instead
-	badCertErr := errorContainsString("remote error: tls: bad certificate")
+	badCertErr := errorContainsString(badCertificateErrorMessage)
 	newIntegrationClientServer(
 		t,
 		cfg,


### PR DESCRIPTION
**What this PR does**:

This PR adds Go 1.21 to the list of versions used on CI.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
