### PR TITLE
Improve TestSpreadMinimizingTokenGenerator_GetMissingTokens

### DIFF
--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -455,9 +455,10 @@ func TestSpreadMinimizingTokenGenerator_GetMissingTokens(t *testing.T) {
 	tokensPerInstance := 512
 	tokenGenerator := createSpreadMinimizingTokenGenerator(t, testInstance, testZone, zones)
 
-	// we get all the tokens for the underlying instance, but we don't mark all of them as taken
+	// We get all the tokens for the underlying instance, but we don't mark all of them as taken
 	// in order to simulate that some tokens were taken by another instance when the method was
-	// first called
+	// first called.
+	// We create missingIndexes, a slice of 3 different missing indexes.
 	missingIndexes := make([]int, 0, 3)
 	for i := 0; i < 3; i++ {
 		missingIndex := rand.Intn(tokensPerInstance - 1)
@@ -477,7 +478,7 @@ func TestSpreadMinimizingTokenGenerator_GetMissingTokens(t *testing.T) {
 		takenTokens = append(takenTokens, token)
 	}
 
-	// we generate the missing tokens, and we ensure that they correspond to the
+	// We generate the missing tokens, and we ensure that they correspond to the
 	// tokens of allTokens having indexes in missingIndexes.
 	tokens := tokenGenerator.GenerateTokens(len(missingIndexes), takenTokens)
 	require.Len(t, tokens, len(missingIndexes))

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -458,7 +458,14 @@ func TestSpreadMinimizingTokenGenerator_GetMissingTokens(t *testing.T) {
 	// we get all the tokens for the underlying instance, but we don't mark all of them as taken
 	// in order to simulate that some tokens were taken by another instance when the method was
 	// first called
-	missingIndexes := []int{rand.Intn(tokensPerInstance - 1), rand.Intn(tokensPerInstance - 1), rand.Intn(tokensPerInstance - 1)}
+	missingIndexes := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		missingIndex := rand.Intn(tokensPerInstance - 1)
+		if slices.Contains(missingIndexes, missingIndex) {
+			continue
+		}
+		missingIndexes = append(missingIndexes, missingIndex)
+	}
 	slices.Sort(missingIndexes)
 	takenTokens := make(Tokens, 0, tokensPerInstance)
 	allTokens := tokenGenerator.GenerateTokens(tokensPerInstance, takenTokens)


### PR DESCRIPTION
**What this PR does**:
It has been reported that `TestSpreadMinimizingTokenGenerator_GetMissingTokens` is flaky. After a more detailed analysis, it has been noticed that in an unlucky case a generation of 3 random integeres
```
missingIndex := []int{rand.Intn(tokensPerInstance - 1), rand.Intn(tokensPerInstance - 1), rand.Intn(tokensPerInstance - 1)}
```
actually returns an array with a repeated element. This is the main cause of the problem and it has been fixed by this PR.

**Which issue(s) this PR fixes**:

Fixes #398 

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
