### PR TITLE
Remove global state from tenant ID parsing package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 * [CHANGE] server: fix incorrect spelling of "gRPC" in `server.Config` fields. #422
 * [CHANGE] memberlist: re-resolve `JoinMembers` during full joins to the cluster (either at startup or periodic). The re-resolution happens on every 100 attempted nodes. This helps speed up joins and respect context cancelation #411
 * [CHANGE] ring: `ring.DoBatch()` was deprecated in favor of `DoBatchWithOptions()`. #431
-* [CHANGE] tenant: Remove `tenant.WithDefaultResolver()` and `SingleResolver` in favor of global functions `tenant.TenantID()`, `tenant.TenantIDs()`,  or `MultiResolver`. #TBD
+* [CHANGE] tenant: Remove `tenant.WithDefaultResolver()` and `SingleResolver` in favor of global functions `tenant.TenantID()`, `tenant.TenantIDs()`,  or `MultiResolver`. #445
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [CHANGE] server: fix incorrect spelling of "gRPC" in `server.Config` fields. #422
 * [CHANGE] memberlist: re-resolve `JoinMembers` during full joins to the cluster (either at startup or periodic). The re-resolution happens on every 100 attempted nodes. This helps speed up joins and respect context cancelation #411
 * [CHANGE] ring: `ring.DoBatch()` was deprecated in favor of `DoBatchWithOptions()`. #431
+* [CHANGE] tenant: Remove `tenant.WithDefaultResolver()` and `SingleResolver` in favor of global functions `tenant.TenantID()`, `tenant.TenantIDs()`,  or `MultiResolver`. #TBD
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/tenant/resolver.go
+++ b/tenant/resolver.go
@@ -2,14 +2,9 @@ package tenant
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/grafana/dskit/user"
-)
-
-var (
-	errInvalidTenantID = errors.New("invalid tenant ID")
 )
 
 // TenantID returns exactly a single tenant ID from the context. It should be
@@ -48,12 +43,9 @@ func TenantIDs(ctx context.Context) ([]string, error) {
 	}
 
 	orgIDs := strings.Split(orgID, tenantIDsSeparator)
