### PR TITLE
services: stop moduleService underlying service after timing out on AwaitRunning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,3 +178,4 @@
 * [BUGFIX] Correctly format `host:port` addresses when using IPv6. #388
 * [BUGFIX] Memberlist's TCP transport will now reject bind addresses that are not IP addresses, such as "localhost", rather than silently converting these to 0.0.0.0 and therefore listening on all addresses. #396
 * [BUGFIX] Ring: use zone-aware logging when all zones are required for quorum. #403
+* [BUGFIX] Services: moduleService could drop stop signals to its underlying service. #409


### PR DESCRIPTION
### Context

We discovered this in the Mimir ruler which can have a subservice which takes a really long time to fully start (order of minutes). If the process start is interrupted during that time, then that service remains running until the process is killed.

### Description of the bug

When `moduleService` is interrupted during startup it immediately enters a Failed state. This means the services manager doesn't attempt to shut it down because it couldn't even start. This is a problem because

1. the moduleService delegates to another services.Service the lifecycle of the underlying service; this means that the state of moduleService may not match that of the underlying service
2. the moduleService can fail its own startup if it couldn't wait for the underlying service to properly start; this means that the service can start properly eventually, but its parent moduleService shows as Failed; this prevents from shutting down the subservice; so the goroutines continue running until the process stops

### Fix

This PR introduces two changes to address this
1. When the startup procedure is interrupted when waiting for the underlying service, assume the underlying service will later complete its startup and return no errors.
2. When stopping the moduleService also account for services which are still left in their starting state. We still want to signal to them to stop.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
