### PR TITLE
Fix computing of min/max of gauges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,7 @@
 * [ENHANCEMENT] Add ability to pass TLS certificates and keys inline when configuring server-side TLS. #349 #363
 * [ENHANCEMENT] Migrate `github.com/weaveworks/common/aws` and `github.com/weaveworks/common/test` packages to corresponding packages in `github.com/grafana/dskit`. #356
 * [ENHANCEMENT] Ring: optionally emit logs and trace events in `DoUntilQuorum`. #361
-* [ENHANCEMENT] metrics: Add `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods. #366 #368
+* [ENHANCEMENT] metrics: Add `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods. #366
 * [ENHANCEMENT] metrics: add `MatchesLabels`, `FindMetricsInFamilyMatchingLabels` and `FindHistogramWithNameAndLabels` test helper methods. #365
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
@@ -160,4 +160,6 @@
 * [BUGFIX] memberlist metrics: fix registration of `memberlist_client_kv_store_count` metric and disable expiration of metrics exposed by memberlist library. #327
 * [BUGFIX] middleware: fix issue where successful gRPC streaming requests are not always captured in metrics. #344
 * [BUGFIX] Ring: `DoUntilQuorum` and `DoUntilQuorumWithoutSuccessfulContextCancellation` will now cancel the context for a zone as soon as first failure for that zone is encountered. #364
+* [BUGFIX] `MetricFamiliesPerTenant.SendMinOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have positive values only. #368
+* [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have negative values only. #368
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGaugesPerTenant` no longer includes tenants, which do not have specified gauge. #368

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,7 @@
 * [ENHANCEMENT] Add ability to pass TLS certificates and keys inline when configuring server-side TLS. #349 #363
 * [ENHANCEMENT] Migrate `github.com/weaveworks/common/aws` and `github.com/weaveworks/common/test` packages to corresponding packages in `github.com/grafana/dskit`. #356
 * [ENHANCEMENT] Ring: optionally emit logs and trace events in `DoUntilQuorum`. #361
