### PR TITLE
ring: Emit logs and trace events in DoUntilQuorum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 * [ENHANCEMENT] Remove dependency on `github.com/weaveworks/common` package by migrating code to a corresponding package in `github.com/grafana/dskit`. #342
 * [ENHANCEMENT] Add ability to pass TLS certificates and keys inline when configuring server-side TLS. #349
 * [ENHANCEMENT] Migrate `github.com/weaveworks/common/aws` and `github.com/weaveworks/common/test` packages to corresponding packages in `github.com/grafana/dskit`. #356
+* [ENHANCEMENT] Ring: optionally emit logs and trace events in `DoUntilQuorum`. #361
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -5,6 +5,11 @@ import (
 	"errors"
 	"sort"
 	"time"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/dskit/spanlogger"
 )
 
 // ReplicationSet describes the instances to talk to for a given key, and how
@@ -28,9 +33,9 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	// Initialise the result tracker, which is use to keep track of successes and failures.
 	var tracker replicationSetResultTracker
 	if r.MaxUnavailableZones > 0 {
-		tracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones)
+		tracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones, kitlog.NewNopLogger())
 	} else {
-		tracker = newDefaultResultTracker(r.Instances, r.MaxErrors)
+		tracker = newDefaultResultTracker(r.Instances, r.MaxErrors, kitlog.NewNopLogger())
 	}
 
 	var (
@@ -98,6 +103,9 @@ type DoUntilQuorumConfig struct {
 	// If non-zero and MinimizeRequests is true, enables hedging.
 	// See docs for DoUntilQuorum for more information.
 	HedgingDelay time.Duration
+
+	// If non-nil, DoUntilQuorum will emit log lines and span events during the call.
+	Logger *spanlogger.SpanLogger
 }
 
 func (c DoUntilQuorumConfig) Validate() error {
@@ -196,6 +204,11 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 		return nil, err
 	}
 
+	var logger kitlog.Logger = cfg.Logger
+	if cfg.Logger == nil {
+		logger = kitlog.NewNopLogger()
+	}
+
 	resultsChan := make(chan instanceResult[T], len(r.Instances))
 	resultsRemaining := len(r.Instances)
 
@@ -215,10 +228,10 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 	var resultTracker replicationSetResultTracker
 	var contextTracker replicationSetContextTracker
 	if r.MaxUnavailableZones > 0 {
-		resultTracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones)
+		resultTracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones, logger)
 		contextTracker = newZoneAwareContextTracker(ctx, r.Instances)
 	} else {
-		resultTracker = newDefaultResultTracker(r.Instances, r.MaxErrors)
+		resultTracker = newDefaultResultTracker(r.Instances, r.MaxErrors, logger)
 		contextTracker = newDefaultContextTracker(ctx, r.Instances)
 	}
 
@@ -270,6 +283,8 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 	for !resultTracker.succeeded() {
 		select {
 		case <-ctx.Done():
+			level.Debug(logger).Log("msg", "parent context done, returning", "err", ctx.Err())
+
 			// No need to cancel individual instance contexts, as they inherit the cancellation from ctx.
 			cleanupResultsAlreadyReceived()
 
@@ -283,12 +298,20 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 			if result.err == nil {
 				resultsMap[result.instance] = result.result
 			} else if resultTracker.failed() {
+				level.Error(logger).Log("msg", "cancelling all requests because quorum cannot be reached")
+
+				if cfg.Logger != nil {
+					_ = cfg.Logger.Error(result.err)
+				}
+
 				contextTracker.cancelAllContexts()
 				cleanupResultsAlreadyReceived()
 				return nil, result.err
 			}
 		}
 	}
+
+	level.Debug(logger).Log("msg", "quorum reached")
 
 	results := make([]T, 0, len(r.Instances))
 

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -155,7 +155,7 @@ func (t *defaultResultTracker) startMinimumRequests() {
 		if len(t.pendingInstances) < t.maxErrors {
 			t.pendingInstances = append(t.pendingInstances, instance)
 		} else {
-			level.Debug(t.logger).Log("msg", "starting request to instance as part of initial set", "instance", instance.Addr)
+			level.Debug(t.logger).Log("msg", "starting request to instance", "reason", "initial requests", "instance", instance.Addr)
 			t.instanceRelease[instance] <- struct{}{}
 		}
 	}
