### PR TITLE
spanlogger: much more efficient debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@
 * [ENHANCEMENT] Migrate `github.com/weaveworks/common/aws` and `github.com/weaveworks/common/test` packages to corresponding packages in `github.com/grafana/dskit`. #356
 * [ENHANCEMENT] Ring: optionally emit logs and trace events in `DoUntilQuorum`. #361
 * [ENHANCEMENT] metrics: Add `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods. #366
+* [ENHANCEMENT] SpanLogger: much more efficient debug logging. #367
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -2,7 +2,8 @@ package spanlogger
 
 import (
 	"context"
-	"sync/atomic"
+
+	"go.uber.org/atomic" // Really just need sync/atomic but there is a lint rule preventing it.
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -33,9 +33,13 @@ var (
 
 // SpanLogger unifies tracing and logging, to reduce repetition.
 type SpanLogger struct {
-	log.Logger
+	ctx        context.Context // context passed in, with logger
+	resolver   TenantResolver  // passed in
+	baseLogger log.Logger      // passed in
+	logger     log.Logger      // initialized on first use
 	opentracing.Span
-	sampled bool
+	sampled      bool
+	debugEnabled bool
 }
 
 // New makes a new SpanLogger with a log.Logger to send logs to. The provided context will have the logger attached
@@ -45,14 +49,17 @@ func New(ctx context.Context, logger log.Logger, method string, resolver TenantR
 	if ids, err := resolver.TenantIDs(ctx); err == nil && len(ids) > 0 {
 		span.SetTag(TenantIDsTagName, ids)
 	}
-	lwc, sampled := withContext(ctx, logger, resolver)
+	_, sampled := tracing.ExtractSampledTraceID(ctx)
 	l := &SpanLogger{
-		Logger:  log.With(lwc, "method", method),
-		Span:    span,
-		sampled: sampled,
+		ctx:          ctx,
+		resolver:     resolver,
+		baseLogger:   log.With(logger, "method", method),
+		Span:         span,
+		sampled:      sampled,
+		debugEnabled: debugEnabled(logger),
 	}
 	if len(kvps) > 0 {
-		level.Debug(l).Log(kvps...)
+		l.DebugLog(kvps...)
 	}
 
 	ctx = context.WithValue(ctx, loggerCtxKey, logger)
@@ -68,22 +75,57 @@ func FromContext(ctx context.Context, fallback log.Logger, resolver TenantResolv
 	if !ok {
 		logger = fallback
 	}
+	sampled := false
 	sp := opentracing.SpanFromContext(ctx)
 	if sp == nil {
 		sp = opentracing.NoopTracer{}.StartSpan("noop")
+	} else {
+		_, sampled = tracing.ExtractSampledTraceID(ctx)
 	}
-	lwc, sampled := withContext(ctx, logger, resolver)
 	return &SpanLogger{
-		Logger:  lwc,
-		Span:    sp,
-		sampled: sampled,
+		ctx:          ctx,
+		baseLogger:   logger,
+		resolver:     resolver,
+		Span:         sp,
+		sampled:      sampled,
+		debugEnabled: debugEnabled(logger),
 	}
+}
+
+// Detect whether we should output debug logging.
+// false iff the logger says it's not enabled; true if the logger doesn't say.
+func debugEnabled(logger log.Logger) bool {
+	if x, ok := logger.(interface{ DebugEnabled() bool }); ok && !x.DebugEnabled() {
+		return false
+	}
+	return true
 }
 
 // Log implements gokit's Logger interface; sends logs to underlying logger and
 // also puts the on the spans.
 func (s *SpanLogger) Log(kvps ...interface{}) error {
-	s.Logger.Log(kvps...)
+	if s.logger == nil {
+		s.logger = s.makeLogger()
+	}
+	s.logger.Log(kvps...)
+	return s.spanLog(kvps...)
+}
+
+// DebugLog is more efficient than level.Debug().Log().
+func (s *SpanLogger) DebugLog(kvps ...interface{}) error {
+	if s.debugEnabled {
+		if s.logger == nil {
+			s.logger = s.makeLogger()
+		}
+		// The call to Log() through an interface makes its argument escape, so make a copy here,
+		// in the debug-only path, so the function is faster for the non-debug path.
+		localCopy := append([]any{}, kvps...)
+		level.Debug(s.logger).Log(localCopy...)
+	}
+	return s.spanLog(kvps...)
+}
+
+func (s *SpanLogger) spanLog(kvps ...interface{}) error {
 	if !s.sampled {
 		return nil
 	}
@@ -105,16 +147,17 @@ func (s *SpanLogger) Error(err error) error {
 	return err
 }
 
-func withContext(ctx context.Context, logger log.Logger, resolver TenantResolver) (log.Logger, bool) {
-	userID, err := resolver.TenantID(ctx)
+func (s *SpanLogger) makeLogger() log.Logger {
+	logger := s.baseLogger
+	userID, err := s.resolver.TenantID(s.ctx)
 	if err == nil && userID != "" {
 		logger = log.With(logger, "user", userID)
 	}
 
-	traceID, ok := tracing.ExtractSampledTraceID(ctx)
+	traceID, ok := tracing.ExtractSampledTraceID(s.ctx)
 	if !ok {
-		return logger, false
+		return logger
 	}
 
-	return log.With(logger, "traceID", traceID), true
+	return log.With(logger, "traceID", traceID)
 }

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -112,7 +112,8 @@ func (s *SpanLogger) Log(kvps ...interface{}) error {
 }
 
 // DebugLog is more efficient than level.Debug().Log().
-func (s *SpanLogger) DebugLog(kvps ...interface{}) error {
+// Also it swallows the error return because nobody checks for errors on debug logs.
+func (s *SpanLogger) DebugLog(kvps ...interface{}) {
 	if s.debugEnabled {
 		if s.logger == nil {
 			s.logger = s.makeLogger()
@@ -122,7 +123,7 @@ func (s *SpanLogger) DebugLog(kvps ...interface{}) error {
 		localCopy := append([]any{}, kvps...)
 		level.Debug(s.logger).Log(localCopy...)
 	}
-	return s.spanLog(kvps...)
+	_ = s.spanLog(kvps...)
 }
 
 func (s *SpanLogger) spanLog(kvps ...interface{}) error {

--- a/spanlogger/spanlogger_test.go
+++ b/spanlogger/spanlogger_test.go
@@ -126,7 +126,7 @@ func BenchmarkSpanLogger(b *testing.B) {
 	})
 	b.Run("debuglog", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = sl.DebugLog("msg", "foo", "more", "data")
+			sl.DebugLog("msg", "foo", "more", "data")
 		}
 	})
 }

--- a/spanlogger/spanlogger_test.go
+++ b/spanlogger/spanlogger_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/pkg/errors"
@@ -110,11 +111,28 @@ func (r fakeResolver) TenantIDs(ctx context.Context) ([]string, error) {
 
 // Using a no-op logger and no tracing provider, measure the overhead of a small log call.
 func BenchmarkSpanLogger(b *testing.B) {
-	logger := log.NewNopLogger()
+	logger := noDebugNoopLogger{}
 	resolver := fakeResolver{}
 	sl, _ := New(context.Background(), logger, "test", resolver, "bar")
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = sl.Log("msg", "foo", "more", "data")
-	}
+	b.Run("log", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = sl.Log("msg", "foo", "more", "data")
+		}
+	})
+	b.Run("level.debug", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = level.Debug(sl).Log("msg", "foo", "more", "data")
+		}
+	})
+	b.Run("debuglog", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = sl.DebugLog("msg", "foo", "more", "data")
+		}
+	})
 }
+
+// Logger which does nothing and implements the DebugEnabled interface used by SpanLogger.
+type noDebugNoopLogger struct{}
+
+func (noDebugNoopLogger) Log(...interface{}) error { return nil }
+func (noDebugNoopLogger) DebugEnabled() bool       { return false }


### PR DESCRIPTION
**What this PR does**:

Defer creating the logger until we need it, and add a `DebugLog` entrypoint so callers that can say whether debug logging is enabled can avoid it entirely.

Previously `SpanLogger` exposed the `Log` member, so I hope nobody was relying on that.

```
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
BenchmarkSpanLogger/log-4                5158831               290.5 ns/op           160 B/op          2 allocs/op
BenchmarkSpanLogger/level.debug-4        1927003               550.0 ns/op           400 B/op          5 allocs/op
BenchmarkSpanLogger/debuglog-4          125852071                9.472 ns/op           0 B/op          0 allocs/op
```

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
