### PR TITLE
Add `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
 * [ENHANCEMENT] Add ability to pass TLS certificates and keys inline when configuring server-side TLS. #349 #363
 * [ENHANCEMENT] Migrate `github.com/weaveworks/common/aws` and `github.com/weaveworks/common/test` packages to corresponding packages in `github.com/grafana/dskit`. #356
 * [ENHANCEMENT] Ring: optionally emit logs and trace events in `DoUntilQuorum`. #361
+* [ENHANCEMENT] metrics: Add `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods. #366
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -103,6 +103,10 @@ func (mfm MetricFamilyMap) MaxGauges(name string) float64 {
 	return max(mfm[name], gaugeValue)
 }
 
+func (mfm MetricFamilyMap) MinGauges(name string) float64 {
+	return min(mfm[name], gaugeValue)
+}
+
 func (mfm MetricFamilyMap) SumHistograms(name string) HistogramData {
 	hd := HistogramData{}
 	mfm.SumHistogramsTo(name, &hd)
@@ -227,11 +231,14 @@ func (d MetricFamiliesPerTenant) sumOfSingleValuesWithLabels(metric string, fn f
 	return result
 }
 
-func (d MetricFamiliesPerTenant) SendMaxOfGauges(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string) {
+func (d MetricFamiliesPerTenant) foldGauges(out chan<- prometheus.Metric, desc *prometheus.Desc, valFn func(MetricFamilyMap) float64, foldFn func(val, res float64) float64) {
 	result := math.NaN()
 	for _, tenantEntry := range d {
-		if value := tenantEntry.metrics.MaxGauges(gauge); math.IsNaN(result) || value > result {
+		value := valFn(tenantEntry.metrics)
+		if math.IsNaN(result) {
 			result = value
+		} else {
+			result = foldFn(value, result)
 		}
 	}
 
@@ -241,6 +248,25 @@ func (d MetricFamiliesPerTenant) SendMaxOfGauges(out chan<- prometheus.Metric, d
 	}
 
 	out <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, result)
+
+}
+
+func (d MetricFamiliesPerTenant) SendMinOfGauges(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string) {
+	d.foldGauges(out, desc, func(familyMap MetricFamilyMap) float64 { return familyMap.MinGauges(gauge) }, func(val, res float64) float64 {
+		if val < res {
+			return val
+		}
+		return res
+	})
+}
+
+func (d MetricFamiliesPerTenant) SendMaxOfGauges(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string) {
+	d.foldGauges(out, desc, func(familyMap MetricFamilyMap) float64 { return familyMap.MaxGauges(gauge) }, func(val, res float64) float64 {
+		if val > res {
+			return val
+		}
+		return res
+	})
 }
 
 func (d MetricFamiliesPerTenant) SendMaxOfGaugesPerTenant(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string) {
@@ -417,14 +443,38 @@ func sum(mf *dto.MetricFamily, fn func(*dto.Metric) float64) float64 {
 	return result
 }
 
-// max returns the max value from all metrics from same metric family (= series with the same metric name, but different labels)
+// max returns the maximum value from all metrics from same metric family (= series with the same metric name, but different labels)
 // Supplied function extracts value.
 func max(mf *dto.MetricFamily, fn func(*dto.Metric) float64) float64 {
+	return fold(mf, fn, func(val, res float64) float64 {
+		if val > res {
+			return val
+		}
+		return res
+	})
+}
+
+// min returns the minimum value from all metrics from same metric family (= series with the same metric name, but different labels)
+// Supplied function extracts value.
+func min(mf *dto.MetricFamily, fn func(*dto.Metric) float64) float64 {
+	return fold(mf, fn, func(val, res float64) float64 {
+		if val < res {
+			return val
+		}
+		return res
+	})
+}
+
+// fold returns value computed from multiple metrics, using folding function. if there are no metrics, it returns 0.
+func fold(mf *dto.MetricFamily, fn func(*dto.Metric) float64, foldFn func(val, res float64) float64) float64 {
 	result := math.NaN()
 
 	for _, m := range mf.GetMetric() {
-		if value := fn(m); math.IsNaN(result) || value > result {
+		value := fn(m)
+		if math.IsNaN(result) {
 			result = value
+		} else {
+			result = foldFn(value, result)
 		}
 	}
 

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -205,7 +205,7 @@ func TestSendSumOfGaugesPerTenantWithLabels(t *testing.T) {
 	}
 }
 
-func TestSendMaxOfGauges(t *testing.T) {
+func TestSendMinMaxOfGauges(t *testing.T) {
 	user1Reg := prometheus.NewRegistry()
 	user2Reg := prometheus.NewRegistry()
 	desc := prometheus.NewDesc("test_metric", "", nil, nil)
@@ -214,29 +214,54 @@ func TestSendMaxOfGauges(t *testing.T) {
 	regs.AddTenantRegistry("user-2", user2Reg)
 
 	// No matching metric.
-	mf := regs.BuildMetricFamiliesPerTenant()
-	actual := collectMetrics(t, func(out chan prometheus.Metric) {
-		mf.SendMaxOfGauges(out, desc, "test_metric")
+	t.Run("min of no gauges", func(t *testing.T) {
+		mf := regs.BuildMetricFamiliesPerTenant()
+		actual := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendMinOfGauges(out, desc, "test_metric")
+		})
+		expected := []*dto.Metric{
+			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(0)}},
+		}
+		require.ElementsMatch(t, expected, actual)
 	})
-	expected := []*dto.Metric{
-		{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(0)}},
-	}
-	require.ElementsMatch(t, expected, actual)
+
+	t.Run("max of no gauges", func(t *testing.T) {
+		mf := regs.BuildMetricFamiliesPerTenant()
+		actual := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendMaxOfGauges(out, desc, "test_metric")
+		})
+		expected := []*dto.Metric{
+			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(0)}},
+		}
+		require.ElementsMatch(t, expected, actual)
+	})
 
 	// Register a metric for each user.
 	user1Metric := promauto.With(user1Reg).NewGauge(prometheus.GaugeOpts{Name: "test_metric"})
 	user2Metric := promauto.With(user2Reg).NewGauge(prometheus.GaugeOpts{Name: "test_metric"})
 	user1Metric.Set(100)
 	user2Metric.Set(80)
-	mf = regs.BuildMetricFamiliesPerTenant()
+	mf := regs.BuildMetricFamiliesPerTenant()
 
-	actual = collectMetrics(t, func(out chan prometheus.Metric) {
-		mf.SendMaxOfGauges(out, desc, "test_metric")
+	t.Run("min of gauges", func(t *testing.T) {
+		actual := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendMinOfGauges(out, desc, "test_metric")
+		})
+		expected := []*dto.Metric{
+			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(80)}},
+		}
+		require.ElementsMatch(t, expected, actual)
 	})
-	expected = []*dto.Metric{
-		{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(100)}},
-	}
-	require.ElementsMatch(t, expected, actual)
+
+	t.Run("max of gauges", func(t *testing.T) {
+		actual := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendMaxOfGauges(out, desc, "test_metric")
+		})
+		expected := []*dto.Metric{
+			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(100)}},
+		}
+		require.ElementsMatch(t, expected, actual)
+	})
 }
 
 func TestSendSumOfHistogramsWithLabels(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

This PR adds `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods for collecting minimum value across all gauges with given name.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
