### PR TITLE
ring: DoUntilQuorum: cancel context for zone as soon as first failure is encountered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,3 +155,4 @@
 * [BUGFIX] ring.Lifecycler: Handle when previous ring state is leaving and the number of tokens has changed. #79
 * [BUGFIX] memberlist metrics: fix registration of `memberlist_client_kv_store_count` metric and disable expiration of metrics exposed by memberlist library. #327
 * [BUGFIX] middleware: fix issue where successful gRPC streaming requests are not always captured in metrics. #344
+* [BUGFIX] Ring: `DoUntilQuorum` and `DoUntilQuorumWithoutSuccessfulContextCancellation` will now cancel the context for a zone as soon as first failure for that zone is encountered. #364


### PR DESCRIPTION
**What this PR does**:

This PR improves the behaviour of `DoUntilQuorum` (and `DoUntilQuorumWithoutSuccessfulContextCancellation`) when a zone fails.

Previously, if a request to an instance failed and zone awareness was enabled, requests to the remaining instances in the same zone weren't cancelled until quorum was reached.

With this change, requests to all instances in the failing zone will be cancelled as soon as the first error is returned.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
