### PR TITLE
refactor httpgrpc request/response utils from httpgrpc/server to httpgrpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-* [CHANGE] Move httpgrpc request & response utils up from httpgrpc/server to httpgrpc package
+* [CHANGE] Move httpgrpc request & response utils up from httpgrpc/server to httpgrpc package #434, #435
 * [CHANGE] Updated the minimum required Go version to 1.20 and update Drone config #420
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Move httpgrpc request & response utils up from httpgrpc/server to httpgrpc package
 * [CHANGE] Updated the minimum required Go version to 1.20 and update Drone config #420
 * [CHANGE] Change `WaitRingStability` and `WaitInstanceState` methods signature to rely on `ReadRing` instead. #251
 * [CHANGE] Added new `-consul.cas-retry-delay` flag. It has a default value of `1s`, while previously there was no delay between retries. #178

--- a/httpgrpc/httpgrpc.go
+++ b/httpgrpc/httpgrpc.go
@@ -42,7 +42,7 @@ func (nopCloser) Close() error { return nil }
 // BytesBuffer returns the underlaying `bytes.buffer` used to build this io.ReadCloser.
 func (n nopCloser) BytesBuffer() *bytes.Buffer { return n.Buffer }
 
-// FromHTTPRequest wraps an ordinary http.Request up into an httpgrpc.HTTPRequest
+// FromHTTPRequest converts an ordinary http.Request into an httpgrpc.HTTPRequest
 func FromHTTPRequest(r *http.Request) (*HTTPRequest, error) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -56,7 +56,7 @@ func FromHTTPRequest(r *http.Request) (*HTTPRequest, error) {
 	}, nil
 }
 
