### PR TITLE
Remove deprecated metrics emitted by Memcached client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [CHANGE] memberlist: re-resolve `JoinMembers` during full joins to the cluster (either at startup or periodic). The re-resolution happens on every 100 attempted nodes. This helps speed up joins and respect context cancelation #411
 * [CHANGE] ring: `ring.DoBatch()` was deprecated in favor of `DoBatchWithOptions()`. #431
 * [CHANGE] tenant: Remove `tenant.WithDefaultResolver()` and `SingleResolver` in favor of global functions `tenant.TenantID()`, `tenant.TenantIDs()`,  or `MultiResolver`. #445
+* [CHANGE] Cache: Remove legacy metrics from Memcached client that contained `_memcached_` in the name. #461
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/cache/remote_cache.go
+++ b/cache/remote_cache.go
@@ -8,8 +8,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	"github.com/grafana/dskit/promregistry"
 )
 
 var (
@@ -24,7 +22,6 @@ const (
 	backendValueMemcached    = "memcached"
 	cacheMetricNamePrefix    = "cache_"
 	getMultiMetricNamePrefix = "getmulti_"
-	legacyMemcachedPrefix    = "memcached_"
 	clientInfoMetricName     = "client_info"
 )
 
@@ -40,12 +37,9 @@ func NewMemcachedCache(name string, logger log.Logger, memcachedClient RemoteCac
 			name,
 			logger,
 			memcachedClient,
-			promregistry.TeeRegisterer{
-				prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix+legacyMemcachedPrefix, reg),
-				prometheus.WrapRegistererWith(
-					prometheus.Labels{labelCacheBackend: backendValueMemcached},
-					prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg)),
-			},
+			prometheus.WrapRegistererWith(
+				prometheus.Labels{labelCacheBackend: backendValueMemcached},
+				prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg)),
 		),
 	}
 }


### PR DESCRIPTION
**What this PR does**:

Before Redis support was added, cache metrics had "memcached" in their names. Now, we use a backend label to identify which cache is being used.

We've been emitting metrics for Memcached with both the old and new names for about 11 months. It's safe to remove them at this point. On Mimir, our dashboards will work with either name so we won't be losing any data.

Example of the old name: `thanos_cache_memcached_hits_total`.

Example of the new name: `thanos_cache_hits_total`.

**Which issue(s) this PR fixes**:

Part of #452

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
