### PR TITLE
Use slices.BinarySearch in util.searchToken

### DIFF
--- a/ring/util.go
+++ b/ring/util.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"golang.org/x/exp/slices"
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/netutil"
@@ -127,9 +128,11 @@ func getZones(tokens map[string][]uint32) []string {
 
 // searchToken returns the offset of the tokens entry holding the range for the provided key.
 func searchToken(tokens []uint32, key uint32) int {
-	i := sort.Search(len(tokens), func(x int) bool {
-		return tokens[x] > key
-	})
+	i, found := slices.BinarySearch(tokens, key)
+	if found {
+		// we want the first token > key, not >= key
+		i = i + 1
+	}
 	if i >= len(tokens) {
 		i = 0
 	}

--- a/ring/util.go
+++ b/ring/util.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"golang.org/x/exp/slices"
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/netutil"
@@ -128,11 +127,9 @@ func getZones(tokens map[string][]uint32) []string {
 
 // searchToken returns the offset of the tokens entry holding the range for the provided key.
 func searchToken(tokens []uint32, key uint32) int {
-	i, found := slices.BinarySearch(tokens, key)
-	if found {
-		// we want the first token > key, not >= key
-		i = i + 1
-	}
+	i := sort.Search(len(tokens), func(x int) bool {
+		return tokens[x] > key
+	})
 	if i >= len(tokens) {
 		i = 0
 	}

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 type RingMock struct {
@@ -435,29 +434,6 @@ func TestSearchToken(t *testing.T) {
 	assert.Equal(t, 1, searchToken(tokens, 4))
 	assert.Equal(t, 0, searchToken(tokens, 5))
 	assert.Equal(t, 0, searchToken(tokens, 7))
-}
-
-func newSearchToken(tokens []uint32, key uint32) int {
-	i, found := slices.BinarySearch(tokens, key)
-	if found {
-		// we want the first token > key, not >= key
-		i = i + 1
-	}
-	if i >= len(tokens) {
-		i = 0
-	}
-	return i
-}
-
-func TestSearchTokenFuncs(t *testing.T) {
-	tokens := GenerateTokens(512*30, []uint32{})
-
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	for i := 0; i < 10000000; i++ {
-		key := r.Uint32()
-		require.Equal(t, searchToken(tokens, key), newSearchToken(tokens, key))
-	}
 }
 
 func BenchmarkSearchToken(b *testing.B) {

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -422,5 +423,34 @@ func TestGetTokenDistance(t *testing.T) {
 	for _, testData := range tests {
 		distance := tokenDistance(testData.from, testData.to)
 		require.Equal(t, testData.expected, distance)
+	}
+}
+
+func TestSearchToken(t *testing.T) {
+	tokens := []uint32{3, 5}
+
+	assert.Equal(t, 0, searchToken(tokens, 0))
+	assert.Equal(t, 1, searchToken(tokens, 3))
+	assert.Equal(t, 1, searchToken(tokens, 4))
+	assert.Equal(t, 0, searchToken(tokens, 5))
+	assert.Equal(t, 0, searchToken(tokens, 7))
+}
+
+func BenchmarkSearchToken(b *testing.B) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tokensPerInstance := 512
+	numInstances := []int{3, 9, 27, 81, 243, 729}
+
+	for _, instances := range numInstances {
+		b.Run(fmt.Sprintf("searchToken_%d_instances", instances), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				tokens := GenerateTokens(instances*tokensPerInstance, []uint32{})
+				hash := r.Uint32()
+				b.StartTimer()
+				searchToken(tokens, hash)
+			}
+		})
 	}
 }

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 type RingMock struct {
@@ -434,6 +435,29 @@ func TestSearchToken(t *testing.T) {
 	assert.Equal(t, 1, searchToken(tokens, 4))
 	assert.Equal(t, 0, searchToken(tokens, 5))
 	assert.Equal(t, 0, searchToken(tokens, 7))
+}
+
+func newSearchToken(tokens []uint32, key uint32) int {
+	i, found := slices.BinarySearch(tokens, key)
+	if found {
+		// we want the first token > key, not >= key
+		i = i + 1
+	}
+	if i >= len(tokens) {
+		i = 0
+	}
+	return i
+}
+
+func TestSearchTokenFuncs(t *testing.T) {
+	tokens := GenerateTokens(512*30, []uint32{})
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 10000000; i++ {
+		key := r.Uint32()
+		require.Equal(t, searchToken(tokens, key), newSearchToken(tokens, key))
+	}
 }
 
 func BenchmarkSearchToken(b *testing.B) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The `slices` package introduces a generic `slices.BinarySearch` which looks to be faster than `sort.Search`, especially as the number of items to search increases.

Benchmark:
```
go test -run='TestSearch' -bench='BenchmarkSearch' -timeout='3h' -benchtime='10000x' -cpu=1 -count=10

name                                   old time/op  new time/op  delta
SearchToken/searchToken_3_instances    89.2ns ± 3%  78.2ns ± 3%  -12.36%  (p=0.000 n=9+8)
SearchToken/searchToken_9_instances     100ns ± 3%    87ns ± 3%  -13.03%  (p=0.000 n=10+10)
SearchToken/searchToken_27_instances    107ns ± 4%    92ns ± 4%  -13.28%  (p=0.000 n=10+9)
SearchToken/searchToken_81_instances    138ns ± 3%   121ns ± 3%  -12.25%  (p=0.000 n=9+10)
SearchToken/searchToken_243_instances   187ns ± 6%   149ns ± 3%  -20.47%  (p=0.000 n=10+9)
SearchToken/searchToken_729_instances   313ns ± 4%   215ns ± 3%  -31.35%  (p=0.000 n=10+9)
```

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`