### PR TITLE
httpgrpc: correct handling of non-loggable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@
 * [ENHANCEMENT] Ring: add support for aborting early if a terminal error is returned by a request initiated by `DoUntilQuorum`. #404 #413
 * [ENHANCEMENT] Memcached: allow to configure write and read buffer size (in bytes). #414
 * [ENHANCEMENT] Server: Add `-server.http-read-header-timeout` option to specify timeout for reading HTTP request header. It defaults to 0, in which case reading of headers can take up to `-server.http-read-timeout`, leaving no time for reading body, if there's any. #423
+* [ENHANCEMENT] Make httpgrpc.Server produce non-loggable errors when a header with key `httpgrpc.DoNotLogErrorHeaderKey` and any value is present in the HTTP response. #421
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/httpgrpc/httpgrpc.go
+++ b/httpgrpc/httpgrpc.go
@@ -6,10 +6,12 @@ package httpgrpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-kit/log/level"
 	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 
 	spb "github.com/gogo/googleapis/google/rpc"
 	"github.com/gogo/protobuf/types"
@@ -44,7 +46,7 @@ func ErrorFromHTTPResponse(resp *HTTPResponse) error {
 
 // HTTPResponseFromError converts a grpc error into an HTTP response
 func HTTPResponseFromError(err error) (*HTTPResponse, bool) {
-	s, ok := status.FromError(err)
+	s, ok := statusFromError(err)
 	if !ok {
 		return nil, false
 	}
@@ -61,6 +63,29 @@ func HTTPResponseFromError(err error) (*HTTPResponse, bool) {
 	}
 
 	return &resp, true
+}
+
+// statusFromError tries to cast the given error into status.Status.
+// If the given error, or any error from its tree are a status.Status,
+// that status.Status and the outcome true are returned.
+// Otherwise, nil and the outcome false are returned.
+// This implementation differs from status.FromError() because the
+// latter checks only if the given error can be cast to status.Status,
+// and doesn't check other errors in the given error's tree.
+func statusFromError(err error) (*status.Status, bool) {
+	if err == nil {
+		return nil, false
+	}
+	type grpcStatus interface{ GRPCStatus() *grpcstatus.Status }
+	var gs grpcStatus
+	if errors.As(err, &gs) {
+		st := gs.GRPCStatus()
+		if st == nil {
+			return nil, false
+		}
+		return status.FromGRPCStatus(st), true
+	}
+	return nil, false
 }
 
 const (

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -2,10 +2,14 @@ package httpgrpc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/gogo/status"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func TestAppendMessageSizeToOutgoingContext(t *testing.T) {
@@ -23,4 +27,147 @@ func TestAppendMessageSizeToOutgoingContext(t *testing.T) {
 
 	require.Equal(t, []string{"GET"}, md.Get(MetadataMethod))
 	require.Equal(t, []string{"/test"}, md.Get(MetadataURL))
+}
+
+func TestErrorf(t *testing.T) {
+	code := 400
+	errMsg := "this is an error"
+	expectedHTTPResponse := &HTTPResponse{
+		Code: int32(code),
+		Body: []byte(errMsg),
+	}
+	err := Errorf(code, errMsg)
+	stat, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, code, int(stat.Code()))
+	require.Equal(t, errMsg, stat.Message())
+	checkDetailAsHTTPResponse(t, expectedHTTPResponse, stat)
+}
+
+func TestErrorFromHTTPResponse(t *testing.T) {
+	var code int32 = 400
+	errMsg := "this is an error"
+	headers := []*Header{{Key: "X-Header", Values: []string{"a", "b", "c"}}}
+	resp := &HTTPResponse{
+		Code:    code,
+		Headers: headers,
+		Body:    []byte(errMsg),
+	}
+	err := ErrorFromHTTPResponse(resp)
+	require.Error(t, err)
+	stat, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, code, int32(stat.Code()))
+	require.Equal(t, errMsg, stat.Message())
+	checkDetailAsHTTPResponse(t, resp, stat)
+}
+
+func TestHTTPResponseFromError(t *testing.T) {
+	msgErr := "this is an error"
+	testCases := map[string]struct {
+		err                  error
+		isGRPCError          bool
+		isHTTPGRCPError      bool
+		expectedHTTPResponse *HTTPResponse
+	}{
+		"no error cannot be parsed to an HTTPResponse": {
+			err: nil,
+		},
+		"a random error cannot be parsed to an HTTPResponse": {
+			err: fmt.Errorf(msgErr),
+		},
+		"a gRPC error built by gogo/status cannot be parsed to an HTTPResponse": {
+			err: status.Error(codes.Internal, msgErr),
+		},
+		"a gRPC error built by grpc/status cannot be parsed to an HTTPResponse": {
+			err: grpcstatus.Error(codes.Internal, msgErr),
+		},
+		"a gRPC error built by httpgrpc can be parsed to an HTTPResponse": {
+			err:                  Errorf(400, msgErr),
+			expectedHTTPResponse: &HTTPResponse{Code: 400, Body: []byte(msgErr)},
+		},
+		"a wrapped gRPC error built by httpgrpc can be parsed to an HTTPResponse": {
+			err:                  fmt.Errorf("wrapped: %w", Errorf(400, msgErr)),
+			expectedHTTPResponse: &HTTPResponse{Code: 400, Body: []byte(msgErr)},
+		},
+	}
+	for testName, testData := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			resp, ok := HTTPResponseFromError(testData.err)
+			if testData.expectedHTTPResponse == nil {
+				require.False(t, ok)
+				require.Nil(t, resp)
+			} else {
+				require.True(t, ok)
+
+			}
+		})
+	}
+}
+
+func TestStatusFromError(t *testing.T) {
+	msgErr := "this is an error"
+	testCases := map[string]struct {
+		err            error
+		expectedStatus *status.Status
+	}{
+		"no error cannot be cast to status.Status": {
+			err: nil,
+		},
+		"a random error cannot be cast to status.Status": {
+			err: fmt.Errorf(msgErr),
+		},
+		"a wrapped error of a random error cannot be cast to status.Status": {
+			err: fmt.Errorf("wrapped: %w", fmt.Errorf(msgErr)),
+		},
+		"a gRPC error built by gogo/status can be cast to status.Status": {
+			err:            status.Error(codes.Internal, msgErr),
+			expectedStatus: status.New(codes.Internal, msgErr),
+		},
+		"a wrapped error of a gRPC error built by gogo/status can be cast to status.Status": {
+			err:            fmt.Errorf("wrapped: %w", status.Error(codes.Internal, msgErr)),
+			expectedStatus: status.New(codes.Internal, msgErr),
+		},
+		"a gRPC error built by grpc/status can be cast to status.Status": {
+			err:            grpcstatus.Error(codes.Internal, msgErr),
+			expectedStatus: status.New(codes.Internal, msgErr),
+		},
+		"a wrapped error of a gRPC error built by grpc/status can be cast to status.Status": {
+			err:            fmt.Errorf("wrapped: %w", grpcstatus.Error(codes.Internal, msgErr)),
+			expectedStatus: status.New(codes.Internal, msgErr),
+		},
+		"a gRPC error built by httpgrpc can be cast to status.Status": {
+			err:            Errorf(400, msgErr),
+			expectedStatus: status.New(400, msgErr),
+		},
+		"a wrapped gRPC error built by httpgrpc can be cast to status.Status": {
+			err:            fmt.Errorf("wrapped: %w", Errorf(400, msgErr)),
+			expectedStatus: status.New(400, msgErr),
+		},
+	}
+	for testName, testData := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			stat, ok := statusFromError(testData.err)
+			if testData.expectedStatus == nil {
+				require.False(t, ok)
+				require.Nil(t, stat)
+			} else {
+				require.True(t, ok)
+				require.NotNil(t, stat)
+				require.Equal(t, testData.expectedStatus.Code(), stat.Code())
+				require.Equal(t, testData.expectedStatus.Message(), stat.Message())
+			}
+		})
+	}
+}
+
+func checkDetailAsHTTPResponse(t *testing.T, httpResponse *HTTPResponse, stat *status.Status) {
+	details := stat.Details()
+	require.Len(t, details, 1)
+	respDetails, ok := details[0].(*HTTPResponse)
+	require.True(t, ok)
+	require.NotNil(t, respDetails)
+	require.Equal(t, httpResponse.Code, respDetails.Code)
+	require.Equal(t, httpResponse.Headers, respDetails.Headers)
+	require.Equal(t, httpResponse.Body, respDetails.Body)
 }

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -78,7 +78,6 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 	if recorder.Code/100 == 5 {
 		err := httpgrpc.ErrorFromHTTPResponse(resp)
 		if _, ok := header[DoNotLogErrorHeaderKey]; ok {
-			recorder.Header().Del(DoNotLogErrorHeaderKey)
 			err = middleware.DoNotLogError{Err: err}
 		}
 		return nil, err

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -7,6 +7,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -101,10 +102,84 @@ func TestError(t *testing.T) {
 
 			assert.Equal(t, "foo\n", recorder.Body.String())
 			assert.Equal(t, 500, recorder.Code)
-			if doNotLog {
-				assert.Equal(t, recorder.Header().Get(DoNotLogErrorHeaderKey), "true")
+			assert.NotContains(t, recorder.Header(), DoNotLogErrorHeaderKey)
+		})
+	}
+}
+
+func TestServerHandleDoNotLogError(t *testing.T) {
+	testCases := map[string]struct {
+		errorCode     int
+		doNotLogError bool
+		expectedError bool
+	}{
+		"HTTPResponse with code 5xx and with DoNotLogError header should return a non-loggable error": {
+			errorCode:     http.StatusInternalServerError,
+			doNotLogError: true,
+			expectedError: true,
+		},
+		"HTTPResponse with code 5xx and without DoNotLogError header should return a loggable error": {
+			errorCode:     http.StatusInternalServerError,
+			expectedError: true,
+		},
+		"HTTPResponse with code different from 5xx and with DoNotLogError header should not return an error": {
+			errorCode:     http.StatusBadRequest,
+			doNotLogError: true,
+			expectedError: false,
+		},
+		"HTTPResponse with code different from 5xx and without DoNotLogError header should not return an error": {
+			errorCode:     http.StatusBadRequest,
+			expectedError: false,
+		},
+	}
+	errMsg := "this is an error"
+	for testName, testData := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if testData.doNotLogError {
+					w.Header().Set(DoNotLogErrorHeaderKey, "true")
+				}
+				http.Error(w, errMsg, testData.errorCode)
+			})
+
+			s := NewServer(h)
+			req := &httpgrpc.HTTPRequest{
+				Method: "GET",
+				Url:    "/test",
+			}
+			resp, err := s.Handle(context.Background(), req)
+			if testData.expectedError {
+				require.Error(t, err)
+				require.Nil(t, resp)
+				var optional middleware.OptionalLogging
+				if testData.doNotLogError {
+					require.ErrorAs(t, err, &optional)
+					require.False(t, optional.ShouldLog(context.Background(), 0))
+				} else {
+					require.False(t, errors.As(err, &optional))
+				}
+				checkError(t, err, testData.errorCode, errMsg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				checkHTTPResponse(t, resp, testData.errorCode, errMsg)
 			}
 		})
