### PR TITLE
Remove an un-necessary go routine in a test

### DIFF
--- a/ring/batch_test.go
+++ b/ring/batch_test.go
@@ -69,9 +69,7 @@ func executeScenario(bt batchTracker, scenarios []scenario) error {
 		}
 	}()
 
-	go func() {
-		wg.Wait()
-	}()
+	wg.Wait()
 
 	select {
 	case err := <-bt.err:


### PR DESCRIPTION
**What this PR does**:
`TestBatchTracker_Record` introduced in https://github.com/grafana/dskit/pull/430 contains an un-necessary go routine in which we just wait for a `WaitGroup`, as remarked [here](https://github.com/grafana/dskit/pull/430#discussion_r1394985293). This PR removes that go routine.

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
