### PR TITLE
moduleService: Fix return of `nil` from starting function when starting failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,4 +179,4 @@
 * [BUGFIX] Correctly format `host:port` addresses when using IPv6. #388
 * [BUGFIX] Memberlist's TCP transport will now reject bind addresses that are not IP addresses, such as "localhost", rather than silently converting these to 0.0.0.0 and therefore listening on all addresses. #396
 * [BUGFIX] Ring: use zone-aware logging when all zones are required for quorum. #403
-* [BUGFIX] Services: moduleService could drop stop signals to its underlying service. #409
+* [BUGFIX] Services: moduleService could drop stop signals to its underlying service. #409 #417

--- a/modules/module_service.go
+++ b/modules/module_service.go
@@ -86,11 +86,10 @@ func (w *moduleService) start(serviceContext context.Context) error {
 	}
 
 	err = w.service.AwaitRunning(serviceContext)
-	if errors.Is(serviceContext.Err(), context.Canceled) && errors.Is(err, context.Canceled) {
-		// We were asked to cancel, but the underlying service may continue starting and complete its startup after we return from moduleService.start.
-		// If we return an error, then we would be considered Failed and won't have moduleService.stop invoked.
-		// We need to invoke moduleService.stop to stop the underlying service in case it finishes starting successfully later.
-		return nil
+	if err != nil {
+		// Make sure that underlying service is stopped before returning
+		// (eg. in case of context cancellation, AwaitRunning returns early, but service may still be starting).
+		_ = services.StopAndAwaitTerminated(context.Background(), w.service)
 	}
 	return err
 }
@@ -104,19 +103,14 @@ func (w *moduleService) run(serviceContext context.Context) error {
 
 func (w *moduleService) stop(_ error) error {
 	var err error
-	switch w.service.State() {
-	case services.Running:
+	if w.service.State() == services.Running {
 		// Only wait for other modules, if underlying service is still running.
 		w.waitForModulesToStop()
-		// Then proceed to also stop this service if we didn't wait it out during moduleService.start.
-		fallthrough
-	case services.Starting:
-		// If upstream services can tolerate this service being failed and/or not started, and they have already started,
-		// they should track the state of this service and change state accordingly.
+
 		level.Debug(w.logger).Log("msg", "stopping", "module", w.name)
 
 		err = services.StopAndAwaitTerminated(context.Background(), w.service)
-	default:
+	} else {
 		err = w.service.FailureCase()
 	}
 

--- a/modules/module_service.go
+++ b/modules/module_service.go
@@ -79,7 +79,7 @@ func (w *moduleService) start(serviceContext context.Context) error {
 
 	// we don't want to let this service to stop until all dependant services are stopped,
 	// so we use independent context here
-	level.Info(w.logger).Log("msg", "initialising", "module", w.name)
+	level.Info(w.logger).Log("msg", "starting", "module", w.name)
 	err := w.service.StartAsync(context.Background())
 	if err != nil {
 		return errors.Wrapf(err, "error starting module: %s", w.name)
@@ -88,10 +88,10 @@ func (w *moduleService) start(serviceContext context.Context) error {
 	err = w.service.AwaitRunning(serviceContext)
 	if err != nil {
 		// Make sure that underlying service is stopped before returning
-		// (eg. in case of context cancellation, AwaitRunning returns early, but service may still be starting).
+		// (e.g. in case of context cancellation, AwaitRunning returns early, but service may still be starting).
 		_ = services.StopAndAwaitTerminated(context.Background(), w.service)
 	}
-	return err
+	return errors.Wrapf(err, "starting module %s", w.name)
 }
 
 func (w *moduleService) run(serviceContext context.Context) error {

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -385,7 +385,7 @@ func TestModuleService_InterruptedFastStartup(t *testing.T) {
 	// We get context cancelled error from service context cancellation.
 	err := moduleSvc.AwaitRunning(context.Background())
 	require.ErrorIs(t, err, context.Canceled)
-	require.ErrorContains(t, err, "starting module")
+	require.ErrorContains(t, err, "starting module A")
 
 	require.True(t, subserviceStopped)
 	require.Equal(t, services.Failed, moduleSvc.State())
@@ -420,7 +420,7 @@ func TestModuleService_InterruptedSlowStartup(t *testing.T) {
 	// We get context.Canceled from moduleService.start.
 	err := services.StopAndAwaitTerminated(context.Background(), moduleSvc)
 	require.ErrorIs(t, err, context.Canceled)
-	require.ErrorContains(t, err, "starting module")
+	require.ErrorContains(t, err, "starting module A")
 
 	assert.True(t, subserviceStopped)
 	require.Equal(t, services.Failed, moduleSvc.State())

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -383,7 +383,9 @@ func TestModuleService_InterruptedFastStartup(t *testing.T) {
 	// Start service using context that's going to be cancelled
 	require.NoError(t, moduleSvc.StartAsync(ctx))
 	// We get context cancelled error from service context cancellation.
-	require.ErrorIs(t, moduleSvc.AwaitRunning(context.Background()), context.Canceled)
+	err := moduleSvc.AwaitRunning(context.Background())
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "starting module")
 
 	require.True(t, subserviceStopped)
 	require.Equal(t, services.Failed, moduleSvc.State())
@@ -416,7 +418,9 @@ func TestModuleService_InterruptedSlowStartup(t *testing.T) {
 	<-subserviceStarted
 
 	// We get context.Canceled from moduleService.start.
-	require.ErrorIs(t, services.StopAndAwaitTerminated(context.Background(), moduleSvc), context.Canceled)
+	err := services.StopAndAwaitTerminated(context.Background(), moduleSvc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "starting module")
 
 	assert.True(t, subserviceStopped)
 	require.Equal(t, services.Failed, moduleSvc.State())


### PR DESCRIPTION
**What this PR does**:

This is alternative fix to https://github.com/grafana/dskit/pull/409, as discussed in thread https://github.com/grafana/dskit/pull/409#discussion_r1368788306.

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