@@ -175,7 +175,7 @@ func (t *defaultResultTracker) startAdditionalRequestsDueTo(reason string) {
 	if len(t.pendingInstances) > 0 {
 		// There are some outstanding requests we could make before we reach maxErrors. Release the next one.
 		i := t.pendingInstances[0]
-		level.Debug(t.logger).Log("msg", "starting request to instance due to "+reason, "instance", i.Addr)
+		level.Debug(t.logger).Log("msg", "starting request to instance", "reason", reason, "instance", i.Addr)
 		t.instanceRelease[i] <- struct{}{}
 		t.pendingInstances = t.pendingInstances[1:]
 	}
@@ -186,7 +186,7 @@ func (t *defaultResultTracker) startAllRequests() {
 
 	for i := range t.instances {
 		instance := &t.instances[i]
-		level.Debug(t.logger).Log("msg", "starting request to instance as part of initial set", "instance", instance.Addr)
+		level.Debug(t.logger).Log("msg", "starting request to instance", "reason", "initial requests", "instance", instance.Addr)
 		t.instanceRelease[instance] = make(chan struct{}, 1)
 		t.instanceRelease[instance] <- struct{}{}
 	}
@@ -341,7 +341,7 @@ func (t *zoneAwareResultTracker) startMinimumRequests() {
 	})
 
 	for i := 0; i < t.minSuccessfulZones; i++ {
-		level.Debug(t.logger).Log("msg", "starting requests to zone as part of initial set", "zone", allZones[i])
+		level.Debug(t.logger).Log("msg", "starting requests to zone", "reason", "initial requests", "zone", allZones[i])
 		t.releaseZone(allZones[i], true)
 	}
 
@@ -361,7 +361,7 @@ func (t *zoneAwareResultTracker) startAdditionalRequests() {
 func (t *zoneAwareResultTracker) startAdditionalRequestsDueTo(reason string) {
 	if len(t.pendingZones) > 0 {
 		// If there are more zones we could try before reaching maxUnavailableZones, release another zone's requests and signal they should start.
-		level.Debug(t.logger).Log("msg", "starting requests to zone due to "+reason, "zone", t.pendingZones[0])
+		level.Debug(t.logger).Log("msg", "starting requests to zone", "reason", reason, "zone", t.pendingZones[0])
 		t.releaseZone(t.pendingZones[0], true)
 		t.pendingZones = t.pendingZones[1:]
 	}
@@ -371,7 +371,7 @@ func (t *zoneAwareResultTracker) startAllRequests() {
 	t.createReleaseChannels()
 
 	for zone := range t.waitingByZone {
-		level.Debug(t.logger).Log("msg", "starting requests to zone as part of initial set", "zone", zone)
+		level.Debug(t.logger).Log("msg", "starting requests to zone", "reason", "initial requests", "zone", zone)
 		t.releaseZone(zone, true)
 	}
 }

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"math/rand"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"go.uber.org/atomic"
 )
 
@@ -82,19 +84,21 @@ type defaultResultTracker struct {
 	instances        []InstanceDesc
 	instanceRelease  map[*InstanceDesc]chan struct{}
 	pendingInstances []*InstanceDesc
+	logger           log.Logger
 }
 
-func newDefaultResultTracker(instances []InstanceDesc, maxErrors int) *defaultResultTracker {
+func newDefaultResultTracker(instances []InstanceDesc, maxErrors int, logger log.Logger) *defaultResultTracker {
 	return &defaultResultTracker{
 		minSucceeded: len(instances) - maxErrors,
 		numSucceeded: 0,
 		numErrors:    0,
 		maxErrors:    maxErrors,
 		instances:    instances,
+		logger:       logger,
 	}
 }
 
-func (t *defaultResultTracker) done(_ *InstanceDesc, err error) {
+func (t *defaultResultTracker) done(instance *InstanceDesc, err error) {
 	if err == nil {
 		t.numSucceeded++
 
@@ -102,8 +106,14 @@ func (t *defaultResultTracker) done(_ *InstanceDesc, err error) {
 			t.onSucceeded()
 		}
 	} else {
+		level.Warn(t.logger).Log(
+			"msg", "instance failed",
+			"instance", instance.Addr,
+			"err", err,
+		)
+
 		t.numErrors++
-		t.startAdditionalRequests()
+		t.startAdditionalRequestsDueTo("failure of other instance")
 	}
 }
 
@@ -145,6 +155,7 @@ func (t *defaultResultTracker) startMinimumRequests() {
 		if len(t.pendingInstances) < t.maxErrors {
 			t.pendingInstances = append(t.pendingInstances, instance)
 		} else {
+			level.Debug(t.logger).Log("msg", "starting request to instance as part of initial set", "instance", instance.Addr)
 			t.instanceRelease[instance] <- struct{}{}
 		}
 	}
@@ -157,9 +168,14 @@ func (t *defaultResultTracker) startMinimumRequests() {
 }
 
 func (t *defaultResultTracker) startAdditionalRequests() {
+	t.startAdditionalRequestsDueTo("hedging")
+}
+
+func (t *defaultResultTracker) startAdditionalRequestsDueTo(reason string) {
 	if len(t.pendingInstances) > 0 {
 		// There are some outstanding requests we could make before we reach maxErrors. Release the next one.
 		i := t.pendingInstances[0]
+		level.Debug(t.logger).Log("msg", "starting request to instance due to "+reason, "instance", i.Addr)
 		t.instanceRelease[i] <- struct{}{}
 		t.pendingInstances = t.pendingInstances[1:]
 	}
@@ -170,6 +186,7 @@ func (t *defaultResultTracker) startAllRequests() {
 
 	for i := range t.instances {
 		instance := &t.instances[i]
+		level.Debug(t.logger).Log("msg", "starting request to instance as part of initial set", "instance", instance.Addr)
 		t.instanceRelease[instance] = make(chan struct{}, 1)
 		t.instanceRelease[instance] <- struct{}{}
 	}
@@ -230,13 +247,15 @@ type zoneAwareResultTracker struct {
 	zoneRelease         map[string]chan struct{}
 	zoneShouldStart     map[string]*atomic.Bool
 	pendingZones        []string
+	logger              log.Logger
 }
 
-func newZoneAwareResultTracker(instances []InstanceDesc, maxUnavailableZones int) *zoneAwareResultTracker {
+func newZoneAwareResultTracker(instances []InstanceDesc, maxUnavailableZones int, logger log.Logger) *zoneAwareResultTracker {
 	t := &zoneAwareResultTracker{
 		waitingByZone:       make(map[string]int),
 		failuresByZone:      make(map[string]int),
 		maxUnavailableZones: maxUnavailableZones,
+		logger:              logger,
 	}
 
 	for _, instance := range instances {
@@ -263,8 +282,15 @@ func (t *zoneAwareResultTracker) done(instance *InstanceDesc, err error) {
 		t.failuresByZone[instance.Zone]++
 
 		if t.failuresByZone[instance.Zone] == 1 {
+			level.Warn(t.logger).Log(
+				"msg", "zone has failed",
+				"zone", instance.Zone,
+				"failingInstance", instance.Addr,
+				"err", err,
+			)
+
 			// If this was the first failure for this zone, release another zone's requests and signal they should start.
-			t.startAdditionalRequests()
+			t.startAdditionalRequestsDueTo("failure of other zone")
 		}
 	}
 }
@@ -315,6 +341,7 @@ func (t *zoneAwareResultTracker) startMinimumRequests() {
 	})
 
 	for i := 0; i < t.minSuccessfulZones; i++ {
+		level.Debug(t.logger).Log("msg", "starting requests to zone as part of initial set", "zone", allZones[i])
 		t.releaseZone(allZones[i], true)
 	}
 
@@ -328,8 +355,13 @@ func (t *zoneAwareResultTracker) startMinimumRequests() {
 }
 
 func (t *zoneAwareResultTracker) startAdditionalRequests() {
+	t.startAdditionalRequestsDueTo("hedging")
+}
+
+func (t *zoneAwareResultTracker) startAdditionalRequestsDueTo(reason string) {
 	if len(t.pendingZones) > 0 {
 		// If there are more zones we could try before reaching maxUnavailableZones, release another zone's requests and signal they should start.
+		level.Debug(t.logger).Log("msg", "starting requests to zone due to "+reason, "zone", t.pendingZones[0])
 		t.releaseZone(t.pendingZones[0], true)
 		t.pendingZones = t.pendingZones[1:]
 	}
@@ -339,6 +371,7 @@ func (t *zoneAwareResultTracker) startAllRequests() {
 	t.createReleaseChannels()
 
 	for zone := range t.waitingByZone {
+		level.Debug(t.logger).Log("msg", "starting requests to zone as part of initial set", "zone", zone)
 		t.releaseZone(zone, true)
 	}
 }

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -199,7 +199,8 @@ func TestDefaultResultTracker_StartAllRequests(t *testing.T) {
 
 		expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
 			"level":    level.DebugValue(),
-			"msg":      "starting request to instance as part of initial set",
+			"msg":      "starting request to instance",
+			"reason":   "initial requests",
 			"instance": instance.Addr,
 		})
 	}
@@ -256,7 +257,8 @@ func TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.
 		for instance := range instancesAwaitReleaseResults {
 			expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
 				"level":    level.DebugValue(),
-				"msg":      "starting request to instance as part of initial set",
+				"msg":      "starting request to instance",
+				"reason":   "initial requests",
 				"instance": instance.Addr,
 			})
 		}
@@ -350,7 +352,8 @@ func TestDefaultResultTracker_StartMinimumRequests_FailingRequestsBelowMaximumAl
 	for _, instance := range instancesReleased[0:2] {
 		expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
 			"level":    level.DebugValue(),
-			"msg":      "starting request to instance as part of initial set",
+			"msg":      "starting request to instance",
+			"reason":   "initial requests",
 			"instance": instance.Addr,
 		})
 	}
@@ -364,7 +367,8 @@ func TestDefaultResultTracker_StartMinimumRequests_FailingRequestsBelowMaximumAl
 		},
 		map[interface{}]interface{}{
 			"level":    level.DebugValue(),
-			"msg":      "starting request to instance due to failure of other instance",
+			"msg":      "starting request to instance",
+			"reason":   "failure of other instance",
 			"instance": instancesReleased[2].Addr,
 		},
 	)
