### PR TITLE
Allow reporting HTTP 4xx codes in status_code label of request duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@
 * [ENHANCEMENT] ring: `ring.DoBatch` and `ring.DoBatchWithOptions` now check the context cancellation while calculating the replication instances, failing if the context was canceld. #454
 * [ENHANCEMENT] Cache: Export Memcached and Redis client types instead of returning the interface, `RemoteCacheClient`, they implement. #453
 * [ENHANCEMENT] SpanProfiler: add spanprofiler package. #448
+* [ENHANCEMENT] Server: Add `-server.report-http-4xx-codes-in-instrumentation-label-enabled` CLI flag to specify whether HTTP 4xx status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that HTTP 4xx status codes are represented with `success` value. #457
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,7 +176,7 @@
 * [ENHANCEMENT] ring: `ring.DoBatch` and `ring.DoBatchWithOptions` now check the context cancellation while calculating the replication instances, failing if the context was canceld. #454
 * [ENHANCEMENT] Cache: Export Memcached and Redis client types instead of returning the interface, `RemoteCacheClient`, they implement. #453
 * [ENHANCEMENT] SpanProfiler: add spanprofiler package. #448
-* [ENHANCEMENT] Server: Add support for `ReportHTTP4XXCodesInInstrumentationLabel`, which specifies whether HTTP 4xx status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that HTTP 4xx status codes are represented with `success` value. #457
+* [ENHANCEMENT] Server: Add support for `ReportHTTP4XXCodesInInstrumentationLabel`, which specifies whether HTTP 4xx status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that HTTP 4xx status codes are represented with `success` value. Moreover, when `ReportHTTP4XXCodesInInstrumentationLabel` is set to true, responses with HTTP status code `4xx` are returned as errors. #457
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,7 +176,7 @@
 * [ENHANCEMENT] ring: `ring.DoBatch` and `ring.DoBatchWithOptions` now check the context cancellation while calculating the replication instances, failing if the context was canceld. #454
 * [ENHANCEMENT] Cache: Export Memcached and Redis client types instead of returning the interface, `RemoteCacheClient`, they implement. #453
 * [ENHANCEMENT] SpanProfiler: add spanprofiler package. #448
-* [ENHANCEMENT] Server: Add `-server.report-http-4xx-codes-in-instrumentation-label-enabled` CLI flag to specify whether HTTP 4xx status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that HTTP 4xx status codes are represented with `success` value. #457
+* [ENHANCEMENT] Server: Add support for `ReportHTTP4XXCodesInInstrumentationLabel`, which specifies whether HTTP 4xx status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that HTTP 4xx status codes are represented with `success` value. #457
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -32,15 +32,13 @@ var (
 	DoNotLogErrorHeaderKey = http.CanonicalHeaderKey("X-DoNotLogError")
 )
 
-type Options func(*Server)
+type Option func(*Server)
 
-var (
-	Return4XXErrorsOption Options = func(s *Server) {
-		s.return4XXErrors = true
-	}
-)
+func WithReturn4XXErrors(s *Server) {
+	s.return4XXErrors = true
+}
 
