### PR TITLE
Make ring.DoBatch() result deterministic

### DIFF
--- a/ring/batch.go
+++ b/ring/batch.go
@@ -181,7 +181,8 @@ func (b *batchTracker) record(itemTrackers []*itemTracker, err error, isClientEr
 		} else {
 			// If we successfully process items in minSuccess instances,
 			// then wake up the waiting rpc, so it can return early.
-			if it.succeeded.Inc() == int32(it.minSuccess) {
+			succeeded := it.succeeded.Inc()
+			if succeeded == int32(it.minSuccess) {
 				if b.rpcsPending.Dec() == 0 {
 					b.done <- struct{}{}
 				}
@@ -190,7 +191,7 @@ func (b *batchTracker) record(itemTrackers []*itemTracker, err error, isClientEr
 
 			// If we successfully called this particular instance, but we don't have any remaining instances to try,
 			// and we failed to call minSuccess instances, then we need to return the last error.
-			if it.succeeded.Load() < int32(it.minSuccess) {
+			if succeeded < int32(it.minSuccess) {
 				if it.remaining.Dec() == 0 {
 					if b.rpcsFailed.Inc() == 1 {
 						b.err <- it.err.Load()

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -181,7 +181,7 @@ func (b *batchTracker) record(itemTrackers []*itemTracker, err error, isClientEr
 		} else {
 			// If we successfully process items in minSuccess instances,
 			// then wake up the waiting rpc, so it can return early.
-			if it.succeeded.Inc() >= int32(it.minSuccess) {
+			if it.succeeded.Inc() == int32(it.minSuccess) {
 				if b.rpcsPending.Dec() == 0 {
 					b.done <- struct{}{}
 				}
@@ -190,9 +190,11 @@ func (b *batchTracker) record(itemTrackers []*itemTracker, err error, isClientEr
 
 			// If we successfully called this particular instance, but we don't have any remaining instances to try,
 			// and we failed to call minSuccess instances, then we need to return the last error.
-			if it.remaining.Dec() == 0 {
-				if b.rpcsFailed.Inc() == 1 {
-					b.err <- it.err.Load()
+			if it.succeeded.Load() < int32(it.minSuccess) {
+				if it.remaining.Dec() == 0 {
+					if b.rpcsFailed.Inc() == 1 {
+						b.err <- it.err.Load()
+					}
 				}
 			}
 		}

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -8,7 +8,8 @@ import (
 	"sync"
 
 	"go.uber.org/atomic"
-	"google.golang.org/grpc/status"
+
+	grpcUtils "github.com/grafana/dskit/grpcutil"
 )
 
 type batchTracker struct {
@@ -44,10 +45,8 @@ func (i *itemTracker) recordError(err error, isClientError func(error) bool) int
 }
 
 func isHTTPStatus4xx(err error) bool {
-	if s, ok := status.FromError(err); ok && s.Code()/100 == 4 {
-		return true
-	}
-	return false
+	code := grpcUtils.ErrorToStatusCode(err)
+	return code/100 == 4
 }
 
 // DoBatch is a special case of DoBatchWithClientError where errors

--- a/ring/batch_test.go
+++ b/ring/batch_test.go
@@ -1,0 +1,82 @@
+package ring
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/httpgrpc"
+)
+
+type scenario struct {
+	itemTrackers []*itemTracker
+	err          error
+}
+
+func TestBatchTracker_Record(t *testing.T) {
+	minSuccess := 2
+	maxFailure := 1
+	replicationFactor := int32(3)
+
+	it1 := &itemTracker{minSuccess: minSuccess, maxFailures: maxFailure}
+	it1.remaining.Store(replicationFactor)
+	it2 := &itemTracker{minSuccess: minSuccess, maxFailures: maxFailure}
+	it2.remaining.Store(replicationFactor)
+
+	itemTrackers := []*itemTracker{it1, it2}
+	bt := batchTracker{
+		done: make(chan struct{}, 1),
+		err:  make(chan error, 1),
+	}
+	bt.rpcsPending.Store(int32(len(itemTrackers)))
+	httpGRPC4xx := httpgrpc.Errorf(http.StatusBadRequest, "this is an error")
+
+	badScenario := []scenario{
+		{itemTrackers: itemTrackers[:1], err: nil},
+		{itemTrackers: itemTrackers[1:], err: httpGRPC4xx},
+		{itemTrackers: itemTrackers[:1], err: nil},
+		{itemTrackers: itemTrackers[:1], err: nil},
+		{itemTrackers: itemTrackers[1:], err: httpGRPC4xx},
+		{itemTrackers: itemTrackers[1:], err: httpGRPC4xx},
+	}
+
+	err := executeScenario(bt, badScenario)
+	require.NoError(t, err)
+
+	goodScenario := []scenario{
+		{itemTrackers: itemTrackers[:1], err: nil},
+		{itemTrackers: itemTrackers[1:], err: httpGRPC4xx},
+		{itemTrackers: itemTrackers[1:], err: httpGRPC4xx},
+		{itemTrackers: itemTrackers[:1], err: nil},
+		{itemTrackers: itemTrackers[:1], err: nil},
+		{itemTrackers: itemTrackers[1:], err: httpGRPC4xx},
+	}
+
+	err = executeScenario(bt, goodScenario)
+	require.Error(t, err)
+}
+
+func executeScenario(bt batchTracker, scenarios []scenario) error {
+	var wg sync.WaitGroup
+	wg.Add(len(scenarios))
+
+	go func() {
+		for _, sc := range scenarios {
+			bt.record(sc.itemTrackers, sc.err, isHTTPStatus4xx)
+			wg.Done()
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+	}()
+
+	select {
+	case err := <-bt.err:
+		return err
+	case <-bt.done:
+		return nil
+	}
+}

--- a/ring/batch_test.go
+++ b/ring/batch_test.go
@@ -43,7 +43,7 @@ func TestBatchTracker_Record(t *testing.T) {
 	}
 
 	err := executeScenario(bt, badScenario)
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	goodScenario := []scenario{
 		{itemTrackers: itemTrackers[:1], err: nil},


### PR DESCRIPTION
**What this PR does**:
This PR fixes a bug present in the `ring.DoBatch()` function. Namely, there might be usecases in which, for the same set of keys, and the same ring instances failing on the same keys, different order of execution of `batchTracker.record()` on different keys gives different values.

For example, let us assume the following scenario:
- replication factor is 3
- number of ring instances is 6 ($I_1$, $I_2$, $I_3$, $I_4$, $I_5$, $I_6$).
- `ring.DoBatch()` is called on 2 keys $k_1$ and $k_2$.
- replication set of $k_1$ is $(I_1, I_2, I_3)$ and of $k_2$ is $(I_4, I_5, I_6)$.
- calls to the `callback` function on $k_1$ on $I_1$, $I_2$ and $I_3$ are successful.
- calls to the `callback` function on $k_2$ on $I_4$, $I_5$ and $I_6$ fail with a `4xx` error. 

The expected outcome of this call to `ring.DoBatch()` is that it would fail with the `4xx` error.
With the current implementation, getting results from ingesters for example in this order: $I_1$, $I_4$, $I_5$, $I_2$, $I_3$, $I_6$ will actually give rise to a failure, but in the case of this order: $I_1$, $I_4$, $I_2$, $I_3$, $I_5$, $I_6$ would actually succeed. The reason for that is that successful execution of $k_1$ on $I_1$, $I_2$, $I_3$ is taken into account more than once.

This PR fixes this problem.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
