### PR TITLE
Fix flaky `TestJoinMembersWithRetryBackoff`

### DIFF
--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -891,11 +891,9 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 				clients = append(clients, kv)
 
 				startKVAndRunClient := func(kv *Client, id string, port int) {
-					err = services.StartAndAwaitRunning(context.Background(), mkv)
-					if err != nil {
-						t.Errorf("failed to start KV: %v", err)
-					}
+					err := services.StartAndAwaitRunning(context.Background(), mkv)
 					kvsStarted.Done()
+					require.NoError(t, err, "failed to start KV: %v")
 					err = runClient(kv, id, key, port, time.Second, start, stop)
 					require.NoError(t, err)
 				}

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"math/rand"
 	"net"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -883,7 +882,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 					time.Sleep(testData.startDelayForRest)
 				}
 
-				mkv := NewKV(cfg, log.NewLogfmtLogger(os.Stdout), &delayedDNSProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
+				mkv := NewKV(cfg, log.NewNopLogger(), &delayedDNSProviderMock{delay: dnsDelay}, prometheus.NewPedanticRegistry()) // Not started yet.
 				watcher.WatchService(mkv)
 
 				kv, err := NewClient(mkv, c)


### PR DESCRIPTION
```
    memberlist_client_test.go:898:
        	Error Trace:	/Users/dimitar/grafana/dskit/kv/memberlist/memberlist_client_test.go:898
        	            				/Users/dimitar/grafana/dskit/kv/memberlist/asm_arm64.s:1197
        	Error:      	Received unexpected error:
        	            	Member-2 failed to join the cluster: &{[%!f(*errors.errorString=&{Failed to join 127.0.0.1:57493: dial tcp 127.0.0.1:57493: connect: connection refused})] %!f(multierror.ErrorFormatFunc=<nil>)}
        	Test:       	TestJoinMembersWithRetryBackoff/Test_late_start_of_DNS_service
```

The failure was caused by the test clients starting and expecting to connect to a KV which still wasn't started. This is unrelated with the backoff that the test asserts on (the backoff happens effectively in the call `err = services.StartAndAwaitRunning(context.Background(), mkv)`).
