### PR TITLE
memberlist: reresolve members with every 100 nodes on Join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [CHANGE] Always include source IPs in HTTP and gRPC server spans. #386
 * [CHANGE] ring: Change `PoolFactory` function type to an interface and create function implementations. #387
 * [CHANGE] server: fix incorrect spelling of "gRPC" in `server.Config` fields. #422
+* [CHANGE] memberlist: re-resolve `JoinMembers` during full joins to the cluster (either at startup or periodic). The re-resolution happens on every 100 attempted nodes. This helps speed up joins and respect context cancelation #411
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -591,7 +591,7 @@ func (m *KV) joinMembersWithRetries(ctx context.Context, numAttempts int, logger
 			MaxRetries: numAttempts,
 		}
 		boff               = backoff.New(ctx, cfg)
-		err                = error(nil)
+		err                error
 		successfullyJoined = 0
 	)
 

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -582,7 +582,7 @@ func (m *KV) joinMembersOnStartup(ctx context.Context) bool {
 
 // joinMembersWithRetries joins m.cfg.JoinMembers 100 at a time. After each batch of 100 it rediscoveres the members.
 // This helps when the list of members is big and by the time we reach the end the originally resolved addresses may be obsolete.
-// joinMembersWithRetries returns an error iff it couldn't successfully join any node.
+// joinMembersWithRetries returns an error iff it couldn't successfully join any node OR the context was cancelled.
 func (m *KV) joinMembersWithRetries(ctx context.Context, numAttempts int, logger log.Logger) (int, error) {
 	var (
 		cfg = backoff.Config{
@@ -658,12 +658,12 @@ func (m *KV) joinMembersInBatches(ctx context.Context) (int, error) {
 		successfullyJoined += joinedInBatch
 	}
 	if successfullyJoined > 0 {
-		lastErr = nil
+		return successfullyJoined, nil
 	}
 	if successfullyJoined == 0 && lastErr == nil {
 		return 0, errors.New("found no nodes to join")
 	}
-	return successfullyJoined, lastErr
+	return 0, lastErr
 }
 
 // joinMembersBatch returns an error only if it couldn't successfully join any nodes or if ctx is cancelled.

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -647,6 +647,7 @@ func (m *KV) joinMembersInBatches(ctx context.Context) (int, error) {
 				break
 			}
 			batch = append(batch, n)
+			attemptedNodes[n] = true
 		}
 
 		// Join batch
@@ -654,12 +655,7 @@ func (m *KV) joinMembersInBatches(ctx context.Context) (int, error) {
 		if err != nil {
 			lastErr = err
 		}
-
-		// Record joined nodes
 		successfullyJoined += joinedInBatch
-		for _, n := range batch {
-			attemptedNodes[n] = true
-		}
 	}
 	if successfullyJoined > 0 {
 		lastErr = nil

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -374,7 +374,8 @@ func NewKV(cfg KVConfig, logger log.Logger, dnsProvider DNSProvider, registerer 
 		mlkv.codecs[c.CodecID()] = c
 	}
 
-	mlkv.Service = services.NewBasicService(mlkv.starting, mlkv.running, mlkv.stopping)
+	mlkv.Service = services.NewBasicService(mlkv.starting, mlkv.running, mlkv.stopping).WithName("memberlist_kv")
+
 	return mlkv
 }
 

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -605,6 +605,9 @@ func (m *KV) joinMembersWithRetries(ctx context.Context, numAttempts int, logger
 		}
 		level.Warn(logger).Log("msg", "joining memberlist cluster", "attempts", boff.NumRetries()+1, "max_attempts", numAttempts, "err", err)
 	}
+	if err == nil && ctx.Err() != nil {
+		err = fmt.Errorf("joining memberlist: %w", context.Cause(ctx))
+	}
 
 	return successfullyJoined, err
 }

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -222,7 +222,7 @@ func generateRandomSuffix(logger log.Logger) string {
 // If joining of the cluster if configured, it is done in Running state, and if join fails and Abort flag is set, service
 // fails.
 type KV struct {
-	services.Service
+	services.NamedService
 
 	cfg        KVConfig
 	logger     log.Logger
@@ -374,7 +374,7 @@ func NewKV(cfg KVConfig, logger log.Logger, dnsProvider DNSProvider, registerer 
 		mlkv.codecs[c.CodecID()] = c
 	}
 
-	mlkv.Service = services.NewBasicService(mlkv.starting, mlkv.running, mlkv.stopping).WithName("memberlist_kv")
+	mlkv.NamedService = services.NewBasicService(mlkv.starting, mlkv.running, mlkv.stopping).WithName("memberlist_kv")
 
 	return mlkv
 }

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -605,8 +605,8 @@ func (m *KV) joinMembersWithRetries(ctx context.Context, numAttempts int, logger
 		}
 		level.Warn(logger).Log("msg", "joining memberlist cluster", "attempts", boff.NumRetries()+1, "max_attempts", numAttempts, "err", err)
 	}