-* [ENHANCEMENT] metrics: Add `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods. #366
+* [ENHANCEMENT] metrics: Add `MetricFamilyMap.MinGauges` and `MetricFamiliesPerTenant.SendMinOfGauges` methods. #366 #368
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109
@@ -159,3 +159,4 @@
 * [BUGFIX] memberlist metrics: fix registration of `memberlist_client_kv_store_count` metric and disable expiration of metrics exposed by memberlist library. #327
 * [BUGFIX] middleware: fix issue where successful gRPC streaming requests are not always captured in metrics. #344
 * [BUGFIX] Ring: `DoUntilQuorum` and `DoUntilQuorumWithoutSuccessfulContextCancellation` will now cancel the context for a zone as soon as first failure for that zone is encountered. #364
+* [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGaugesPerTenant` no longer includes tenants, which do not have specified gauge. #368

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -103,7 +103,7 @@ func (mfm MetricFamilyMap) SumGauges(name string) float64 {
 
 // MaxGauges returns max of gauges or NaN, if no gauge was found.
 func (mfm MetricFamilyMap) MaxGauges(name string) float64 {
-	return fold(mfm[name], gaugeValueNaN, func(val, res float64) float64 {
+	return fold(mfm[name], gaugeValueOrNaN, func(val, res float64) float64 {
 		if val > res {
 			return val
 		}
@@ -113,7 +113,7 @@ func (mfm MetricFamilyMap) MaxGauges(name string) float64 {
 
 // MinGauges returns minimum of gauges or NaN if no gauge was found.
 func (mfm MetricFamilyMap) MinGauges(name string) float64 {
-	return fold(mfm[name], gaugeValueNaN, func(val, res float64) float64 {
+	return fold(mfm[name], gaugeValueOrNaN, func(val, res float64) float64 {
 		if val < res {
 			return val
 		}
@@ -461,7 +461,7 @@ func sum(mf *dto.MetricFamily, fn func(*dto.Metric) float64) float64 {
 	return result
 }
 
-// fold returns value computed from multiple metrics, using folding function. if there are no metrics, it returns 0.
+// fold returns value computed from multiple metrics, using folding function. if there are no metrics, it returns NaN.
 func fold(mf *dto.MetricFamily, fn func(*dto.Metric) float64, foldFn func(val, res float64) float64) float64 {
 	result := math.NaN()
 
@@ -484,8 +484,8 @@ func fold(mf *dto.MetricFamily, fn func(*dto.Metric) float64, foldFn func(val, r
 func counterValue(m *dto.Metric) float64 { return m.GetCounter().GetValue() }
 func gaugeValue(m *dto.Metric) float64   { return m.GetGauge().GetValue() }
 
-// gaugeValueNaN returns Gauge value or math.NaN.
-func gaugeValueNaN(m *dto.Metric) float64 {
+// gaugeValueOrNaN returns Gauge value or math.NaN.
+func gaugeValueOrNaN(m *dto.Metric) float64 {
 	if m == nil || m.Gauge == nil || m.Gauge.Value == nil {
 		return math.NaN()
 	}

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -91,7 +91,7 @@ func NewMetricFamilyMap(metrics []*dto.MetricFamily) (MetricFamilyMap, error) {
 	return perMetricName, nil
 }
 
-// SumCounters returns sum of gauges or 0, if no gauge was found.
+// SumCounters returns sum of counters or 0, if no counter was found.
 func (mfm MetricFamilyMap) SumCounters(name string) float64 {
 	return sum(mfm[name], counterValue)
 }

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -461,12 +461,6 @@ func sum(mf *dto.MetricFamily, fn func(*dto.Metric) float64) float64 {
 	return result
 }
 
-// max returns the maximum value from all metrics from same metric family (= series with the same metric name, but different labels)
-// Supplied function extracts value.
-
-// min returns the minimum value from all metrics from same metric family (= series with the same metric name, but different labels)
-// Supplied function extracts value.
-
 // fold returns value computed from multiple metrics, using folding function. if there are no metrics, it returns 0.
 func fold(mf *dto.MetricFamily, fn func(*dto.Metric) float64, foldFn func(val, res float64) float64) float64 {
 	result := math.NaN()

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -34,20 +35,58 @@ func TestSum(t *testing.T) {
 	}}, counterValue))
 }
 
-func TestMax(t *testing.T) {
-	require.Equal(t, float64(0), max(nil, counterValue))
-	require.Equal(t, float64(0), max(&dto.MetricFamily{Metric: nil}, counterValue))
-	require.Equal(t, float64(0), max(&dto.MetricFamily{Metric: []*dto.Metric{{Counter: &dto.Counter{}}}}, counterValue))
-	require.Equal(t, 12345.6789, max(&dto.MetricFamily{Metric: []*dto.Metric{{Counter: &dto.Counter{Value: proto.Float64(12345.6789)}}}}, counterValue))
-	require.Equal(t, 7890.12345, max(&dto.MetricFamily{Metric: []*dto.Metric{
-		{Counter: &dto.Counter{Value: proto.Float64(1234.56789)}},
-		{Counter: &dto.Counter{Value: proto.Float64(7890.12345)}},
-	}}, counterValue))
-	// using 'counterValue' as function only works on counters
-	require.Equal(t, float64(0), max(&dto.MetricFamily{Metric: []*dto.Metric{
-		{Gauge: &dto.Gauge{Value: proto.Float64(12345.6789)}},
-		{Gauge: &dto.Gauge{Value: proto.Float64(7890.12345)}},
-	}}, counterValue))
+func checkFloats(t *testing.T, exp, val float64) {
+	if math.IsNaN(val) {
+		if !math.IsNaN(exp) {
+			require.Fail(t, "expected %s got NaN", exp)
+		}
+	} else if math.IsNaN(exp) {
+		require.Fail(t, "expected NaN, got %s", val)
+	} else {
+		require.Equal(t, exp, val)
+	}
+}
+
+func TestMinGauges(t *testing.T) {
+	type testcase struct {
+		exp float64
+		mf  MetricFamilyMap
+	}
+
+	for _, tc := range []testcase{
+		{exp: math.NaN(), mf: MetricFamilyMap{}},
+		{exp: math.NaN(), mf: MetricFamilyMap{"metric": nil}},
+		{exp: math.NaN(), mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: nil}}},
+		{exp: math.NaN(), mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: []*dto.Metric{{Gauge: &dto.Gauge{}}}}}},
+		{exp: 12345.6789, mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: proto.Float64(12345.6789)}}}}}},
+		{exp: 1234.56789, mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: []*dto.Metric{
+			{Gauge: &dto.Gauge{Value: proto.Float64(1234.56789)}},
+			{Gauge: &dto.Gauge{Value: proto.Float64(7890.12345)}},
+		}}}},
+	} {
+		checkFloats(t, tc.mf.MinGauges("metric"), tc.exp)
+	}
+}
+
+func TestMaxGauges(t *testing.T) {
+	type testcase struct {
+		exp float64
+		mf  MetricFamilyMap
+	}
+
+	for _, tc := range []testcase{
+		{exp: math.NaN(), mf: MetricFamilyMap{}},
+		{exp: math.NaN(), mf: MetricFamilyMap{"metric": nil}},
+		{exp: math.NaN(), mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: nil}}},
+		{exp: math.NaN(), mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: []*dto.Metric{{Gauge: &dto.Gauge{}}}}}},
+		{exp: 12345.6789, mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: proto.Float64(12345.6789)}}}}}},
+		{exp: 7890.12345, mf: MetricFamilyMap{"metric": &dto.MetricFamily{Metric: []*dto.Metric{
+			{Gauge: &dto.Gauge{Value: proto.Float64(1234.56789)}},
+			{Gauge: &dto.Gauge{Value: proto.Float64(7890.12345)}},
+		}}}},
+	} {
+		checkFloats(t, tc.mf.MaxGauges("metric"), tc.exp)
+	}
 }
 
 func TestCounterValue(t *testing.T) {
@@ -55,6 +94,13 @@ func TestCounterValue(t *testing.T) {
 	require.Equal(t, float64(0), counterValue(&dto.Metric{}))
 	require.Equal(t, float64(0), counterValue(&dto.Metric{Counter: &dto.Counter{}}))
 	require.Equal(t, 543857.12837, counterValue(&dto.Metric{Counter: &dto.Counter{Value: proto.Float64(543857.12837)}}))
+}
+
+func TestGaugeValueNan(t *testing.T) {
+	require.True(t, math.IsNaN(gaugeValueNaN(nil)))
+	require.True(t, math.IsNaN(gaugeValueNaN(&dto.Metric{})))
+	require.True(t, math.IsNaN(gaugeValueNaN(&dto.Metric{Gauge: &dto.Gauge{}})))
+	require.Equal(t, 543857.12837, gaugeValueNaN(&dto.Metric{Gauge: &dto.Gauge{Value: proto.Float64(543857.12837)}}))
 }
 
 func TestGetMetricsWithLabelNames(t *testing.T) {
@@ -205,63 +251,101 @@ func TestSendSumOfGaugesPerTenantWithLabels(t *testing.T) {
 	}
 }
 
+func checkSingleGauge(t *testing.T, actual []*dto.Metric, val float64) {
+	require.Len(t, actual, 1)
+	require.Nil(t, actual[0].Label)
+	g := actual[0].GetGauge()
+	require.NotNil(t, g)
+	require.Equal(t, val, g.GetValue())
+}
+
 func TestSendMinMaxOfGauges(t *testing.T) {
+	const (
+		userLabel = "user"
+		user1     = "user-1"
+		user2     = "user-2"
+	)
+
 	user1Reg := prometheus.NewRegistry()
 	user2Reg := prometheus.NewRegistry()
 	desc := prometheus.NewDesc("test_metric", "", nil, nil)
+	descUser := prometheus.NewDesc("per_tenant", "", []string{userLabel}, nil)
 	regs := NewTenantRegistries(log.NewNopLogger())
-	regs.AddTenantRegistry("user-1", user1Reg)
-	regs.AddTenantRegistry("user-2", user2Reg)
 
-	// No matching metric.
-	t.Run("min of no gauges", func(t *testing.T) {
+	regs.AddTenantRegistry(user1, user1Reg)
+	regs.AddTenantRegistry(user2, user2Reg)
+
+	verifySendMinOfGauges := func(t *testing.T, val float64) {
 		mf := regs.BuildMetricFamiliesPerTenant()
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
 			mf.SendMinOfGauges(out, desc, "test_metric")
 		})
-		expected := []*dto.Metric{
-			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(0)}},
-		}
-		require.ElementsMatch(t, expected, actual)
-	})
+		checkSingleGauge(t, actual, val)
+	}
 
