### PR TITLE
Add TokenRanges.Equal

### DIFF
--- a/ring/token_range.go
+++ b/ring/token_range.go
@@ -9,6 +9,7 @@ import (
 
 // TokenRanges describes token ranges owned by an instance.
 // It consists of [start, end] pairs, where both start and end are inclusive.
+// For example TokenRanges with values [5, 10, 20, 30] covers tokens [5..10] and [20..30].
 type TokenRanges []uint32
 
 func (tr TokenRanges) IncludesKey(key uint32) bool {
@@ -34,6 +35,20 @@ func (tr TokenRanges) IncludesKey(key uint32) bool {
 	default:
 		return false
 	}
+}
+
+func (tr TokenRanges) Equal(other TokenRanges) bool {
+	if len(tr) != len(other) {
+		return false
+	}
+
+	for i := 0; i < len(tr); i++ {
+		if tr[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // GetTokenRangesForInstance returns the token ranges owned by an instance in the ring.

--- a/ring/token_range_test.go
+++ b/ring/token_range_test.go
@@ -21,6 +21,15 @@ func TestKeyInTokenRanges(t *testing.T) {
 	require.False(t, ranges.IncludesKey(20))
 }
 
+func TestTokenRangesEqual(t *testing.T) {
+	ranges := TokenRanges{4, 8, 12, 16}
+	require.True(t, ranges.Equal(TokenRanges{4, 8, 12, 16}))
+	require.False(t, ranges.Equal(TokenRanges{4, 8}))
+	require.False(t, ranges.Equal(TokenRanges{4, 8, 12, 17}))
+	require.False(t, ranges.Equal(TokenRanges{4, 8, 12, 17, 20, 25}))
+	require.False(t, ranges.Equal(nil))
+}
+
 func TestGetTokenRangesForInstance(t *testing.T) {
 	numZones := 3
 


### PR DESCRIPTION
**What this PR does**:

Add `TokenRanges.Equal` method. Mimir uses this to check if ingester's token ranges have changed.

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
