### PR TITLE
Simplify SpreadMinimizingTokenGenerator for easier reuse in partitions ring.

### DIFF
--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -25,7 +25,7 @@ const (
 func TestBasicLifecycler_GetTokenGenerator(t *testing.T) {
 	cfg := prepareBasicLifecyclerConfig()
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true)
 	require.NoError(t, err)
 
 	tests := []TokenGenerator{nil, NewRandomTokenGenerator(), spreadMinimizingTokenGenerator}

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -70,7 +70,7 @@ func TestLifecyclerConfig_Validate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, pathToTokens, cfg.TokensFilePath)
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true)
 	require.NoError(t, err)
 
 	cfg.RingTokenGenerator = spreadMinimizingTokenGenerator
@@ -88,7 +88,7 @@ func TestLifecycler_TokenGenerator(t *testing.T) {
 
 	cfg := testLifecyclerConfig(ringConfig, "instance-1")
 
-	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true, log.NewNopLogger())
+	spreadMinimizingTokenGenerator, err := NewSpreadMinimizingTokenGenerator(cfg.ID, cfg.Zone, []string{zone(1), zone(2), zone(3)}, true)
 	require.NoError(t, err)
 
 	tests := []TokenGenerator{nil, initTokenGenerator(t), spreadMinimizingTokenGenerator}
@@ -1343,7 +1343,7 @@ func TestWaitBeforeJoining(t *testing.T) {
 	spreadMinimizingZones := []string{zone(1), zone(2), zone(3)}
 	canJoinTimeout := 5 * time.Second
 	spreadMinimizingTokenGenerator := func(targetInstanceID string, canJoinEnabled bool) TokenGenerator {
-		tokenGenerator, err := NewSpreadMinimizingTokenGenerator(targetInstanceID, targetZone, spreadMinimizingZones, canJoinEnabled, log.NewNopLogger())
+		tokenGenerator, err := NewSpreadMinimizingTokenGenerator(targetInstanceID, targetZone, spreadMinimizingZones, canJoinEnabled)
 		require.NoError(t, err)
 		return tokenGenerator
 	}
@@ -1476,7 +1476,7 @@ func TestAutoJoinWithSpreadMinimizingTokenGenerator(t *testing.T) {
 
 	// Token generator of the instance with id 0 will call CanJoin with a delay of canJoinDelay,
 	// in such a way that instance with id 1 waits for it.
-	tokenGeneratorWithDelay, err := newSpreadMinimizingTokenGeneratorWithDelay(firstInstanceID, zoneID, spreadMinimizingZones, true, canJoinDelay, log.NewNopLogger())
+	tokenGeneratorWithDelay, err := newSpreadMinimizingTokenGeneratorWithDelay(firstInstanceID, zoneID, spreadMinimizingZones, true, canJoinDelay)
 	require.NoError(t, err)
 	firstCfg := testLifecyclerConfig(ringConfig, firstInstanceID)
 	firstCfg.NumTokens = optimalTokensPerInstance
@@ -1486,7 +1486,7 @@ func TestAutoJoinWithSpreadMinimizingTokenGenerator(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), firstLifecycler))
 	defer services.StopAndAwaitTerminated(context.Background(), firstLifecycler) //nolint:errcheck
 
-	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(secondInstanceID, zoneID, spreadMinimizingZones, true, log.NewNopLogger())
+	tokenGenerator, err := NewSpreadMinimizingTokenGenerator(secondInstanceID, zoneID, spreadMinimizingZones, true)
 	require.NoError(t, err)
 	secondCfg := testLifecyclerConfig(ringConfig, secondInstanceID)
 	secondCfg.NumTokens = optimalTokensPerInstance

--- a/ring/spread_minimizing_token_generator.go
+++ b/ring/spread_minimizing_token_generator.go
@@ -69,17 +69,16 @@ func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZo
 		return nil, err
 	}
 
-	return NewSpreadMinimizingTokenGeneratorForInstanceAndZoneID(prefix, instanceID, zoneID, canJoinEnabled)
+	return NewSpreadMinimizingTokenGeneratorForInstanceAndZoneID(prefix, instanceID, zoneID, canJoinEnabled), nil
 }
 
