### PR TITLE
gRPC server: add ability to reject methods early, before reading the request into memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 * [FEATURE] Add `flagext.ParseFlagsAndArguments()` and `flagext.ParseFlagsWithoutArguments()` utilities. #341
 * [FEATURE] Add `log.RateLimitedLogger` for limiting the rate of logging. The `logger_rate_limit_discarded_log_lines_total` metrics traces the total number of discarded log lines per level. #352
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
-* [FEATURE] Server: Add inflight requests limit for gRPC server. This can be configured using `-server.grpc.max-inflight-requests` or in runtime by calling `SetGrpcMaxInflightRequests`. Server can also use optional `GrpcMethodLimiter` implementation, which can perform additional checks before gRPC request is accepted. #377
+* [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [FEATURE] Add `flagext.ParseFlagsAndArguments()` and `flagext.ParseFlagsWithoutArguments()` utilities. #341
 * [FEATURE] Add `log.RateLimitedLogger` for limiting the rate of logging. The `logger_rate_limit_discarded_log_lines_total` metrics traces the total number of discarded log lines per level. #352
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
+* [FEATURE] Server: Add inflight requests limit for gRPC server. This can be configured using `-server.grpc.max-inflight-requests` or in runtime by calling `SetGrpcMaxInflightRequests`. Server can also use optional `GrpcMethodLimiter` implementation, which can perform additional checks before gRPC request is accepted. #377
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38

--- a/server/limits.go
+++ b/server/limits.go
@@ -14,12 +14,12 @@ import (
 )
 
 type GrpcMethodLimiter interface {
-	// RpcCallStarting is called before request has been read into memory.
+	// RPCCallStarting is called before request has been read into memory.
 	// All that's known about the request at this point is grpc method name.
 	// Returned error should be convertible to gRPC Status via status.FromError,
 	// otherwise gRPC-server implementation-specific error will be returned to the client (codes.PermissionDenied in grpc@v1.55.0).
-	RpcCallStarting(methodName string) error
-	RpcCallFinished(methodName string)
+	RPCCallStarting(methodName string) error
+	RPCCallFinished(methodName string)
 }
 
 // Custom type to hide it from other packages.
@@ -92,7 +92,7 @@ func (g *grpcLimitCheck) TapHandle(ctx context.Context, info *tap.Info) (context
 	}
 
 	if g.methodLimiter != nil {
-		if err := g.methodLimiter.RpcCallStarting(info.FullMethodName); err != nil {
+		if err := g.methodLimiter.RPCCallStarting(info.FullMethodName); err != nil {
 			return ctx, err
 		}
 	}
@@ -115,7 +115,7 @@ func (g *grpcLimitCheck) HandleRPC(ctx context.Context, rpcStats stats.RPCStats)
 	if name, ok := ctx.Value(requestFullMethod).(string); ok {
 		g.inflight.Dec()
 		if g.methodLimiter != nil {
-			g.methodLimiter.RpcCallFinished(name)
+			g.methodLimiter.RPCCallFinished(name)
 		}
 	}
 }
@@ -135,8 +135,5 @@ func isMethodNameValid(method string) bool {
 		method = method[1:]
 	}
 	pos := strings.LastIndex(method, "/")
-	if pos == -1 {
-		return false
-	}
-	return true
+	return pos >= 0
 }

--- a/server/limits.go
+++ b/server/limits.go
@@ -4,16 +4,11 @@ import (
 	"context"
 	"strings"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"
-	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
 )
 
-type GrpcMethodLimiter interface {
+type GrpcInflightMethodLimiter interface {
 	// RPCCallStarting is called before request has been read into memory.
 	// All that's known about the request at this point is grpc method name.
 	// Returned error should be convertible to gRPC Status via status.FromError,
@@ -28,103 +23,58 @@ type grpcLimitCheckContextKey int
 // Presence of this key in the context indicates that inflight request counter was increased for this request, and needs to be decreased when request ends.
 const (
 	requestFullMethod grpcLimitCheckContextKey = 1
-
-	errTooManyInflightRequestsMsg = "too many inflight requests"
 )
 
-var errTooManyInflightRequests = status.Error(codes.Unavailable, errTooManyInflightRequestsMsg)
-
-func newGrpcLimitCheck(maxInflight int, methodLimiter GrpcMethodLimiter, namespace string, reg prometheus.Registerer) *grpcLimitCheck {
-	c := &grpcLimitCheck{
+func newGrpcInflightLimitCheck(methodLimiter GrpcInflightMethodLimiter) *grpcInflightLimitCheck {
+	return &grpcInflightLimitCheck{
 		methodLimiter: methodLimiter,
 	}
-	c.maxInflight.Store(int64(maxInflight))
-
-	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "grpc_inflight_requests",
-		Help:      "Current number of inflight requests handled by gRPC server.",
-	}, func() float64 {
-		return float64(c.inflight.Load())
-	})
-
-	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "grpc_max_inflight_requests",
-		Help:      "Current limit of inflight requests that gRPC server can handle. 0 means no limit.",
-	}, func() float64 {
-		return float64(c.maxInflight.Load())
-	})
-
-	return c
 }
 
