### PR TITLE
`DoUntilQuorum`: provide causes when cancelling contexts, and don't log cancellation as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 * [ENHANCEMENT] ring: Replaced `DoBatchWithClientError()` with `DoBatchWithOptions()`, allowing a new option to use a custom `Go(func())` implementation that may use pre-allocated workers instead of spawning a new goroutine for each request. #431
 * [ENHANCEMENT] ring: add support for prioritising zones when using `DoUntilQuorum` with request minimisation and zone awareness. #440
 * [ENHANCEMENT] ballast: add utility function to allocate heap ballast. #446
+* [ENHANCEMENT] ring: use and provide context cancellation causes in `DoUntilQuorum`. #449
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109
@@ -198,3 +199,4 @@
 * [BUGFIX] Memberlist's TCP transport will now reject bind addresses that are not IP addresses, such as "localhost", rather than silently converting these to 0.0.0.0 and therefore listening on all addresses. #396
 * [BUGFIX] Ring: use zone-aware logging when all zones are required for quorum. #403
 * [BUGFIX] Services: moduleService could drop stop signals to its underlying service. #409 #417
+* [BUGFIX] ring: don't mark trace spans as failed if `DoUntilQuorum` terminates due to cancellation. #449 

--- a/cancellation/error.go
+++ b/cancellation/error.go
@@ -3,6 +3,9 @@ package cancellation
 import (
 	"context"
 	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type cancellationError struct {
@@ -27,4 +30,8 @@ func (e cancellationError) Is(err error) bool {
 
 func (e cancellationError) Unwrap() error {
 	return e.inner
+}
+
+func (e cancellationError) GRPCStatus() *status.Status {
+	return status.New(codes.Canceled, e.Error())
 }

--- a/cancellation/error.go
+++ b/cancellation/error.go
@@ -1,0 +1,30 @@
+package cancellation
+
+import (
+	"context"
+	"fmt"
+)
+
+type cancellationError struct {
+	inner error
+}
+
+func NewError(err error) error {
+	return cancellationError{err}
+}
+
+func NewErrorf(format string, args ...any) error {
+	return NewError(fmt.Errorf(format, args...))
+}
+
+func (e cancellationError) Error() string {
+	return "context canceled: " + e.inner.Error()
+}
+
+func (e cancellationError) Is(err error) bool {
+	return err == context.Canceled
+}
+
+func (e cancellationError) Unwrap() error {
+	return e.inner
+}

--- a/cancellation/error_test.go
+++ b/cancellation/error_test.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,9 +17,15 @@ func TestCancellationError(t *testing.T) {
 	require.True(t, errors.Is(directlyNestedErr, context.Canceled))
 	require.True(t, errors.Is(directlyNestedErr, io.ErrNoProgress))
 	require.False(t, errors.Is(directlyNestedErr, io.EOF))
+	s, ok := status.FromError(directlyNestedErr)
+	require.True(t, ok)
+	require.Equal(t, codes.Canceled, s.Code())
 
 	indirectlyNestedErr := NewErrorf("something went wrong: %w", io.ErrNoProgress)
 	require.True(t, errors.Is(indirectlyNestedErr, context.Canceled))
 	require.True(t, errors.Is(indirectlyNestedErr, io.ErrNoProgress))
 	require.False(t, errors.Is(directlyNestedErr, io.EOF))
+	s, ok = status.FromError(directlyNestedErr)
+	require.True(t, ok)
+	require.Equal(t, codes.Canceled, s.Code())
 }

--- a/cancellation/error_test.go
+++ b/cancellation/error_test.go
@@ -1,0 +1,22 @@
+package cancellation
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancellationError(t *testing.T) {
+	directlyNestedErr := NewError(io.ErrNoProgress)
+	require.True(t, errors.Is(directlyNestedErr, context.Canceled))
+	require.True(t, errors.Is(directlyNestedErr, io.ErrNoProgress))
+	require.False(t, errors.Is(directlyNestedErr, io.EOF))
+
+	indirectlyNestedErr := NewErrorf("something went wrong: %w", io.ErrNoProgress)
+	require.True(t, errors.Is(indirectlyNestedErr, context.Canceled))
+	require.True(t, errors.Is(indirectlyNestedErr, io.ErrNoProgress))
+	require.False(t, errors.Is(directlyNestedErr, io.EOF))
+}

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -310,7 +310,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 	}
 
 	terminate := func(err error) ([]T, error) {
-		if cfg.Logger != nil {
+		if cfg.Logger != nil && !errors.Is(err, context.Canceled) { // Cancellation is not an error.
 			ext.Error.Set(cfg.Logger.Span, true)
 		}
 

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/opentracing/opentracing-go/ext"
 
+	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/spanlogger"
 )
 
@@ -213,7 +214,7 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, cfg DoUntilQuor
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	wrappedF := func(ctx context.Context, desc *InstanceDesc, _ context.CancelFunc) (T, error) {
+	wrappedF := func(ctx context.Context, desc *InstanceDesc, _ context.CancelCauseFunc) (T, error) {
 		return f(ctx, desc)
 	}
 
@@ -232,7 +233,7 @@ func DoUntilQuorum[T any](ctx context.Context, r ReplicationSet, cfg DoUntilQuor
 //     DoUntilQuorumWithoutSuccessfulContextCancellation
 //
 // Failing to do this may result in a memory leak.
-func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Context, r ReplicationSet, cfg DoUntilQuorumConfig, f func(context.Context, *InstanceDesc, context.CancelFunc) (T, error), cleanupFunc func(T)) ([]T, error) {
+func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Context, r ReplicationSet, cfg DoUntilQuorumConfig, f func(context.Context, *InstanceDesc, context.CancelCauseFunc) (T, error), cleanupFunc func(T)) ([]T, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -309,12 +310,12 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 		}
 	}
 
-	terminate := func(err error) ([]T, error) {
+	terminate := func(err error, cause string) ([]T, error) {
 		if cfg.Logger != nil && !errors.Is(err, context.Canceled) { // Cancellation is not an error.
 			ext.Error.Set(cfg.Logger.Span, true)
 		}
 
-		contextTracker.cancelAllContexts()
+		contextTracker.cancelAllContexts(cancellation.NewErrorf(cause))
 		cleanupResultsAlreadyReceived()
 		return nil, err
 	}
@@ -330,12 +331,13 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 	for !resultTracker.succeeded() {
 		select {
 		case <-ctx.Done():
-			level.Debug(logger).Log("msg", "parent context done, returning", "err", ctx.Err())
+			err := context.Cause(ctx)
+			level.Debug(logger).Log("msg", "parent context done, returning", "err", err)
 
 			// No need to cancel individual instance contexts, as they inherit the cancellation from ctx.
 			cleanupResultsAlreadyReceived()
 
-			return nil, ctx.Err()
+			return nil, err
 		case <-hedgingTrigger:
 			resultTracker.startAdditionalRequests()
 		case result := <-resultsChan:
@@ -344,7 +346,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 			if result.err != nil && cfg.IsTerminalError != nil && cfg.IsTerminalError(result.err) {
 				level.Warn(logger).Log("msg", "cancelling all outstanding requests because a terminal error occurred", "err", result.err)
 				// We must return before calling resultTracker.done() below, otherwise done() might start further requests if request minimisation is enabled.
-				return terminate(result.err)
+				return terminate(result.err, "a terminal error occurred")
 			}
 
 			resultTracker.done(result.instance, result.err)
@@ -352,11 +354,11 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 			if result.err == nil {
 				resultsMap[result.instance] = result.result
 			} else {
-				contextTracker.cancelContextFor(result.instance)
+				contextTracker.cancelContextFor(result.instance, cancellation.NewErrorf("this instance returned an error: %w", result.err))
 
 				if resultTracker.failed() {
-					level.Error(logger).Log("msg", "cancelling all requests because quorum cannot be reached")
-					return terminate(result.err)
+					level.Error(logger).Log("msg", "cancelling all outstanding requests because quorum cannot be reached")
+					return terminate(result.err, "quorum cannot be reached")
 				}
 			}
 		}
@@ -374,12 +376,12 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 			if resultTracker.shouldIncludeResultFrom(instance) {
 				results = append(results, result)
 			} else {
-				contextTracker.cancelContextFor(instance)
+				contextTracker.cancelContextFor(instance, cancellation.NewErrorf("quorum reached, result not required from this instance"))
 				cleanupFunc(result)
 			}
 		} else {
 			// Nothing to clean up (yet) - this will be handled by deferred call above.
-			contextTracker.cancelContextFor(instance)
+			contextTracker.cancelContextFor(instance, cancellation.NewErrorf("quorum reached, result not required from this instance"))
 		}
 	}
 

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -63,15 +63,15 @@ type replicationSetContextTracker interface {
 	// The context.CancelFunc will only cancel the context for this instance (ie. if this tracker
 	// is zone-aware, calling the context.CancelFunc should not cancel contexts for other instances
 	// in the same zone).
-	contextFor(instance *InstanceDesc) (context.Context, context.CancelFunc)
+	contextFor(instance *InstanceDesc) (context.Context, context.CancelCauseFunc)
 
 	// Cancels the context for instance previously obtained with contextFor.
 	// This method may cancel the context for other instances if those other instances are part of
 	// the same zone and this tracker is zone-aware.
-	cancelContextFor(instance *InstanceDesc)
+	cancelContextFor(instance *InstanceDesc, cause error)
 
 	// Cancels all contexts previously obtained with contextFor.
-	cancelAllContexts()
+	cancelAllContexts(cause error)
 }
 
 var errResultNotNeeded = errors.New("result from this instance is not needed")
@@ -196,7 +196,7 @@ func (t *defaultResultTracker) startAllRequests() {
 func (t *defaultResultTracker) awaitStart(ctx context.Context, instance *InstanceDesc) error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	case _, ok := <-t.instanceRelease[instance]:
 		if ok {
 			return nil
@@ -208,32 +208,32 @@ func (t *defaultResultTracker) awaitStart(ctx context.Context, instance *Instanc
 
 type defaultContextTracker struct {
 	ctx         context.Context
-	cancelFuncs map[*InstanceDesc]context.CancelFunc
+	cancelFuncs map[*InstanceDesc]context.CancelCauseFunc
 }
 
 func newDefaultContextTracker(ctx context.Context, instances []InstanceDesc) *defaultContextTracker {
 	return &defaultContextTracker{
 		ctx:         ctx,
-		cancelFuncs: make(map[*InstanceDesc]context.CancelFunc, len(instances)),
+		cancelFuncs: make(map[*InstanceDesc]context.CancelCauseFunc, len(instances)),
 	}
 }
 
-func (t *defaultContextTracker) contextFor(instance *InstanceDesc) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(t.ctx)
+func (t *defaultContextTracker) contextFor(instance *InstanceDesc) (context.Context, context.CancelCauseFunc) {
+	ctx, cancel := context.WithCancelCause(t.ctx)
 	t.cancelFuncs[instance] = cancel
 	return ctx, cancel
 }
 
-func (t *defaultContextTracker) cancelContextFor(instance *InstanceDesc) {
+func (t *defaultContextTracker) cancelContextFor(instance *InstanceDesc, cause error) {
 	if cancel, ok := t.cancelFuncs[instance]; ok {
-		cancel()
+		cancel(cause)
 		delete(t.cancelFuncs, instance)
 	}
 }
 
-func (t *defaultContextTracker) cancelAllContexts() {
+func (t *defaultContextTracker) cancelAllContexts(cause error) {
 	for instance, cancel := range t.cancelFuncs {
-		cancel()
+		cancel(cause)
 		delete(t.cancelFuncs, instance)
 	}
 }
@@ -410,7 +410,7 @@ func (t *zoneAwareResultTracker) releaseZone(zone string, shouldStart bool) {
 func (t *zoneAwareResultTracker) awaitStart(ctx context.Context, instance *InstanceDesc) error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	case <-t.zoneRelease[instance.Zone]:
 		if t.zoneShouldStart[instance.Zone].Load() {
 			return nil
@@ -422,18 +422,18 @@ func (t *zoneAwareResultTracker) awaitStart(ctx context.Context, instance *Insta
 
 type zoneAwareContextTracker struct {
 	contexts    map[*InstanceDesc]context.Context
-	cancelFuncs map[*InstanceDesc]context.CancelFunc
+	cancelFuncs map[*InstanceDesc]context.CancelCauseFunc
 }
 
 func newZoneAwareContextTracker(ctx context.Context, instances []InstanceDesc) *zoneAwareContextTracker {
 	t := &zoneAwareContextTracker{
 		contexts:    make(map[*InstanceDesc]context.Context, len(instances)),
-		cancelFuncs: make(map[*InstanceDesc]context.CancelFunc, len(instances)),
+		cancelFuncs: make(map[*InstanceDesc]context.CancelCauseFunc, len(instances)),
 	}
 
 	for i := range instances {
 		instance := &instances[i]
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel := context.WithCancelCause(ctx)
 		t.contexts[instance] = ctx
 		t.cancelFuncs[instance] = cancel
 	}
@@ -441,26 +441,26 @@ func newZoneAwareContextTracker(ctx context.Context, instances []InstanceDesc) *
 	return t
 }
 
-func (t *zoneAwareContextTracker) contextFor(instance *InstanceDesc) (context.Context, context.CancelFunc) {
+func (t *zoneAwareContextTracker) contextFor(instance *InstanceDesc) (context.Context, context.CancelCauseFunc) {
 	return t.contexts[instance], t.cancelFuncs[instance]
 }
 
-func (t *zoneAwareContextTracker) cancelContextFor(instance *InstanceDesc) {
+func (t *zoneAwareContextTracker) cancelContextFor(instance *InstanceDesc, cause error) {
 	// Why not create a per-zone parent context to make this easier?
 	// If we create a per-zone parent context, we'd need to have some way to cancel the per-zone context when the last of the individual
 	// contexts in a zone are cancelled using the context.CancelFunc returned from contextFor.
 	for i, cancel := range t.cancelFuncs {
 		if i.Zone == instance.Zone {
-			cancel()
+			cancel(cause)
 			delete(t.contexts, i)
 			delete(t.cancelFuncs, i)
 		}
 	}
 }
 
-func (t *zoneAwareContextTracker) cancelAllContexts() {
+func (t *zoneAwareContextTracker) cancelAllContexts(cause error) {
 	for instance, cancel := range t.cancelFuncs {
-		cancel()
+		cancel(cause)
 		delete(t.contexts, instance)
 		delete(t.cancelFuncs, instance)
 	}


### PR DESCRIPTION
**What this PR does**:

This PR improves the handling of context cancellations in `DoUntilQuorum`:

* if a cause is provided when cancelling the parent context passed to `DoUntilQuorum`, that cause will be returned by `DoUntilQuorum` if it terminates due to cancellation (if no cause is available, `context.Cause()` will fall back to `context.Canceled`, preserving the existing behaviour)
* `DoUntilQuorum` will provide a cause when cancelling contexts it controls
* `DoUntilQuorum` will no longer mark the trace span as failed if the call fails due to cancellation

Note that this introduces a breaking change to the signature of `DoUntilQuorumWithoutSuccessfulContextCancellation`: the function provided must now accept a `context.CancelCauseFunc` instead of a `context.CancelFunc`.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
