### PR TITLE
Use seeded random generator in tests.

### DIFF
--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -91,7 +91,7 @@ func TestLifecycler_TokenGenerator(t *testing.T) {
 	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, log.NewNopLogger())
 	require.NoError(t, err)
 
-	tests := []TokenGenerator{nil, NewRandomTokenGenerator(), spreadMinimizingTokenGenerator}
+	tests := []TokenGenerator{nil, initTokenGenerator(t), spreadMinimizingTokenGenerator}
 
 	for _, testData := range tests {
 		cfg.RingTokenGenerator = testData
@@ -545,7 +545,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	lifecyclerConfig.NumTokens = numTokens
 
 	// Simulate ingester with 64 tokens left the ring in LEAVING state
-	origTokens := GenerateTokens(64, nil)
+	origTokens := initTokenGenerator(t).GenerateTokens(64, nil)
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
@@ -621,7 +621,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 	lifecyclerConfig.NumTokens = numTokens
 
 	// Simulate ingester with 128 tokens left the ring in LEAVING state
-	origTokens := GenerateTokens(128, nil)
+	origTokens := initTokenGenerator(t).GenerateTokens(128, nil)
 	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
@@ -1019,7 +1019,7 @@ func TestRestartIngester_NoUnregister_LongHeartbeat(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	origTokens := GenerateTokens(100, nil)
+	origTokens := initTokenGenerator(t).GenerateTokens(100, nil)
 
 	const id = "test"
 	registeredAt := time.Now().Add(-1 * time.Hour)
@@ -1356,7 +1356,7 @@ func TestWaitBeforeJoining(t *testing.T) {
 	}{
 		"RandomTokenGenerator never returns errors": {
 			targetInstanceID: instanceName(3, 1),
-			tokenGenerator:   NewRandomTokenGenerator(),
+			tokenGenerator:   initTokenGenerator(t),
 		},
 		"SpreadMinimizingTokenGenerator with CanJoinEnabled=false never returns errors": {
 			targetInstanceID: instanceName(3, 1),

--- a/ring/token_generator_test.go
+++ b/ring/token_generator_test.go
@@ -34,8 +34,3 @@ func TestRandomTokenGenerator_IgnoresOldTokens(t *testing.T) {
 		}
 	}
 }
-
-// GenerateTokens generates numTokens unique, random and sorted tokens for testing purposes.
-func GenerateTokens(tokensCount int, takenTokens []uint32) Tokens {
-	return NewRandomTokenGenerator().GenerateTokens(tokensCount, takenTokens)
-}

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -438,6 +438,7 @@ func TestSearchToken(t *testing.T) {
 
 func BenchmarkSearchToken(b *testing.B) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	gen := initTokenGenerator(b)
 
 	tokensPerInstance := 512
 	numInstances := []int{3, 9, 27, 81, 243, 729}
@@ -446,7 +447,7 @@ func BenchmarkSearchToken(b *testing.B) {
 		b.Run(fmt.Sprintf("searchToken_%d_instances", instances), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				tokens := GenerateTokens(instances*tokensPerInstance, []uint32{})
+				tokens := gen.GenerateTokens(instances*tokensPerInstance, []uint32{})
 				hash := r.Uint32()
 				b.StartTimer()
 				searchToken(tokens, hash)


### PR DESCRIPTION
**What this PR does**:

This PR replaces use of `GenerateTokens` in tests with generator initialized by `initTokenGenerator(b)`, which also logs used seed.

Extracted from https://github.com/grafana/dskit/pull/433, to make it smaller.

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
