### PR TITLE
Log closed connections without any response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@
  * `middleware.UnaryClientInstrumentInterceptor`
  * `middleware.StreamClientInstrumentInterceptor`
  * `middleware.Instrument`
+* [ENHANCEMENT] Server: Added new `-server.http-log-closed-connections-without-response-enabled` option to log details about closed connections that received no response. #426
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/concurrency/buffer.go
+++ b/concurrency/buffer.go
@@ -24,3 +24,10 @@ func (sb *SyncBuffer) String() string {
 
 	return sb.buf.String()
 }
+
+func (sb *SyncBuffer) Reset() {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
+	sb.buf.Reset()
+}

--- a/middleware/zero_response.go
+++ b/middleware/zero_response.go
@@ -1,0 +1,127 @@
+package middleware
+
+import (
+	"errors"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"sync"
+
+	"github.com/go-kit/log"
+	"go.uber.org/atomic"
+)
+
+// NewZeroResponseListener returns a Listener that logs all connections that encountered io timeout on reads, and were closed before sending any response.
+func NewZeroResponseListener(list net.Listener, log log.Logger) net.Listener {
+	return &zeroResponseListener{
+		Listener: list,
+		log:      log,
+		bufPool: sync.Pool{
+			New: func() any { return make([]byte, 0, requestBufSize) },
+		},
+	}
+}
+
+// Size of buffer for read data. We log this eventually.
+const requestBufSize = 512
+
+type zeroResponseListener struct {
+	net.Listener
+	log     log.Logger
+	bufPool sync.Pool
+}
+
+func (zl *zeroResponseListener) Accept() (net.Conn, error) {
+	conn, err := zl.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	buf := zl.bufPool.Get().([]byte)
+	buf = buf[:0]
+	return &zeroResponseConn{Conn: conn, log: zl.log, buf: buf, returnPool: &zl.bufPool}, nil
+}
+
+type zeroResponseConn struct {
+	net.Conn
+
+	log        log.Logger
+	once       sync.Once
+	returnPool *sync.Pool
+
+	bufMu sync.Mutex
+	buf   []byte // Buffer with first requestBufSize bytes from connection. Set to nil as soon as data is written to the connection.
+
+	lastReadErrIsDeadlineExceeded atomic.Bool
+}
+
+func (zc *zeroResponseConn) Read(b []byte) (n int, err error) {
+	n, err = zc.Conn.Read(b)
+	if err != nil && errors.Is(err, os.ErrDeadlineExceeded) {
+		zc.lastReadErrIsDeadlineExceeded.Store(true)
+	} else {
+		zc.lastReadErrIsDeadlineExceeded.Store(false)
+	}
+
+	// Store first requestBufSize read bytes on connection into the buffer for logging.
+	if n > 0 {
+		zc.bufMu.Lock()
+		defer zc.bufMu.Unlock()
+
+		if zc.buf != nil {
+			rem := requestBufSize - len(zc.buf) // how much space is in our buffer.
+			if rem > n {
+				rem = n
+			}
+			if rem > 0 {
+				zc.buf = append(zc.buf, b[:rem]...)
+			}
+		}
+	}
+	return
+}
+
+func (zc *zeroResponseConn) Write(b []byte) (n int, err error) {
+	n, err = zc.Conn.Write(b)
+	if n > 0 {
+		zc.bufMu.Lock()
+		if zc.buf != nil {
+			zc.returnPool.Put(zc.buf)
+			zc.buf = nil
+		}
+		zc.bufMu.Unlock()
+	}
+	return
+}
+
+var authRegexp = regexp.MustCompile("((?i)\\r\\nauthorization:\\s+)(\\S+\\s+)(\\S+)")
+
+func (zc *zeroResponseConn) Close() error {
+	err := zc.Conn.Close()
+
+	zc.once.Do(func() {
+		zc.bufMu.Lock()
+		defer zc.bufMu.Unlock()
+
+		// If buffer was already returned, it means there was some data written on the connection, nothing to do.
+		if zc.buf == nil {
+			return
+		}
+
+		// If we didn't write anything to this connection, and we've got timeout while reading data, it looks like
+		// slow a slow client failing to send a request to us.
+		if !zc.lastReadErrIsDeadlineExceeded.Load() {
+			return
+		}
+
+		b := zc.buf
+		b = authRegexp.ReplaceAll(b, []byte("${1}${2}***")) // Replace value in Authorization header with ***.
+
+		_ = zc.log.Log("msg", "read timeout, connection closed with no response", "read", strconv.Quote(string(b)), "remote", zc.RemoteAddr().String())
+
+		zc.returnPool.Put(zc.buf)
+		zc.buf = nil
+	})
+
+	return err
+}

--- a/middleware/zero_response.go
+++ b/middleware/zero_response.go
@@ -94,7 +94,7 @@ func (zc *zeroResponseConn) Write(b []byte) (n int, err error) {
 	return
 }
 
