### PR TITLE
`DoUntilQuorum`: add the ability to prioritise zones when request minimisation is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,8 @@
  * `middleware.Instrument`
 * [ENHANCEMENT] Server: Added new `-server.http-log-closed-connections-without-response-enabled` option to log details about closed connections that received no response. #426
 * [ENHANCEMENT] ring: Added new function `DoBatchWithClientError()` that extends an already existing `DoBatch()`. The former differentiates between client and server errors by the filtering function passed as a parameter. This way client and server errors can be tracked separately. The function returns only when there is a quorum of either error class. #427
-* [ENHANCMENET] ring: Replaced `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use pre-allocated workers instead of spawning a new goroutine for each request. #431
+* [ENHANCEMENT] ring: Replaced `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use pre-allocated workers instead of spawning a new goroutine for each request. #431
+* [ENHANCEMENT] ring: add support for prioritising zones when using `DoUntilQuorum` with request minimisation and zone awareness. #440
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -37,7 +37,7 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	// Initialise the result tracker, which is use to keep track of successes and failures.
 	var tracker replicationSetResultTracker
 	if r.MaxUnavailableZones > 0 {
-		tracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones, kitlog.NewNopLogger())
+		tracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones, nil, kitlog.NewNopLogger())
 	} else {
 		tracker = newDefaultResultTracker(r.Instances, r.MaxErrors, kitlog.NewNopLogger())
 	}
@@ -123,6 +123,17 @@ type DoUntilQuorumConfig struct {
 	// total response size across all instances is reached, making further requests to other
 	// instances would not be worthwhile.
 	IsTerminalError func(error) bool
+
+	// ZoneSorter orders the provided zones in preference order, for use when MinimizeRequests is true
+	// and DoUntilQuorum is operating in zone-aware mode. If not set, zones will be used in a
+	// randomly-selected order.
+	//
+	// Earlier zones will be used first.
+	// The function can modify the provided slice of zones in place.
+	//
+	// This can be used to prioritise zones that are more likely to succeed, or are expected to complete
+	// faster, for example.
+	ZoneSorter ZoneSorter
 }
 
 func (c DoUntilQuorumConfig) Validate() error {
@@ -168,8 +179,12 @@ func (c DoUntilQuorumConfig) Validate() error {
 // r.MaxUnavailableZones is 1 and there are three zones, DoUntilQuorum will initially only call f for instances in two
 // zones, and only call f for instances in the remaining zone if a request in the initial two zones fails.
 //
-// DoUntilQuorum will randomly select available zones / instances such that calling DoUntilQuorum multiple times with
-// the same ReplicationSet should evenly distribute requests across all zones / instances.
+// If cfg.ZoneSorter is non-nil and DoUntilQuorum is operating in zone-aware mode, DoUntilQuorum will initiate requests
+// to zones in the order returned by the sorter.
+//
+// If cfg.ZoneSorter is nil, or DoUntilQuorum is operating in non-zone-aware mode, DoUntilQuorum will randomly select
+// available zones / instances such that calling DoUntilQuorum multiple times with the same ReplicationSet should evenly
+// distribute requests across all zones / instances.
 //
 // If cfg.HedgingDelay is non-zero, DoUntilQuorum will call f for an additional zone's instances (if zone-aware) / an
 // additional instance (if not zone-aware) every cfg.HedgingDelay until one of the termination conditions above is
@@ -249,7 +264,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 	var resultTracker replicationSetResultTracker
 	var contextTracker replicationSetContextTracker
 	if r.MaxUnavailableZones > 0 || r.ZoneAwarenessEnabled {
-		resultTracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones, logger)
+		resultTracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones, cfg.ZoneSorter, logger)
 		contextTracker = newZoneAwareContextTracker(ctx, r.Instances)
 	} else {
 		resultTracker = newDefaultResultTracker(r.Instances, r.MaxErrors, logger)

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -130,6 +130,7 @@ type DoUntilQuorumConfig struct {
 	//
 	// Earlier zones will be used first.
 	// The function can modify the provided slice of zones in place.
+	// All provided zones must be returned exactly once.
 	//
 	// This can be used to prioritise zones that are more likely to succeed, or are expected to complete
 	// faster, for example.

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -684,7 +684,7 @@ func TestDoUntilQuorumWithoutSuccessfulContextCancellation_CancelsEntireZoneImme
 			case <-waitForFailingZoneToSeeCancelledContext:
 				// Nothing more to do.
 			case <-time.After(2 * time.Second):
-				require.FailNowf(t, "%s gave up waiting for instance in failing zone to report its context had been cancelled", instance.Addr)
+				require.FailNow(t, "gave up waiting for instance in failing zone to report its context had been cancelled: "+instance.Addr)
 			}
 		}
 

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -629,6 +629,54 @@ func TestDoUntilQuorumWithoutSuccessfulContextCancellation_TerminalError(t *test
 	cleanupTracker.assertCorrectCleanup(nil, calledInstances[0:3])
 }
 
