### PR TITLE
`DoUntilQuorum`: improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@
 * [ENHANCEMENT] Ring: Add ID attribute to `InstanceDesc` for ring members. #387
 * [ENHANCEMENT] httpgrpc, grpcutil: added constants and functions for adding request details into outgoing grpc metadata. #391
 * [ENHANCEMENT] Ring: clarify the message logged by `DoUntilQuorum` when the first failure in a zone occurs. #402
+* [ENHANCEMENT] Ring: include instance ID in log messages emitted by `DoUntilQuorum`. #402
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 * [ENHANCEMENT] server: clarify documentation for `-server.grpc-max-concurrent-streams` CLI flag. #369
 * [ENHANCEMENT] Ring: Add ID attribute to `InstanceDesc` for ring members. #387
 * [ENHANCEMENT] httpgrpc, grpcutil: added constants and functions for adding request details into outgoing grpc metadata. #391
+* [ENHANCEMENT] Ring: clarify the message logged by `DoUntilQuorum` when the first failure in a zone occurs. #402
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -283,7 +283,7 @@ func (t *zoneAwareResultTracker) done(instance *InstanceDesc, err error) {
 
 		if t.failuresByZone[instance.Zone] == 1 {
 			level.Warn(t.logger).Log(
-				"msg", "zone has failed",
+				"msg", "request to instance has failed, zone cannot contribute to quorum",
 				"zone", instance.Zone,
 				"failingInstance", instance.Addr,
 				"err", err,

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -108,7 +108,8 @@ func (t *defaultResultTracker) done(instance *InstanceDesc, err error) {
 	} else {
 		level.Warn(t.logger).Log(
 			"msg", "instance failed",
-			"instance", instance.Addr,
+			"instanceAddr", instance.Addr,
+			"instanceID", instance.Id,
 			"err", err,
 		)
 
@@ -155,7 +156,7 @@ func (t *defaultResultTracker) startMinimumRequests() {
 		if len(t.pendingInstances) < t.maxErrors {
 			t.pendingInstances = append(t.pendingInstances, instance)
 		} else {
-			level.Debug(t.logger).Log("msg", "starting request to instance", "reason", "initial requests", "instance", instance.Addr)
+			level.Debug(t.logger).Log("msg", "starting request to instance", "reason", "initial requests", "instanceAddr", instance.Addr, "instanceID", instance.Id)
 			t.instanceRelease[instance] <- struct{}{}
 		}
 	}
@@ -175,7 +176,7 @@ func (t *defaultResultTracker) startAdditionalRequestsDueTo(reason string) {
 	if len(t.pendingInstances) > 0 {
 		// There are some outstanding requests we could make before we reach maxErrors. Release the next one.
 		i := t.pendingInstances[0]
-		level.Debug(t.logger).Log("msg", "starting request to instance", "reason", reason, "instance", i.Addr)
+		level.Debug(t.logger).Log("msg", "starting request to instance", "reason", reason, "instanceAddr", i.Addr, "instanceID", i.Id)
 		t.instanceRelease[i] <- struct{}{}
 		t.pendingInstances = t.pendingInstances[1:]
 	}
@@ -186,7 +187,7 @@ func (t *defaultResultTracker) startAllRequests() {
 
 	for i := range t.instances {
 		instance := &t.instances[i]
-		level.Debug(t.logger).Log("msg", "starting request to instance", "reason", "initial requests", "instance", instance.Addr)
+		level.Debug(t.logger).Log("msg", "starting request to instance", "reason", "initial requests", "instanceAddr", instance.Addr, "instanceID", instance.Id)
 		t.instanceRelease[instance] = make(chan struct{}, 1)
 		t.instanceRelease[instance] <- struct{}{}
 	}
@@ -285,7 +286,8 @@ func (t *zoneAwareResultTracker) done(instance *InstanceDesc, err error) {
 			level.Warn(t.logger).Log(
 				"msg", "request to instance has failed, zone cannot contribute to quorum",
 				"zone", instance.Zone,
-				"failingInstance", instance.Addr,
+				"failingInstanceAddr", instance.Addr,
+				"failingInstanceID", instance.Id,
 				"err", err,
 			)
 

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -181,10 +181,10 @@ func TestDefaultResultTracker_AwaitStart_ContextCancelled(t *testing.T) {
 }
 
 func TestDefaultResultTracker_StartAllRequests(t *testing.T) {
-	instance1 := InstanceDesc{Addr: "127.0.0.1"}
-	instance2 := InstanceDesc{Addr: "127.0.0.2"}
-	instance3 := InstanceDesc{Addr: "127.0.0.3"}
-	instance4 := InstanceDesc{Addr: "127.0.0.4"}
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Id: "instance-1"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Id: "instance-2"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Id: "instance-3"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Id: "instance-4"}
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	logger := &testLogger{}
@@ -198,10 +198,11 @@ func TestDefaultResultTracker_StartAllRequests(t *testing.T) {
 		require.NoError(t, tracker.awaitStart(context.Background(), instance), "requests for all instances should be released immediately")
 
 		expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-			"level":    level.DebugValue(),
-			"msg":      "starting request to instance",
-			"reason":   "initial requests",
-			"instance": instance.Addr,
+			"level":        level.DebugValue(),
+			"msg":          "starting request to instance",
+			"reason":       "initial requests",
+			"instanceAddr": instance.Addr,
+			"instanceID":   instance.Id,
 		})
 	}
 
@@ -211,10 +212,10 @@ func TestDefaultResultTracker_StartAllRequests(t *testing.T) {
 func TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.T) {
 	t.Parallel()
 
-	instance1 := InstanceDesc{Addr: "127.0.0.1"}
-	instance2 := InstanceDesc{Addr: "127.0.0.2"}
-	instance3 := InstanceDesc{Addr: "127.0.0.3"}
-	instance4 := InstanceDesc{Addr: "127.0.0.4"}
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Id: "instance-1"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Id: "instance-2"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Id: "instance-3"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Id: "instance-4"}
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	instanceRequestCounts := make([]atomic.Uint64, len(instances))
@@ -258,10 +259,11 @@ func TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.
 
 		for instance := range instancesAwaitReleaseResults {
 			expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-				"level":    level.DebugValue(),
-				"msg":      "starting request to instance",
-				"reason":   "initial requests",
-				"instance": instance.Addr,
+				"level":        level.DebugValue(),
+				"msg":          "starting request to instance",
+				"reason":       "initial requests",
+				"instanceAddr": instance.Addr,
+				"instanceID":   instance.Id,
 			})
 		}
 
@@ -292,10 +294,10 @@ func TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.
 }
 
 func TestDefaultResultTracker_StartMinimumRequests_FailingRequestsBelowMaximumAllowed(t *testing.T) {
-	instance1 := InstanceDesc{Addr: "127.0.0.1"}
-	instance2 := InstanceDesc{Addr: "127.0.0.2"}
-	instance3 := InstanceDesc{Addr: "127.0.0.3"}
-	instance4 := InstanceDesc{Addr: "127.0.0.4"}
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Id: "instance-1"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Id: "instance-2"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Id: "instance-3"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Id: "instance-4"}
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	logger := &testLogger{}
@@ -353,25 +355,28 @@ func TestDefaultResultTracker_StartMinimumRequests_FailingRequestsBelowMaximumAl
 
 	for _, instance := range instancesReleased[0:2] {
 		expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-			"level":    level.DebugValue(),
-			"msg":      "starting request to instance",
-			"reason":   "initial requests",
-			"instance": instance.Addr,
+			"level":        level.DebugValue(),
+			"msg":          "starting request to instance",
+			"reason":       "initial requests",
+			"instanceAddr": instance.Addr,
+			"instanceID":   instance.Id,
 		})
 	}
 
 	expectedLogMessages = append(expectedLogMessages,
 		map[interface{}]interface{}{
-			"level":    level.WarnValue(),
-			"msg":      "instance failed",
-			"instance": instancesReleased[1].Addr,
-			"err":      errors.New("something went wrong"),
+			"level":        level.WarnValue(),
+			"msg":          "instance failed",
+			"instanceAddr": instancesReleased[1].Addr,
+			"instanceID":   instancesReleased[1].Id,
+			"err":          errors.New("something went wrong"),
 		},
 		map[interface{}]interface{}{
-			"level":    level.DebugValue(),
-			"msg":      "starting request to instance",
-			"reason":   "failure of other instance",
-			"instance": instancesReleased[2].Addr,
+			"level":        level.DebugValue(),
+			"msg":          "starting request to instance",
+			"reason":       "failure of other instance",
+			"instanceAddr": instancesReleased[2].Addr,
+			"instanceID":   instancesReleased[2].Id,
 		},
 	)
 
