### PR TITLE
httpgrpc: Add headers in http grpc error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
+* [ENHANCEMENT] Add headers in HTTP gRPC error in order to be converted back to a HTTP response with HTTPResponseFromError. #416
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38

--- a/httpgrpc/httpgrpc.go
+++ b/httpgrpc/httpgrpc.go
@@ -28,6 +28,14 @@ func Errorf(code int, tmpl string, args ...interface{}) error {
 	})
 }
 
+func ErrorfWithHeaders(code int, headers []*Header, tmpl string, args ...interface{}) error {
+	return ErrorFromHTTPResponse(&HTTPResponse{
+		Code:    int32(code),
+		Body:    []byte(fmt.Sprintf(tmpl, args...)),
+		Headers: headers,
+	})
+}
+
 // ErrorFromHTTPResponse converts an HTTP response into a grpc error
 func ErrorFromHTTPResponse(resp *HTTPResponse) error {
 	a, err := types.MarshalAny(resp)

--- a/middleware/grpc_instrumentation_test.go
+++ b/middleware/grpc_instrumentation_test.go
@@ -39,6 +39,16 @@ func TestErrorCode_Any5xx(t *testing.T) {
 	assert.Equal(t, "5xx", a)
 }
 
+func TestErrorCode_5xx_WithHeaders(t *testing.T) {
+	err := httpgrpc.ErrorfWithHeaders(http.StatusNotImplemented, []*httpgrpc.Header{
+		{Key: "X-Test", Values: []string{"test"}},
+	}, "Fail")
+	resp, ok := httpgrpc.HTTPResponseFromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusNotImplemented, int(resp.Code))
+	assert.Contains(t, resp.Headers, &httpgrpc.Header{Key: "X-Test", Values: []string{"test"}})
+}
+
 func TestErrorCode_Any4xx(t *testing.T) {
 	err := httpgrpc.Errorf(http.StatusConflict, "Fail")
 	a := errorCode(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

In the context of incorporating a retry-after mechanism for all errors that can be recovered, we must compute the retry-after duration within the distributor and include it in the httpgrpc error. This PR focuses on encoding the header within the httpgrpc error, enabling it to be subsequently transmitted to the http response.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