+func TestDoUntilQuorumWithoutSuccessfulContextCancellation_ZoneSorting(t *testing.T) {
+	replicationSet := ReplicationSet{
+		Instances: []InstanceDesc{
+			{Addr: "zone-a-replica-1", Zone: "zone-a"},
+			{Addr: "zone-a-replica-2", Zone: "zone-a"},
+			{Addr: "zone-b-replica-1", Zone: "zone-b"},
+			{Addr: "zone-b-replica-2", Zone: "zone-b"},
+			{Addr: "zone-c-replica-1", Zone: "zone-c"},
+			{Addr: "zone-c-replica-2", Zone: "zone-c"},
+			{Addr: "zone-d-replica-1", Zone: "zone-d"},
+			{Addr: "zone-d-replica-2", Zone: "zone-d"},
+		},
+		MaxUnavailableZones: 2,
+	}
+
+	defer goleak.VerifyNone(t)
+
+	ctx := context.Background()
+	cleanupTracker := newCleanupTracker(t, 0)
+	mtx := &sync.RWMutex{}
+	calledInstances := []string{}
+
+	f := func(ctx context.Context, desc *InstanceDesc, cancel context.CancelFunc) (string, error) {
+		cleanupTracker.trackCall(ctx, desc, cancel)
+
+		mtx.Lock()
+		defer mtx.Unlock()
+		calledInstances = append(calledInstances, desc.Addr)
+
+		return desc.Addr, nil
+	}
+
+	cfg := DoUntilQuorumConfig{
+		MinimizeRequests: true,
+		ZoneSorter: func(zones []string) []string {
+			return []string{"zone-b", "zone-d", "zone-a", "zone-c"}
+		},
+	}
+
+	actualResults, err := DoUntilQuorumWithoutSuccessfulContextCancellation(ctx, replicationSet, cfg, f, cleanupTracker.cleanup)
+	require.ElementsMatch(t, actualResults, []string{"zone-b-replica-1", "zone-b-replica-2", "zone-d-replica-1", "zone-d-replica-2"})
+	require.ElementsMatch(t, actualResults, calledInstances)
+	require.NoError(t, err)
+
+	cleanupTracker.collectCleanedUpInstances()
+	cleanupTracker.assertCorrectCleanup(calledInstances, nil)
+}
+
 func TestDoUntilQuorumWithoutSuccessfulContextCancellation_CancelsEntireZoneImmediatelyOnSingleFailure(t *testing.T) {
 	defer goleak.VerifyNone(t)
 

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -1355,6 +1355,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_ZoneSorting(t *testing.T) {
 	}
 
 	tracker := newZoneAwareResultTracker(instances, 2, zoneSorter, log.NewNopLogger())
+	tracker.startMinimumRequests()
 
 	for i := range instances {
 		i := i
@@ -1383,7 +1384,6 @@ func TestZoneAwareResultTracker_StartMinimumRequests_ZoneSorting(t *testing.T) {
 		}, time.Second, 10*time.Millisecond, msg+", zones released are: ", released)
 	}
 
-	tracker.startMinimumRequests()
 	requireZonesReleased([]bool{true, false, true, false}, "first two zones (A and C) should be released immediately")
 
 	tracker.done(&instances[0], errors.New("zone A failed"))

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -803,7 +803,7 @@ func TestZoneAwareResultTracker(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			testCase.run(t, newZoneAwareResultTracker(testCase.instances, testCase.maxUnavailableZones, log.NewNopLogger()))
+			testCase.run(t, newZoneAwareResultTracker(testCase.instances, testCase.maxUnavailableZones, nil, log.NewNopLogger()))
 		})
 	}
 }
