### PR TITLE
Add SpanProfiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 * [ENHANCEMENT] ring: Replaced `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use pre-allocated workers instead of spawning a new goroutine for each request. #431
 * [ENHANCEMENT] ring: add support for prioritising zones when using `DoUntilQuorum` with request minimisation and zone awareness. #440
 * [ENHANCEMENT] ballast: add utility function to allocate heap ballast. #446
+* [ENHANCEMENT] SpanProfiler: add spanprofiler package.
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@
 * [ENHANCEMENT] ring: Replaced `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use pre-allocated workers instead of spawning a new goroutine for each request. #431
 * [ENHANCEMENT] ring: add support for prioritising zones when using `DoUntilQuorum` with request minimisation and zone awareness. #440
 * [ENHANCEMENT] ballast: add utility function to allocate heap ballast. #446
-* [ENHANCEMENT] SpanProfiler: add spanprofiler package.
+* [ENHANCEMENT] SpanProfiler: add spanprofiler package. #448
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/spanprofiler/README.md
+++ b/spanprofiler/README.md
@@ -1,0 +1,104 @@
+# Span Profiler for OpenTracing-Go
+
+## Overview
+
+The Span Profiler for OpenTracing-Go is a package that seamlessly integrates `opentracing-go` instrumentation with
+profiling through the use of pprof labels.
+
+Accessing trace span profiles is made convenient through the Grafana Explore view. You can find a complete example setup
+with Grafana Tempo in the [Pyroscope repository](https://github.com/grafana/pyroscope/tree/main/examples/tracing/tempo):
+
+![image](https://github.com/grafana/otel-profiling-go/assets/12090599/31e33cd1-818b-4116-b952-c9ec7b1fb593)
+
+## Usage
+
+There are two primary ways to use the Span Profiler:
+
+### 1. Wrap the Global Tracer.
+
+You can wrap the global tracer using `spanprofiler.NewTracer`:
+
+```go
+import (
+    "github.com/opentracing/opentracing-go"
+    "github.com/grafana/dskit/spanprofiler"
+)
+
+func main() {
+    // Initialize your OpenTracing tracer
+    tracer := opentracing.GlobalTracer()
+    // Wrap it with the tracer-profiler 
+    wrappedTracer := spanprofiler.NewTracer(tracer)
+    // Use the wrapped tracer in your application
+    opentracing.SetGlobalTracer(wrappedTracer)
+
+    // Or, as an oneliner:
+    // opentracing.SetGlobalTracer(spanprofiler.NewTracer(opentracing.GlobalTracer()))
+
+    // Your application logic here
+}
+```
+
+For efficiency, the tracer selectively records profiles for _root_ spans — the initial _local_ span in a process — since
+a trace may encompass thousands of spans. All stack trace samples accumulated during the execution of their child spans
+contribute to the root span's profile. In practical terms, this signifies that, for instance, an HTTP request results
+in a singular profile, irrespective of the numerous spans within the trace. It's important to note that these profiles
+don't extend beyond the boundaries of a single process.
+
+The limitation of this approach is that only spans created within the same goroutine, or its children, as the parent are
+taken into account. Consequently, in scenarios involving asynchronous execution, where the parent span context is passed
+to another goroutine, explicit profiling becomes necessary using `spanprofiler.StartSpanFromContext`.
+
+### 2. Profile individual spans.
+
+The `spanprofiler.StartSpanFromContext` function allows you to granularly control which spans to profile:
+
+```go
+func YourOperationName(ctx context.Background()) {
+    // Start a span and enable profiling for it
+    span, ctx := spanprofiler.StartSpanFromContext(ctx, "YourOperationName", tracer)
+    defer span.Finish() // Finish the span when done
+
+    // Use the span in your application logic
+}
+```
+
+The function guarantees that the span is to be profiled.
+
+Both methods can be employed either in conjunction or independently. Our recommendation is to utilize the tracer for
+seamless integration, reserving explicit span profiling only for cases where spans are spawned in detached goroutines.
+
+## Implementation details
+
+When a new trace span is created, and is eligible for profiling, the tracer sets `span_id` and `span_name` [pprof labels](https://github.com/google/pprof/blob/master/doc/README.md#tag-filtering)
+that point to the respective span. These labels are stored in the goroutine's local storage and inherited by any
+subsequent child goroutines.
+
+`span_name` is available as a regular label and can be used in the query expressions. For example, the following query 
+will show you profile for the code that is not covered with traces:
+```
+{service_name="my-service",span_name=""}
+```
+
+Additionally, trace spans are identified by the `pyroscope.profile.id` attribute, indicating the associated profile.
+This allows to find such spans in the trace view (in the screenshot) and fetch profiles for specific spans.
+
+It's important to note that the presence of this attribute does not guarantee profile availability; stack trace samples
+might not be collected if the CPU time utilized falls below the sample interval (10ms).
+
+It is crucial to understand that this module doesn't directly control the pprof profiler; its initialization is still
+necessary for profile collection. This initialization can be achieved through the `runtime/pprof` package, or using the
+[Pyroscope client](https://github.com/grafana/pyroscope-go).
+
+Limitations:
+ - Only CPU profiling is fully supported at the moment.
+ - Only [Jaeger tracer](https://github.com/jaegertracing/jaeger-client-go) implementation is supported.
+
+## Performance implications
+
+The typical performance impact is generally imperceptible and primarily arises from the cost of pprof labeling. However,
+intensive use of pprof labels may have negative impact on the profiled application.
+
+In the case of the tracer provided by this package, the `StartSpan` method wrapper introduces an approximate 20% increase
+in CPU time compared to the original call. In vase majority of cases, the overhead constitutes less than 0.01% of the total
+CPU time and is considered safe for deployment in production systems.

--- a/spanprofiler/spanprofiler.go
+++ b/spanprofiler/spanprofiler.go
@@ -1,0 +1,107 @@
+package spanprofiler
+
+import (
+	"context"
+	"runtime/pprof"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+)
+
+// StartSpanFromContext starts and returns a Span with `operationName`, using
+// any Span found within `ctx` as a ChildOfRef. If no such parent could be
+// found, StartSpanFromContext creates a root (parentless) Span.
+//
+// The call sets `operationName` as `span_name` pprof label, and the new span
+// identifier as `span_id` pprof label, if the trace is sampled.
+//
+// The second return value is a context.Context object built around the
+// returned Span.
+//
+// Example usage:
+//
+//	SomeFunction(ctx context.Context, ...) {
+//	    sp, ctx := opentracing.StartSpanFromContext(ctx, "SomeFunction")
+//	    defer sp.Finish()
+//	    ...
+//	}
+func StartSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
+	return StartSpanFromContextWithTracer(ctx, opentracing.GlobalTracer(), operationName, opts...)
+}
+
+// StartSpanFromContextWithTracer starts and returns a span with `operationName`
+// using  a span found within the context as a ChildOfRef. If that doesn't exist
+// it creates a root span. It also returns a context.Context object built
+// around the returned span.
+//
+// The call sets `operationName` as `span_name` pprof label, and the new span
+// identifier as `span_id` pprof label, if the trace is sampled.
+//
+// It's behavior is identical to StartSpanFromContext except that it takes an explicit
+// tracer as opposed to using the global tracer.
+func StartSpanFromContextWithTracer(ctx context.Context, tracer opentracing.Tracer, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
+	span, ctx := opentracing.StartSpanFromContextWithTracer(ctx, tracer, operationName, opts...)
+	spanCtx, ok := span.Context().(jaeger.SpanContext)
+	if ok {
+		span = wrapJaegerSpanWithGoroutineLabels(ctx, span, operationName, sampledSpanID(spanCtx))
+	}
+	return span, ctx
+}
+
+func wrapJaegerSpanWithGoroutineLabels(
+	parentCtx context.Context,
+	span opentracing.Span,
+	operationName string,
+	spanID string,
+) *spanWrapper {
+	// Note that pprof labels are propagated through the goroutine's local
+	// storage and are always copied to child goroutines. This way, stack
+	// trace samples collected during execution of child spans will be taken
+	// into account at the root.
+	var ctx context.Context
+	if spanID != "" {
+		ctx = pprof.WithLabels(parentCtx, pprof.Labels(
+			spanNameLabelName, operationName,
+			spanIDLabelName, spanID))
+	} else {
+		// Even if the trace has not been sampled, we still need to keep track
+		// of samples that belong to the span (all spans with the given name).
+		ctx = pprof.WithLabels(parentCtx, pprof.Labels(
+			spanNameLabelName, operationName))
+	}
+	// Goroutine labels should be set as early as possible,
+	// in order to capture the overhead of the function call.
+	pprof.SetGoroutineLabels(ctx)
+	// We create a span wrapper to ensure we remove the newly attached pprof
+	// labels when span finishes. The need of this wrapper is questioned:
+	// as we do not have the original context, we could leave the goroutine
+	// labels – normally, span is finished at the very end of the goroutine's
+	// lifetime, so no significant side effects should take place.
+	w := spanWrapper{
+		parentPprofCtx:  parentCtx,
+		currentPprofCtx: ctx,
+	}
+	w.Span = span.SetTag(profileIDTagKey, spanID)
+	return &w
+}
+
+type spanWrapper struct {
+	parentPprofCtx  context.Context
+	currentPprofCtx context.Context
+	opentracing.Span
+}
+
+func (s *spanWrapper) Finish() {
+	s.Span.Finish()
+	pprof.SetGoroutineLabels(s.parentPprofCtx)
+	s.currentPprofCtx = s.parentPprofCtx
+}
+
+// sampledSpanID returns the span ID, if the span is sampled,
+// otherwise an empty string is returned.
+func sampledSpanID(spanCtx jaeger.SpanContext) string {
+	if spanCtx.IsSampled() {
+		return spanCtx.SpanID().String()
+	}
+	return ""
+}

--- a/spanprofiler/spanprofiler_test.go
+++ b/spanprofiler/spanprofiler_test.go
@@ -1,0 +1,35 @@
+package spanprofiler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-client-go"
+)
+
+func TestSpanProfiler_pprof_labels_propagation(t *testing.T) {
+	tt := initTestTracer(t)
+	defer func() { require.NoError(t, tt.Close()) }()
+
+	t.Run("pprof labels are not propagated to child spans", func(t *testing.T) {
+		rootSpan, ctx := StartSpanFromContext(context.Background(), "RootSpan")
+		defer rootSpan.Finish()
+		rootLabels := spanPprofLabels(rootSpan)
+		require.Equal(t, rootLabels["span_name"], "RootSpan")
+		rootSpanID, err := jaeger.SpanIDFromString(rootLabels["span_id"])
+		require.NoError(t, err)
+
+		// Regardless of anything, pprof labels are attached to the current
+		// goroutine, and the "pyroscope.profile.id" tag is set.
+		childSpan, _ := StartSpanFromContext(ctx, "ChildSpan")
+		defer childSpan.Finish()
+		childLabels := spanPprofLabels(childSpan)
+		require.Equal(t, childLabels["span_name"], "ChildSpan")
+		childSpanID, err := jaeger.SpanIDFromString(childLabels["span_id"])
+		require.NoError(t, err)
+
+		require.NotEqual(t, rootSpanID, childSpanID)
+		require.Equal(t, childSpanID.String(), spanTags(childSpan)["pyroscope.profile.id"])
+	})
+}

--- a/spanprofiler/tracer.go
+++ b/spanprofiler/tracer.go
@@ -1,0 +1,109 @@
+package spanprofiler
+
+import (
+	"context"
+	"unsafe"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+)
+
+const (
+	profileIDTagKey = "pyroscope.profile.id"
+
+	spanIDLabelName   = "span_id"
+	spanNameLabelName = "span_name"
+)
+
+type tracer struct{ opentracing.Tracer }
+
+// NewTracer creates a new opentracing.Tracer with the span profiler integrated.
+//
+// For efficiency, the tracer selectively records profiles for _root_ spans
+// — the initial _local_ span in a process — since a trace may encompass
+// thousands of spans. All stack trace samples accumulated during the execution
+// of their child spans contribute to the root span's profile. In practical
+// terms, this signifies that, for instance, an HTTP request results in a
+// singular profile, irrespective of the numerous spans within the trace. It's
+// important to note that these profiles don't extend beyond the boundaries of
+// a single process.
+//
+// The limitation of this approach is that only spans created within the same
+// goroutine, or its children, as the parent are taken into account.
+// Consequently, in scenarios involving asynchronous execution, where the parent
+// span context is passed to another goroutine, explicit profiling becomes
+// necessary using `spanprofiler.StartSpanFromContext`.
+func NewTracer(tr opentracing.Tracer) opentracing.Tracer { return &tracer{tr} }
+
+func (t *tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	span := t.Tracer.StartSpan(operationName, opts...)
+	spanCtx, ok := span.Context().(jaeger.SpanContext)
+	if !ok {
+		return span
+	}
+	// pprof labels are attached only once, at the span root level.
+	if !isRootSpan(opts...) {
+		return span
+	}
+	// The pprof label API assumes that pairs of labels are passed through the
+	// context. Unfortunately, the opentracing Tracer API doesn't match this
+	// concept: this makes it impossible to save an existing pprof context and
+	// all the original pprof labels associated with the goroutine.
+	ctx := context.Background()
+	return wrapJaegerSpanWithGoroutineLabels(ctx, span, operationName, sampledSpanID(spanCtx))
+}
+
+// isRootSpan reports whether the span is a root span.
+//
+// There are only two valid cases: if the span is the first span in the trace,
+// or is the first _local_ span in the trace.
+//
+// An exception is made for FollowsFrom reference: spans without an explicit
+// parent are considered as root ones.
+func isRootSpan(opts ...opentracing.StartSpanOption) bool {
+	parent, ok := parentSpanContextFromRef(opts...)
+	return !ok || isRemoteSpan(parent)
+}
+
+// parentSpanContextFromRef returns the first parent reference.
+func parentSpanContextFromRef(options ...opentracing.StartSpanOption) (sc jaeger.SpanContext, ok bool) {
+	var sso opentracing.StartSpanOptions
+	for _, option := range options {
+		option.Apply(&sso)
+	}
+	for _, ref := range sso.References {
+		if ref.Type == opentracing.ChildOfRef && ref.ReferencedContext != nil {
+			sc, ok = ref.ReferencedContext.(jaeger.SpanContext)
+			return sc, ok
+		}
+	}
+	return sc, ok
+}
+
+// isRemoteSpan reports whether the span context represents a remote parent.
+//
+// NOTE(kolesnikovae): this is ugly, but the only reliable method I found.
+// The opentracing-go package and Jaeger client are not meant to change as
+// both are deprecated.
+func isRemoteSpan(c jaeger.SpanContext) bool {
+	jaegerCtx := *(*jaegerSpanCtx)(unsafe.Pointer(&c))
+	return jaegerCtx.remote
+}
+
+// jaegerSpanCtx represents memory layout of the jaeger.SpanContext type.
+type jaegerSpanCtx struct {
+	traceID  [16]byte   // TraceID
+	spanID   [8]byte    // SpanID
+	parentID [8]byte    // SpanID
+	baggage  uintptr    // map[string]string
+	debugID  [2]uintptr // string
+
+	// samplingState is a pointer to a struct that has "localRootSpan" member,
+	// which we could probably use: that would allow omitting quite expensive
+	// parentSpanContextFromRef call. However, interpreting the pointer and
+	// the complex struct memory layout is more complicated and dangerous.
+	samplingState uintptr
+
+	// remote indicates that span context represents a remote parent
+	remote bool
+}

--- a/spanprofiler/tracer_test.go
+++ b/spanprofiler/tracer_test.go
@@ -1,0 +1,128 @@
+package spanprofiler
+
+import (
+	"context"
+	"io"
+	"runtime/pprof"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-client-go"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
+)
+
+func TestTracer_pprof_labels_propagation(t *testing.T) {
+	tt := initTestTracer(t)
+	defer func() { require.NoError(t, tt.Close()) }()
+
+	t.Run("root span name and ID are propagated as pprof labels", func(t *testing.T) {
+		rootSpan, _ := opentracing.StartSpanFromContext(context.Background(), "RootSpan")
+		defer rootSpan.Finish()
+		pprofLabels := spanPprofLabels(rootSpan)
+		// Label / tag names should be specified explicitly.
+		require.Equal(t, pprofLabels["span_name"], "RootSpan")
+		_, err := jaeger.SpanIDFromString(pprofLabels["span_id"])
+		require.NoError(t, err)
+		// Make sure the root span has "pyroscope.profile.id" attribute,
+		// and it matches the corresponding pprof label.
+		require.Equal(t, pprofLabels["span_id"], spanTags(rootSpan)["pyroscope.profile.id"])
+	})
+
+	t.Run("pprof labels are propagated to child spans", func(t *testing.T) {
+		rootSpan, ctx := opentracing.StartSpanFromContext(context.Background(), "RootSpan")
+		defer rootSpan.Finish()
+		childSpan, _ := opentracing.StartSpanFromContext(ctx, "ChildSpan")
+		defer childSpan.Finish()
+		// Goroutine labels are inherited from the parent,
+		// we do not set them repeatedly for the child spans.
+		require.Empty(t, spanPprofLabels(childSpan))
+		// Only the root span is annotated with the profile ID tag.
+		require.Nil(t, spanTags(childSpan)["pyroscope.profile.id"])
+	})
+
+	t.Run("pprof labels are not propagated to child spans after parent is finished", func(t *testing.T) {
+		rootSpan, ctx := opentracing.StartSpanFromContext(context.Background(), "RootSpan")
+		rootLabels := spanPprofLabels(rootSpan)
+		require.NotEmpty(t, rootLabels)
+		// This removes the labels from the goroutine's storage.
+		// Note that we can't access them (Go runtime does not provide public
+		// methods) but we rely on SetGoroutineLabels implementation:
+		// tracer alters currentPprofCtx, so that it actually points to the
+		// parentPprofCtx – the state prior StartSpanFromContext call.
+		rootSpan.Finish()
+		childSpan, _ := opentracing.StartSpanFromContext(ctx, "ChildSpan")
+		defer childSpan.Finish()
+		childLabels := spanPprofLabels(childSpan)
+		require.Empty(t, childLabels)
+	})
+
+	t.Run("pprof labels are not propagated to child spans if they are created in a separate goroutine hierarchy", func(t *testing.T) {
+		c := make(chan opentracing.SpanContext)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Normally, we assume that pprof labels are propagated to child
+			// goroutines, and we do not have to set pprof labels for each nested
+			// span repeatedly. However, if the child span is created in a sibling
+			// goroutine, no pprof labels will be attached.
+			// The exact span relation (child of / follows from) does not matter.
+			span := opentracing.StartSpan("ChildSpan", opentracing.ChildOf(<-c))
+			require.Empty(t, spanPprofLabels(span))
+			span.Finish()
+		}()
+		rootSpan, _ := opentracing.StartSpanFromContext(context.Background(), "RootSpan")
+		defer rootSpan.Finish()
+		c <- rootSpan.Context()
+		<-done
+	})
+}
+
+func initTestTracer(t *testing.T) io.Closer {
+	t.Helper()
+	// We can't use mock tracer as we actually rely on the
+	// Jaeger tracer implementation details.
+	c := &jaegercfg.Configuration{
+		ServiceName: "test",
+		Sampler: &jaegercfg.SamplerConfig{
+			Type:  jaeger.SamplerTypeConst,
+			Param: 1,
+		},
+		Reporter: &jaegercfg.ReporterConfig{
+			LocalAgentHostPort: "127.0.0.100:16686",
+		},
+	}
+	tr, closer, err := c.NewTracer()
+	require.NoError(t, err)
+	opentracing.SetGlobalTracer(NewTracer(tr))
+	return closer
+}
+
+func spanPprofLabels(span opentracing.Span) map[string]string {
+	labels := make(map[string]string)
+	forSpanPprofLabels(span, func(key, value string) bool {
+		labels[key] = value
+		return true
+	})
+	return labels
+}
+
+func forSpanPprofLabels(span opentracing.Span, fn func(key, value string) bool) {
+	w, ok := span.(*spanWrapper)
+	if !ok {
+		return
+	}
+	pprof.ForLabels(w.currentPprofCtx, fn)
+}
+
+func spanTags(span opentracing.Span) opentracing.Tags {
+	w, ok := span.(*spanWrapper)
+	if !ok {
+		return nil
+	}
+	s, ok := w.Span.(*jaeger.Span)
+	if !ok {
+		return nil
+	}
+	return s.Tags()
+}


### PR DESCRIPTION
The PR introduces `spanprofiler`. Its purpose is to facilitate "request-scoped" profiles with minimal effort and impact on application performance. The use of OpenTracing and [OpenTelemetry](https://github.com/grafana/otel-profiling-go) SDK interfaces appears to be the simplest solution to this problem. For a detailed description, please refer to the [README](https://github.com/grafana/dskit/blob/feat/add-spanprofiler/spanprofiler/README.md) note.

We've successfully integrated and tested this feature in our internal deployments over the past two months with no reported issues.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