@@ -541,12 +545,14 @@ func TestDefaultResultTracker_StartAdditionalRequests(t *testing.T) {
 	expectedLogMessages := []map[interface{}]interface{}{
 		{
 			"level":    level.DebugValue(),
-			"msg":      "starting request to instance as part of initial set",
+			"msg":      "starting request to instance",
+			"reason":   "initial requests",
 			"instance": instancesReleased[0].Addr,
 		},
 		{
 			"level":    level.DebugValue(),
-			"msg":      "starting request to instance as part of initial set",
+			"msg":      "starting request to instance",
+			"reason":   "initial requests",
 			"instance": instancesReleased[1].Addr,
 		},
 	}
@@ -556,7 +562,8 @@ func TestDefaultResultTracker_StartAdditionalRequests(t *testing.T) {
 	waitForInstancesReleased(3, "should release a third request after startAdditionalRequests()")
 	expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
 		"level":    level.DebugValue(),
-		"msg":      "starting request to instance due to hedging",
+		"msg":      "starting request to instance",
+		"reason":   "hedging",
 		"instance": instancesReleased[2].Addr,
 	})
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
@@ -565,7 +572,8 @@ func TestDefaultResultTracker_StartAdditionalRequests(t *testing.T) {
 	waitForInstancesReleased(4, "should release remaining request after startAdditionalRequests()")
 	expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
 		"level":    level.DebugValue(),
-		"msg":      "starting request to instance due to hedging",
+		"msg":      "starting request to instance",
+		"reason":   "hedging",
 		"instance": instancesReleased[3].Addr,
 	})
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
@@ -828,9 +836,10 @@ func TestZoneAwareResultTracker_StartAllRequests(t *testing.T) {
 
 	for _, zone := range []string{"zone-a", "zone-b", "zone-c"} {
 		expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-			"level": level.DebugValue(),
-			"msg":   "starting requests to zone as part of initial set",
-			"zone":  zone,
+			"level":  level.DebugValue(),
+			"msg":    "starting requests to zone",
+			"reason": "initial requests",
+			"zone":   zone,
 		})
 	}
 