@@ -504,10 +509,10 @@ func TestDefaultResultTracker_StartMinimumRequests_MaxErrorsIsNumberOfInstances(
 }
 
 func TestDefaultResultTracker_StartAdditionalRequests(t *testing.T) {
-	instance1 := InstanceDesc{Addr: "127.0.0.1"}
-	instance2 := InstanceDesc{Addr: "127.0.0.2"}
-	instance3 := InstanceDesc{Addr: "127.0.0.3"}
-	instance4 := InstanceDesc{Addr: "127.0.0.4"}
+	instance1 := InstanceDesc{Addr: "127.0.0.1", Id: "instance-1"}
+	instance2 := InstanceDesc{Addr: "127.0.0.2", Id: "instance-2"}
+	instance3 := InstanceDesc{Addr: "127.0.0.3", Id: "instance-3"}
+	instance4 := InstanceDesc{Addr: "127.0.0.4", Id: "instance-4"}
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4}
 
 	logger := &testLogger{}
@@ -546,16 +551,18 @@ func TestDefaultResultTracker_StartAdditionalRequests(t *testing.T) {
 	waitForInstancesReleased(2, "should initially release two requests")
 	expectedLogMessages := []map[interface{}]interface{}{
 		{
-			"level":    level.DebugValue(),
-			"msg":      "starting request to instance",
-			"reason":   "initial requests",
-			"instance": instancesReleased[0].Addr,
+			"level":        level.DebugValue(),
+			"msg":          "starting request to instance",
+			"reason":       "initial requests",
+			"instanceAddr": instancesReleased[0].Addr,
+			"instanceID":   instancesReleased[0].Id,
 		},
 		{
-			"level":    level.DebugValue(),
-			"msg":      "starting request to instance",
-			"reason":   "initial requests",
-			"instance": instancesReleased[1].Addr,
+			"level":        level.DebugValue(),
+			"msg":          "starting request to instance",
+			"reason":       "initial requests",
+			"instanceAddr": instancesReleased[1].Addr,
+			"instanceID":   instancesReleased[1].Id,
 		},
 	}
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
@@ -563,20 +570,22 @@ func TestDefaultResultTracker_StartAdditionalRequests(t *testing.T) {
 	tracker.startAdditionalRequests()
 	waitForInstancesReleased(3, "should release a third request after startAdditionalRequests()")
 	expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-		"level":    level.DebugValue(),
-		"msg":      "starting request to instance",
-		"reason":   "hedging",
-		"instance": instancesReleased[2].Addr,
+		"level":        level.DebugValue(),
+		"msg":          "starting request to instance",
+		"reason":       "hedging",
+		"instanceAddr": instancesReleased[2].Addr,
+		"instanceID":   instancesReleased[2].Id,
 	})
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
 
 	tracker.startAdditionalRequests()
 	waitForInstancesReleased(4, "should release remaining request after startAdditionalRequests()")
 	expectedLogMessages = append(expectedLogMessages, map[interface{}]interface{}{
-		"level":    level.DebugValue(),
-		"msg":      "starting request to instance",
-		"reason":   "hedging",
-		"instance": instancesReleased[3].Addr,
+		"level":        level.DebugValue(),
+		"msg":          "starting request to instance",
+		"reason":       "hedging",
+		"instanceAddr": instancesReleased[3].Addr,
+		"instanceID":   instancesReleased[3].Id,
 	})
 	require.ElementsMatch(t, expectedLogMessages, logger.messages)
 }
