### PR TITLE
Make more tests run in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help: ## Display this help and any documented user-facing targets. Other undocum
 
 .PHONY: test
 test: ## Runs Go tests
-	go test -tags netgo -timeout 30m -race -count 1 ./...
+	go test -tags netgo -timeout 30m -race -count 1 -p 4 ./...
 
 .PHONY: lint
 lint: .tools/bin/misspell .tools/bin/faillint .tools/bin/golangci-lint ## Runs misspell, golangci-lint, and faillint

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help: ## Display this help and any documented user-facing targets. Other undocum
 
 .PHONY: test
 test: ## Runs Go tests
-	go test -tags netgo -timeout 30m -race -count 1 -p 4 ./...
+	go test -tags netgo -timeout 30m -race -count 1 ./...
 
 .PHONY: lint
 lint: .tools/bin/misspell .tools/bin/faillint .tools/bin/golangci-lint ## Runs misspell, golangci-lint, and faillint

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -353,6 +353,8 @@ func TestCASErrorWithRetries(t *testing.T) {
 }
 
 func TestCASNoChange(t *testing.T) {
+	t.Parallel()
+
 	withFixtures(t, func(t *testing.T, kv *Client) {
 		err := cas(kv, key, func(in *data) (*data, bool, error) {
 			if in == nil {
@@ -447,6 +449,8 @@ func TestCASFailedBecauseOfVersionChanges(t *testing.T) {
 }
 
 func TestMultipleCAS(t *testing.T) {
+	t.Parallel()
+
 	c := dataCodec{}
 
 	var cfg KVConfig
@@ -547,6 +551,8 @@ func defaultKVConfig(i int) KVConfig {
 }
 
 func TestMultipleClients(t *testing.T) {
+	t.Parallel()
+
 	members := 10
 
 	err := testMultipleClientsWithConfigGenerator(t, members, defaultKVConfig)
@@ -554,6 +560,8 @@ func TestMultipleClients(t *testing.T) {
 }
 
 func TestMultipleClientsWithMixedLabelsAndExpectFailure(t *testing.T) {
+	t.Parallel()
+
 	// We want 3 members, they will be configured with the following labels:
 	// 1) ""
 	// 2) "label1"
@@ -581,6 +589,8 @@ func TestMultipleClientsWithMixedLabelsAndExpectFailure(t *testing.T) {
 }
 
 func TestMultipleClientsWithMixedLabelsAndClusterLabelVerificationDisabled(t *testing.T) {
+	t.Parallel()
+
 	// We want 3 members, all will have the cluster label verification disabled.
 	// They will be configured with mixed labels, and some without any labels.
 	//
@@ -606,6 +616,8 @@ func TestMultipleClientsWithMixedLabelsAndClusterLabelVerificationDisabled(t *te
 }
 
 func TestMultipleClientsWithSameLabelWithClusterLabelVerification(t *testing.T) {
+	t.Parallel()
+
 	members := 10
 	label := "myTestLabel"
 
@@ -759,6 +771,7 @@ func testMultipleClientsWithConfigGenerator(t *testing.T, members int, configGen
 }
 
 func TestJoinMembersWithRetryBackoff(t *testing.T) {
+
 	c := dataCodec{}
 
 	const members = 3
@@ -787,7 +800,11 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			var clients []*Client
 
 			stop := make(chan struct{})

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -845,6 +845,8 @@ func TestCheckReady_CheckRingHealth(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			ctx := context.Background()
 
 			ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
@@ -1136,6 +1138,8 @@ func TestTokensOnDisk(t *testing.T) {
 }
 
 func TestDeletePersistedTokensOnShutdown(t *testing.T) {
+	t.Parallel()
+
 	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
@@ -1297,6 +1301,8 @@ func TestJoinInJoiningState(t *testing.T) {
 }
 
 func TestWaitBeforeJoining(t *testing.T) {
+	t.Parallel()
+
 	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -844,6 +844,8 @@ func TestCheckReady_CheckRingHealth(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -209,6 +209,8 @@ func TestDefaultResultTracker_StartAllRequests(t *testing.T) {
 }
 
 func TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.T) {
+	t.Parallel()
+
 	instance1 := InstanceDesc{Addr: "127.0.0.1"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3"}
@@ -847,6 +849,8 @@ func TestZoneAwareResultTracker_StartAllRequests(t *testing.T) {
 }
 
 func TestZoneAwareResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.T) {
+	t.Parallel()
+
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instance3 := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-b"}

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1829,7 +1829,11 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 
 	for _, updateOldestRegisteredTimestamp := range []bool{false, true} {
 		for _, numInstances := range numInitialInstances {
+			numInstances := numInstances
+
 			for _, numZones := range numInitialZones {
+				numZones := numZones
+
 				testName := fmt.Sprintf("num instances = %d, num zones = %d, update oldest registered timestamp = %v", numInstances, numZones, updateOldestRegisteredTimestamp)
 
 				t.Run(testName, func(t *testing.T) {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1833,6 +1833,8 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 				testName := fmt.Sprintf("num instances = %d, num zones = %d, update oldest registered timestamp = %v", numInstances, numZones, updateOldestRegisteredTimestamp)
 
 				t.Run(testName, func(t *testing.T) {
+					t.Parallel()
+
 					// Randomise the seed but log it in case we need to reproduce the test on failure.
 					seed := time.Now().UnixNano()
 					rand.Seed(seed)
@@ -1968,6 +1970,8 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 }
 
 func TestRing_ShuffleShardWithLookback_Caching(t *testing.T) {
+	t.Parallel()
+
 	userID := "user-1"
 	otherUserID := "user-2"
 	subringSize := 3
@@ -2674,6 +2678,8 @@ func TestRingUpdates(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			inmem, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
@@ -2767,6 +2773,8 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestRing_ShuffleShard_Caching(t *testing.T) {
+	t.Parallel()
+
 	inmem, closer := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
 		MaxCasRetries: 20,
 		CasRetryDelay: 500 * time.Millisecond,

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2681,6 +2681,8 @@ func TestRingUpdates(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1828,6 +1828,8 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 	)
 
 	for _, updateOldestRegisteredTimestamp := range []bool{false, true} {
+		updateOldestRegisteredTimestamp := updateOldestRegisteredTimestamp
+
 		for _, numInstances := range numInitialInstances {
 			numInstances := numInstances
 

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -324,6 +324,8 @@ func TestSpreadMinimizingTokenGenerator_CalculateNewToken(t *testing.T) {
 }
 
 func TestSpreadMinimizingTokenGenerator_GenerateAllTokensIdempotent(t *testing.T) {
+	t.Parallel()
+
 	maxInstanceID := 128
 	for instanceID := 0; instanceID < maxInstanceID; instanceID++ {
 		for _, zone := range zones {
@@ -351,6 +353,8 @@ func TestSpreadMinimizingTokenGenerator_VerifyTokensByZone(t *testing.T) {
 }
 
 func TestSpreadMinimizingTokenGenerator_VerifyInstanceOwnershipSpreadByZone(t *testing.T) {
+	t.Parallel()
+
 	tokensPerInstance := 512
 	instancesPerZone := 10000
 	instanceByToken, tokensByZone := createTokensForAllInstancesAndZones(t, instancesPerZone, tokensPerInstance)
@@ -370,6 +374,8 @@ func TestSpreadMinimizingTokenGenerator_VerifyInstanceOwnershipSpreadByZone(t *t
 }
 
 func TestSpreadMinimizingTokenGenerator_CheckTokenUniqueness(t *testing.T) {
+	t.Parallel()
+
 	tokensPerInstance := 512
 	instanceID := 10000
 	allTokens := make(map[uint32]bool, tokensPerInstance*(instanceID+1)*len(zones))


### PR DESCRIPTION
**What this PR does**:

This PR speeds up tests in `ring` and `kv/memberlist` packages by making some tests to run in parallel.

Before:

```
ok  	github.com/grafana/dskit/kv/memberlist	102.439s
ok  	github.com/grafana/dskit/ring	622.030s
```

After:

```
ok  	github.com/grafana/dskit/kv/memberlist	36.196s
ok  	github.com/grafana/dskit/ring	250.460s
```

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
