### PR TITLE
Allow server.Server to return internal gRPC errors with HTTPResponses

### DIFF
--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -44,9 +44,30 @@ func TestErrorf(t *testing.T) {
 	checkDetailAsHTTPResponse(t, expectedHTTPResponse, stat)
 }
 
+func TestHTTPErrorf(t *testing.T) {
+	httpErrorStatusCode := 400
+	httpErrorStatusMsg := "this is an error"
+	expectedHTTPResponse := &HTTPResponse{
+		Code: int32(httpErrorStatusCode),
+		Body: []byte(httpErrorStatusMsg),
+	}
+
+	err := HTTPErrorf(httpErrorStatusCode, httpErrorStatusMsg)
+	require.Error(t, err)
+	require.Equal(t, expectedHTTPResponse, err.GetHTTPResponse())
+
+	stat, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, stat.Code())
+	require.Equal(t, httpErrorStatusMsg, stat.Message())
+	checkDetailAsHTTPResponse(t, expectedHTTPResponse, stat)
+}
+
 func TestErrorFromHTTPResponse(t *testing.T) {
-	var code int32 = 400
-	errMsg := "this is an error"
+	const (
+		code   int32 = 400
+		errMsg       = "this is an error"
+	)
 	headers := []*Header{{Key: "X-Header", Values: []string{"a", "b", "c"}}}
 	resp := &HTTPResponse{
 		Code:    code,
@@ -62,8 +83,29 @@ func TestErrorFromHTTPResponse(t *testing.T) {
 	checkDetailAsHTTPResponse(t, resp, stat)
 }
 
+func TestHTTPErrorFromHTTPResponse(t *testing.T) {
+	const (
+		code   = 400
+		errMsg = "this is an error"
+	)
+	headers := []*Header{{Key: "X-Header", Values: []string{"a", "b", "c"}}}
+	resp := &HTTPResponse{
+		Code:    code,
+		Headers: headers,
+		Body:    []byte(errMsg),
+	}
+	err := HTTPErrorFromHTTPResponse(resp)
+	require.Error(t, err)
+	stat, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, stat.Code())
+	require.Equal(t, errMsg, stat.Message())
+	checkDetailAsHTTPResponse(t, resp, stat)
+}
+
 func TestHTTPResponseFromError(t *testing.T) {
-	msgErr := "this is an error"
+	const msgErr = "this is an error"
+	var resp = &HTTPResponse{Code: 400, Body: []byte(msgErr)}
 	testCases := map[string]struct {
 		err                  error
 		isGRPCError          bool
@@ -84,11 +126,19 @@ func TestHTTPResponseFromError(t *testing.T) {
 		},
 		"a gRPC error built by httpgrpc can be parsed to an HTTPResponse": {
 			err:                  Errorf(400, msgErr),
-			expectedHTTPResponse: &HTTPResponse{Code: 400, Body: []byte(msgErr)},
+			expectedHTTPResponse: resp,
 		},
 		"a wrapped gRPC error built by httpgrpc can be parsed to an HTTPResponse": {
 			err:                  fmt.Errorf("wrapped: %w", Errorf(400, msgErr)),
-			expectedHTTPResponse: &HTTPResponse{Code: 400, Body: []byte(msgErr)},
+			expectedHTTPResponse: resp,
+		},
+		"an instance of HTTPError can be parsed to an HTTPResponse": {
+			err:                  HTTPErrorFromHTTPResponse(resp),
+			expectedHTTPResponse: resp,
+		},
+		"a wrapped instance of HTTPError can be parsed to an HTTPResponse": {
+			err:                  fmt.Errorf("wrapped: %w", HTTPErrorFromHTTPResponse(resp)),
+			expectedHTTPResponse: resp,
 		},
 	}
 	for testName, testData := range testCases {
@@ -99,7 +149,7 @@ func TestHTTPResponseFromError(t *testing.T) {
 				require.Nil(t, resp)
 			} else {
 				require.True(t, ok)
-
+				checkEqualHTTPResponses(t, testData.expectedHTTPResponse, resp)
 			}
 		})
 	}
@@ -111,7 +161,11 @@ func checkDetailAsHTTPResponse(t *testing.T, httpResponse *HTTPResponse, stat *s
 	respDetails, ok := details[0].(*HTTPResponse)
 	require.True(t, ok)
 	require.NotNil(t, respDetails)
-	require.Equal(t, httpResponse.Code, respDetails.Code)
-	require.Equal(t, httpResponse.Headers, respDetails.Headers)
-	require.Equal(t, httpResponse.Body, respDetails.Body)
+	checkEqualHTTPResponses(t, httpResponse, respDetails)
+}
+
+func checkEqualHTTPResponses(t *testing.T, expectedResp, resp *HTTPResponse) {
+	require.Equal(t, expectedResp.GetCode(), resp.GetCode())
+	require.Equal(t, expectedResp.GetHeaders(), resp.GetHeaders())
+	require.Equal(t, expectedResp.GetBody(), resp.GetBody())
 }

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -38,6 +38,10 @@ func WithReturn4XXErrors(s *Server) {
 	s.return4XXErrors = true
 }
 