+	}
+}
+
+func checkError(t *testing.T, err error, expectedCode int, expectedMessage string) {
+	resp, ok := httpgrpc.HTTPResponseFromError(err)
+	require.True(t, ok)
+	checkHTTPResponse(t, resp, expectedCode, expectedMessage)
+}
+
+func checkHTTPResponse(t *testing.T, resp *httpgrpc.HTTPResponse, expectedCode int, expectedBody string) {
+	require.Equal(t, int32(expectedCode), resp.GetCode())
+	require.Equal(t, fmt.Sprintf("%s\n", expectedBody), string(resp.GetBody()))
+	hs := resp.GetHeaders()
+	for _, h := range hs {
+		require.NotEqual(t, DoNotLogErrorHeaderKey, h.Key)
 	}
 }
 

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -151,3 +151,37 @@ func TestTracePropagation(t *testing.T) {
 	assert.Equal(t, "world", recorder.Body.String())
 	assert.Equal(t, 200, recorder.Code)
 }
+
+func TestContainsDoNotLogErrorKey(t *testing.T) {
+	testCases := map[string]struct {
+		header          http.Header
+		expectedOutcome bool
+	}{
+		"if headers do not contain X-DoNotLogError, return false": {
+			header: http.Header{
+				"X-First":  []string{"a", "b", "c"},
+				"X-Second": []string{"1", "2"},
+			},
+			expectedOutcome: false,
+		},
+		"if headers contain X-DoNotLogError with a value, return true": {
+			header: http.Header{
+				"X-First":         []string{"a", "b", "c"},
+				"X-DoNotLogError": []string{"true"},
+			},
+			expectedOutcome: true,
+		},
+		"if headers contain X-DoNotLogError without a value, return true": {
+			header: http.Header{
+				"X-First":         []string{"a", "b", "c"},
+				"X-DoNotLogError": nil,
+			},
+			expectedOutcome: true,
+		},
+	}
+	for testName, testData := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			require.Equal(t, testData.expectedOutcome, containsDoNotLogErrorKey(testData.header))
+		})
+	}
+}