-// grpcLimitCheck implements gRPC TapHandle and gRPC stats.Handler.
-// grpcLimitCheck can track inflight requests, and reject requests before even reading them into memory.
-type grpcLimitCheck struct {
-	methodLimiter GrpcMethodLimiter
-
-	inflight    atomic.Int64
-	maxInflight atomic.Int64
+// grpcInflightLimitCheck implements gRPC TapHandle and gRPC stats.Handler.
+// grpcInflightLimitCheck can track inflight requests, and reject requests before even reading them into memory.
+type grpcInflightLimitCheck struct {
+	methodLimiter GrpcInflightMethodLimiter
 }
 
 // TapHandle is called after receiving grpc request and headers, but before reading any request data yet.
 // If we reject request here, it won't be counted towards any metrics (eg. in middleware.grpcStatsHandler).
 // If we accept request (not return error), eventually HandleRPC with stats.End notification will be called.
-func (g *grpcLimitCheck) TapHandle(ctx context.Context, info *tap.Info) (context.Context, error) {
-	v := g.inflight.Inc()
-	decreaseInflightInDefer := true
-	defer func() {
-		if decreaseInflightInDefer {
-			g.inflight.Dec()
-		}
-	}()
-
+func (g *grpcInflightLimitCheck) TapHandle(ctx context.Context, info *tap.Info) (context.Context, error) {
 	if !isMethodNameValid(info.FullMethodName) {
-		// If method name is not valid, we let the request continue, but decrease inflight requests.
-		// Otherwise, we would not have an option to decrease it later, because in this case grpc server will not call stat handler when request finishes.
+		// If method name is not valid, we let the request continue, but not call method limiter.
+		// Otherwise, we would not be able to call method limiter again when the call finishes, because in this case grpc server will not call stat handler.
 		return ctx, nil
 	}
 
-	l := g.maxInflight.Load()
-	if l > 0 && v > l {
-		return ctx, errTooManyInflightRequests
+	if err := g.methodLimiter.RPCCallStarting(info.FullMethodName); err != nil {
+		return ctx, err
 	}
 
-	if g.methodLimiter != nil {
-		if err := g.methodLimiter.RPCCallStarting(info.FullMethodName); err != nil {
-			return ctx, err
-		}
-	}
-
-	decreaseInflightInDefer = false
 	ctx = context.WithValue(ctx, requestFullMethod, info.FullMethodName)
 	return ctx, nil
 }
 
-func (g *grpcLimitCheck) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+func (g *grpcInflightLimitCheck) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
 	return ctx
 }
 
-func (g *grpcLimitCheck) HandleRPC(ctx context.Context, rpcStats stats.RPCStats) {
+func (g *grpcInflightLimitCheck) HandleRPC(ctx context.Context, rpcStats stats.RPCStats) {
 	// when request ends, and we started "inflight" request tracking for it, finish it.
 	if _, ok := rpcStats.(*stats.End); !ok {
 		return
 	}
 
 	if name, ok := ctx.Value(requestFullMethod).(string); ok {
-		g.inflight.Dec()
-		if g.methodLimiter != nil {
-			g.methodLimiter.RPCCallFinished(name)
-		}
+		g.methodLimiter.RPCCallFinished(name)
 	}
 }
 
-func (g *grpcLimitCheck) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+func (g *grpcInflightLimitCheck) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
 	return ctx
 }
 
-func (g *grpcLimitCheck) HandleConn(_ context.Context, _ stats.ConnStats) {
+func (g *grpcInflightLimitCheck) HandleConn(_ context.Context, _ stats.ConnStats) {
 	// Not interested.
 }
 

--- a/server/limits.go
+++ b/server/limits.go
@@ -102,7 +102,7 @@ func (g *grpcLimitCheck) TapHandle(ctx context.Context, info *tap.Info) (context
 	return ctx, nil
 }
 
-func (g *grpcLimitCheck) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+func (g *grpcLimitCheck) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
 	return ctx
 }
 

--- a/server/limits.go
+++ b/server/limits.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/tap"
+)
+
+type GrpcMethodLimiter interface {
+	// RpcCallStarting is called before request has been read into memory.
+	// All that's known about the request at this point is grpc method name.
+	// Returned error should be convertible to gRPC Status via status.FromError,
+	// otherwise gRPC-server implementation-specific error will be returned to the client (codes.PermissionDenied in grpc@v1.55.0).
+	RpcCallStarting(methodName string) error
+	RpcCallFinished(methodName string)
+}
+
+// Custom type to hide it from other packages.
+type grpcLimitCheckContextKey int
+
+// Presence of this key in the context indicates that inflight request counter was increased for this request, and needs to be decreased when request ends.
+const (
+	requestFullMethod grpcLimitCheckContextKey = 1
+
+	errTooManyInflightRequestsMsg = "too many inflight requests"
+)
+
+var errTooManyInflightRequests = status.Error(codes.Unavailable, errTooManyInflightRequestsMsg)
+
+func newGrpcLimitCheck(maxInflight int, methodLimiter GrpcMethodLimiter, namespace string, reg prometheus.Registerer) *grpcLimitCheck {
+	c := &grpcLimitCheck{
+		methodLimiter: methodLimiter,
+	}
+	c.maxInflight.Store(int64(maxInflight))
+
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "grpc_inflight_requests",
+		Help:      "Current number of inflight requests handled by gRPC server.",
+	}, func() float64 {
+		return float64(c.inflight.Load())
+	})
+
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "grpc_max_inflight_requests",
+		Help:      "Current limit of inflight requests that gRPC server can handle. 0 means no limit.",
+	}, func() float64 {
+		return float64(c.maxInflight.Load())
+	})
+
+	return c
+}
+
+// grpcLimitCheck implements gRPC TapHandle and gRPC stats.Handler.
+// grpcLimitCheck can track inflight requests, and reject requests before even reading them into memory.
+type grpcLimitCheck struct {
+	methodLimiter GrpcMethodLimiter
+
+	inflight    atomic.Int64
+	maxInflight atomic.Int64
+}
+
+// TapHandle is called after receiving grpc request and headers, but before reading any request data yet.
+// If we reject request here, it won't be counted towards any metrics (eg. in middleware.grpcStatsHandler).
+// If we accept request (not return error), eventually HandleRPC with stats.End notification will be called.
+func (g *grpcLimitCheck) TapHandle(ctx context.Context, info *tap.Info) (context.Context, error) {
+	v := g.inflight.Inc()
+	decreaseInflightInDefer := true
+	defer func() {
+		if decreaseInflightInDefer {
+			g.inflight.Dec()
+		}
+	}()
+
+	if !isMethodNameValid(info.FullMethodName) {
+		// If method name is not valid, we let the request continue, but decrease inflight requests.
+		// Otherwise, we would not have an option to decrease it later, because in this case grpc server will not call stat handler when request finishes.
+		return ctx, nil
+	}
+
+	l := g.maxInflight.Load()
+	if l > 0 && v > l {
+		return ctx, errTooManyInflightRequests
+	}
+
+	if g.methodLimiter != nil {
+		if err := g.methodLimiter.RpcCallStarting(info.FullMethodName); err != nil {
+			return ctx, err
+		}
+	}
+
+	decreaseInflightInDefer = false
+	ctx = context.WithValue(ctx, requestFullMethod, info.FullMethodName)
+	return ctx, nil
+}
+
+func (g *grpcLimitCheck) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (g *grpcLimitCheck) HandleRPC(ctx context.Context, rpcStats stats.RPCStats) {
+	// when request ends, and we started "inflight" request tracking for it, finish it.
+	if _, ok := rpcStats.(*stats.End); !ok {
+		return
+	}
+
+	if name, ok := ctx.Value(requestFullMethod).(string); ok {
+		g.inflight.Dec()
+		if g.methodLimiter != nil {
+			g.methodLimiter.RpcCallFinished(name)
+		}
+	}
+}
+
+func (g *grpcLimitCheck) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (g *grpcLimitCheck) HandleConn(_ context.Context, _ stats.ConnStats) {
+	// Not interested.
+}
+
+// This function mimics the check in grpc library, server.go, handleStream method. handleStream method can stop processing early,
+// without calling stat handler if the method name is invalid.
+func isMethodNameValid(method string) bool {
+	if method != "" && method[0] == '/' {
+		method = method[1:]
+	}
+	pos := strings.LastIndex(method, "/")
+	if pos == -1 {
+		return false
+	}
+	return true
+}

