### PR TITLE
Add ability to log all source hosts from http header instead of only the first one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
+* [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
 * [ENHANCEMENT] Add middleware package. #38

--- a/middleware/source_ips_test.go
+++ b/middleware/source_ips_test.go
@@ -192,7 +192,208 @@ func TestGetSourceIPs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sourceIPs, err := NewSourceIPs("", "")
+			sourceIPs, err := NewSourceIPs("", "", false)
+			require.NoError(t, err)
+
+			if got := sourceIPs.Get(tt.req); got != tt.want {
+				t.Errorf("GetSource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetSourceIPsFullExtract(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *http.Request
+		want string
+	}{
+		{
+			name: "no header",
+			req:  &http.Request{RemoteAddr: "192.168.1.100:3454"},
+			want: "192.168.1.100",
+		},
+		{
+			name: "no header and remote has no port",
+			req:  &http.Request{RemoteAddr: "192.168.1.100"},
+			want: "192.168.1.100",
+		},
+		{
+			name: "no header, remote address is invalid",
+			req:  &http.Request{RemoteAddr: "192.168.100"},
+			want: "192.168.100",
+		},
+		{
+			name: "X-Forwarded-For and single forward address",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"172.16.1.1"},
+				},
+			},
+			want: "172.16.1.1, 192.168.1.100",
+		},
+		{
+			name: "X-Forwarded-For and single forward address which is same as remote",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"192.168.1.100"},
+				},
+			},
+			want: "192.168.1.100",
+		},
+		{
+			name: "single IPv6 X-Forwarded-For address",
+			req: &http.Request{
+				RemoteAddr: "[2001:db9::1]:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"2001:db8::1"},
+				},
+			},
+			want: "2001:db8::1, 2001:db9::1",
+		},
+		{
+			name: "single X-Forwarded-For address no RemoteAddr",
+			req: &http.Request{
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"172.16.1.1"},
+				},
+			},
+			want: "172.16.1.1",
+		},
+		{
+			name: "multiple X-Forwarded-For with remote",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"172.16.1.1, 10.10.13.20"},
+				},
+			},
+			want: "172.16.1.1, 10.10.13.20, 192.168.1.100",
+		},
+		{
+			name: "multiple X-Forwarded-For with remote and no spaces",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"172.16.1.1,10.10.13.20,10.11.16.46"},
+				},
+			},
+			want: "172.16.1.1, 10.10.13.20, 10.11.16.46, 192.168.1.100",
+		},
+		{
+			name: "multiple X-Forwarded-For with IPv6 remote",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"[2001:db8:cafe::17]:4711, 10.10.13.20"},
+				},
+			},
+			want: "2001:db8:cafe::17, 10.10.13.20, 192.168.1.100",
+		},
+		{
+			name: "no header, no remote",
+			req:  &http.Request{},
+			want: "",
+		},
+		{
+			name: "X-Real-IP with IPv6 remote with port",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xRealIP): {"[2001:db8:cafe::17]:4711"},
+				},
+			},
+			want: "2001:db8:cafe::17, 192.168.1.100",
+		},
+		{
+			name: "X-Real-IP with IPv4 remote",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xRealIP): {"192.169.1.200"},
+				},
+			},
+			want: "192.169.1.200, 192.168.1.100",
+		},
+		{
+			name: "X-Real-IP with IPv4 remote and X-Forwarded-For",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"[2001:db8:cafe::17]:4711, 10.10.13.20"},
+					http.CanonicalHeaderKey(xRealIP):       {"192.169.1.200"},
+				},
+			},
+			want: "192.169.1.200, 192.168.1.100",
+		},
+		{
+			name: "Forwarded with IPv4 remote",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(forwarded): {"for=192.169.1.200"},
+				},
+			},
+			want: "192.169.1.200, 192.168.1.100",
+		},
+		{
+			name: "Forwarded with IPv4 and proto and by fields",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(forwarded): {"for=192.0.2.60;proto=http;by=203.0.113.43"},
+				},
+			},
+			want: "192.0.2.60, 192.168.1.100",
+		},
+		{
+			name: "Forwarded with IPv6 and IPv4 remote",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(forwarded): {"for=[2001:db8:cafe::17]:4711,for=192.169.1.200"},
+				},
+			},
+			want: "2001:db8:cafe::17, 192.169.1.200, 192.168.1.100",
+		},
+		{
+			name: "Forwarded with X-Real-IP and X-Forwarded-For",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(xForwardedFor): {"[2001:db8:cafe::17]:4711, 10.10.13.20"},
+					http.CanonicalHeaderKey(xRealIP):       {"192.169.1.200"},
+					http.CanonicalHeaderKey(forwarded):     {"for=[2001:db8:cafe::17]:4711,for=192.169.1.200"},
+				},
+			},
+			want: "2001:db8:cafe::17, 192.169.1.200, 192.168.1.100",
+		},
+		{
+			name: "Forwarded returns hostname",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(forwarded): {"for=workstation.local"},
+				},
+			},
+			want: "workstation.local, 192.168.1.100",
+		},
+		{
+			name: "Forwarded is case insensitive",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey(forwarded): {"For=192.168.1.1"},
+				},
+			},
+			want: "192.168.1.1, 192.168.1.100",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceIPs, err := NewSourceIPs("", "", true)
 			require.NoError(t, err)
 
 			if got := sourceIPs.Get(tt.req); got != tt.want {
@@ -246,7 +447,7 @@ func TestGetSourceIPsWithCustomRegex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sourceIPs, err := NewSourceIPs("SomeHeader", "((?:[0-9]{1,3}\\.){3}[0-9]{1,3})")
+			sourceIPs, err := NewSourceIPs("SomeHeader", "((?:[0-9]{1,3}\\.){3}[0-9]{1,3})", false)
 			require.NoError(t, err)
 
 			if got := sourceIPs.Get(tt.req); got != tt.want {
@@ -255,16 +456,71 @@ func TestGetSourceIPsWithCustomRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSourceIPsWithCustomRegexFullExtract(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *http.Request
+		want string
+	}{
+		{
+			name: "no header",
+			req:  &http.Request{RemoteAddr: "192.168.1.100:3454"},
+			want: "192.168.1.100",
+		},
+		{
+			name: "No matching entry in the header",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey("SomeHeader"): {"not matching"},
+				},
+			},
+			want: "192.168.1.100",
+		},
+		{
+			name: "one matching entry in the header",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey("SomeHeader"): {"172.16.1.1"},
+				},
+			},
+			want: "172.16.1.1, 192.168.1.100",
+		},
+		{
+			name: "multiple matching entries in the header",
+			req: &http.Request{
+				RemoteAddr: "192.168.1.100:3454",
+				Header: map[string][]string{
+					http.CanonicalHeaderKey("SomeHeader"): {"172.16.1.1,172.16.2.1"},
+				},
+			},
+			want: "172.16.1.1, 172.16.2.1, 192.168.1.100",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceIPs, err := NewSourceIPs("SomeHeader", "((?:[0-9]{1,3}\\.){3}[0-9]{1,3})", true)
+			require.NoError(t, err)
+
+			if got := sourceIPs.Get(tt.req); got != tt.want {
+				t.Errorf("GetSource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInvalid(t *testing.T) {
-	sourceIPs, err := NewSourceIPs("Header", "")
+	sourceIPs, err := NewSourceIPs("Header", "", false)
 	require.Empty(t, sourceIPs)
 	require.Error(t, err)
 
-	sourceIPs, err = NewSourceIPs("", "a(.*)b")
+	sourceIPs, err = NewSourceIPs("", "a(.*)b", false)
 	require.Empty(t, sourceIPs)
 	require.Error(t, err)
 
-	sourceIPs, err = NewSourceIPs("Header", "[*")
+	sourceIPs, err = NewSourceIPs("Header", "[*", false)
 	require.Empty(t, sourceIPs)
 	require.Error(t, err)
 }

--- a/middleware/source_ips_test.go
+++ b/middleware/source_ips_test.go
@@ -238,7 +238,7 @@ func TestGetSourceIPsWithCustomRegex(t *testing.T) {
 			req: &http.Request{
 				RemoteAddr: "192.168.1.100:3454",
 				Header: map[string][]string{
-					http.CanonicalHeaderKey("SomeHeader"): {"172.16.1.1", "172.16.2.1"},
+					http.CanonicalHeaderKey("SomeHeader"): {"172.16.1.1,172.16.2.1"},
 				},
 			},
 			want: "172.16.1.1, 192.168.1.100",

--- a/server/server.go
+++ b/server/server.go
@@ -130,6 +130,7 @@ type Config struct {
 	LogLevel                     log.Level        `yaml:"log_level"`
 	Log                          gokit_log.Logger `yaml:"-"`
 	LogSourceIPs                 bool             `yaml:"log_source_ips_enabled"`
+	LogSourceIPsFull             bool             `yaml:"log_source_ips_full"`
 	LogSourceIPsHeader           string           `yaml:"log_source_ips_header"`
 	LogSourceIPsRegex            string           `yaml:"log_source_ips_regex"`
 	LogRequestHeaders            bool             `yaml:"log_request_headers"`
@@ -194,6 +195,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.LogFormat, "log.format", log.LogfmtFormat, "Output log messages in the given format. Valid formats: [logfmt, json]")
 	cfg.LogLevel.RegisterFlags(f)
 	f.BoolVar(&cfg.LogSourceIPs, "server.log-source-ips-enabled", false, "Optionally log the source IPs.")
+	f.BoolVar(&cfg.LogSourceIPsFull, "server.log-source-ips-full", false, "Log all source IPs instead of only the originating one. Only used if server.log-source-ips-enabled is true")
 	f.StringVar(&cfg.LogSourceIPsHeader, "server.log-source-ips-header", "", "Header field storing the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
 	f.StringVar(&cfg.LogSourceIPsRegex, "server.log-source-ips-regex", "", "Regex for matching the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
 	f.BoolVar(&cfg.LogRequestHeaders, "server.log-request-headers", false, "Optionally log request headers.")
@@ -470,7 +472,7 @@ func RegisterInstrumentationWithGatherer(router *mux.Router, gatherer prometheus
 }
 
 func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logger gokit_log.Logger) ([]middleware.Interface, error) {
-	sourceIPs, err := middleware.NewSourceIPs(cfg.LogSourceIPsHeader, cfg.LogSourceIPsRegex)
+	sourceIPs, err := middleware.NewSourceIPs(cfg.LogSourceIPsHeader, cfg.LogSourceIPsRegex, cfg.LogSourceIPsFull)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up source IP extraction: %w", err)
 	}


### PR DESCRIPTION
This PR add the ability to extract all hosts from a custom header or the standard one Forwarded, X-Real-IP, X-Forwraded-For.
    
This list of hosts can then be used for informational purposes.
    
Previous behavior remains the default one and new one can be triggered by setting a configuration flag `server.log-source-ips-full to true.`

This PR follow [this conversation](https://grafana.slack.com/archives/C039863E8P7/p1700840526610699).
