### PR TITLE
ring.DoBatch with goroutine pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,7 @@
  * `middleware.Instrument`
 * [ENHANCEMENT] Server: Added new `-server.http-log-closed-connections-without-response-enabled` option to log details about closed connections that received no response. #426
 * [ENHANCEMENT] ring: Added new function `DoBatchWithClientError()` that extends an already existing `DoBatch()`. The former differentiates between client and server errors by the filtering function passed as a parameter. This way client and server errors can be tracked separately. The function returns only when there is a quorum of either error class. #427
-* [ENHANCMENET] ring: Replaced the aforemented `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use preallocated workers instead of spawning a new goroutine for each request. #431
+* [ENHANCMENET] ring: Replaced `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use pre-allocated workers instead of spawning a new goroutine for each request. #431
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [CHANGE] Always include source IPs in HTTP and gRPC server spans. #386
 * [CHANGE] ring: Change `PoolFactory` function type to an interface and create function implementations. #387
 * [CHANGE] server: fix incorrect spelling of "gRPC" in `server.Config` fields. #422
+* [CHANGE] ring: `ring.DoBatch()` was deprecated in favor of `DoBatchWithOptions()`. #431
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338
@@ -164,6 +165,7 @@
  * `middleware.Instrument`
 * [ENHANCEMENT] Server: Added new `-server.http-log-closed-connections-without-response-enabled` option to log details about closed connections that received no response. #426
 * [ENHANCEMENT] ring: Added new function `DoBatchWithClientError()` that extends an already existing `DoBatch()`. The former differentiates between client and server errors by the filtering function passed as a parameter. This way client and server errors can be tracked separately. The function returns only when there is a quorum of either error class. #427