-func applyServerOptions(s *Server, opts ...Options) *Server {
+func applyServerOptions(s *Server, opts ...Option) *Server {
 	for _, opt := range opts {
 		opt(s)
 	}
@@ -55,7 +53,7 @@ type Server struct {
 }
 
 // NewServer makes a new Server.
-func NewServer(handler http.Handler, opts ...Options) *Server {
+func NewServer(handler http.Handler, opts ...Option) *Server {
 	return applyServerOptions(&Server{handler: handler}, opts...)
 }
 

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -32,17 +32,31 @@ var (
 	DoNotLogErrorHeaderKey = http.CanonicalHeaderKey("X-DoNotLogError")
 )
 
+type Options func(*Server)
+
+var (
+	Return4XXErrorsOption Options = func(s *Server) {
+		s.return4XXErrors = true
+	}
+)
+
+func applyServerOptions(s *Server, opts ...Options) *Server {
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
 // Server implements HTTPServer.  HTTPServer is a generated interface that gRPC
 // servers must implement.
 type Server struct {
-	handler http.Handler
+	handler         http.Handler
+	return4XXErrors bool
 }
 
 // NewServer makes a new Server.
-func NewServer(handler http.Handler) *Server {
-	return &Server{
-		handler: handler,
-	}
+func NewServer(handler http.Handler, opts ...Options) *Server {
+	return applyServerOptions(&Server{handler: handler}, opts...)
 }
 
 // Handle implements HTTPServer.
@@ -67,7 +81,7 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 		Headers: httpgrpc.FromHeader(header),
 		Body:    recorder.Body.Bytes(),
 	}
-	if recorder.Code/100 == 5 {
+	if s.shouldReturnError(resp) {
 		err := httpgrpc.ErrorFromHTTPResponse(resp)
 		if doNotLogError {
 			err = middleware.DoNotLogError{Err: err}
@@ -75,6 +89,11 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (s Server) shouldReturnError(resp *httpgrpc.HTTPResponse) bool {
+	mask := resp.GetCode() / 100
+	return mask == 5 || (s.return4XXErrors && mask == 4)
 }
 
 // Client is a http.Handler that forwards the request over gRPC.

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -25,6 +25,20 @@ import (
 	"github.com/grafana/dskit/user"
 )
 
+func TestReturn4XXErrorsOption(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprint(w, "test")
+		require.NoError(t, err)
+	})
+	server := NewServer(handler)
+	require.NotNil(t, server)
+	require.False(t, server.return4XXErrors)
+
+	server = NewServer(handler, []Options{Return4XXErrorsOption}...)
+	require.NotNil(t, server)
+	require.True(t, server.return4XXErrors)
+}
+
 type testServer struct {
 	*Server
 	URL        string
@@ -158,6 +172,74 @@ func TestServerHandleDoNotLogError(t *testing.T) {
 				} else {
 					require.False(t, errors.As(err, &optional))
 				}
+				checkError(t, err, testData.errorCode, errMsg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				checkHTTPResponse(t, resp, testData.errorCode, errMsg)
+			}
+		})
+	}
+}
+
+func TestServerHandleReturn4XXErrors(t *testing.T) {
+	testCases := map[string]struct {
+		errorCode       int
+		return4xxErrors bool
+		expectedError   bool
+	}{
+		"HTTPResponse with code 5xx should return an error when server creates with Return4XXErrorsOption": {
+			errorCode:       http.StatusInternalServerError,
+			return4xxErrors: true,
+			expectedError:   true,
+		},
+		"HTTPResponse with code 5xx should return an error when server creates without Return4XXErrorsOption": {
+			errorCode:       http.StatusInternalServerError,
+			return4xxErrors: false,
+			expectedError:   true,
+		},
+		"HTTPResponse with code 4xx should return an error when server creates with Return4XXErrorsOption": {
+			errorCode:       http.StatusBadRequest,
+			return4xxErrors: true,
+			expectedError:   true,
+		},
+		"HTTPResponse with code 4xx should not return an error when server creates without Return4XXErrorsOption": {
+			errorCode:       http.StatusBadRequest,
+			return4xxErrors: false,
+			expectedError:   false,
+		},
+		"HTTPResponse with code different from 5xx and 4xx should not return an error when server creates with Return4XXErrorsOption": {
+			errorCode:       http.StatusNoContent,
+			return4xxErrors: true,
+			expectedError:   false,
+		},
+		"HTTPResponse with code different from 5xx and 4xx should not return an error when server creates without Return4XXErrorsOption": {
+			errorCode:       http.StatusNoContent,
+			return4xxErrors: false,
+			expectedError:   false,
+		},
+	}
+	errMsg := "this is an error"
+	for testName, testData := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, errMsg, testData.errorCode)
+			})
+
+			var serverOptions []Options
+			if testData.return4xxErrors {
+				serverOptions = []Options{Return4XXErrorsOption}
+			}
+			s := NewServer(h, serverOptions...)
+
+			req := &httpgrpc.HTTPRequest{
+				Method: "GET",
+				Url:    "/test",
+			}
+			resp, err := s.Handle(context.Background(), req)
+			if testData.expectedError {
+				require.Error(t, err)
+				require.Nil(t, resp)
 				checkError(t, err, testData.errorCode, errMsg)
 			} else {
 				require.NoError(t, err)

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -30,11 +30,13 @@ func TestReturn4XXErrorsOption(t *testing.T) {
 		_, err := fmt.Fprint(w, "test")
 		require.NoError(t, err)
 	})
-	server := NewServer(handler)
+	serverOptions := make([]Option, 0, 1)
+	server := NewServer(handler, serverOptions...)
 	require.NotNil(t, server)
 	require.False(t, server.return4XXErrors)
 
-	server = NewServer(handler, []Option{WithReturn4XXErrors}...)
+	serverOptions = append(serverOptions, WithReturn4XXErrors)
+	server = NewServer(handler, serverOptions...)
 	require.NotNil(t, server)
 	require.True(t, server.return4XXErrors)
 }

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -34,7 +34,7 @@ func TestReturn4XXErrorsOption(t *testing.T) {
 	require.NotNil(t, server)
 	require.False(t, server.return4XXErrors)
 
-	server = NewServer(handler, []Options{Return4XXErrorsOption}...)
+	server = NewServer(handler, []Option{WithReturn4XXErrors}...)
 	require.NotNil(t, server)
 	require.True(t, server.return4XXErrors)
 }
@@ -226,9 +226,9 @@ func TestServerHandleReturn4XXErrors(t *testing.T) {
 				http.Error(w, errMsg, testData.errorCode)
 			})
 
-			var serverOptions []Options
+			var serverOptions []Option
 			if testData.return4xxErrors {
-				serverOptions = []Options{Return4XXErrorsOption}
+				serverOptions = []Option{WithReturn4XXErrors}
 			}
 			s := NewServer(h, serverOptions...)
 

