### PR TITLE
cache: distinguish between connect and request error reason

### DIFF
--- a/cache/client.go
+++ b/cache/client.go
@@ -22,7 +22,7 @@ const (
 	reasonAsyncBufferFull = "async-buffer-full"
 	reasonMalformedKey    = "malformed-key"
 	reasonConnectTimeout  = "connect-timeout"
-	reasonTimeout         = "timeout"
+	reasonTimeout         = "request-timeout"
 	reasonServerError     = "server-error"
 	reasonNetworkError    = "network-error"
 	reasonOther           = "other"

--- a/cache/client.go
+++ b/cache/client.go
@@ -21,6 +21,7 @@ const (
 	reasonMaxItemSize     = "max-item-size"
 	reasonAsyncBufferFull = "async-buffer-full"
 	reasonMalformedKey    = "malformed-key"
+	reasonConnectTimeout  = "connect-timeout"
 	reasonTimeout         = "timeout"
 	reasonServerError     = "server-error"
 	reasonNetworkError    = "network-error"
@@ -199,7 +200,7 @@ func (c *baseClient) trackError(op string, err error) {
 	var netErr net.Error
 	switch {
 	case errors.As(err, &connErr):
-		c.metrics.failures.WithLabelValues(op, reasonTimeout).Inc()
+		c.metrics.failures.WithLabelValues(op, reasonConnectTimeout).Inc()
 	case errors.As(err, &netErr):
 		if netErr.Timeout() {
 			c.metrics.failures.WithLabelValues(op, reasonTimeout).Inc()


### PR DESCRIPTION
This PR adds an additional cache error reason (`connect-timeout`) in order to distinguish between timeout errors originated during a cache operation and those resulting from a connection attempt.
