### PR TITLE
Expose HTTP Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [CHANGE] tenant: Remove `tenant.WithDefaultResolver()` and `SingleResolver` in favor of global functions `tenant.TenantID()`, `tenant.TenantIDs()`,  or `MultiResolver`. #445
 * [CHANGE] Cache: Remove legacy metrics from Memcached client that contained `_memcached_` in the name. #461
 * [CHANGE] memberlist: Change default for `memberlist.stream-timeout` from `10s` to `2s`. #458
+* [CHANGE] Expose `BuildHTTPMiddleware` to enable dskit `Server` instrumentation addition on external `*mux.Router`s. #459
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338


### PR DESCRIPTION
**What this PR does**:
This PR, paired with #460, cleans up a previous attempt to route GRPC and HTTP on the same port and allows a complete solution to be developed in a dependent application.

The previous attempt, using cmux, broke TLS on the shared port. The new approach is to create a dskit Server and do the routing ourselves like so:
```
server.HTTP.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
	// route to GRPC server if it's a GRPC request
	if req.ProtoMajor == 2 && strings.Contains(req.Header.Get("Content-Type"), "application/grpc") {
		server.GRPC.ServeHTTP(w, req)
		return
	}

	// default to standard http server
	router.ServeHTTP(w, req)
})
```

`router` is an internal `*mux.Router` with all normal http paths configured. However, for instrumentation to work correctly we need to add dskit's Server's http middleware to this internal router that dskit does not have access to. This PR exposes this middleware so we can share the same instrumentation.

Another option is to put this extra routing layer inside dskit, but I feel like this option is unlikely to be used by others and this is a cleaner way to allow Tempo to do what it needs without impacting others. I never really liked the solution we reverted in #460 and am happy to see it go away in favor of this.

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
