### PR TITLE
server: Better document new server.TLSConfig parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@
 * [ENHANCEMENT] Ring: add support for hedging to `DoUntilQuorum` when request minimization is enabled. #330
 * [ENHANCEMENT] Lifecycler: allow instances to register in ascending order of ids in case of spread minimizing token generation strategy. #326
 * [ENHANCEMENT] Remove dependency on `github.com/weaveworks/common` package by migrating code to a corresponding package in `github.com/grafana/dskit`. #342
-* [ENHANCEMENT] Add ability to pass TLS certificates and keys inline when configuring server-side TLS. #349
+* [ENHANCEMENT] Add ability to pass TLS certificates and keys inline when configuring server-side TLS. #349 #363
 * [ENHANCEMENT] Migrate `github.com/weaveworks/common/aws` and `github.com/weaveworks/common/test` packages to corresponding packages in `github.com/grafana/dskit`. #356
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/server/server.go
+++ b/server/server.go
@@ -57,9 +57,9 @@ type SignalHandler interface {
 
 // TLSConfig contains TLS parameters for Config.
 type TLSConfig struct {
-	TLSCert       string        `yaml:"cert"`
-	TLSKey        config.Secret `yaml:"key"`
-	ClientCAsText string        `yaml:"client_ca"`
+	TLSCert       string        `yaml:"cert" doc:"description=Server TLS certificate. This configuration parameter is YAML only."`
+	TLSKey        config.Secret `yaml:"key" doc:"description=Server TLS key. This configuration parameter is YAML only."`
+	ClientCAsText string        `yaml:"client_ca" doc:"description=Root certificate authority used to verify client certificates. This configuration parameter is YAML only."`
 	TLSCertPath   string        `yaml:"cert_file"`
 	TLSKeyPath    string        `yaml:"key_file"`
 	ClientAuth    string        `yaml:"client_auth_type"`


### PR DESCRIPTION
**What this PR does**:
Add custom documentation to new `server.TLSConfig` parameters added in #349 from docs.

See draft Mimir [PR](https://github.com/grafana/mimir/pull/5729), for how the custom documentation takes effect.

Also fixing some flaky server tests.

**Which issue(s) this PR fixes**:

**Checklist**
- [na] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