-// ToHTTPRequest unwraps an ordinary http.Request from an httpgrpc.HTTPRequest
+// ToHTTPRequest converts httpgrpc.HTTPRequest to http.Request.
 func ToHTTPRequest(ctx context.Context, r *HTTPRequest) (*http.Request, error) {
 	req, err := http.NewRequest(r.Method, r.Url, nopCloser{Buffer: bytes.NewBuffer(r.Body)})
 	if err != nil {

--- a/httpgrpc/httpgrpc.go
+++ b/httpgrpc/httpgrpc.go
@@ -21,13 +21,6 @@ import (
 	"github.com/grafana/dskit/log"
 )
 
-var (
-	// DoNotLogErrorHeaderKey is a header key used for marking non-loggable errors. More precisely, if an HTTP response
-	// has a status code 5xx, and contains a header with key DoNotLogErrorHeaderKey and any values, the generated error
-	// will be marked as non-loggable.
-	DoNotLogErrorHeaderKey = http.CanonicalHeaderKey("X-DoNotLogError")
-)
-
 const (
 	MetadataMethod = "httpgrpc-method"
 	MetadataURL    = "httpgrpc-url"
@@ -103,9 +96,6 @@ func ToHeader(hs []*Header, header http.Header) {
 func FromHeader(hs http.Header) []*Header {
 	result := make([]*Header, 0, len(hs))
 	for k, vs := range hs {
-		if k == DoNotLogErrorHeaderKey {
-			continue
-		}
 		result = append(result, &Header{
 			Key:    k,
 			Values: vs,

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -5,10 +5,8 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -27,13 +25,6 @@ import (
 	"github.com/grafana/dskit/middleware"
 )
 
-var (
-	// DoNotLogErrorHeaderKey is a header key used for marking non-loggable errors. More precisely, if an HTTP response
-	// has a status code 5xx, and contains a header with key DoNotLogErrorHeaderKey and any values, the generated error
-	// will be marked as non-loggable.
-	DoNotLogErrorHeaderKey = http.CanonicalHeaderKey("X-DoNotLogError")
-)
-
 // Server implements HTTPServer.  HTTPServer is a generated interface that gRPC
 // servers must implement.
 type Server struct {
@@ -47,18 +38,9 @@ func NewServer(handler http.Handler) *Server {
 	}
 }
 
-type nopCloser struct {
-	*bytes.Buffer
-}
-
-func (nopCloser) Close() error { return nil }
-
-// BytesBuffer returns the underlaying `bytes.buffer` used to build this io.ReadCloser.
-func (n nopCloser) BytesBuffer() *bytes.Buffer { return n.Buffer }
-
 // Handle implements HTTPServer.
 func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
-	req, err := UnwrapHTTPRequest(ctx, r)
+	req, err := httpgrpc.ToHTTPRequest(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +50,12 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 	header := recorder.Header()
 	resp := &httpgrpc.HTTPResponse{
 		Code:    int32(recorder.Code),
-		Headers: fromHeader(header),
+		Headers: httpgrpc.FromHeader(header),
 		Body:    recorder.Body.Bytes(),
 	}
 	if recorder.Code/100 == 5 {
 		err := httpgrpc.ErrorFromHTTPResponse(resp)
-		if _, ok := header[DoNotLogErrorHeaderKey]; ok {
+		if _, ok := header[httpgrpc.DoNotLogErrorHeaderKey]; ok {
 			err = middleware.DoNotLogError{Err: err}
 		}
 		return nil, err
@@ -161,51 +143,6 @@ func NewClient(address string) (*Client, error) {
 	}, nil
 }
 
-// WrapHTTPRequest wraps an ordinary http.Request up into an httpgrpc.HTTPRequest
-func WrapHTTPRequest(r *http.Request) (*httpgrpc.HTTPRequest, error) {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-	return &httpgrpc.HTTPRequest{
-		Method:  r.Method,
-		Url:     r.RequestURI,
-		Body:    body,
-		Headers: fromHeader(r.Header),
-	}, nil
-}
-
-// UnwrapHTTPRequest unwraps an ordinary http.Request from an httpgrpc.HTTPRequest
-func UnwrapHTTPRequest(ctx context.Context, r *httpgrpc.HTTPRequest) (*http.Request, error) {
-	req, err := http.NewRequest(r.Method, r.Url, nopCloser{Buffer: bytes.NewBuffer(r.Body)})
-	if err != nil {
-		return nil, err
-	}
-	toHeader(r.Headers, req.Header)
-	req = req.WithContext(ctx)
-	req.RequestURI = r.Url
-	req.ContentLength = int64(len(r.Body))
-	return req, nil
-}
-
-// WriteResponse converts an httpgrpc response to an HTTP one
-func WriteResponse(w http.ResponseWriter, resp *httpgrpc.HTTPResponse) error {
-	toHeader(resp.Headers, w.Header())
-	w.WriteHeader(int(resp.Code))
-	_, err := w.Write(resp.Body)
-	return err
-}
-
-// WriteError converts an httpgrpc error to an HTTP one
-func WriteError(w http.ResponseWriter, err error) {
-	resp, ok := httpgrpc.HTTPResponseFromError(err)
-	if ok {
-		_ = WriteResponse(w, resp)
-	} else {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-}
-
 // ServeHTTP implements http.Handler
 func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if tracer := opentracing.GlobalTracer(); tracer != nil {
@@ -216,7 +153,7 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	req, err := WrapHTTPRequest(r)
+	req, err := httpgrpc.FromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -233,28 +170,8 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := WriteResponse(w, resp); err != nil {
+	if err := httpgrpc.WriteResponse(w, resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-}
-
-func toHeader(hs []*httpgrpc.Header, header http.Header) {
-	for _, h := range hs {
-		header[h.Key] = h.Values
-	}
-}
-
-func fromHeader(hs http.Header) []*httpgrpc.Header {
-	result := make([]*httpgrpc.Header, 0, len(hs))
-	for k, vs := range hs {
-		if k == DoNotLogErrorHeaderKey {
-			continue
-		}
-		result = append(result, &httpgrpc.Header{
-			Key:    k,
-			Values: vs,
-		})
-	}
-	return result
 }

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -82,7 +82,7 @@ func TestError(t *testing.T) {
 		t.Run(fmt.Sprintf("test header when DoNotLogErrorHeaderKey is %spresent", stat), func(t *testing.T) {
 			server, err := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if doNotLog {
-					w.Header().Set(DoNotLogErrorHeaderKey, "true")
+					w.Header().Set(httpgrpc.DoNotLogErrorHeaderKey, "true")
 				}
 				// Does a Fprintln, injecting a newline.
 				http.Error(w, "foo", http.StatusInternalServerError)
@@ -102,7 +102,7 @@ func TestError(t *testing.T) {
 
 			assert.Equal(t, "foo\n", recorder.Body.String())
 			assert.Equal(t, 500, recorder.Code)
-			assert.NotContains(t, recorder.Header(), DoNotLogErrorHeaderKey)
+			assert.NotContains(t, recorder.Header(), httpgrpc.DoNotLogErrorHeaderKey)
 		})
 	}
 }
@@ -137,7 +137,7 @@ func TestServerHandleDoNotLogError(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if testData.doNotLogError {
-					w.Header().Set(DoNotLogErrorHeaderKey, "true")
+					w.Header().Set(httpgrpc.DoNotLogErrorHeaderKey, "true")
 				}
 				http.Error(w, errMsg, testData.errorCode)
 			})
@@ -179,7 +179,7 @@ func checkHTTPResponse(t *testing.T, resp *httpgrpc.HTTPResponse, expectedCode i
 	require.Equal(t, fmt.Sprintf("%s\n", expectedBody), string(resp.GetBody()))
 	hs := resp.GetHeaders()
 	for _, h := range hs {
-		require.NotEqual(t, DoNotLogErrorHeaderKey, h.Key)
+		require.NotEqual(t, httpgrpc.DoNotLogErrorHeaderKey, h.Key)
 	}
 }
 

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -82,7 +82,7 @@ func TestError(t *testing.T) {
 		t.Run(fmt.Sprintf("test header when DoNotLogErrorHeaderKey is %spresent", stat), func(t *testing.T) {
 			server, err := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if doNotLog {
-					w.Header().Set(httpgrpc.DoNotLogErrorHeaderKey, "true")
+					w.Header().Set(DoNotLogErrorHeaderKey, "true")
 				}
 				// Does a Fprintln, injecting a newline.
 				http.Error(w, "foo", http.StatusInternalServerError)
@@ -102,7 +102,7 @@ func TestError(t *testing.T) {
 
 			assert.Equal(t, "foo\n", recorder.Body.String())
 			assert.Equal(t, 500, recorder.Code)
-			assert.NotContains(t, recorder.Header(), httpgrpc.DoNotLogErrorHeaderKey)
+			assert.NotContains(t, recorder.Header(), DoNotLogErrorHeaderKey)
 		})
 	}
 }
@@ -137,7 +137,7 @@ func TestServerHandleDoNotLogError(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if testData.doNotLogError {
-					w.Header().Set(httpgrpc.DoNotLogErrorHeaderKey, "true")
+					w.Header().Set(DoNotLogErrorHeaderKey, "true")
 				}
 				http.Error(w, errMsg, testData.errorCode)
 			})
@@ -179,7 +179,7 @@ func checkHTTPResponse(t *testing.T, resp *httpgrpc.HTTPResponse, expectedCode i
 	require.Equal(t, fmt.Sprintf("%s\n", expectedBody), string(resp.GetBody()))
 	hs := resp.GetHeaders()
 	for _, h := range hs {
-		require.NotEqual(t, httpgrpc.DoNotLogErrorHeaderKey, h.Key)
+		require.NotEqual(t, DoNotLogErrorHeaderKey, h.Key)
 	}
 }
 

--- a/server/server_tracing_test.go
+++ b/server/server_tracing_test.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/grafana/dskit/httpgrpc"
-	httpgrpcServer "github.com/grafana/dskit/httpgrpc/server"
 	"github.com/grafana/dskit/log"
 	"github.com/grafana/dskit/middleware"
 )
@@ -240,7 +239,7 @@ func TestHTTPGRPCTracing(t *testing.T) {
 				client httpgrpc.HTTPClient, req *http.Request,
 			) (*httpgrpc.HTTPResponse, error) {
 				req.RequestURI = req.URL.String()
-				grpcReq, err := httpgrpcServer.WrapHTTPRequest(req)
+				grpcReq, err := httpgrpc.FromHTTPRequest(req)
 				require.NoError(t, err)
 				return client.Handle(req.Context(), grpcReq)
 			}


### PR DESCRIPTION
In response to feedback on https://github.com/grafana/mimir/pull/6694, tried to tee up a little more descriptive naming.

Having these utils be used prefixed with package name `httpgrpc` allows for clearer usage without a longer name: `httpgrpc.FromHTTPRequest` and `httpgrpc.ToHTTPRequest`, rather than `server.FromHTTPRequest` and `server.ToHTTPRequest`.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
