### PR TITLE
log: fix name of burst parameter

### DIFF
--- a/log/ratelimit.go
+++ b/log/ratelimit.go
@@ -20,7 +20,7 @@ type RateLimitedLogger struct {
 
 // NewRateLimitedLogger returns a log.Logger that is limited to the given number of logs per second,
 // with the given burst size.
-func NewRateLimitedLogger(logger log.Logger, logsPerSecond float64, logsPerSecondBurst int, registry prometheus.Registerer) log.Logger {
+func NewRateLimitedLogger(logger log.Logger, logsPerSecond float64, logsBurstSize int, registry prometheus.Registerer) log.Logger {
 	discardedLogLinesCounter := promauto.With(registry).NewCounterVec(prometheus.CounterOpts{
 		Name: "logger_rate_limit_discarded_log_lines_total",
 		Help: "Total number of discarded log lines per level.",
@@ -28,7 +28,7 @@ func NewRateLimitedLogger(logger log.Logger, logsPerSecond float64, logsPerSecon
 
 	return &RateLimitedLogger{
 		next:                          logger,
-		limiter:                       rate.NewLimiter(rate.Limit(logsPerSecond), logsPerSecondBurst),
+		limiter:                       rate.NewLimiter(rate.Limit(logsPerSecond), logsBurstSize),
 		discardedInfoLogLinesCounter:  discardedLogLinesCounter.WithLabelValues(level.InfoValue().String()),
 		discardedDebugLogLinesCounter: discardedLogLinesCounter.WithLabelValues(level.DebugValue().String()),
 		discardedWarnLogLinesCounter:  discardedLogLinesCounter.WithLabelValues(level.WarnValue().String()),


### PR DESCRIPTION
**What this PR does**:

Fix a parameter name - burst is a _size_ not a _rate_.

We have made terrible mistakes elsewhere due to this misunderstanding.

**Checklist**
- NA Tests updated
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