--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -7,7 +7,6 @@ package middleware
 import (
 	"context"
 	"errors"
-	"net/http"
 	"time"
 
 	"github.com/go-kit/log"
@@ -23,10 +22,6 @@ import (
 
 const (
 	gRPC = "gRPC"
-)
-
-var (
-	DoNotLogErrorHeader = http.CanonicalHeaderKey("X-DoNotLogError")
 )
 
 // An error can implement ShouldLog() to control whether GRPCServerLog will log.

--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -7,6 +7,7 @@ package middleware
 import (
 	"context"
 	"errors"
+	"net/http"
 	"time"
 
 	"github.com/go-kit/log"
@@ -24,10 +25,20 @@ const (
 	gRPC = "gRPC"
 )
 
+var (
+	DoNotLogErrorHeader = http.CanonicalHeaderKey("X-DoNotLogError")
+)
+
 // An error can implement ShouldLog() to control whether GRPCServerLog will log.
 type OptionalLogging interface {
 	ShouldLog(ctx context.Context, duration time.Duration) bool
 }
+
+type DoNotLogError struct{ Err error }
+
+func (i DoNotLogError) Error() string                                     { return i.Err.Error() }
+func (i DoNotLogError) Unwrap() error                                     { return i.Err }
+func (i DoNotLogError) ShouldLog(_ context.Context, _ time.Duration) bool { return false }
 
 // GRPCServerLog logs grpc requests, errors, and latency.
 type GRPCServerLog struct {


### PR DESCRIPTION
**What this PR does**:
This PR allows correct handling of non-loggable errors. 

First of all, it introduces `middleware.DoNotLogError` type, representing the errors that should not be logged. Additionally, it introduces `httpgrpc.DoNotLogErrorHeaderKey`, an HTTP header key with value `X-DoNotLogError`. In case of an erroneous `HTTPResponse`, the presence of this header means that the corresponding error should not be logged. 

When `httpgrpc`'s `Server.Handle()` receives a response from the HTTP server, an `HTTPResponse` object is created. `HTTPResponse`s with a status `5xx` are translated into gRPC errors, by using the `httpgrpc` package. Before this PR, all these errors were loggable. This PR allows `Server.Handle()` to return errors that should not be logged. More precisely, the presence of a header with key `httpgrpc.DoNotLogHeader` and any value in an erroneous `HTTPResponse` indicates to `Servier.Handle()` to wrap the gRPC error (created by the `httpgrpc` package) with a `httpgrpc.DoNotLogError`.

One more change introduced by this PR concerns `httpgrpc.HTTPResponseFromError()`. Namely, before this PR, errors built by `httpgrpc` package and wrapped with another error, were not recognized by `httpgrpc.HTTPResponseFromError()`. This PR fixes that behavior.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/mimir/issues/6008.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