-var authRegexp = regexp.MustCompile("((?i)\\r\\nauthorization:\\s+)(\\S+\\s+)(\\S+)")
+var authRegexp = regexp.MustCompile(`((?i)\r\nauthorization:\s+)(\S+\s+)(\S+)`)
 
 func (zc *zeroResponseConn) Close() error {
 	err := zc.Conn.Close()

--- a/middleware/zero_response_test.go
+++ b/middleware/zero_response_test.go
@@ -1,0 +1,142 @@
+package middleware
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/concurrency"
+	"github.com/grafana/dskit/test"
+)
+
+func TestZeroResponseLogger(t *testing.T) {
+	const body = "Hello"
+
+	s := http.Server{
+		Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(body))
+		}),
+		ReadTimeout:       0,
+		ReadHeaderTimeout: 1 * time.Second,
+	}
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	logBuf := concurrency.SyncBuffer{}
+	zrl := NewZeroResponseListener(ln, log.NewLogfmtLogger(&logBuf))
+
+	go func() {
+		_ = s.Serve(zrl)
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	t.Run("multiple quick requests", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			r, err := http.Get("http://" + ln.Addr().String())
+			require.NoError(t, err)
+			defer func() { _ = r.Body.Close() }()
+
+			require.Equal(t, 200, r.StatusCode)
+			read, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, body, string(read))
+		}
+	})
+
+	t.Run("slow request", func(t *testing.T) {
+		logBuf.Reset()
+
+		c, err := net.Dial("tcp", ln.Addr().String())
+		require.NoError(t, err)
+		defer func() {
+			_ = c.Close()
+		}()
+
+		_, err = c.Write([]byte("GET / HTTP/1.1\r\nHost: somehost:12345\r\n")) // unfinished request
+		require.NoError(t, err)
+
+		// HTTP server will close the connection in 1 second (see above config), without any response.
+		read, err := io.ReadAll(c)
+		require.NoError(t, err)
+		require.Equal(t, "", string(read))
+
+		// Wait a bit until connection is closed and log message logged.
+		test.Poll(t, 1*time.Second, true, func() interface{} {
+			return logBuf.String() != ""
+		})
+
+		require.Contains(t, logBuf.String(), `msg="read timeout, connection closed with no response"`)
+		require.Contains(t, logBuf.String(), `read="\"GET / HTTP/1.1\\r\\nHost: somehost:12345\\r\\n\""`)
+		require.Contains(t, logBuf.String(), `remote=`)
+	})
+
+	t.Run("slow request with multiple writes", func(t *testing.T) {
+		logBuf.Reset()
+
+		c, err := net.Dial("tcp", ln.Addr().String())
+		require.NoError(t, err)
+		defer func() {
+			_ = c.Close()
+		}()
+
+		_, err = c.Write([]byte("GET / HTTP/1.1\r\n"))
+		require.NoError(t, err)
+		_, err = c.Write([]byte("X-Org-ScopeID: 54321\r\n"))
+		require.NoError(t, err)
+		_, err = c.Write([]byte("Host: somehost:12345\r\n"))
+		require.NoError(t, err)
+
+		// HTTP server will close the connection in 1 second (see above config), without any response.
+		read, err := io.ReadAll(c)
+		require.NoError(t, err)
+		require.Equal(t, "", string(read))
+
+		// Wait a bit until connection is closed and log message logged.
+		test.Poll(t, 1*time.Second, true, func() interface{} {
+			return logBuf.String() != ""
+		})
+
+		require.Contains(t, logBuf.String(), `msg="read timeout, connection closed with no response"`)
+		require.Contains(t, logBuf.String(), `read="\"GET / HTTP/1.1\\r\\nX-Org-ScopeID: 54321\\r\\nHost: somehost:12345\\r\\n\""`)
+		require.Contains(t, logBuf.String(), `remote=`)
+	})
+
+	t.Run("slow request with authorization header", func(t *testing.T) {
+		logBuf.Reset()
+
+		c, err := net.Dial("tcp", ln.Addr().String())
+		require.NoError(t, err)
+		defer func() {
+			_ = c.Close()
+		}()
+
+		_, err = c.Write([]byte("GET / HTTP/1.1\r\n"))
+		require.NoError(t, err)
+		_, err = c.Write([]byte("X-Org-ScopeID: 54321\r\n"))
+		require.NoError(t, err)
+		_, err = c.Write([]byte("Authorization: Basic YWFhOmJiYg==\r\n"))
+		require.NoError(t, err)
+
+		// HTTP server will close the connection in 1 second (see above config), without any response.
+		read, err := io.ReadAll(c)
+		require.NoError(t, err)
+		require.Equal(t, "", string(read))
+
+		// Wait a bit until connection is closed and log message logged.
+		test.Poll(t, 1*time.Second, true, func() interface{} {
+			return logBuf.String() != ""
+		})
+
+		require.Contains(t, logBuf.String(), `msg="read timeout, connection closed with no response"`)
+		require.Contains(t, logBuf.String(), `read="\"GET / HTTP/1.1\\r\\nX-Org-ScopeID: 54321\\r\\nAuthorization: Basic ***\\r\\n\""`)
+		require.Contains(t, logBuf.String(), `remote=`)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -177,7 +177,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HTTPServerReadHeaderTimeout, "server.http-read-header-timeout", 0, "Read timeout for HTTP request headers. If set to 0, value of -server.http-read-timeout is used.")
 	f.DurationVar(&cfg.HTTPServerWriteTimeout, "server.http-write-timeout", 30*time.Second, "Write timeout for HTTP server")
 	f.DurationVar(&cfg.HTTPServerIdleTimeout, "server.http-idle-timeout", 120*time.Second, "Idle timeout for HTTP server")
-	f.BoolVar(&cfg.HTTPLogClosedConnectionsWithoutResponse, "server.http_log_closed_connections_without_response_enabled", false, "Log closed connections that did not receive any response, most likely because client didn't send any request within timeout.")
+	f.BoolVar(&cfg.HTTPLogClosedConnectionsWithoutResponse, "server.http-log-closed-connections-without-response-enabled", false, "Log closed connections that did not receive any response, most likely because client didn't send any request within timeout.")
 	f.IntVar(&cfg.GRPCServerMaxRecvMsgSize, "server.grpc-max-recv-msg-size-bytes", 4*1024*1024, "Limit on the size of a gRPC message this server can receive (bytes).")
 	f.IntVar(&cfg.GRPCServerMaxSendMsgSize, "server.grpc-max-send-msg-size-bytes", 4*1024*1024, "Limit on the size of a gRPC message this server can send (bytes).")
 	f.UintVar(&cfg.GRPCServerMaxConcurrentStreams, "server.grpc-max-concurrent-streams", 100, "Limit on the number of concurrent streams for gRPC calls per client connection (0 = unlimited)")

--- a/server/server.go
+++ b/server/server.go
@@ -103,6 +103,8 @@ type Config struct {
 	HTTPServerWriteTimeout        time.Duration `yaml:"http_server_write_timeout"`
 	HTTPServerIdleTimeout         time.Duration `yaml:"http_server_idle_timeout"`
 
+	HTTPLogClosedConnectionsWithoutResponse bool `yaml:"http_log_closed_connections_without_response_enabled"`
+
 	GRPCOptions                   []grpc.ServerOption            `yaml:"-"`
 	GRPCMiddleware                []grpc.UnaryServerInterceptor  `yaml:"-"`
 	GRPCStreamMiddleware          []grpc.StreamServerInterceptor `yaml:"-"`
@@ -175,6 +177,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HTTPServerReadHeaderTimeout, "server.http-read-header-timeout", 0, "Read timeout for HTTP request headers. If set to 0, value of -server.http-read-timeout is used.")
 	f.DurationVar(&cfg.HTTPServerWriteTimeout, "server.http-write-timeout", 30*time.Second, "Write timeout for HTTP server")
 	f.DurationVar(&cfg.HTTPServerIdleTimeout, "server.http-idle-timeout", 120*time.Second, "Idle timeout for HTTP server")
+	f.BoolVar(&cfg.HTTPLogClosedConnectionsWithoutResponse, "server.http_log_closed_connections_without_response_enabled", false, "Log closed connections that did not receive any response, most likely because client didn't send any request within timeout.")
 	f.IntVar(&cfg.GRPCServerMaxRecvMsgSize, "server.grpc-max-recv-msg-size-bytes", 4*1024*1024, "Limit on the size of a gRPC message this server can receive (bytes).")
 	f.IntVar(&cfg.GRPCServerMaxSendMsgSize, "server.grpc-max-send-msg-size-bytes", 4*1024*1024, "Limit on the size of a gRPC message this server can send (bytes).")
 	f.UintVar(&cfg.GRPCServerMaxConcurrentStreams, "server.grpc-max-concurrent-streams", 100, "Limit on the number of concurrent streams for gRPC calls per client connection (0 = unlimited)")
@@ -263,6 +266,9 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		return nil, err
 	}
 	httpListener = middleware.CountingListener(httpListener, metrics.TCPConnections.WithLabelValues("http"))
+	if cfg.HTTPLogClosedConnectionsWithoutResponse {
+		httpListener = middleware.NewZeroResponseListener(httpListener, level.Warn(logger))
+	}
 
 	metrics.TCPConnectionsLimit.WithLabelValues("http").Set(float64(cfg.HTTPConnLimit))
 	if cfg.HTTPConnLimit > 0 {


### PR DESCRIPTION
**What this PR does**:

HTTP Server closes connections early (**with no response, or running any handler**) if client fails to send complete HTTP **request headers** within timeout. To help troubleshooting such attempts, this PR adds option `-server.http-log-closed-connections-without-response-enabled`, which enables logging of closed connections to HTTP server that received no response. First 512 bytes read from connection is also logged (while removing credentials from Authorization header).

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