-func NewSpreadMinimizingTokenGeneratorForInstanceAndZoneID(instancePrefix string, instanceID, zoneID int, canJoinEnabled bool) (*SpreadMinimizingTokenGenerator, error) {
-	tokenGenerator := &SpreadMinimizingTokenGenerator{
+func NewSpreadMinimizingTokenGeneratorForInstanceAndZoneID(instancePrefix string, instanceID, zoneID int, canJoinEnabled bool) *SpreadMinimizingTokenGenerator {
+	return &SpreadMinimizingTokenGenerator{
 		instanceID:     instanceID,
 		instancePrefix: instancePrefix,
 		zoneID:         zoneID,
 		canJoinEnabled: canJoinEnabled,
 	}
-	return tokenGenerator, nil
 }
 
 func parseInstanceID(instanceID string) (string, int, error) {

--- a/ring/spread_minimizing_token_generator.go
+++ b/ring/spread_minimizing_token_generator.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
-
 	"golang.org/x/exp/slices"
 )
 
@@ -22,11 +20,10 @@ const (
 )
 
 var (
-	instanceIDRegex          = regexp.MustCompile(`^(.*)-(\d+)$`)
+	instanceIDRegex          = regexp.MustCompile(`^(.*-)(\d+)$`)
 	errorBadInstanceIDFormat = func(instanceID string) error {
 		return fmt.Errorf("unable to extract instance id from %q", instanceID)
 	}
-	errorNoPreviousInstance = fmt.Errorf("impossible to find the instance preceding the target instance, because it is the first instance")
 
 	errorMissingPreviousInstance = func(requiredInstanceID string) error {
 		return fmt.Errorf("the instance %q has not been registered to the ring or has no tokens yet", requiredInstanceID)
@@ -50,7 +47,7 @@ var (
 
 type SpreadMinimizingTokenGenerator struct {
 	instanceID            int
-	instance              string
+	instancePrefix        string
 	zoneID                int
 	spreadMinimizingZones []string
 	canJoinEnabled        bool
@@ -58,6 +55,15 @@ type SpreadMinimizingTokenGenerator struct {
 }
 
 func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZones []string, canJoinEnabled bool, logger log.Logger) (*SpreadMinimizingTokenGenerator, error) {
+	prefix, instanceID, err := parseInstanceID(instance)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSpreadMinimizingTokenGeneratorForInstanceID(prefix, instanceID, zone, spreadMinimizingZones, canJoinEnabled, logger)
+}
+
+func NewSpreadMinimizingTokenGeneratorForInstanceID(instancePrefix string, instanceID int, zone string, spreadMinimizingZones []string, canJoinEnabled bool, logger log.Logger) (*SpreadMinimizingTokenGenerator, error) {
 	if len(spreadMinimizingZones) <= 0 || len(spreadMinimizingZones) > maxZonesCount {
 		return nil, errorZoneCountOutOfBound(len(spreadMinimizingZones))
 	}
@@ -66,10 +72,6 @@ func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZo
 	if !slices.IsSorted(sortedZones) {
 		sort.Strings(sortedZones)
 	}
-	instanceID, err := parseInstanceID(instance)
-	if err != nil {
-		return nil, err
-	}
 	zoneID, err := findZoneID(zone, sortedZones)
 	if err != nil {
 		return nil, err
@@ -77,7 +79,7 @@ func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZo
 
 	tokenGenerator := &SpreadMinimizingTokenGenerator{
 		instanceID:            instanceID,
-		instance:              instance,
+		instancePrefix:        instancePrefix,
 		zoneID:                zoneID,
 		spreadMinimizingZones: sortedZones,
 		canJoinEnabled:        canJoinEnabled,
@@ -86,32 +88,13 @@ func NewSpreadMinimizingTokenGenerator(instance, zone string, spreadMinimizingZo
 	return tokenGenerator, nil
 }
 
-func parseInstanceID(instanceID string) (int, error) {
+func parseInstanceID(instanceID string) (string, int, error) {
 	parts := instanceIDRegex.FindStringSubmatch(instanceID)
 	if len(parts) != 3 {
-		return 0, errorBadInstanceIDFormat(instanceID)
+		return "", 0, errorBadInstanceIDFormat(instanceID)
 	}
-	return strconv.Atoi(parts[2])
-}
-
-// previousInstance determines the string id of the instance preceding the given instance string id.
-// If it is impossible to parse the given instanceID, or it is impossible to determine its predecessor
-// because the passed instanceID has a bad format, or has no predecessor, an error is returned.
-// For examples, my-instance-1 is preceded by instance my-instance-0, but my-instance-0 has no
-// predecessor because its index is 0.
-func previousInstance(instanceID string) (string, error) {
-	parts := instanceIDRegex.FindStringSubmatch(instanceID)
-	if len(parts) != 3 {
-		return "", errorBadInstanceIDFormat(instanceID)
-	}
-	id, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return "", err
-	}
-	if id == 0 {
-		return "", errorNoPreviousInstance
-	}
-	return fmt.Sprintf("%s-%d", parts[1], id-1), nil
+	val, err := strconv.Atoi(parts[2])
+	return parts[1], val, err
 }
 
 // findZoneID gets a zone name and a slice of sorted zones,
@@ -339,13 +322,10 @@ func (t *SpreadMinimizingTokenGenerator) CanJoin(instances map[string]InstanceDe
 		return nil
 	}
 
-	prevInstance, err := previousInstance(t.instance)
-	if err != nil {
-		if errors.Is(err, errorNoPreviousInstance) {
-			return nil
-		}
-		return err
+	if t.instanceID == 0 {
+		return nil
 	}
+	prevInstance := fmt.Sprintf("%s%d", t.instancePrefix, t.instanceID-1)
 	instanceDesc, ok := instances[prevInstance]
 	if ok && len(instanceDesc.Tokens) != 0 {
 		return nil

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -28,21 +28,25 @@ var (
 
 func TestSpreadMinimizingTokenGenerator_ParseInstanceID(t *testing.T) {
 	tests := map[string]struct {
-		instanceID    string
-		expectedID    int
-		expectedError error
+		instanceID     string
+		expectedPrefix string
+		expectedID     int
+		expectedError  error
 	}{
 		"instance-zone-a-10 is correct": {
-			instanceID: "instance-zone-a-10",
-			expectedID: 10,
+			instanceID:     "instance-zone-a-10",
+			expectedPrefix: "instance-zone-a-",
+			expectedID:     10,
 		},
 		"instance-zone-b-0 is correct": {
-			instanceID: "instance-zone-b-0",
-			expectedID: 0,
+			instanceID:     "instance-zone-b-0",
+			expectedPrefix: "instance-zone-b-",
+			expectedID:     0,
 		},
 		"store-gateway-zone-c-7 is correct": {
-			instanceID: "store-gateway-zone-c-7",
-			expectedID: 7,
+			instanceID:     "store-gateway-zone-c-7",
+			expectedPrefix: "store-gateway-zone-c-",
+			expectedID:     7,
 		},
 		"instance-zone-c is not valid": {
 			instanceID:    "instance-zone-c",
@@ -54,56 +58,14 @@ func TestSpreadMinimizingTokenGenerator_ParseInstanceID(t *testing.T) {
 		},
 	}
 	for _, testData := range tests {
-		id, err := parseInstanceID(testData.instanceID)
+		prefix, id, err := parseInstanceID(testData.instanceID)
 		if testData.expectedError != nil {
 			require.Error(t, err)
 			require.Equal(t, testData.expectedError, err)
 		} else {
 			require.NoError(t, err)
+			require.Equal(t, testData.expectedPrefix, prefix)
 			require.Equal(t, testData.expectedID, id)
-		}
-	}
-}
-
-func TestSpreadMinimizingTokenGenerator_PreviousInstanceID(t *testing.T) {
-	tests := map[string]struct {
-		instanceID         string
-		expectedInstanceID string
-		expectedError      error
-	}{
-		"previous instance of instance-zone-a-10 is instance-zone-a-9": {
-			instanceID:         "instance-zone-a-10",
-			expectedInstanceID: "instance-zone-a-9",
-		},
-		"previous instance of instance-zone-b-1 is instance-zone-b-0": {
-			instanceID:         "instance-zone-b-1",
-			expectedInstanceID: "instance-zone-b-0",
-		},
-		"previous instance of store-gateway-zone-c-1000 is store-gateway-zone-c-999": {
-			instanceID:         "store-gateway-zone-c-1000",
-			expectedInstanceID: "store-gateway-zone-c-999",
-		},
-		"instance-zone-0 has no previous instance": {
-			instanceID:    "instance-zone-0",
-			expectedError: errorNoPreviousInstance,
-		},
-		"instance-zone-c is not valid": {
-			instanceID:    "instance-zone-c",
-			expectedError: errorBadInstanceIDFormat("instance-zone-c"),
-		},
-		"empty instance is not valid": {
-			instanceID:    "",
-			expectedError: errorBadInstanceIDFormat(""),
-		},
-	}
-	for _, testData := range tests {
-		id, err := previousInstance(testData.instanceID)
-		if testData.expectedError != nil {
-			require.Error(t, err)
-			require.Equal(t, testData.expectedError, err)
-		} else {
-			require.NoError(t, err)
-			require.Equal(t, testData.expectedInstanceID, id)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does**:

This PR simplifies internals of  `SpreadMinimizingTokenGenerator`: it removes logger, slice with zones, parsing of instance when computing previous instance.

These changes make it easier to reuse this token generator in partitions ring code (https://github.com/grafana/dskit/compare/partitions-ring branch).

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