@@ -891,9 +900,10 @@ func TestZoneAwareResultTracker_StartMinimumRequests_NoFailingRequests(t *testin
 			tracker.done(&instance2, nil)
 
 			expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-				"level": level.DebugValue(),
-				"msg":   "starting requests to zone as part of initial set",
-				"zone":  "zone-a",
+				"level":  level.DebugValue(),
+				"msg":    "starting requests to zone",
+				"reason": "initial requests",
+				"zone":   "zone-a",
 			})
 		}
 
@@ -903,9 +913,10 @@ func TestZoneAwareResultTracker_StartMinimumRequests_NoFailingRequests(t *testin
 			tracker.done(&instance4, nil)
 
 			expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-				"level": level.DebugValue(),
-				"msg":   "starting requests to zone as part of initial set",
-				"zone":  "zone-b",
+				"level":  level.DebugValue(),
+				"msg":    "starting requests to zone",
+				"reason": "initial requests",
+				"zone":   "zone-b",
 			})
 		}
 
@@ -915,9 +926,10 @@ func TestZoneAwareResultTracker_StartMinimumRequests_NoFailingRequests(t *testin
 			tracker.done(&instance6, nil)
 
 			expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-				"level": level.DebugValue(),
-				"msg":   "starting requests to zone as part of initial set",
-				"zone":  "zone-c",
+				"level":  level.DebugValue(),
+				"msg":    "starting requests to zone",
+				"reason": "initial requests",
+				"zone":   "zone-c",
 			})
 		}
 