+* [ENHANCMENET] ring: Replaced the aforemented `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use preallocated workers instead of spawning a new goroutine for each request. #431
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/concurrency/worker.go
+++ b/concurrency/worker.go
@@ -1,0 +1,38 @@
+package concurrency
+
+// NewReusableGoroutinesPool creates a new worker pool with the given size.
+// These workers will run the workloads passed through Go() calls.
+// If all workers are busy, Go() will spawn a new goroutine to run the workload.
+func NewReusableGoroutinesPool(size int) *ReusableGoroutinesPool {
+	p := &ReusableGoroutinesPool{
+		jobs: make(chan func()),
+	}
+	for i := 0; i < size; i++ {
+		go func() {
+			for f := range p.jobs {
+				f()
+			}
+		}()
+	}
+	return p
+}
+
+type ReusableGoroutinesPool struct {
+	jobs chan func()
+}
+
+// Go will run the given function in a worker of the pool.
+// If all workers are busy, Go() will spawn a new goroutine to run the workload.
+func (p *ReusableGoroutinesPool) Go(f func()) {
+	select {
+	case p.jobs <- f:
+	default:
+		go f()
+	}
+}
+
+// Close stops the workers of the pool.
+// No new Do() calls should be performed after calling Close().
+// Close does NOT wait for all jobs to finish, it is the caller's responsibility to ensure that in the provided workloads.
+// Close is intended to be used in tests to ensure that no goroutines are leaked.
+func (p *ReusableGoroutinesPool) Close() { close(p.jobs) }

--- a/concurrency/worker_test.go
+++ b/concurrency/worker_test.go
@@ -1,0 +1,48 @@
+package concurrency
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReusableGoroutinesPool(t *testing.T) {
+	baseGoroutines := runtime.NumGoroutine()
+	const workers = 2
+
+	w := NewReusableGoroutinesPool(workers)
+	require.Equal(t, baseGoroutines+workers, runtime.NumGoroutine())
+
+	// Wait a little bit so both goroutines would be waiting on the jobs chan.
+	time.Sleep(10 * time.Millisecond)
+
+	ch := make(chan struct{})
+	w.Go(func() { <-ch })
+	require.Equal(t, baseGoroutines+workers, runtime.NumGoroutine())
+	w.Go(func() { <-ch })
+	require.Equal(t, baseGoroutines+workers, runtime.NumGoroutine())
+	w.Go(func() { <-ch })
+	require.Equal(t, baseGoroutines+workers+1, runtime.NumGoroutine())
+
+	// end workloads, we should have only the workers again.
+	close(ch)
+	for i := 0; i < 1000; i++ {
+		if runtime.NumGoroutine() == baseGoroutines+workers {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.Equal(t, baseGoroutines+workers, runtime.NumGoroutine())
+
+	// close the workers, eventually they should be gone.
+	w.Close()
+	for i := 0; i < 1000; i++ {
+		if runtime.NumGoroutine() == baseGoroutines {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("expected %d goroutines after closing, got %d", baseGoroutines, runtime.NumGoroutine())
+}

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -50,32 +50,56 @@ func isHTTPStatus4xx(err error) bool {
 	return false
 }
 
-// DoBatch is a special case of DoBatchWithClientError where errors
-// containing HTTP status code 4xx are treated as client errors.
+// DoBatch is a deprecated version of DoBatchWithOptions where grpc errors containing status codes 4xx are treated as client errors.
+// Deprecated. Use DoBatchWithOptions instead.
 func DoBatch(ctx context.Context, op Operation, r ReadRing, keys []uint32, callback func(InstanceDesc, []int) error, cleanup func()) error {
-	return DoBatchWithClientError(ctx, op, r, keys, callback, cleanup, isHTTPStatus4xx)
+	return DoBatchWithOptions(ctx, op, r, keys, callback, DoBatchOptions{
+		Cleanup:       cleanup,
+		IsClientError: isHTTPStatus4xx,
+	})
 }
 
-// DoBatchWithClientError request against a set of keys in the ring,
-// handling replication and failures. For example if we want to write
-// N items where they may all hit different instances, and we want them
-// all replicated R ways with quorum writes, we track the relationship
-// between batch RPCs and the items within them.
+// DoBatchOptions defines options for the DoBatchWithOptions call.
+// Zero value options are valid, as well as individual zero valued fields.
+type DoBatchOptions struct {
+	// Cleanup is always called, either on an error before starting the batches or after they are all finished.
+	// If nil, a noop will be called.
+	Cleanup func()
+
+	// IsClientError classifies errors returned by `callback()` into client or server errors.
+	// See `batchTracker.record()` function for details about how errors are combined into final error returned by DoBatchWithClientError.
+	// If nil, a default implementation is used that classifies grpc errors containing status codes 4xx as client errors.
+	IsClientError func(error) bool
+
+	// Go will be used to spawn the callback goroutines, and can be used to use a worker pool like concurrency.ReusableGoroutinesPool.
+	Go func(func())
+}
+
+func (o *DoBatchOptions) setDefaults() {
+	if o.Cleanup == nil {
+		o.Cleanup = func() {}
+	}
+	if o.IsClientError == nil {
+		o.IsClientError = isHTTPStatus4xx
+	}
+	if o.Go == nil {
+		o.Go = func(f func()) { go f() }
+	}
+}
+
+// DoBatchWithOptions request against a set of keys in the ring, handling replication and failures.
+// For example if we want to write N items where they may all hit different instances,
+// and we want them all replicated R ways with quorum writes,
+// we track the relationship between batch RPCs and the items within them.
 //
-// callback() is passed the instance to target, and the indexes of the keys
-// to send to that instance.
-//
-// cleanup() is always called, either on an error before starting the batches
-// or after they all finish.
-//
-// isClientError() classifies errors returned by `callback()` into client or
-// server errors. See `batchTracker.record()` function for details about how
-// errors are combined into final error returned by DoBatchWithClientError.
+// See comments on DoBatchOptions for available options for this call.
 //
 // Not implemented as a method on Ring, so we can test separately.
-func DoBatchWithClientError(ctx context.Context, op Operation, r ReadRing, keys []uint32, callback func(InstanceDesc, []int) error, cleanup func(), isClientError func(error) bool) error {
+func DoBatchWithOptions(ctx context.Context, op Operation, r ReadRing, keys []uint32, callback func(InstanceDesc, []int) error, o DoBatchOptions) error {
+	o.setDefaults()
+
 	if r.InstancesCount() <= 0 {
-		cleanup()
+		o.Cleanup()
 		return fmt.Errorf("DoBatch: InstancesCount <= 0")
 	}
 	expectedTrackers := len(keys) * (r.ReplicationFactor() + 1) / r.InstancesCount()
@@ -90,7 +114,7 @@ func DoBatchWithClientError(ctx context.Context, op Operation, r ReadRing, keys 
 	for i, key := range keys {
 		replicationSet, err := r.Get(key, op, bufDescs[:0], bufHosts[:0], bufZones[:0])
 		if err != nil {
-			cleanup()
+			o.Cleanup()
 			return err
 		}
 		itemTrackers[i].minSuccess = len(replicationSet.Instances) - replicationSet.MaxErrors
@@ -121,19 +145,19 @@ func DoBatchWithClientError(ctx context.Context, op Operation, r ReadRing, keys 
 
 	wg.Add(len(instances))
 	for _, i := range instances {
-		go func(i instance) {
+		i := i
+		o.Go(func() {
 			err := callback(i.desc, i.indexes)
-			tracker.record(i.itemTrackers, err, isClientError)
+			tracker.record(i.itemTrackers, err, o.IsClientError)
 			wg.Done()
-		}(i)
+		})
 	}
 
 	// Perform cleanup at the end.
-	go func() {
+	o.Go(func() {
 		wg.Wait()
-
-		cleanup()
-	}()
+		o.Cleanup()
+	})
 
 	select {
 	case err := <-tracker.err:

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -75,7 +75,7 @@ type DoBatchOptions struct {
 	Go func(func())
 }
 
-func (o *DoBatchOptions) setDefaults() {
+func (o *DoBatchOptions) replaceZeroValuesWithDefaults() {
 	if o.Cleanup == nil {
 		o.Cleanup = func() {}
 	}
@@ -96,7 +96,7 @@ func (o *DoBatchOptions) setDefaults() {
 //
 // Not implemented as a method on Ring, so we can test separately.
 func DoBatchWithOptions(ctx context.Context, op Operation, r ReadRing, keys []uint32, callback func(InstanceDesc, []int) error, o DoBatchOptions) error {
-	o.setDefaults()
+	o.replaceZeroValuesWithDefaults()
 
 	if r.InstancesCount() <= 0 {
 		o.Cleanup()

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	dsmath "github.com/grafana/dskit/internal/math"
@@ -58,28 +59,54 @@ func benchmarkBatch(b *testing.B, numInstances, numKeys int) {
 
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
+	cfg.HeartbeatTimeout = time.Hour // A minute is not enough to run all benchmarks.
 	r, err := NewWithStoreClientAndStrategy(cfg, testRingName, testRingKey, nil, NewDefaultReplicationStrategy(), prometheus.NewRegistry(), log.NewNopLogger())
 	require.NoError(b, err)
 	r.updateRingState(desc)
 
 	ctx := context.Background()
-	callback := func(InstanceDesc, []int) error { return nil }
-	cleanup := func() {}
+	callback := func(InstanceDesc, []int) error { return deepStack(64) }
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	keys := make([]uint32, numKeys)
 	// Generate a batch of N random keys, and look them up
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		generateKeys(rnd, numKeys, keys)
-		err := DoBatch(ctx, Write, r, keys, callback, cleanup)
-		require.NoError(b, err)
-	}
+
+	// run with `benchstat -col /go` to get stats on different go= options.
+	// ref: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
+
+	b.Run("go=default", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			generateKeys(rnd, numKeys, keys)
+			err := DoBatchWithOptions(ctx, Write, r, keys, callback, DoBatchOptions{})
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("go=concurrency.NonBlockingWorkerPool", func(b *testing.B) {
+		pool := concurrency.NewReusableGoroutinesPool(100)
+		b.Cleanup(pool.Close)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			generateKeys(rnd, numKeys, keys)
+			err := DoBatchWithOptions(ctx, Write, r, keys, callback, DoBatchOptions{Go: pool.Go})
+			require.NoError(b, err)
+		}
+	})
 }
 
 func generateKeys(r *rand.Rand, numTokens int, dest []uint32) {
 	for i := 0; i < numTokens; i++ {
 		dest[i] = r.Uint32()
 	}
+}
+
+//go:noinline
+func deepStack(depth int) error {
+	if depth == 0 {
+		return nil
+	}
+	return deepStack(depth - 1)
 }
 
 func BenchmarkUpdateRingState(b *testing.B) {
@@ -196,7 +223,10 @@ func TestDoBatch_QuorumError(t *testing.T) {
 			require.NoError(t, err)
 			return instanceReturnErrors[instanceID]
 		}
-		return DoBatchWithClientError(ctx, Write, ring, operationKeys, returnInstanceError, unfinishedDoBatchCalls.Done, isClientError)
+		return DoBatchWithOptions(ctx, Write, ring, operationKeys, returnInstanceError, DoBatchOptions{
+			Cleanup:       func() { unfinishedDoBatchCalls.Done() },
+			IsClientError: isClientError,
+		})
 	}
 
 	updateState := func(instanceIDs []string, state InstanceState) {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -82,7 +82,7 @@ func benchmarkBatch(b *testing.B, numInstances, numKeys int) {
 		}
 	})
 
-	b.Run("go=concurrency.NonBlockingWorkerPool", func(b *testing.B) {
+	b.Run("go=concurrency.ReusableGoroutinesPool", func(b *testing.B) {
 		pool := concurrency.NewReusableGoroutinesPool(100)
 		b.Cleanup(pool.Close)
 


### PR DESCRIPTION
This adds an option to `ring.DoBatch` to run the callbacks through a function provided that could make use of a goroutine pool (with concurrency.ReusableGoroutinesPool as an implementation).

This should help in Mimir's distributors to avoid extra stack allocation on every new goroutine created to perform a push to an ingester.

Since there was a recent change to `DoBatch` that added an `isClientError` param, I made a more generic version `DoBatchWithOptions`. I also made the cleanup optional, since I see it's
not so common to pass it down.

With this change, I also marked as deprecated the default `ring.DoBatch` version.

I did two benchmark versions, showing some imrovement in CPU time on the pooled version:

```
$ benchstat -col /go bench.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/dskit/ring
cpu: 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz
                 │   default    │  concurrency.NonBlockingWorkerPool   │
                 │    sec/op    │    sec/op     vs base                │
Batch10x100-16     69.04µ ±  0%   64.53µ ±  0%   -6.53% (p=0.000 n=20)
Batch100x100-16    131.6µ ±  1%   123.8µ ±  1%   -5.94% (p=0.000 n=20)
Batch100x1000-16   2.088m ± 30%   1.146m ± 39%  -45.12% (p=0.001 n=20)
geomean            266.7µ         209.2µ        -21.57%
```