@@ -1025,11 +1034,12 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximum
 
 	expectedLogMessages = append(expectedLogMessages,
 		map[interface{}]interface{}{
-			"level":           level.WarnValue(),
-			"msg":             "request to instance has failed, zone cannot contribute to quorum",
-			"zone":            instancesReleased[0].Zone,
-			"failingInstance": instancesReleased[0].Addr,
-			"err":             errors.New("something went wrong"),
+			"level":               level.WarnValue(),
+			"msg":                 "request to instance has failed, zone cannot contribute to quorum",
+			"zone":                instancesReleased[0].Zone,
+			"failingInstanceAddr": instancesReleased[0].Addr,
+			"failingInstanceID":   instancesReleased[0].Id,
+			"err":                 errors.New("something went wrong"),
 		},
 		map[interface{}]interface{}{
 			"level":  level.DebugValue(),

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -1026,7 +1026,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximum
 	expectedLogMessages = append(expectedLogMessages,
 		map[interface{}]interface{}{
 			"level":           level.WarnValue(),
-			"msg":             "zone has failed",
+			"msg":             "request to instance has failed, zone cannot contribute to quorum",
 			"zone":            instancesReleased[0].Zone,
 			"failingInstance": instancesReleased[0].Addr,
 			"err":             errors.New("something went wrong"),


### PR DESCRIPTION
**What this PR does**:

This PR:

* clarifies the message logged by `DoUntilQuorum` when the first failure in a zone occurs
* adds the instance ID (from #387) to messages logged by `DoUntilQuorum`

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
