### PR TITLE
`DoUntilQuorum`: don't use non-zone-aware logging when all zones are required for quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,3 +174,4 @@
 * [BUGFIX] `MetricFamiliesPerTenant.SendMaxOfGaugesPerTenant` no longer includes tenants, which do not have specified gauge. #368
 * [BUGFIX] Correctly format `host:port` addresses when using IPv6. #388
 * [BUGFIX] Memberlist's TCP transport will now reject bind addresses that are not IP addresses, such as "localhost", rather than silently converting these to 0.0.0.0 and therefore listening on all addresses. #396
+* [BUGFIX] Ring: use zone-aware logging when all zones are required for quorum. #403

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -208,7 +208,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 	}
 
 	if r.ZoneAwarenessEnabled && r.MaxErrors > 0 {
-		return nil, fmt.Errorf("invalid ReplicationSet: MaxErrors is non-zero (is %v) but ZoneAwarenessEnabled is true", r.MaxErrors)
+		return nil, fmt.Errorf("invalid ReplicationSet: MaxErrors is non-zero (is %v) and ZoneAwarenessEnabled is true", r.MaxErrors)
 	}
 
 	var logger kitlog.Logger = cfg.Logger

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -24,6 +24,8 @@ type ReplicationSet struct {
 	// Maximum number of different zones in which instances can fail. Max unavailable zones and
 	// max errors are mutually exclusive.
 	MaxUnavailableZones int
+
+	ZoneAwarenessEnabled bool
 }
 
 // Do function f in parallel for all replicas in the set, erroring if we exceed

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -3,6 +3,7 @@ package ring
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
@@ -122,7 +123,7 @@ func (c DoUntilQuorumConfig) Validate() error {
 //
 // # Result selection
 //
-// If r.MaxUnavailableZones is greater than zero, DoUntilQuorum operates in zone-aware mode:
+// If r.MaxUnavailableZones is greater than zero, or r.ZoneAwarenessEnabled is true, DoUntilQuorum operates in zone-aware mode:
 //   - DoUntilQuorum returns an error if calls to f for instances in more than r.MaxUnavailableZones zones return errors
 //   - Otherwise, DoUntilQuorum returns all results from all replicas in the first zones for which f succeeds
 //     for every instance in that zone (eg. if there are 3 zones and r.MaxUnavailableZones is 1, DoUntilQuorum will
@@ -206,6 +207,10 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 		return nil, err
 	}
 
+	if r.ZoneAwarenessEnabled && r.MaxErrors > 0 {
+		return nil, fmt.Errorf("invalid ReplicationSet: MaxErrors is non-zero (is %v) but ZoneAwarenessEnabled is true", r.MaxErrors)
+	}
+
 	var logger kitlog.Logger = cfg.Logger
 	if cfg.Logger == nil {
 		logger = kitlog.NewNopLogger()
@@ -229,7 +234,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 
 	var resultTracker replicationSetResultTracker
 	var contextTracker replicationSetContextTracker
-	if r.MaxUnavailableZones > 0 {
+	if r.MaxUnavailableZones > 0 || r.ZoneAwarenessEnabled {
 		resultTracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones, logger)
 		contextTracker = newZoneAwareContextTracker(ctx, r.Instances)
 	} else {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -523,9 +523,10 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	}
 
 	return ReplicationSet{
-		Instances:           healthyInstances,
-		MaxErrors:           maxErrors,
-		MaxUnavailableZones: maxUnavailableZones,
+		Instances:            healthyInstances,
+		MaxErrors:            maxErrors,
+		MaxUnavailableZones:  maxUnavailableZones,
+		ZoneAwarenessEnabled: r.cfg.ZoneAwarenessEnabled,
 	}, nil
 }
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -998,14 +998,16 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 
 			// Check the replication set has the correct settings
 			replicationSet, err := ring.GetReplicationSetForOperation(Read)
-			if testData.expectedError == nil {
-				require.NoError(t, err)
-			} else {
+			if testData.expectedError != nil {
 				require.Equal(t, testData.expectedError, err)
+				return
 			}
+
+			require.NoError(t, err)
 
 			assert.Equal(t, testData.expectedMaxErrors, replicationSet.MaxErrors)
 			assert.Equal(t, testData.expectedMaxUnavailableZones, replicationSet.MaxUnavailableZones)
+			assert.True(t, replicationSet.ZoneAwarenessEnabled)
 
 			returnAddresses := []string{}
 			for _, instance := range replicationSet.Instances {


### PR DESCRIPTION
**What this PR does**:

This PR fixes an issue where `DoUntilQuorum` may generate more log messages and span events than expected when zone-awareness is enabled but all healthy zones are required for quorum. (For example, zone-awareness is enabled, three zones are running with 100 instances each, but one instance in the first zone is unavailable, so all instances in the other two zones are required for quorum.)

Previously, if zone-awareness was enabled and all healthy zones were required for quorum, both `ReplicationSet.MaxErrors` and `ReplicationSet.MaxUnavailableZones` would be 0. `DoUntilQuorum` would then default to non-zone-aware mode. In non-zone-aware mode, `DoUntilQuorum` logs a `starting request to instance` message for every instance.

In contrast, in zone-aware mode, `DoUntilQuorum` logs a `starting requests to zone` message for each unique zone.

In the example above, with all instances healthy, `DoUntilQuorum` would log two or three `starting requests to zone` messages, but as soon as one instance becomes unhealthy, a subsequent `DoUntilQuorum` call would log 200 `starting request to instance` messages. 

This PR changes the behaviour of `DoUntilQuorum` to always run in zone-aware mode if zone-awareness is enabled, even if both `ReplicationSet.MaxErrors` and `ReplicationSet.MaxUnavailableZones` are 0.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
