### PR TITLE
Fix issue where applying httpgrpc tracing middleware results in all HTTP requests having duplicate trace spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,3 +200,4 @@
 * [BUGFIX] Ring: use zone-aware logging when all zones are required for quorum. #403
 * [BUGFIX] Services: moduleService could drop stop signals to its underlying service. #409 #417
 * [BUGFIX] ring: don't mark trace spans as failed if `DoUntilQuorum` terminates due to cancellation. #449 
+* [BUGFIX] middleware: fix issue where applications that used the httpgrpc tracing middleware would generate duplicate spans for incoming HTTP requests. #451

--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -5,13 +5,17 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+
+	"github.com/grafana/dskit/httpgrpc"
 
 	"github.com/gorilla/mux"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"google.golang.org/grpc"
 )
 
 // Dummy dependency to enforce that we have a nethttp version newer
@@ -46,27 +50,8 @@ func (t Tracer) Wrap(next http.Handler) http.Handler {
 	return nethttp.Middleware(opentracing.GlobalTracer(), next, options...)
 }
 
-// HTTPGRPCTracer is a middleware which traces incoming httpgrpc requests.
-type HTTPGRPCTracer struct {
-	RouteMatcher RouteMatcher
-}
-
-// InitHTTPGRPCMiddleware initializes gorilla/mux-compatible HTTP middleware
-//
-// HTTPGRPCTracer is specific to the server-side handling of HTTP requests which were
-// wrapped into gRPC requests and routed through the httpgrpc.HTTP/Handle gRPC.
-//
-// HTTPGRPCTracer.Wrap must be attached to the same mux.Router assigned to dskit/server.Config.Router
-// but it does not need to be attached to dskit/server.Config.HTTPMiddleware.
-// dskit/server.Config.HTTPMiddleware is applied to direct HTTP requests not routed through gRPC;
-// the server utilizes the default http middleware Tracer.Wrap for those standard http requests.
-func InitHTTPGRPCMiddleware(router *mux.Router) *mux.Router {
-	middleware := HTTPGRPCTracer{RouteMatcher: router}
-	router.Use(middleware.Wrap)
-	return router
-}
-
-// Wrap creates and decorates server-side tracing spans for httpgrpc requests
+// HTTPGRPCTracingInterceptor adds additional information about the encapsulated HTTP request
+// to httpgrpc trace spans.
 //
 // The httpgrpc client wraps HTTP requests up into a generic httpgrpc.HTTP/Handle gRPC method.
 // The httpgrpc server unwraps httpgrpc.HTTP/Handle gRPC requests into HTTP requests
@@ -80,39 +65,52 @@ func InitHTTPGRPCMiddleware(router *mux.Router) *mux.Router {
 // and attaches the HTTP server span tags to the parent httpgrpc.HTTP/Handle gRPC span, allowing
 // tracing tooling to differentiate the HTTP requests represented by the httpgrpc.HTTP/Handle spans.
 //
-// opentracing-contrib/go-stdlib/nethttp.Middleware could not be used here
-// as it does not expose options to access and tag the incoming parent span.
-func (hgt HTTPGRPCTracer) Wrap(next http.Handler) http.Handler {
-	httpOperationNameFunc := makeHTTPOperationNameFunc(hgt.RouteMatcher)
-	fn := func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		tracer := opentracing.GlobalTracer()
+// Note that we cannot do this in the httpgrpc Server implementation, as some applications (eg.
+// Mimir's queriers) call Server.Handle() directly, which means we'd attach HTTP-request related
+// span tags to whatever parent span is active in the caller, rather than the /httpgrpc.HTTP/Handle
+// span created by the tracing middleware for requests that arrive over the network.
+func HTTPGRPCTracingInterceptor(router *mux.Router) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		if info.FullMethod != "/httpgrpc.HTTP/Handle" {
+			return handler(ctx, req)
+		}
 
+		httpgrpcRequest, ok := req.(*httpgrpc.HTTPRequest)
+		if !ok {
+			return handler(ctx, req)
+		}
+
+		httpRequest, err := httpgrpc.ToHTTPRequest(ctx, httpgrpcRequest)
+		if err != nil {
+			return handler(ctx, req)
+		}
+
+		tracer := opentracing.GlobalTracer()
 		parentSpan := opentracing.SpanFromContext(ctx)
 
 		// extract relevant span & tag data from request
-		method := r.Method
-		matchedRoute := getRouteName(hgt.RouteMatcher, r)
-		urlPath := r.URL.Path
-		userAgent := r.Header.Get("User-Agent")
+		method := httpRequest.Method
+		routeName := getRouteName(router, httpRequest)
+		urlPath := httpRequest.URL.Path
+		userAgent := httpRequest.Header.Get("User-Agent")
 
 		// tag parent httpgrpc.HTTP/Handle server span, if it exists
 		if parentSpan != nil {
 			parentSpan.SetTag(string(ext.HTTPUrl), urlPath)
 			parentSpan.SetTag(string(ext.HTTPMethod), method)
-			parentSpan.SetTag("http.route", matchedRoute)
+			parentSpan.SetTag("http.route", routeName)
 			parentSpan.SetTag("http.user_agent", userAgent)
 		}
 
 		// create and start child HTTP span
 		// mirroring opentracing-contrib/go-stdlib/nethttp.Middleware span name and tags
-		childSpanName := httpOperationNameFunc(r)
+		childSpanName := getOperationName(routeName, httpRequest)
 		startSpanOpts := []opentracing.StartSpanOption{
 			ext.SpanKindRPCServer,
 			opentracing.Tag{Key: string(ext.Component), Value: "net/http"},
 			opentracing.Tag{Key: string(ext.HTTPUrl), Value: urlPath},
 			opentracing.Tag{Key: string(ext.HTTPMethod), Value: method},
-			opentracing.Tag{Key: "http.route", Value: matchedRoute},
+			opentracing.Tag{Key: "http.route", Value: routeName},
 			opentracing.Tag{Key: "http.user_agent", Value: userAgent},
 		}
 		if parentSpan != nil {
@@ -127,19 +125,21 @@ func (hgt HTTPGRPCTracer) Wrap(next http.Handler) http.Handler {
 		childSpan := tracer.StartSpan(childSpanName, startSpanOpts...)
 		defer childSpan.Finish()
 
-		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), childSpan))
-		next.ServeHTTP(w, r)
+		ctx = opentracing.ContextWithSpan(ctx, childSpan)
+		return handler(ctx, req)
 	}
