### PR TITLE
Make httpgrpc.Server return 4xx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@
 * [ENHANCEMENT] ring: `ring.DoBatch` and `ring.DoBatchWithOptions` now check the context cancellation while calculating the replication instances, failing if the context was canceld. #454
 * [ENHANCEMENT] Cache: Export Memcached and Redis client types instead of returning the interface, `RemoteCacheClient`, they implement. #453
 * [ENHANCEMENT] SpanProfiler: add spanprofiler package. #448
+* [ENHANCEMENT] Make httpgrpc.Server return 4xx errors when a header with key `httpgrpc.Return4XXErrorsKey` and any value is present in the HTTP response. If `httpgrpc.Return4XXErrorsKey` is not present in the HTTP response, only 5xx errors are returned. #455
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109


### PR DESCRIPTION
**What this PR does**:
Currently, `httpgrpc`'s `Server.Handle()` returns an error only if a response received from the HTTP server contains a `5xx` HTTP status code. Responses with any other HTTP status code (e.g., `4xx`) are converted to non-erroneous `HTTPResponse` objects. As a consequence, the correlated `status_code` labels in the request duration metrics is `success`.

This PR allows `Server.Handle()` to return errors even in case of a `4xx` HTTP status code. Namely, the presence of a header with key `httpgrpc.Return4XXErrorsKey` and any value in a response received from HTTP server indicates to `Server.Handle()` to convert that response to an error. This way the correlated `status_code` labels in the request duration metrics will be `4xx`.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/mimir/issues/1830

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