-	if err == nil && ctx.Err() != nil {
-		err = fmt.Errorf("joining memberlist: %w", context.Cause(ctx))
+	if err == nil && boff.Err() != nil {
+		err = fmt.Errorf("joining memberlist: %w", boff.Err())
 	}
 
 	return successfullyJoined, err

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -672,7 +672,8 @@ func (m *KV) joinMembersBatch(ctx context.Context, nodes []string) (successfully
 		if ctx.Err() != nil {
 			return successfullyJoined, fmt.Errorf("joining batch: %w", context.Cause(ctx))
 		}
-		// Attempt to join a single node. Complexity shouldn't be different from passing all the node IPs to Join.
+		// Attempt to join a single node.
+		// The cost of calling Join shouldn't be different between passing all nodes in one invocation versus passing a single node per invocation.
 		reached, err := m.memberlist.Join(nodes[nodeIdx : nodeIdx+1])
 		successfullyJoined += reached
 		if err != nil {

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -602,7 +602,7 @@ func (m *KV) joinMembersInBatches(ctx context.Context, numAttempts int, logger l
 			joinedInBatch  int
 			err            error
 		)
-		for batchHasMore := true; batchHasMore; successfullyJoined += joinedInBatch {
+		for batchHasMore := true; boff.Ongoing() && batchHasMore; successfullyJoined += joinedInBatch {
 			// Rediscover nodes and try to join a subset of them with each batch.
 			// When the list of nodes is large by the time we reach the end of the list some of the
 			// IPs can be unreachable.

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"math/rand"
 	"net"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -843,7 +842,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 				for {
 					select {
 					case err := <-watcher.Chan():
-						t.Errorf("service reported error: %v", err.Error())
+						t.Errorf("service reported error: %v", err)
 					case <-stop:
 						return
 					}
@@ -883,7 +882,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 					time.Sleep(testData.startDelayForRest)
 				}
 
-				mkv := NewKV(cfg, log.NewLogfmtLogger(os.Stdout), &delayedDNSProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
+				mkv := NewKV(cfg, log.NewNopLogger(), &delayedDNSProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
 				watcher.WatchService(mkv)
 
 				kv, err := NewClient(mkv, c)

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -842,7 +843,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 				for {
 					select {
 					case err := <-watcher.Chan():
-						t.Errorf("service reported error: %v", err)
+						t.Errorf("service reported error: %v", err.Error())
 					case <-stop:
 						return
 					}
@@ -882,7 +883,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 					time.Sleep(testData.startDelayForRest)
 				}
 
-				mkv := NewKV(cfg, log.NewNopLogger(), &delayedDNSProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
+				mkv := NewKV(cfg, log.NewLogfmtLogger(os.Stdout), &delayedDNSProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
 				watcher.WatchService(mkv)
 
 				kv, err := NewClient(mkv, c)


### PR DESCRIPTION
### Description 

This change solves three problems:
1. Context cancelations aren't respected in Join. Sometimes join might take as long as 25 minutes and there is no way to cancel it. Now we check the context on every 100 joined nodes
2. `Join` will attempt to join member IPs that become obsolete between the time discoverMembers runs and memberlist initiates a push-pull with the node. Reresolve `JoinMembers` addresses after joining every 100 nodes. This helps to clean up obsolete IPs that will be tried at the end of the Join procedure
3. (minor) fast joining on startup doesn't respect context cancelations

The side effect of this change is that there will be more DNS resolutions for the JoinMembers.

**Note to reviewers:** `TestJoinMembersWithRetryBackoff` seems to sometimes fail locally, but it should be an unrelated failure. I believe it should be fixed by this https://github.com/grafana/dskit/pull/412.

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