-	t.Run("max of no gauges", func(t *testing.T) {
+	verifySendMaxOfGauges := func(t *testing.T, val float64) {
 		mf := regs.BuildMetricFamiliesPerTenant()
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
 			mf.SendMaxOfGauges(out, desc, "test_metric")
 		})
-		expected := []*dto.Metric{
-			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(0)}},
+		checkSingleGauge(t, actual, val)
+	}
+
+	verifySendMaxOfGaugesPerTenant := func(t *testing.T, perTenantValues map[string]float64) {
+		mf := regs.BuildMetricFamiliesPerTenant()
+		collected := collectMetrics(t, func(out chan prometheus.Metric) {
+			mf.SendMaxOfGaugesPerTenant(out, descUser, "test_metric")
+		})
+
+		require.Len(t, collected, len(perTenantValues))
+		for _, a := range collected {
+			require.Len(t, a.GetLabel(), 1)
+			require.Equal(t, userLabel, a.GetLabel()[0].GetName())
+			tenant := a.GetLabel()[0].GetValue()
+			val, ok := perTenantValues[tenant]
+			require.True(t, ok, "tenant not found in the map: %s", tenant)
+			g := a.GetGauge()
+			require.NotNil(t, g)
+			require.Equal(t, val, g.GetValue())
+
+			delete(perTenantValues, tenant)
 		}
-		require.ElementsMatch(t, expected, actual)
-	})
+
+		require.Len(t, perTenantValues, 0)
+	}
+
+	// No matching metric.
+	verifySendMinOfGauges(t, 0)
+	verifySendMaxOfGauges(t, 0)
+	verifySendMaxOfGaugesPerTenant(t, map[string]float64{})
 
 	// Register a metric for each user.
 	user1Metric := promauto.With(user1Reg).NewGauge(prometheus.GaugeOpts{Name: "test_metric"})