+func WithHTTPErrorsEnabled(s *Server) {
+	s.httpErrorsEnabled = true
+}
+
 func applyServerOptions(s *Server, opts ...Option) *Server {
 	for _, opt := range opts {
 		opt(s)
@@ -48,8 +52,9 @@ func applyServerOptions(s *Server, opts ...Option) *Server {
 // Server implements HTTPServer.  HTTPServer is a generated interface that gRPC
 // servers must implement.
 type Server struct {
-	handler         http.Handler
-	return4XXErrors bool
+	handler           http.Handler
+	return4XXErrors   bool
+	httpErrorsEnabled bool
 }
 
 // NewServer makes a new Server.
@@ -80,13 +85,20 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 		Body:    recorder.Body.Bytes(),
 	}
 	if s.shouldReturnError(resp) {
-		err := httpgrpc.ErrorFromHTTPResponse(resp)
+		err := s.errorFromResponse(resp)
 		if doNotLogError {
 			err = middleware.DoNotLogError{Err: err}
 		}
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (s Server) errorFromResponse(resp *httpgrpc.HTTPResponse) error {
+	if s.httpErrorsEnabled {
+		return httpgrpc.HTTPErrorFromHTTPResponse(resp)
+	}
+	return httpgrpc.ErrorFromHTTPResponse(resp)
 }
 
 func (s Server) shouldReturnError(resp *httpgrpc.HTTPResponse) bool {

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -38,8 +38,8 @@ func WithReturn4XXErrors(s *Server) {
 	s.return4XXErrors = true
 }
 
-func WithHTTPErrorsEnabled(s *Server) {
-	s.httpErrorsEnabled = true
+func WithSendOverGRPCAsInternal(s *Server) {
+	s.sendOverGRPCAsInternal = true
 }
 
 func applyServerOptions(s *Server, opts ...Option) *Server {
@@ -52,9 +52,9 @@ func applyServerOptions(s *Server, opts ...Option) *Server {
 // Server implements HTTPServer.  HTTPServer is a generated interface that gRPC
 // servers must implement.
 type Server struct {
-	handler           http.Handler
-	return4XXErrors   bool
-	httpErrorsEnabled bool
+	handler                http.Handler
+	return4XXErrors        bool
+	sendOverGRPCAsInternal bool
 }
 
 // NewServer makes a new Server.
@@ -95,8 +95,8 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 }
 
 func (s Server) errorFromResponse(resp *httpgrpc.HTTPResponse) error {
-	if s.httpErrorsEnabled {
-		return httpgrpc.HTTPErrorFromHTTPResponse(resp)
+	if s.sendOverGRPCAsInternal {
+		return httpgrpc.InternalErrorFromHTTPResponse(resp)
 	}
 	return httpgrpc.ErrorFromHTTPResponse(resp)
 }

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -49,12 +49,12 @@ func TestWithHTTPErrorsEnabled(t *testing.T) {
 	serverOptions := make([]Option, 0, 1)
 	server := NewServer(handler, serverOptions...)
 	require.NotNil(t, server)
-	require.False(t, server.httpErrorsEnabled)
+	require.False(t, server.sendOverGRPCAsInternal)
 
-	serverOptions = append(serverOptions, WithHTTPErrorsEnabled)
+	serverOptions = append(serverOptions, WithSendOverGRPCAsInternal)
 	server = NewServer(handler, serverOptions...)
 	require.NotNil(t, server)
-	require.True(t, server.httpErrorsEnabled)
+	require.True(t, server.sendOverGRPCAsInternal)
 }
 
 type testServer struct {
@@ -274,19 +274,19 @@ func TestServerHandleWithErrors(t *testing.T) {
 		withHTTPErrors bool
 		expectedError  bool
 	}{
-		"HTTPResponse with code 5xx should return the same code when server created with WithHTTPErrors": {
+		"HTTPResponse with code 5xx should return the same code when server created with WithSendOverGRPCAsInternal": {
 			errorCode:      http.StatusInternalServerError,
 			withHTTPErrors: true,
 		},
-		"HTTPResponse with code 5xx should return the same code when server created without WithHTTPErrors": {
+		"HTTPResponse with code 5xx should return the same code when server created without WithSendOverGRPCAsInternal": {
 			errorCode:      http.StatusInternalServerError,
 			withHTTPErrors: false,
 		},
-		"HTTPResponse with code 4xx should return the same code when server created with WithHTTPErrors": {
+		"HTTPResponse with code 4xx should return the same code when server created with WithSendOverGRPCAsInternal": {
 			errorCode:      http.StatusUnprocessableEntity,
 			withHTTPErrors: true,
 		},
-		"HTTPResponse with code 4xx should return the same code when server created without WithHTTPErrors": {
+		"HTTPResponse with code 4xx should return the same code when server created without WithSendOverGRPCAsInternal": {
 			errorCode:      http.StatusUnprocessableEntity,
 			withHTTPErrors: false,
 		},
@@ -301,7 +301,7 @@ func TestServerHandleWithErrors(t *testing.T) {
 			serverOptions := make([]Option, 0, 2)
 			serverOptions = append(serverOptions, WithReturn4XXErrors)
 			if testData.withHTTPErrors {
-				serverOptions = append(serverOptions, WithHTTPErrorsEnabled)
+				serverOptions = append(serverOptions, WithSendOverGRPCAsInternal)
 			}
 			s := NewServer(h, serverOptions...)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