@@ -811,7 +811,7 @@ func TestZoneAwareResultTracker(t *testing.T) {
 func TestZoneAwareResultTracker_AwaitStart_ContextCancelled(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instances := []InstanceDesc{instance1}
-	tracker := newZoneAwareResultTracker(instances, 0, log.NewNopLogger())
+	tracker := newZoneAwareResultTracker(instances, 0, nil, log.NewNopLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -834,7 +834,7 @@ func TestZoneAwareResultTracker_StartAllRequests(t *testing.T) {
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6}
 
 	logger := &testLogger{}
-	tracker := newZoneAwareResultTracker(instances, 1, logger)
+	tracker := newZoneAwareResultTracker(instances, 1, nil, logger)
 
 	tracker.startAllRequests()
 
@@ -872,7 +872,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_NoFailingRequests(t *testin
 
 	for testIteration := 0; testIteration < 900; testIteration++ {
 		logger := &testLogger{}
-		tracker := newZoneAwareResultTracker(instances, 1, logger)
+		tracker := newZoneAwareResultTracker(instances, 1, nil, logger)
 		tracker.startMinimumRequests()
 
 		mtx := sync.RWMutex{}
@@ -979,7 +979,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximum
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
 	logger := &testLogger{}
-	tracker := newZoneAwareResultTracker(instances, 2, logger)
+	tracker := newZoneAwareResultTracker(instances, 2, nil, logger)
 	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
@@ -1079,7 +1079,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesLessThanMaximum
 	instance8 := InstanceDesc{Addr: "127.0.0.8", Zone: "zone-d"}
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
-	tracker := newZoneAwareResultTracker(instances, 2, log.NewNopLogger())
+	tracker := newZoneAwareResultTracker(instances, 2, nil, log.NewNopLogger())
 	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
@@ -1184,7 +1184,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesEqualToMaximumA
 	instance8 := InstanceDesc{Addr: "127.0.0.8", Zone: "zone-d"}
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
-	tracker := newZoneAwareResultTracker(instances, 2, log.NewNopLogger())
+	tracker := newZoneAwareResultTracker(instances, 2, nil, log.NewNopLogger())
 	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
@@ -1255,7 +1255,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_FailingZonesGreaterThanMaxi
 	instance8 := InstanceDesc{Addr: "127.0.0.8", Zone: "zone-d"}
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
-	tracker := newZoneAwareResultTracker(instances, 2, log.NewNopLogger())
+	tracker := newZoneAwareResultTracker(instances, 2, nil, log.NewNopLogger())
 	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}
@@ -1311,7 +1311,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_MaxUnavailableZonesIsNumber
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
 	instances := []InstanceDesc{instance1, instance2}
-	tracker := newZoneAwareResultTracker(instances, 1, log.NewNopLogger())
+	tracker := newZoneAwareResultTracker(instances, 1, nil, log.NewNopLogger())
 	tracker.startMinimumRequests()
 
 	wg := sync.WaitGroup{}
@@ -1341,6 +1341,58 @@ func TestZoneAwareResultTracker_StartMinimumRequests_MaxUnavailableZonesIsNumber
 	}
 }
 
+func TestZoneAwareResultTracker_StartMinimumRequests_ZoneSorting(t *testing.T) {
+	zoneAInstance := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	zoneBInstance := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-b"}
+	zoneCInstance := InstanceDesc{Addr: "127.0.0.3", Zone: "zone-c"}
+	zoneDInstance := InstanceDesc{Addr: "127.0.0.4", Zone: "zone-d"}
+	instances := []InstanceDesc{zoneAInstance, zoneBInstance, zoneCInstance, zoneDInstance}
+	mtx := sync.Mutex{}
+	released := []bool{false, false, false, false}
+
+	zoneSorter := func(zones []string) []string {
+		return []string{"zone-c", "zone-a", "zone-d", "zone-b"}
+	}
+
+	tracker := newZoneAwareResultTracker(instances, 2, zoneSorter, log.NewNopLogger())
+
+	for i := range instances {
+		i := i
+		instance := &instances[i]
+		go func() {
+			err := tracker.awaitStart(context.Background(), instance)
+			require.NoError(t, err)
+			mtx.Lock()
+			released[i] = true
+			mtx.Unlock()
+		}()
+	}
+
+	requireZonesReleased := func(expected []bool, msg string) {
+		require.Eventually(t, func() bool {
+			mtx.Lock()
+			defer mtx.Unlock()
+
+			for i, e := range expected {
+				if released[i] != e {
+					return false
+				}
+			}
+
+			return true
+		}, time.Second, 10*time.Millisecond, msg+", zones released are: ", released)
+	}
+
+	tracker.startMinimumRequests()
+	requireZonesReleased([]bool{true, false, true, false}, "first two zones (A and C) should be released immediately")
+
+	tracker.done(&instances[0], errors.New("zone A failed"))
+	requireZonesReleased([]bool{true, false, true, true}, "third zone (D) should be released after first failure")
+
+	tracker.done(&instances[3], errors.New("zone D failed"))
+	requireZonesReleased([]bool{true, true, true, true}, "final zone (C) should be released after first failure")
+}
+
 func TestZoneAwareResultTracker_StartAdditionalRequests(t *testing.T) {
 	instance1 := InstanceDesc{Addr: "127.0.0.1", Zone: "zone-a"}
 	instance2 := InstanceDesc{Addr: "127.0.0.2", Zone: "zone-a"}
@@ -1353,7 +1405,7 @@ func TestZoneAwareResultTracker_StartAdditionalRequests(t *testing.T) {
 	instances := []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6, instance7, instance8}
 
 	logger := &testLogger{}
-	tracker := newZoneAwareResultTracker(instances, 2, logger)
+	tracker := newZoneAwareResultTracker(instances, 2, nil, logger)
 	tracker.startMinimumRequests()
 
 	mtx := sync.RWMutex{}


### PR DESCRIPTION
**What this PR does**:

This PR adds support for prioritising zones when using `DoUntilQuorum` with request minimisation and zone awareness.

This is useful when the caller has additional knowledge about the zones and wants to prioritise using some over others. For example, the caller might have observed that some zones are faster or under less load and want to preference these over other, slower or more heavily loaded zones.

**Which issue(s) this PR fixes**:

Related: https://github.com/grafana/mimir/pull/6726

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
