### PR TITLE
Always add source IPs to spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [CHANGE] Remove `grpcutil.IsGRPCContextCanceled()` in favour of `grpcutil.IsCanceled()`. #357
 * [CHANGE] Remove `logrus` and `log.Interface`. #359
 * [CHANGE] Remove jaeger-specific opentracing usage in `middleware.HTTPGRPCTracer`. #372
+* [CHANGE] Always include source IPs in HTTP and gRPC server spans. #386
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338


### PR DESCRIPTION
The flag is called `-server.server.log-source-ips-enabled` and it is strange that it controls if source IPs are added to spans too. Suggested by @bboreham

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
