### PR TITLE
ClientPool: expose method to remove client by value

### DIFF
--- a/ring/client/pool.go
+++ b/ring/client/pool.go
@@ -157,15 +157,44 @@ func (p *Pool) RemoveClientFor(addr string) {
 	client, ok := p.clients[addr]
 	if ok {
 		delete(p.clients, addr)
-		if p.clientsMetric != nil {
-			p.clientsMetric.Add(-1)
+		p.closeClient(addr, client)
+	}
+}
+
+func (p *Pool) closeClient(addr string, client PoolClient) {
+	if p.clientsMetric != nil {
+		p.clientsMetric.Add(-1)
+	}
+	// Close in the background since this operation may take awhile and we have a mutex
+	go func(addr string, closer PoolClient) {
+		if err := closer.Close(); err != nil {
+			level.Error(p.logger).Log("msg", fmt.Sprintf("error closing connection to %s", p.clientName), "addr", addr, "err", err)
 		}
-		// Close in the background since this operation may take awhile and we have a mutex
-		go func(addr string, closer PoolClient) {
-			if err := closer.Close(); err != nil {
-				level.Error(p.logger).Log("msg", fmt.Sprintf("error closing connection to %s", p.clientName), "addr", addr, "err", err)
-			}
-		}(addr, client)
+	}(addr, client)
+}
+
+// RemoveClient removes the client instance from the pool if it is still there and not cleaned up by health check.
+// The value of client needs to be the same as returned by GetClientForInstance or GetClientFor.
+// If addr is not empty and contains the same addr passed when obtaining the client, then the operation is sped up.
+func (p *Pool) RemoveClient(client PoolClient, addr string) {
+	p.Lock()
+	defer p.Unlock()
+	if addr != "" {
+		cachedClient, _ := p.clients[addr]
+		if cachedClient != client {
+			return
+		}
+		delete(p.clients, addr)
+		p.closeClient(addr, client)
+		return
+	}
+	for addr, cachedClient := range p.clients {
+		if cachedClient != client {
+			continue
+		}
+		delete(p.clients, addr)
+		p.closeClient(addr, client)
+		return
 	}
 }
 

--- a/ring/client/pool.go
+++ b/ring/client/pool.go
@@ -180,8 +180,7 @@ func (p *Pool) RemoveClient(client PoolClient, addr string) {
 	p.Lock()
 	defer p.Unlock()
 	if addr != "" {
-		cachedClient, _ := p.clients[addr]
-		if cachedClient != client {
+		if p.clients[addr] != client {
 			return
 		}
 		delete(p.clients, addr)


### PR DESCRIPTION
This PR adds a method to remove a client from the pool only if it already hasn't been removed.

This helps in cases where concurrent users of the client want to remove the same client instance and then immediately after that get a new instance. Clients can remove each other's new instances since the access to the pool is serialized via the mutex. If the clients retry removing a client on failed connections this can lead to live-lock.
