### PR TITLE
ring.DoBatch: check context cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@
 * [ENHANCEMENT] ring: add support for prioritising zones when using `DoUntilQuorum` with request minimisation and zone awareness. #440
 * [ENHANCEMENT] ballast: add utility function to allocate heap ballast. #446
 * [ENHANCEMENT] ring: use and provide context cancellation causes in `DoUntilQuorum`. #449
+* [ENHANCEMENT] ring: `ring.DoBatch` and `ring.DoBatchWithOptions` now check the context cancellation while calculating the replication instances, failing if the context was canceld. #454
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -199,7 +199,6 @@ func TestDoBatchZeroInstances(t *testing.T) {
 }
 
 func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
-	// It takes ~4s to do 5M keys on my M3 laptop. So we're going to cancel the context after 400ms.
 	const (
 		numKeys      = 5e6
 		numInstances = 100

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -198,6 +198,59 @@ func TestDoBatchZeroInstances(t *testing.T) {
 	require.Error(t, DoBatch(ctx, Write, &r, keys, callback, cleanup))
 }
 
+func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
+	// It takes ~4s to do 5M keys on my M3 laptop. So we're going to cancel the context after 400ms.
+	const (
+		numKeys      = 5e6
+		numInstances = 100
+		numZones     = 3
+	)
+	keys := make([]uint32, numKeys)
+	generateKeys(rand.New(rand.NewSource(0)), numKeys, keys)
+
+	callback := func(InstanceDesc, []int) error { return nil }
+	desc := &Desc{Ingesters: generateRingInstances(NewRandomTokenGeneratorWithSeed(0), numInstances, numZones, numTokens)}
+	r := Ring{
+		cfg: Config{
+			HeartbeatTimeout:     time.Hour,
+			ZoneAwarenessEnabled: true,
+			SubringCacheDisabled: true,
+			ReplicationFactor:    numZones,
+		},
+		ringDesc:             desc,
+		ringTokens:           desc.GetTokens(),
+		ringTokensByZone:     desc.getTokensByZone(),
+		ringInstanceByToken:  desc.getTokensInfo(),
+		ringZones:            getZones(desc.getTokensByZone()),
+		shuffledSubringCache: map[subringCacheKey]*Ring{},
+		strategy:             NewDefaultReplicationStrategy(),
+		lastTopologyChange:   time.Now(),
+	}
+	// Measure how long does it take for a call to succeed.
+	t0 := time.Now()
+	err := DoBatchWithOptions(context.Background(), Write, &r, keys, callback, DoBatchOptions{})
+	duration := time.Since(t0)
+	require.NoError(t, err)
+	t.Logf("Call took %s", duration)
+
+	// Make a second call cancelling after a hundredth of duration of the first one.
+	// For a 4s first call, this is 40ms: should be enough for this test to not be flaky.
+	ctx, cancel := context.WithTimeout(context.Background(), duration/100)
+	defer cancel()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	err = DoBatchWithOptions(ctx, Write, &r, keys, func(_ InstanceDesc, _ []int) error {
+		t.Errorf("should not be called.")
+		return nil
+	}, DoBatchOptions{Cleanup: wg.Done})
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Wait until cleanup to make sure that callback was never called.
+	wg.Wait()
+}
+
 func TestDoBatch_QuorumError(t *testing.T) {
 	const (
 		// we should run several write request to make sure we don't have any race condition on the batchTracker code


### PR DESCRIPTION
**What this PR does**:

This changes ring.DoBatch & ring.DoBatchWithOptions to check the context cancellation, as it might take a while to calculate the instances for all keys and sometimes it doesn't make sense to proceed with the callbacks.

**Which issue(s) this PR fixes**:

None.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