--- a/server/limits_test.go
+++ b/server/limits_test.go
@@ -1,0 +1,289 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	protobuf "github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"github.com/grafana/dskit/test"
+)
+
+func TestGrpcLimitCheckMalformedMethodName(t *testing.T) {
+	ts := &testServer{finishRequest: make(chan struct{})}
+
+	limitCheck := newGrpcLimitCheck(5, nil, "", nil)
+
+	c := setupGrpcServerWithCheckAndClient(t, ts, limitCheck)
+
+	out := &protobuf.Empty{}
+	err := c.(*fakeServerClient).cc.Invoke(context.Background(), "bad_method_name", &protobuf.Empty{}, out)
+
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unimplemented, s.Code())
+	require.Contains(t, s.Message(), "malformed method name")
+	require.Equal(t, int64(0), limitCheck.inflight.Load())
+}
+
+func checkGrpcStatusError(t *testing.T, err error, code codes.Code, msg string) {
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, code, s.Code())
+	require.Equal(t, msg, s.Message())
+}
+
+func callToSucceed(c FakeServerClient) error {
+	_, err := c.Succeed(context.Background(), &protobuf.Empty{})
+	return err
+}
+
+func callToSleep(c FakeServerClient) error {
+	_, err := c.Sleep(context.Background(), &protobuf.Empty{})
+	return err
+}
+
+func callToStreaming(msgsPerStreamCall int) func(c FakeServerClient) error {
+	return func(c FakeServerClient) error {
+		rcvd := 0
+		s, err := c.StreamSleep(context.Background(), &protobuf.Empty{})
+		if err != nil {
+			return err
+		}
+
+		for {
+			_, err := s.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return err
+			}
+			rcvd++
+		}
+
+		if rcvd != msgsPerStreamCall {
+			return fmt.Errorf("invalid number of received messages: %d", rcvd)
+		}
+		return nil
+	}
+}
+
+func TestGrpcLimitCheckUnary(t *testing.T) {
+	const msgsPerStreamCall = 5
+	const protectedMethodName = "/server.FakeServer/Succeed"
+
+	t.Run("grpcLimit=5, methodLimit=3", func(t *testing.T) {
+		testGrpcLimitCheckWithMethodLimiter(t, 5, 3, msgsPerStreamCall, protectedMethodName, callToSucceed, callToSleep, callToStreaming(msgsPerStreamCall))
+	})
+
+	t.Run("grpcLimit=unlimited, methodLimit=3", func(t *testing.T) {
+		testGrpcLimitCheckWithMethodLimiter(t, 5, 3, msgsPerStreamCall, protectedMethodName, callToSucceed, callToSleep, callToStreaming(msgsPerStreamCall))
+	})
+
+	t.Run("grpcLimit=5, methodLimit=unlimited", func(t *testing.T) {
+		testGrpcLimitCheckWithMethodLimiter(t, 5, 0, msgsPerStreamCall, protectedMethodName, callToSucceed, callToSleep, callToStreaming(msgsPerStreamCall))
+	})
+}
+
+func TestGrpcLimitCheckStreaming(t *testing.T) {
+	const msgsPerStreamCall = 5
+	const protectedMethodName = "/server.FakeServer/StreamSleep"
+
+	t.Run("grpcLimit=5, methodLimit=3", func(t *testing.T) {
+		testGrpcLimitCheckWithMethodLimiter(t, 5, 3, msgsPerStreamCall, protectedMethodName, callToStreaming(msgsPerStreamCall), callToSucceed, callToSleep)
+	})
+
+	t.Run("grpcLimit=unlimited, methodLimit=3", func(t *testing.T) {
+		testGrpcLimitCheckWithMethodLimiter(t, 5, 3, msgsPerStreamCall, protectedMethodName, callToStreaming(msgsPerStreamCall), callToSucceed, callToSleep)
+	})
+
+	t.Run("grpcLimit=5, methodLimit=unlimited", func(t *testing.T) {
+		testGrpcLimitCheckWithMethodLimiter(t, 5, 0, msgsPerStreamCall, protectedMethodName, callToStreaming(msgsPerStreamCall), callToSucceed, callToSleep)
+	})
+}
+
+func testGrpcLimitCheckWithMethodLimiter(
+	t *testing.T,
+	grpcLimit, protectedMethodLimit, msgsPerStreamCall int,
+	protectedMethodName string,
+	callToProtectedMethod func(c FakeServerClient) error,
+	callsToUnprotectedMethods ...func(c FakeServerClient) error,
+) {
+	if grpcLimit != 0 && grpcLimit < protectedMethodLimit {
+		t.Fatal("invalid combination of parameters for this test")
+	}
+
+	ts := &testServer{finishRequest: make(chan struct{}), msgPerStreamCall: msgsPerStreamCall}
+	var m GrpcMethodLimiter
+	if protectedMethodLimit > 0 {
+		m = &methodLimiter{method: protectedMethodName, methodInflightLimit: protectedMethodLimit}
+	}
+
+	limitCheck := newGrpcLimitCheck(grpcLimit, m, "", nil)
+
+	c := setupGrpcServerWithCheckAndClient(t, ts, limitCheck)
+
+	// start background requests for method with method limit (Succeed)
+	started := sync.WaitGroup{}
+	finished := sync.WaitGroup{}
+
+	if protectedMethodLimit > 0 {
+		for i := 0; i < protectedMethodLimit; i++ {
+			started.Add(1)
+			finished.Add(1)
+
+			go func() {
+				started.Done()
+				defer finished.Done()
+
+				err := callToProtectedMethod(c)
+				require.NoError(t, err)
+			}()
+		}
+
+		// Wait until all goroutines start and all calls are in-flight calls for protected method.
+		started.Wait()
+		test.Poll(t, 1*time.Second, int64(protectedMethodLimit), func() interface{} {
+			return limitCheck.inflight.Load()
+		})
+
+		// Another request to limited method should fail.
+		err := callToProtectedMethod(c)
+		checkGrpcStatusError(t, err, 123, "too many requests to "+protectedMethodName)
+	}
+
+	// However we can start more requests to different (unprotected) method
+	extraCalls := 10
+	if grpcLimit > 0 {
+		extraCalls = grpcLimit - protectedMethodLimit
+	}
+
+	for i := 0; i < extraCalls; i++ {
+		started.Add(1)
+		finished.Add(1)
+
+		go func() {
+			started.Done()
+			defer finished.Done()
+
+			for _, fn := range callsToUnprotectedMethods {
+				err := fn(c)
+				require.NoError(t, err)
+			}
+		}()
+	}
+
+	// Wait until all goroutines start and all calls are in-flight.
+	started.Wait()
+	test.Poll(t, 1*time.Second, int64(protectedMethodLimit+extraCalls), func() interface{} {
+		return limitCheck.inflight.Load()
+	})
+
+	if grpcLimit > 0 {
+		// But now we're really at the limit -- we used all grpc inflight limit calls. Everything should return codes.Unavailable now.
+		for _, fn := range append(callsToUnprotectedMethods, callToProtectedMethod) {
+			err := fn(c)
+			checkGrpcStatusError(t, err, codes.Unavailable, errTooManyInflightRequestsMsg)
+		}
+	}
+
+	// unblock all pending and future requests, and wait for goroutines to finish
+	close(ts.finishRequest)
+	finished.Wait()
+
+	require.Equal(t, int64(0), limitCheck.inflight.Load())
+
+	// Another request to protected or unprotected method should succeed again.
+	for _, fn := range append(callsToUnprotectedMethods, callToProtectedMethod) {
+		err := fn(c)
+		require.NoError(t, err)
+	}
+}
+
+func setupGrpcServerWithCheckAndClient(t *testing.T, ts *testServer, g *grpcLimitCheck) FakeServerClient {
+	server := grpc.NewServer(grpc.InTapHandle(g.TapHandle), grpc.StatsHandler(g))
+	RegisterFakeServerServer(server, ts)
+
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	go func() {
+		_ = server.Serve(l)
+	}()
+
+	t.Cleanup(func() {
+		_ = l.Close()
+	})
+
+	cc, err := grpc.Dial(l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = cc.Close()
+	})
+
+	return NewFakeServerClient(cc)
+}
+
+type testServer struct {
+	FakeServer
+
+	msgPerStreamCall int
+	finishRequest    chan struct{}
+}
+
+func (ts *testServer) Succeed(_ context.Context, _ *protobuf.Empty) (*protobuf.Empty, error) {
+	<-ts.finishRequest
+	return &protobuf.Empty{}, nil
+}
+
+func (ts *testServer) Sleep(_ context.Context, _ *protobuf.Empty) (*protobuf.Empty, error) {
+	<-ts.finishRequest
+	return &protobuf.Empty{}, nil
+}
+
+func (ts *testServer) StreamSleep(_ *protobuf.Empty, stream FakeServer_StreamSleepServer) error {
+	for i := 0; i < ts.msgPerStreamCall; i++ {
+		_ = stream.Send(&protobuf.Empty{})
+		<-ts.finishRequest
+	}
+	return nil
+}
+
+type methodLimiter struct {
+	method              string
+	methodInflightLimit int
+	inflight            atomic.Int64
+}
+
+func (m *methodLimiter) RpcCallStarting(methodName string) error {
+	if methodName == m.method {
+		v := m.inflight.Inc()
+		if v > int64(m.methodInflightLimit) {
+			m.inflight.Dec()
+			return status.Error(123, "too many requests to "+m.method)
+		}
+	}
+	return nil
+}
+
+func (m *methodLimiter) RpcCallFinished(methodName string) {
+	if methodName == m.method {
+		m.inflight.Dec()
+	}
+}

