### PR TITLE
kv/memberlist: fix incorrect TCP transport host parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,3 +172,4 @@
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have negative values only. #368
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGaugesPerTenant` no longer includes tenants, which do not have specified gauge. #368
 * [BUGFIX] Correctly format `host:port` addresses when using IPv6. #388
+* [BUGFIX] TCPTransport will reject BindAddr entries that are not an IP address, like "localhost" (previously, these would listen on 0.0.0.0) #396

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,4 +172,4 @@
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGauges` will no longer return 0 if some tenant doesn't have the gauge in their registry, and other tenants have negative values only. #368
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGaugesPerTenant` no longer includes tenants, which do not have specified gauge. #368
 * [BUGFIX] Correctly format `host:port` addresses when using IPv6. #388
-* [BUGFIX] TCPTransport will reject BindAddr entries that are not an IP address, like "localhost" (previously, these would listen on 0.0.0.0) #396
+* [BUGFIX] Memberlist's TCP transport will now reject bind addresses that are not IP addresses, such as "localhost", rather than silently converting these to 0.0.0.0 and therefore listening on all addresses. #396

--- a/kv/memberlist/http_status_handler_test.go
+++ b/kv/memberlist/http_status_handler_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestPage(t *testing.T) {
 	conf := memberlist.DefaultLANConfig()
+	localhostBindAddrsOnce.Do(setLocalhostBindAddrs)
+	conf.BindAddr = localhostBindAddrs[0]
 	ml, err := memberlist.Create(conf)
 	require.NoError(t, err)
 

--- a/kv/memberlist/http_status_handler_test.go
+++ b/kv/memberlist/http_status_handler_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestPage(t *testing.T) {
 	conf := memberlist.DefaultLANConfig()
-	localhostBindAddrsOnce.Do(setLocalhostBindAddrs)
-	conf.BindAddr = localhostBindAddrs[0]
+	conf.BindAddr = getLocalhostAddr()
 	ml, err := memberlist.Create(conf)
 	require.NoError(t, err)
 

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -316,7 +316,10 @@ func withFixtures(t *testing.T, testFN func(t *testing.T, kv *Client)) {
 
 	var cfg KVConfig
 	flagext.DefaultValues(&cfg)
-	cfg.TCPTransport = TCPTransportConfig{}
+	localhostBindAddrsOnce.Do(setLocalhostBindAddrs)
+	cfg.TCPTransport = TCPTransportConfig{
+		BindAddrs: localhostBindAddrs,
+	}
 	cfg.Codecs = []codec.Codec{c}
 
 	mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
@@ -468,8 +471,12 @@ func TestMultipleCAS(t *testing.T) {
 
 	c := dataCodec{}
 
+	localhostBindAddrsOnce.Do(setLocalhostBindAddrs)
 	var cfg KVConfig
 	flagext.DefaultValues(&cfg)
+	cfg.TCPTransport = TCPTransportConfig{
+		BindAddrs: localhostBindAddrs,
+	}
 	cfg.Codecs = []codec.Codec{c}
 
 	mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
@@ -1272,7 +1279,12 @@ func TestMessageBuffer(t *testing.T) {
 func TestNotifyMsgResendsOnlyChanges(t *testing.T) {
 	codec := dataCodec{}
 
-	cfg := KVConfig{}
+	localhostBindAddrsOnce.Do(setLocalhostBindAddrs)
+	cfg := KVConfig{
+		TCPTransport: TCPTransportConfig{
+			BindAddrs: localhostBindAddrs,
+		},
+	}
 	// We will be checking for number of messages in the broadcast queue, so make sure to use known retransmit factor.
 	cfg.RetransmitMult = 1
 	cfg.Codecs = append(cfg.Codecs, codec)
@@ -1337,7 +1349,12 @@ func TestNotifyMsgResendsOnlyChanges(t *testing.T) {
 func TestSendingOldTombstoneShouldNotForwardMessage(t *testing.T) {
 	codec := dataCodec{}
 
-	cfg := KVConfig{}
+	localhostBindAddrsOnce.Do(setLocalhostBindAddrs)
+	cfg := KVConfig{
+		TCPTransport: TCPTransportConfig{
+			BindAddrs: localhostBindAddrs,
+		},
+	}
 	// We will be checking for number of messages in the broadcast queue, so make sure to use known retransmit factor.
 	cfg.RetransmitMult = 1
 	cfg.LeftIngestersTimeout = 5 * time.Minute
@@ -1481,6 +1498,10 @@ func TestDelegateMethodsDontCrashBeforeKVStarts(t *testing.T) {
 
 	cfg := KVConfig{}
 	cfg.Codecs = append(cfg.Codecs, codec)
+	localhostBindAddrsOnce.Do(setLocalhostBindAddrs)
+	cfg.TCPTransport = TCPTransportConfig{
+		BindAddrs: localhostBindAddrs,
+	}
 
 	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
 

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -39,7 +39,7 @@ const colonColon = "::"
 
 // TCPTransportConfig is a configuration structure for creating new TCPTransport.
 type TCPTransportConfig struct {
-	// BindAddrs is a list of addresses to bind to.
+	// BindAddrs is a list of IP addresses to bind to.
 	BindAddrs flagext.StringSlice `yaml:"bind_addr"`
 
 	// BindPort is the port to listen on, for each address above.
@@ -147,6 +147,9 @@ func NewTCPTransport(config TCPTransportConfig, logger log.Logger, registerer pr
 	port := config.BindPort
 	for _, addr := range config.BindAddrs {
 		ip := net.ParseIP(addr)
+		if ip == nil {
+			return nil, fmt.Errorf("could not parse bind addr %q as IP address", addr)
+		}
 
 		tcpAddr := &net.TCPAddr{IP: ip, Port: port}
 

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -100,5 +100,5 @@ func TestNonIPsAreRejected(t *testing.T) {
 	cfg := TCPTransportConfig{BindAddrs: flagext.StringSlice{"localhost"}}
 	_, err := NewTCPTransport(cfg, nil, nil)
 	require.Error(t, err)
-	require.Equal(t, err.Error(), `could not parse bind addr "localhost" as IP address`)
+	require.EqualError(t, err, `could not parse bind addr "localhost" as IP address`)
 }

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -99,11 +99,6 @@ func TestFinalAdvertiseAddr(t *testing.T) {
 func TestNonIPsAreRejected(t *testing.T) {
 	cfg := TCPTransportConfig{BindAddrs: flagext.StringSlice{"localhost"}}
 	_, err := NewTCPTransport(cfg, nil, nil)
-	if err == nil {
-		t.Fatal("expected non-nil err, got nil")
-	}
-	want := `could not parse bind addr "localhost" as IP address`
-	if err.Error() != want {
-		t.Fatalf("NewTCPTransport with non-IP address BindAddr: got %v, want %v", err, want)
-	}
+	require.Error(t, err)
+	require.Equal(t, err.Error(), `could not parse bind addr "localhost" as IP address`)
 }

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -20,14 +20,14 @@ func TestTCPTransport_WriteTo_ShouldNotLogAsWarningExpectedFailures(t *testing.T
 		unexpectedLogs string
 	}{
 		"should not log 'connection refused' by default": {
-			remoteAddr:     "localhost:12345",
+			remoteAddr:     "127.0.0.1:12345",
 			unexpectedLogs: "connection refused",
 		},
 		"should log 'connection refused' if debug log level is enabled": {
 			setup: func(t *testing.T, cfg *TCPTransportConfig) {
 				cfg.TransportDebug = true
 			},
-			remoteAddr:   "localhost:12345",
+			remoteAddr:   "127.0.0.1:12345",
 			expectedLogs: "connection refused",
 		},
 	}
@@ -39,7 +39,7 @@ func TestTCPTransport_WriteTo_ShouldNotLogAsWarningExpectedFailures(t *testing.T
 
 			cfg := TCPTransportConfig{}
 			flagext.DefaultValues(&cfg)
-			cfg.BindAddrs = []string{"localhost"}
+			cfg.BindAddrs = []string{"127.0.0.1"}
 			cfg.BindPort = 0
 			if testData.setup != nil {
 				testData.setup(t, &cfg)
@@ -69,7 +69,7 @@ func TestFinalAdvertiseAddr(t *testing.T) {
 	}{
 		"should not fail with local address specified": {
 			advertiseAddr: "127.0.0.1",
-			bindAddrs:     []string{"localhost"},
+			bindAddrs:     []string{"127.0.0.1"},
 			bindPort:      0,
 		},
 	}

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -99,6 +99,5 @@ func TestFinalAdvertiseAddr(t *testing.T) {
 func TestNonIPsAreRejected(t *testing.T) {
 	cfg := TCPTransportConfig{BindAddrs: flagext.StringSlice{"localhost"}}
 	_, err := NewTCPTransport(cfg, nil, nil)
-	require.Error(t, err)
 	require.EqualError(t, err, `could not parse bind addr "localhost" as IP address`)
 }

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -95,3 +95,15 @@ func TestFinalAdvertiseAddr(t *testing.T) {
 		})
 	}
 }
+
+func TestNonIPsAreRejected(t *testing.T) {
+	cfg := TCPTransportConfig{BindAddrs: flagext.StringSlice{"localhost"}}
+	_, err := NewTCPTransport(cfg, nil, nil)
+	if err == nil {
+		t.Fatal("expected non-nil err, got nil")
+	}
+	want := `could not parse bind addr "localhost" as IP address`
+	if err.Error() != want {
+		t.Fatalf("NewTCPTransport with non-IP address BindAddr: got %v, want %v", err, want)
+	}
+}


### PR DESCRIPTION
Previously, if you passed "localhost" as the bind address for a TCPTransport, we would attempt to parse this as an IP address, fail, and then begin listening on 0.0.0.0.

This is a security issue since 0.0.0.0 binds to all interfaces, including public ones, while "localhost" is a shortcut for an IP address that is typically is only accessible from the local machine, not the wider Internet. A user who intended to bind only to the loopback interface might inadvertently expose a server to the public Internet.

Fix this by returning an error if you attempt to pass a BindAddr to TCPTransport that is not actually an IP address. Also, fix the tests to resolve "localhost" to an IP address before proceeding - typically, but not always, this is 127.0.0.1, which is why we try to parse the loopback address instead of hardcoding it.

I can confirm that on a Mac, with this patch applied I no longer get dialog boxes warning me that the tests are attempting to listen on 0.0.0.0.

Updates #381.