--- a/server/server.go
+++ b/server/server.go
@@ -96,7 +96,7 @@ type Config struct {
 
 	RegisterInstrumentation                  bool `yaml:"register_instrumentation"`
 	ReportGRPCCodesInInstrumentationLabel    bool `yaml:"report_grpc_codes_in_instrumentation_label_enabled"`
-	ReportHTTP4XXCodesInInstrumentationLabel bool `yaml:"report_http_4xx_codes_in_instrumentation_label_enabled"`
+	ReportHTTP4XXCodesInInstrumentationLabel bool `yaml:"-"`
 	ExcludeRequestInLog                      bool `yaml:"-"`
 	DisableRequestSuccessLog                 bool `yaml:"-"`
 
@@ -175,7 +175,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.GRPCConnLimit, "server.grpc-conn-limit", 0, "Maximum number of simultaneous grpc connections, <=0 to disable")
 	f.BoolVar(&cfg.RegisterInstrumentation, "server.register-instrumentation", true, "Register the intrumentation handlers (/metrics etc).")
 	f.BoolVar(&cfg.ReportGRPCCodesInInstrumentationLabel, "server.report-grpc-codes-in-instrumentation-label-enabled", false, "If set to true, gRPC statuses will be reported in instrumentation labels with their string representations. Otherwise, they will be reported as \"error\".")
-	f.BoolVar(&cfg.ReportHTTP4XXCodesInInstrumentationLabel, "server.report-http-4xx-codes-in-instrumentation-label-enabled", false, "If set to true, HTTP 4xx statuses will be reported in instrumentation labels as \"4xx\". Otherwise, they will be reported as \"success\".")
 	f.DurationVar(&cfg.ServerGracefulShutdownTimeout, "server.graceful-shutdown-timeout", 30*time.Second, "Timeout for graceful shutdowns")
 	f.DurationVar(&cfg.HTTPServerReadTimeout, "server.http-read-timeout", 30*time.Second, "Read timeout for entire HTTP request, including headers and body.")
 	f.DurationVar(&cfg.HTTPServerReadHeaderTimeout, "server.http-read-header-timeout", 0, "Read timeout for HTTP request headers. If set to 0, value of -server.http-read-timeout is used.")
@@ -552,9 +551,9 @@ func (s *Server) Run() error {
 		}
 	}()
 
-	var serverOptions []httpgrpc_server.Options
+	var serverOptions []httpgrpc_server.Option
 	if s.cfg.ReportHTTP4XXCodesInInstrumentationLabel {
-		serverOptions = []httpgrpc_server.Options{httpgrpc_server.Return4XXErrorsOption}
+		serverOptions = []httpgrpc_server.Option{httpgrpc_server.WithReturn4XXErrors}
 	}
 	// Setup gRPC server for HTTP over gRPC, ensure we don't double-count the middleware
 	httpgrpc.RegisterHTTPServer(s.GRPC, httpgrpc_server.NewServer(s.HTTP, serverOptions...))

--- a/server/server.go
+++ b/server/server.go
@@ -551,9 +551,9 @@ func (s *Server) Run() error {
 		}
 	}()
 
-	var serverOptions []httpgrpc_server.Option
+	serverOptions := make([]httpgrpc_server.Option, 0, 1)
 	if s.cfg.ReportHTTP4XXCodesInInstrumentationLabel {
-		serverOptions = []httpgrpc_server.Option{httpgrpc_server.WithReturn4XXErrors}
+		serverOptions = append(serverOptions, httpgrpc_server.WithReturn4XXErrors)
 	}
 	// Setup gRPC server for HTTP over gRPC, ensure we don't double-count the middleware
 	httpgrpc.RegisterHTTPServer(s.GRPC, httpgrpc_server.NewServer(s.HTTP, serverOptions...))


### PR DESCRIPTION
**What this PR does**:
Currently, `httpgrpc`'s `Server.Handle()` returns an error only if a response received from the HTTP server contains a `5xx` HTTP status code. Responses with any other HTTP status code (e.g., `4xx`) are converted to non-erroneous `HTTPResponse` objects. As a consequence, the correlated requests are reported with `status_code` labels `success` in the request duration metrics.

This PR allows `Server.Handle()` to return errors even in case of a `4xx` HTTP status code. Namely, when constructor `httpgrpc.NewSerer()` is invoked with the newly introduced `httpgrpc.WithReturn4XXErrors` server option, the created `httpgrpc.Server` will return errors with `4xx` HTTP status codes. This way the correlated requests will be denoted with `status_code` label `4xx` in the request duration metrics.

In order to guarantee backwards compatibility, reporting of HTTP `4xx` status codes as labels is disabled by default and could be enabled by setting the new `server.Config.ReportHTTP4XXCodesInInstrumentationLabel` to `true`.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/mimir/issues/1830

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