-
-	return http.HandlerFunc(fn)
 }
 
 func makeHTTPOperationNameFunc(routeMatcher RouteMatcher) func(r *http.Request) string {
 	return func(r *http.Request) string {
-		op := getRouteName(routeMatcher, r)
-		if op == "" {
-			return "HTTP " + r.Method
-		}
-		return fmt.Sprintf("HTTP %s - %s", r.Method, op)
+		routeName := getRouteName(routeMatcher, r)
+		return getOperationName(routeName, r)
 	}
+}
+
+func getOperationName(routeName string, r *http.Request) string {
+	if routeName == "" {
+		return "HTTP " + r.Method
+	}
+	return fmt.Sprintf("HTTP %s - %s", r.Method, routeName)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -350,6 +350,22 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 
 	level.Info(logger).Log("msg", "server listening on addresses", "http", httpListener.Addr(), "grpc", grpcListener.Addr())
 
+	// Setup HTTP server
+	var router *mux.Router
+	if cfg.Router != nil {
+		router = cfg.Router
+	} else {
+		router = mux.NewRouter()
+	}
+	if cfg.PathPrefix != "" {
+		// Expect metrics and pprof handlers to be prefixed with server's path prefix.
+		// e.g. /loki/metrics or /loki/debug/pprof
+		router = router.PathPrefix(cfg.PathPrefix).Subrouter()
+	}
+	if cfg.RegisterInstrumentation {
+		RegisterInstrumentationWithGatherer(router, gatherer)
+	}
+
 	// Setup gRPC server
 	serverLog := middleware.GRPCServerLog{
 		Log:                      logger,
@@ -363,6 +379,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,
 		otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer()),
+		middleware.HTTPGRPCTracingInterceptor(router), // This must appear after the OpenTracingServerInterceptor.
 		middleware.UnaryServerInstrumentInterceptor(metrics.RequestDuration, reportGRPCStatusesOptions...),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
@@ -418,22 +435,6 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	}
 	grpcServer := grpc.NewServer(grpcOptions...)
 	grpcOnHTTPServer := grpc.NewServer(grpcOptions...)