-	for _, orgID := range orgIDs {
-		if err := ValidTenantID(orgID); err != nil {
+	for _, id := range orgIDs {
+		if err := ValidTenantID(id); err != nil {
 			return nil, err
-		}
-		if containsUnsafePathSegments(orgID) {
-			return nil, errInvalidTenantID
 		}
 	}
 
@@ -89,16 +81,4 @@ func (t *MultiResolver) TenantID(ctx context.Context) (string, error) {
 
 func (t *MultiResolver) TenantIDs(ctx context.Context) ([]string, error) {
 	return TenantIDs(ctx)
-}
-
-// containsUnsafePathSegments will return true if the string is a directory
-// reference like `.` and `..` or if any path separator character like `/` and
-// `\` can be found.
-func containsUnsafePathSegments(id string) bool {
-	// handle the relative reference to current and parent path.
-	if id == "." || id == ".." {
-		return true
-	}
-
-	return strings.ContainsAny(id, "\\/")
 }

--- a/tenant/resolver_test.go
+++ b/tenant/resolver_test.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,92 +23,36 @@ type resolverTestCase struct {
 	tenantIDs    []string
 }
 
-func (tc *resolverTestCase) test(r Resolver) func(t *testing.T) {
-	return func(t *testing.T) {
-
-		ctx := context.Background()
-		if tc.headerValue != nil {
-			ctx = user.InjectOrgID(ctx, *tc.headerValue)
-		}
-
-		tenantID, err := r.TenantID(ctx)
-		if tc.errTenantID != nil {
-			assert.Equal(t, tc.errTenantID, err)
-		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, tc.tenantID, tenantID)
-		}
-
-		tenantIDs, err := r.TenantIDs(ctx)
-		if tc.errTenantIDs != nil {
-			assert.Equal(t, tc.errTenantIDs, err)
-		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, tc.tenantIDs, tenantIDs)
-		}
-	}
-}
-
-var commonResolverTestCases = []resolverTestCase{
-	{
-		name:         "no-header",
-		errTenantID:  user.ErrNoOrgID,
-		errTenantIDs: user.ErrNoOrgID,
-	},
-	{
-		name:        "empty",
-		headerValue: strptr(""),
-		tenantIDs:   []string{""},
-	},
-	{
-		name:        "single-tenant",
-		headerValue: strptr("tenant-a"),
-		tenantID:    "tenant-a",
-		tenantIDs:   []string{"tenant-a"},
-	},
-	{
-		name:         "parent-dir",
-		headerValue:  strptr(".."),
-		errTenantID:  errInvalidTenantID,
-		errTenantIDs: errInvalidTenantID,
-	},
-	{
-		name:         "current-dir",
-		headerValue:  strptr("."),
-		errTenantID:  errInvalidTenantID,
-		errTenantIDs: errInvalidTenantID,
-	},
-}
-
-func TestSingleResolver(t *testing.T) {
-	r := NewSingleResolver()
-	for _, tc := range append(commonResolverTestCases, []resolverTestCase{
+func TestTenantIDs(t *testing.T) {
+	for _, tc := range []resolverTestCase{
 		{
-			name:        "multi-tenant",
-			headerValue: strptr("tenant-a|tenant-b"),
-			tenantID:    "tenant-a|tenant-b",
-			tenantIDs:   []string{"tenant-a|tenant-b"},
+			name:         "no-header",
+			errTenantID:  user.ErrNoOrgID,
+			errTenantIDs: user.ErrNoOrgID,
 		},
 		{
-			name:         "containing-forward-slash",
-			headerValue:  strptr("forward/slash"),
+			name:        "empty",
+			headerValue: strptr(""),
+			tenantIDs:   []string{""},
+		},
+		{
+			name:        "single-tenant",
+			headerValue: strptr("tenant-a"),
+			tenantID:    "tenant-a",
+			tenantIDs:   []string{"tenant-a"},
+		},
+		{
+			name:         "parent-dir",
+			headerValue:  strptr(".."),
 			errTenantID:  errInvalidTenantID,
 			errTenantIDs: errInvalidTenantID,
 		},
 		{
-			name:         "containing-backward-slash",
-			headerValue:  strptr(`backward\slash`),
+			name:         "current-dir",
+			headerValue:  strptr("."),
 			errTenantID:  errInvalidTenantID,
 			errTenantIDs: errInvalidTenantID,
 		},
-	}...) {
-		t.Run(tc.name, tc.test(r))
-	}
-}
-
-func TestMultiResolver(t *testing.T) {
-	r := NewMultiResolver()
-	for _, tc := range append(commonResolverTestCases, []resolverTestCase{
 		{
 			name:        "multi-tenant",
 			headerValue: strptr("tenant-a|tenant-b"),
@@ -144,7 +89,34 @@ func TestMultiResolver(t *testing.T) {
 			errTenantID:  &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
 			errTenantIDs: &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
 		},
-	}...) {
-		t.Run(tc.name, tc.test(r))
+		{
+			name:         "too-long",
+			headerValue:  strptr(strings.Repeat("123", MaxTenantIDLength)),
+			errTenantID:  errTenantIDTooLong,
+			errTenantIDs: errTenantIDTooLong,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.headerValue != nil {
+				ctx = user.InjectOrgID(ctx, *tc.headerValue)
+			}
+
+			tenantID, err := TenantID(ctx)
+			if tc.errTenantID != nil {
+				assert.Equal(t, tc.errTenantID, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.tenantID, tenantID)
+			}
+
+			tenantIDs, err := TenantIDs(ctx)
+			if tc.errTenantIDs != nil {
+				assert.Equal(t, tc.errTenantIDs, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.tenantIDs, tenantIDs)
+			}
+		})
 	}
 }

--- a/tenant/resolver_test.go
+++ b/tenant/resolver_test.go
@@ -44,14 +44,14 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name:         "parent-dir",
 			headerValue:  strptr(".."),
-			errTenantID:  errInvalidTenantID,
-			errTenantIDs: errInvalidTenantID,
+			errTenantID:  errUnsafeTenantID,
+			errTenantIDs: errUnsafeTenantID,
 		},
 		{
 			name:         "current-dir",
 			headerValue:  strptr("."),
-			errTenantID:  errInvalidTenantID,
-			errTenantIDs: errInvalidTenantID,
+			errTenantID:  errUnsafeTenantID,
+			errTenantIDs: errUnsafeTenantID,
 		},
 		{
 			name:        "multi-tenant",
@@ -74,8 +74,8 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name:         "multi-tenant-with-relative-path",
 			headerValue:  strptr("tenant-a|tenant-b|.."),
-			errTenantID:  errInvalidTenantID,
-			errTenantIDs: errInvalidTenantID,
+			errTenantID:  errUnsafeTenantID,
+			errTenantIDs: errUnsafeTenantID,
 		},
 		{
 			name:         "containing-forward-slash",

--- a/tenant/tenant_test.go
+++ b/tenant/tenant_test.go
@@ -29,6 +29,14 @@ func TestValidTenantIDs(t *testing.T) {
 			name: strings.Repeat("a", 151),
 			err:  strptr("tenant ID is too long: max 150 characters"),
 		},
+		{
+			name: ".",
+			err:  strptr("tenant ID is '.' or '..'"),
+		},
+		{
+			name: "..",
+			err:  strptr("tenant ID is '.' or '..'"),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidTenantID(tc.name)


### PR DESCRIPTION
**What this PR does**:

Remove the ability to set a global "default" parser for tenant IDs since this makes uses of this package fragile and bug prone. This also removes the `SingleResolver` struct which does not support multiple tenant IDs and was previously the default logic.

All code for parsing tenant IDs is now aware of multiple tenant IDs separated by a `|` character. Consumers that don't want to support multiple tenant IDs at all should use the `TenantID()` method which returns an error if there are multiple tenant IDs. Consumers that wish to optionally support multiple tenant IDs should validate incoming input to ensure only a single ID is present.

This changes the default behavior of `TenantID()` and `TenantIDs()` in two
ways:
    
* `SingleResolver` did not previously enforce a limit on the length of a tenant
   ID. A limit of 150 characters is now enforced. This has always been the
   documented behavior as far back as Cortex, where this code originated. Not
   enforcing it was an oversight.
* `SingleResolver` previously allowed tenant IDs to contain the `|` character.
   This is no longer allowed as part of a tenant ID and instead will be treated
   as a divider between multiple tenant IDs. This has always been the documented
   behavior as far back as Cortex, where this code originated. Not enforcing it
   was an oversight.

**Which issue(s) this PR fixes**:

Fixes #443

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