@@ -986,9 +998,10 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximum
 
 	for _, zone := range uniqueZones(instancesReleased) {
 		expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-			"level": level.DebugValue(),
-			"msg":   "starting requests to zone as part of initial set",
-			"zone":  zone,
+			"level":  level.DebugValue(),
+			"msg":    "starting requests to zone",
+			"reason": "initial requests",
+			"zone":   zone,
 		})
 	}
 
@@ -1015,9 +1028,10 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximum
 			"err":             errors.New("something went wrong"),
 		},
 		map[interface{}]interface{}{
-			"level": level.DebugValue(),
-			"msg":   "starting requests to zone due to failure of other zone",
-			"zone":  instancesReleased[4].Zone,
+			"level":  level.DebugValue(),
+			"msg":    "starting requests to zone",
+			"reason": "failure of other zone",
+			"zone":   instancesReleased[4].Zone,
 		},
 	)
 
@@ -1361,14 +1375,16 @@ func TestZoneAwareResultTracker_StartAdditionalRequests(t *testing.T) {
 	initialZones := uniqueZones(instancesReleased)
 	expectedLogMessages := []map[interface{}]interface{}{
 		{
-			"level": level.DebugValue(),
-			"msg":   "starting requests to zone as part of initial set",
-			"zone":  initialZones[0],
+			"level":  level.DebugValue(),
+			"msg":    "starting requests to zone",
+			"reason": "initial requests",
+			"zone":   initialZones[0],
 		},
 		{
-			"level": level.DebugValue(),
-			"msg":   "starting requests to zone as part of initial set",
-			"zone":  initialZones[1],
+			"level":  level.DebugValue(),
+			"msg":    "starting requests to zone",
+			"reason": "initial requests",
+			"zone":   initialZones[1],
 		},
 	}
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
@@ -1376,18 +1392,20 @@ func TestZoneAwareResultTracker_StartAdditionalRequests(t *testing.T) {
 	tracker.startAdditionalRequests()
 	waitForZonesReleased(3, "should release a third zone after startAdditionalRequests()")
 	expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-		"level": level.DebugValue(),
-		"msg":   "starting requests to zone due to hedging",
-		"zone":  instancesReleased[4].Zone,
+		"level":  level.DebugValue(),
+		"msg":    "starting requests to zone",
+		"reason": "hedging",
+		"zone":   instancesReleased[4].Zone,
 	})
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
 
 	tracker.startAdditionalRequests()
 	waitForZonesReleased(4, "should release remaining zone after startAdditionalRequests()")
 	expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-		"level": level.DebugValue(),
-		"msg":   "starting requests to zone due to hedging",
-		"zone":  instancesReleased[6].Zone,
+		"level":  level.DebugValue(),
+		"msg":    "starting requests to zone",
+		"reason": "hedging",
+		"zone":   instancesReleased[6].Zone,
 	})
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
 }


### PR DESCRIPTION
**What this PR does**:

This PR improves the observability of `DoUntilQuorum` by optionally emitting logs and trace events during execution.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
