### PR TITLE
all: use net.JoinHostPort instead of fmt.Sprintf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,3 +171,4 @@
 * [BUGFIX] `MetricFamiliesPerTenant.SendMinOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have positive values only. #368
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have negative values only. #368
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGaugesPerTenant` no longer includes tenants, which do not have specified gauge. #368
+* [BUGFIX] Correctly format `host:port` addresses when using IPv6. #388

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -107,7 +108,7 @@ func newIntegrationClientServer(
 	}()
 
 	httpURL := fmt.Sprintf("https://localhost:%d/hello", httpPort)
-	grpcHost := fmt.Sprintf("localhost:%d", grpcPort)
+	grpcHost := net.JoinHostPort("localhost", strconv.Itoa(grpcPort))
 
 	for _, tc := range tcs {
 		tlsClientConfig, err := tc.tlsConfig.GetTLSConfig()

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -80,7 +80,7 @@ type Client struct {
 }
 
 // ParseURL deals with direct:// style URLs, as well as kubernetes:// urls.
-// For backwards compatibility it treats URLs without schems as kubernetes://.
+// For backwards compatibility it treats URLs without schemes as kubernetes://.
 func ParseURL(unparsed string) (string, error) {
 	// if it has :///, this is the kuberesolver v2 URL. Return it as it is.
 	if strings.Contains(unparsed, ":///") {
@@ -115,7 +115,7 @@ func ParseURL(unparsed string) (string, error) {
 		if len(parts) > 2 {
 			domain = domain + "." + parts[2]
 		}
-		address := fmt.Sprintf("kubernetes:///%s%s:%s", service, domain, port)
+		address := fmt.Sprintf("kubernetes:///%s", net.JoinHostPort(service+domain, port))
 		return address, nil
 
 	default:

--- a/ring/example/local/local.go
+++ b/ring/example/local/local.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -87,7 +88,7 @@ func runCluster() {
 	}
 	defer services.StopAndAwaitTerminated(ctx, lfc)
 
-	listener, err := net.Listen("tcp", bindaddr+":8100")
+	listener, err := net.Listen("tcp", net.JoinHostPort(bindaddr, "8100"))
 	if err != nil {
 		panic(err)
 	}
@@ -211,7 +212,7 @@ func SimpleRing(store kv.Client) (*ring.Ring, error) {
 func SimpleRingLifecycler(store kv.Client, bindaddr string, bindport int) (*ring.BasicLifecycler, error) {
 	var config ring.BasicLifecyclerConfig
 	config.ID = bindaddr
-	config.Addr = fmt.Sprintf("%s:%d", bindaddr, bindport)
+	config.Addr = net.JoinHostPort(bindaddr, strconv.Itoa(bindport))
 
 	var delegate ring.BasicLifecyclerDelegate
 

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -3,8 +3,10 @@ package ring
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"sort"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -513,7 +515,7 @@ func TestLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
 	assert.Greater(t, desc.GetTimestamp(), int64(0))
 	assert.Equal(t, testInstanceID, desc.GetId())
 	assert.Equal(t, ACTIVE, desc.GetState())
-	assert.Equal(t, fmt.Sprintf("%s:%d", lifecyclerCfg.Addr, lifecyclerCfg.Port), desc.GetAddr())
+	assert.Equal(t, net.JoinHostPort(lifecyclerCfg.Addr, strconv.Itoa(lifecyclerCfg.Port)), desc.GetAddr())
 	assert.Equal(t, lifecyclerCfg.Zone, desc.Zone)
 	assert.Equal(t, prevTokens, Tokens(desc.GetTokens()))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // anonymous import to get the pprof handler registered
+	"strconv"
 	"strings"
 	"time"
 
@@ -251,7 +252,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		network = DefaultNetwork
 	}
 	// Setup listeners first, so we can fail early if the port is in use.
-	httpListener, err := net.Listen(network, fmt.Sprintf("%s:%d", cfg.HTTPListenAddress, cfg.HTTPListenPort))
+	httpListener, err := net.Listen(network, net.JoinHostPort(cfg.HTTPListenAddress, strconv.Itoa(cfg.HTTPListenPort)))
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +276,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	if network == "" {
 		network = DefaultNetwork
 	}
-	grpcListener, err := net.Listen(network, fmt.Sprintf("%s:%d", cfg.GRPCListenAddress, cfg.GRPCListenPort))
+	grpcListener, err := net.Listen(network, net.JoinHostPort(cfg.GRPCListenAddress, strconv.Itoa(cfg.GRPCListenPort)))
 	if err != nil {
 		return nil, err
 	}

--- a/server/server_tracing_test.go
+++ b/server/server_tracing_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -89,12 +91,13 @@ func TestHTTPGRPCTracing(t *testing.T) {
 
 	helloRouteName := "hello"
 	helloRouteTmpl := "/hello"
-	helloRouteURLRaw := fmt.Sprintf("http://%s:%d/hello", httpAddress, httpPort)
+	hostport := net.JoinHostPort(httpAddress, strconv.Itoa(httpPort))
+	helloRouteURLRaw := fmt.Sprintf("http://%s/hello", hostport)
 	helloRouteURL, err := url.Parse(helloRouteURLRaw)
 	require.NoError(t, err)
 
 	helloPathParamRouteTmpl := "/hello/{pathParam}"
-	helloPathParamRouteURLRaw := fmt.Sprintf("http://%s:%d/hello/world", httpAddress, httpPort)
+	helloPathParamRouteURLRaw := fmt.Sprintf("http://%s/hello/world", hostport)
 	helloPathParamRouteURL, err := url.Parse(helloPathParamRouteURLRaw)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This will ensure ipv6 compatibility for provided hosts, and this method should also be faster than the general purpose fmt.Sprintf, which must first parse the input string.

Fixes #380.


**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
