### PR TITLE
Fix benchmarks and run them in CI

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -29,9 +29,21 @@ local step = {
     image: images.golang(golang_version),
     commands: ['make test'],
   } + depends_on('make-lint'),
+
+  test_benchmarks(golang_version):: {
+    name: 'make-test-benchmarks (go %s)' % golang_version,
+    image: images.golang(golang_version),
+    commands: ['make test-benchmarks'],
+  } + depends_on('make-lint'),
 };
 
-local test_steps = [step.test(v) for v in supported_golang_versions];
+local test_steps = [
+  // Run tests with all supported golang versions.
+  step.test(v) for v in supported_golang_versions
+] + [
+  // Run benchmarks with one (the latest) supported golang version: we just want to make sure they're up to date.
+  step.test_benchmarks(supported_golang_versions[std.length(supported_golang_versions)-1]),
+];
 
 [
   pipeline.new('validate-pr') {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -7,7 +7,7 @@
          "commands": [
             "make mod-check"
          ],
-         "image": "golang:1.21.0",
+         "image": "golang:1.21.3",
          "name": "make-mod-check"
       },
       {
@@ -17,7 +17,7 @@
          "depends_on": [
             "make-mod-check"
          ],
-         "image": "golang:1.21.0",
+         "image": "golang:1.21.3",
          "name": "make-lint"
       },
       {
@@ -42,6 +42,16 @@
       },
       {
          "commands": [
+            "make test-benchmarks"
+         ],
+         "depends_on": [
+            "make-lint"
+         ],
+         "image": "golang:1.21.3",
+         "name": "make-test-benchmarks (go 1.21.3)"
+      },
+      {
+         "commands": [
             "apt-get update && apt-get -y install unzip",
             "go mod vendor",
             "make check-protos"
@@ -49,13 +59,13 @@
          "depends_on": [
             "make-mod-check"
          ],
-         "image": "golang:1.21.0",
+         "image": "golang:1.21.3",
          "name": "make-check-protos"
       }
    ]
 }
 ---
 kind: signature
-hmac: cc85df30ab5ea7fb028057d36dec2fb6676df9343afbac6bdc9ea99b2c913b74
+hmac: 2419eded398bf02c5da0040762394904d32600544b660d06378c1e75ec9432c4
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ help: ## Display this help and any documented user-facing targets. Other undocum
 test: ## Runs Go tests
 	go test -tags netgo -timeout 30m -race -count 1 ./...
 
+.PHONY: test-benchmarks
+test-benchmarks: ## Runs Go benchmarks with 1 iteration to make sure they still make sense
+	go test -tags netgo -run=NONE -bench=. -benchtime=1x -timeout 30m ./...
+
 .PHONY: lint
 lint: .tools/bin/misspell .tools/bin/faillint .tools/bin/golangci-lint ## Runs misspell, golangci-lint, and faillint
 	misspell -error README.md CONTRIBUTING.md LICENSE

--- a/ring/bench/ring_memberlist_test.go
+++ b/ring/bench/ring_memberlist_test.go
@@ -64,9 +64,7 @@ func BenchmarkMemberlistReceiveWithRingDesc(b *testing.B) {
 
 	var cfg memberlist.KVConfig
 	flagext.DefaultValues(&cfg)
-	cfg.TCPTransport = memberlist.TCPTransportConfig{
-		BindAddrs: []string{"localhost"},
-	}
+	cfg.TCPTransport = memberlist.TCPTransportConfig{}
 	cfg.Codecs = []codec.Codec{c}
 
 	mkv := memberlist.NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())


### PR DESCRIPTION
There were two benchmarks that were outdated, and didn't pass.
This fixes the benchmarks, adds `make test-benchmarks` target and runs that in CI with the latest golang version.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