-	user2Metric := promauto.With(user2Reg).NewGauge(prometheus.GaugeOpts{Name: "test_metric"})
 	user1Metric.Set(100)
+
+	verifySendMinOfGauges(t, 100)
+	verifySendMaxOfGauges(t, 100)
+	verifySendMaxOfGaugesPerTenant(t, map[string]float64{user1: 100})
+
+	// Register metric for another user.
+	user2Metric := promauto.With(user2Reg).NewGauge(prometheus.GaugeOpts{Name: "test_metric"})
 	user2Metric.Set(80)
-	mf := regs.BuildMetricFamiliesPerTenant()
 
-	t.Run("min of gauges", func(t *testing.T) {
-		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendMinOfGauges(out, desc, "test_metric")
-		})
-		expected := []*dto.Metric{
-			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(80)}},
-		}
-		require.ElementsMatch(t, expected, actual)
-	})
+	verifySendMinOfGauges(t, 80)
+	verifySendMaxOfGauges(t, 100)
+	verifySendMaxOfGaugesPerTenant(t, map[string]float64{user1: 100, user2: 80})
 
-	t.Run("max of gauges", func(t *testing.T) {
-		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendMaxOfGauges(out, desc, "test_metric")
-		})
-		expected := []*dto.Metric{
-			{Label: nil, Gauge: &dto.Gauge{Value: proto.Float64(100)}},
-		}
-		require.ElementsMatch(t, expected, actual)
-	})
+	// Remove user1.
+	regs.RemoveTenantRegistry(user1, false)
+	verifySendMinOfGauges(t, 80)
+	verifySendMaxOfGauges(t, 80)
+	verifySendMaxOfGaugesPerTenant(t, map[string]float64{user2: 80})
+
+	// Remove second user.
+	regs.RemoveTenantRegistry(user2, false)
+	verifySendMinOfGauges(t, 0)
+	verifySendMaxOfGauges(t, 0)
+	verifySendMaxOfGaugesPerTenant(t, map[string]float64{})
 }
 
 func TestSendSumOfHistogramsWithLabels(t *testing.T) {

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -346,20 +346,20 @@ func TestSendMinMaxOfGauges(t *testing.T) {
 	verifySendMaxOfGauges(t, 100)
 	verifySendMaxOfGaugesPerTenant(t, map[string]float64{user1: 100, user2: 80, user3: -1000})
 
-	// Remove user1.
-	regs.RemoveTenantRegistry(user1, false)
+	// Remove gauge from first user.
+	user1Reg.Unregister(user1Metric)
 	verifySendMinOfGauges(t, -1000)
 	verifySendMaxOfGauges(t, 80)
 	verifySendMaxOfGaugesPerTenant(t, map[string]float64{user2: 80, user3: -1000})
 
-	// Remove second user.
-	regs.RemoveTenantRegistry(user2, false)
+	// Remove gauge from second user.
+	user2Reg.Unregister(user2Metric)
 	verifySendMinOfGauges(t, -1000)
 	verifySendMaxOfGauges(t, -1000)
 	verifySendMaxOfGaugesPerTenant(t, map[string]float64{user3: -1000})
 
-	// Remove third user.
-	regs.RemoveTenantRegistry(user3, false)
+	// Remove gauge from third user.
+	user3Reg.Unregister(user3Metric)
 	verifySendMinOfGauges(t, 0)
 	verifySendMaxOfGauges(t, 0)
 	verifySendMaxOfGaugesPerTenant(t, map[string]float64{})

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -319,7 +319,7 @@ func TestSendMinMaxOfGauges(t *testing.T) {
 	verifySendMaxOfGauges(t, 0)
 	verifySendMaxOfGaugesPerTenant(t, map[string]float64{})
 
-	// Register a metric for each user.
+	// Register a metric for one user.
 	user1Metric := promauto.With(user1Reg).NewGauge(prometheus.GaugeOpts{Name: "test_metric"})
 	user1Metric.Set(100)
 

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -97,10 +97,10 @@ func TestCounterValue(t *testing.T) {
 }
 
 func TestGaugeValueNan(t *testing.T) {
-	require.True(t, math.IsNaN(gaugeValueNaN(nil)))
-	require.True(t, math.IsNaN(gaugeValueNaN(&dto.Metric{})))
-	require.True(t, math.IsNaN(gaugeValueNaN(&dto.Metric{Gauge: &dto.Gauge{}})))
-	require.Equal(t, 543857.12837, gaugeValueNaN(&dto.Metric{Gauge: &dto.Gauge{Value: proto.Float64(543857.12837)}}))
+	require.True(t, math.IsNaN(gaugeValueOrNaN(nil)))
+	require.True(t, math.IsNaN(gaugeValueOrNaN(&dto.Metric{})))
+	require.True(t, math.IsNaN(gaugeValueOrNaN(&dto.Metric{Gauge: &dto.Gauge{}})))
+	require.Equal(t, 543857.12837, gaugeValueOrNaN(&dto.Metric{Gauge: &dto.Gauge{Value: proto.Float64(543857.12837)}}))
 }
 
 func TestGetMetricsWithLabelNames(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

This PR fixes sending of min/max of gauges:

- `MetricFamilyMap.MinGauges`, `MaxGauges` now return `NaN` if no gauge was found. Previously `0` was returned, but that made it difficult to distinguish between missing gauge and gauge with 0 value, and this distinction is important when computing min/max across tenants.
- `MetricFamiliesPerTenant.SendMaxOfGaugesPerTenant` no longer includes tenants, which do not have specified gauge.

- `MetricFamiliesPerTenant.SendMinOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have positive values only.

- `MetricFamiliesPerTenant.SendMaxOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have negative values only.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