-
-	// Setup HTTP server
-	var router *mux.Router
-	if cfg.Router != nil {
-		router = cfg.Router
-	} else {
-		router = mux.NewRouter()
-	}
-	if cfg.PathPrefix != "" {
-		// Expect metrics and pprof handlers to be prefixed with server's path prefix.
-		// e.g. /loki/metrics or /loki/debug/pprof
-		router = router.PathPrefix(cfg.PathPrefix).Subrouter()
-	}
-	if cfg.RegisterInstrumentation {
-		RegisterInstrumentationWithGatherer(router, gatherer)
-	}
 
 	sourceIPs, err := middleware.NewSourceIPs(cfg.LogSourceIPsHeader, cfg.LogSourceIPsRegex)
 	if err != nil {

--- a/server/server_tracing_test.go
+++ b/server/server_tracing_test.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/require"
@@ -83,7 +82,6 @@ func assertTracingSpans(
 }
 
 func TestHTTPGRPCTracing(t *testing.T) {
-
 	httpPort := 9099
 	httpAddress := "127.0.0.1"
 
@@ -186,7 +184,6 @@ func TestHTTPGRPCTracing(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-
 			observer := testObserver{}
 			tracer, closer := jaeger.NewTracer(
 				"test",
@@ -204,7 +201,6 @@ func TestHTTPGRPCTracing(t *testing.T) {
 			cfg.GRPCListenPort = 1234
 			cfg.GRPCServerMaxRecvMsgSize = 4 * 1024 * 1024
 			cfg.GRPCServerMaxSendMsgSize = 4 * 1024 * 1024
-			cfg.Router = middleware.InitHTTPGRPCMiddleware(mux.NewRouter())
 			cfg.MetricsNamespace = "testing_httpgrpc_tracing_" + middleware.MakeLabelValue(testName)
 			var lvl log.Level
 			require.NoError(t, lvl.Set("info"))

--- a/server/server_tracing_test.go
+++ b/server/server_tracing_test.go
@@ -124,15 +124,13 @@ func TestHTTPGRPCTracing(t *testing.T) {
 		useHTTPOverGRPC      bool
 		routeName            string // leave blank for unnamed route tests
 		routeTmpl            string
-		routeLabel           string
 		reqURL               string
 		expectedTagsByOpName map[string]map[string]string
 	}{
-		"http over grpc: named route with no params in path template": {
+		"HTTP over gRPC: named route with no params in path template": {
 			useHTTPOverGRPC: true,
 			routeName:       helloRouteName,
 			routeTmpl:       helloRouteTmpl,
-			routeLabel:      expectedHelloRouteLabel,
 			reqURL:          helloRouteURLRaw,
 			expectedTagsByOpName: map[string]map[string]string{
 				"/httpgrpc.HTTP/Handle": {
@@ -144,21 +142,19 @@ func TestHTTPGRPCTracing(t *testing.T) {
 				expectedOpNameHelloHTTPSpan: expectedTagsHelloHTTPSpan,
 			},
 		},
-		"http direct request: named route with no params in path template": {
+		"HTTP direct request: named route with no params in path template": {
 			useHTTPOverGRPC: false,
 			routeName:       helloRouteName,
 			routeTmpl:       helloRouteTmpl,
-			routeLabel:      expectedHelloRouteLabel,
 			reqURL:          helloRouteURLRaw,
 			expectedTagsByOpName: map[string]map[string]string{
 				expectedOpNameHelloHTTPSpan: expectedTagsHelloHTTPSpan,
 			},
 		},
-		"http over grpc: unnamed route with params in path template": {
+		"HTTP over gRPC: unnamed route with params in path template": {
 			useHTTPOverGRPC: true,
 			routeName:       "",
 			routeTmpl:       helloPathParamRouteTmpl,
-			routeLabel:      expectedHelloPathParamRouteLabel,
 			reqURL:          helloPathParamRouteURLRaw,
 			expectedTagsByOpName: map[string]map[string]string{
 				"/httpgrpc.HTTP/Handle": {
@@ -170,11 +166,10 @@ func TestHTTPGRPCTracing(t *testing.T) {
 				expectedOpNameHelloPathParamHTTPSpan: expectedTagsHelloPathParamHTTPSpan,
 			},
 		},
-		"http direct request: unnamed route with params in path template": {
+		"HTTP direct request: unnamed route with params in path template": {
 			useHTTPOverGRPC: false,
 			routeName:       "",
 			routeTmpl:       helloPathParamRouteTmpl,
-			routeLabel:      expectedHelloPathParamRouteLabel,
 			reqURL:          helloPathParamRouteURLRaw,
 			expectedTagsByOpName: map[string]map[string]string{
 				expectedOpNameHelloPathParamHTTPSpan: expectedTagsHelloPathParamHTTPSpan,

--- a/server/server_tracing_test.go
+++ b/server/server_tracing_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go"
+	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -75,10 +76,10 @@ func assertTracingSpans(
 		// collect observed span operation names
 		observedSpanOpNames = append(observedSpanOpNames, spanObserver.OpName)
 	}
-	for opName := range expectedTagsByOpName {
-		// assert all expected operations were observed
-		require.Contains(t, observedSpanOpNames, opName)
-	}
+
+	// Make sure observed all the spans we expected (and that we only observed each one once)
+	expectedSpanOpNames := maps.Keys(expectedTagsByOpName)
+	require.ElementsMatch(t, observedSpanOpNames, expectedSpanOpNames)
 }
 
 func TestHTTPGRPCTracing(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

This PR fixes the issue where applications that use the httpgrpc tracing middleware (through `middleware.InitHTTPGRPCMiddleware`) would have traces for all incoming HTTP calls duplicated.

For example, note the duplicate `HTTP POST - api_v1_push` spans in this trace from a Mimir distributor:

<img width="1914" alt="Screenshot 2023-12-13 at 12 50 20 pm" src="https://github.com/grafana/dskit/assets/4017646/4c757d1c-a5f2-44d1-94c0-5026d5cf6663">

The fix changes the HTTP middleware to a gRPC interceptor that is then able to accurately filter incoming requests and apply the additional information only to httpgrpc requests. 

One downside of this is that we'll convert the request to a `http.Request` twice now: once in the interceptor, and again in the httpgrpc handler, but this seems like the neatest solution. 

Related: https://github.com/grafana/dskit/pull/353

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