--- a/server/limits_test.go
+++ b/server/limits_test.go
@@ -271,7 +271,7 @@ type methodLimiter struct {
 	inflight            atomic.Int64
 }
 
-func (m *methodLimiter) RpcCallStarting(methodName string) error {
+func (m *methodLimiter) RPCCallStarting(methodName string) error {
 	if methodName == m.method {
 		v := m.inflight.Inc()
 		if v > int64(m.methodInflightLimit) {
@@ -282,7 +282,7 @@ func (m *methodLimiter) RpcCallStarting(methodName string) error {
 	return nil
 }
 
-func (m *methodLimiter) RpcCallFinished(methodName string) {
+func (m *methodLimiter) RPCCallFinished(methodName string) {
 	if methodName == m.method {
 		m.inflight.Dec()
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -202,11 +202,10 @@ func (cfg *Config) registererOrDefault() prometheus.Registerer {
 //
 // Servers will be automatically instrumented for Prometheus metrics.
 type Server struct {
-	cfg             Config
-	handler         SignalHandler
-	grpcListener    net.Listener
-	httpListener    net.Listener
-	grpcServerLimit *grpcInflightLimitCheck
+	cfg          Config
+	handler      SignalHandler
+	grpcListener net.Listener
+	httpListener net.Listener
 
 	// These fields are used to support grpc over the http server
 	//  if RouteHTTPToGRPC is set. the fields are kept here

--- a/server/server.go
+++ b/server/server.go
@@ -118,6 +118,7 @@ type Config struct {
 	GRPCServerTimeout                  time.Duration `yaml:"grpc_server_keepalive_timeout"`
 	GRPCServerMinTimeBetweenPings      time.Duration `yaml:"grpc_server_min_time_between_pings"`
 	GRPCServerPingWithoutStreamAllowed bool          `yaml:"grpc_server_ping_without_stream_allowed"`
+	GRPCServerMaxInflightRequests      int           `yaml:"grpc_server_max_inflight_requests"`
 
 	LogFormat                    string           `yaml:"log_format"`
 	LogLevel                     log.Level        `yaml:"log_level"`
@@ -137,6 +138,9 @@ type Config struct {
 	Gatherer   prometheus.Gatherer   `yaml:"-"`
 
 	PathPrefix string `yaml:"http_path_prefix"`
+
+	// This limiter is called for every started and finished gRPC request.
+	GrpcMethodLimiter GrpcMethodLimiter `yaml:"-"`
 }
 
 var infinty = time.Duration(math.MaxInt64)
@@ -176,6 +180,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.GRPCServerTimeout, "server.grpc.keepalive.timeout", time.Second*20, "After having pinged for keepalive check, the duration after which an idle connection should be closed, Default: 20s")
 	f.DurationVar(&cfg.GRPCServerMinTimeBetweenPings, "server.grpc.keepalive.min-time-between-pings", 5*time.Minute, "Minimum amount of time a client should wait before sending a keepalive ping. If client sends keepalive ping more often, server will send GOAWAY and close the connection.")
 	f.BoolVar(&cfg.GRPCServerPingWithoutStreamAllowed, "server.grpc.keepalive.ping-without-stream-allowed", false, "If true, server allows keepalive pings even when there are no active streams(RPCs). If false, and client sends ping when there are no active streams, server will send GOAWAY and close the connection.")
+	f.IntVar(&cfg.GRPCServerMaxInflightRequests, "server.grpc.max-inflight-requests", 0, "If not 0, and gRPC server is already handling this number of requests, gRPC server will reject any additional incoming requests without consuming more resources. 0 disables the check.")
 	f.StringVar(&cfg.PathPrefix, "server.path-prefix", "", "Base path to serve all API routes from (e.g. /v1/)")
 	f.StringVar(&cfg.LogFormat, "log.format", log.LogfmtFormat, "Output log messages in the given format. Valid formats: [logfmt, json]")
 	cfg.LogLevel.RegisterFlags(f)
@@ -199,10 +204,11 @@ func (cfg *Config) registererOrDefault() prometheus.Registerer {
 //
 // Servers will be automatically instrumented for Prometheus metrics.
 type Server struct {
-	cfg          Config
-	handler      SignalHandler
-	grpcListener net.Listener
-	httpListener net.Listener
+	cfg             Config
+	handler         SignalHandler
+	grpcListener    net.Listener
+	httpListener    net.Listener
+	grpcServerLimit *grpcLimitCheck
 
 	// These fields are used to support grpc over the http server
 	//  if RouteHTTPToGRPC is set. the fields are kept here
@@ -367,6 +373,8 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		PermitWithoutStream: cfg.GRPCServerPingWithoutStreamAllowed,
 	}
 
+	grpcServerLimit := newGrpcLimitCheck(cfg.GRPCServerMaxInflightRequests, cfg.GrpcMethodLimiter, cfg.MetricsNamespace, cfg.registererOrDefault())
+
 	grpcOptions := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(grpcMiddleware...),
 		grpc.ChainStreamInterceptor(grpcStreamMiddleware...),
@@ -375,11 +383,13 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		grpc.MaxRecvMsgSize(cfg.GPRCServerMaxRecvMsgSize),
 		grpc.MaxSendMsgSize(cfg.GRPCServerMaxSendMsgSize),
 		grpc.MaxConcurrentStreams(uint32(cfg.GPRCServerMaxConcurrentStreams)),
+		grpc.InTapHandle(grpcServerLimit.TapHandle),
 		grpc.StatsHandler(middleware.NewStatsHandler(
 			metrics.ReceivedMessageSize,
 			metrics.SentMessageSize,
 			metrics.InflightRequests,
 		)),
+		grpc.StatsHandler(grpcServerLimit),
 	}
 	grpcOptions = append(grpcOptions, cfg.GRPCOptions...)
 	if grpcTLSConfig != nil {
@@ -459,6 +469,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		grpcOnHTTPListener: grpcOnHTTPListener,
 		handler:            handler,
 		grpchttpmux:        grpchttpmux,
+		grpcServerLimit:    grpcServerLimit,
 
 		HTTP:             router,
 		HTTPServer:       httpServer,
@@ -573,4 +584,8 @@ func (s *Server) Shutdown() {
 
 	_ = s.HTTPServer.Shutdown(ctx)
 	s.GRPC.GracefulStop()
+}
+
+func (s *Server) SetGrpcMaxInflightRequests(limit int) {
+	s.grpcServerLimit.maxInflight.Store(int64(limit))
 }


### PR DESCRIPTION
**What this PR does**:

This PR introduces adds a way to reject calls to gRPC methods early, right after gRPC server receives request headers, but before reading the request body and starting a goroutine.

This PR is generalization of Mimir's https://github.com/grafana/mimir/pull/5976. Description in that PR explains this approach and why it works.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
