### PR TITLE
Ring: Add `HasReplicationSetChangedWithoutStateOrAddr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@
 * [ENHANCEMENT] Cache: Export Memcached and Redis client types instead of returning the interface, `RemoteCacheClient`, they implement. #453
 * [ENHANCEMENT] SpanProfiler: add spanprofiler package. #448
 * [ENHANCEMENT] Server: Add support for `ReportHTTP4XXCodesInInstrumentationLabel`, which specifies whether HTTP 4xx status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that HTTP 4xx status codes are represented with `success` value. Moreover, when `ReportHTTP4XXCodesInInstrumentationLabel` is set to true, responses with HTTP status code `4xx` are returned as errors. #457
+* [ENHANCEMENT] Ring: Add `HasReplicationSetChangedWithoutStateOrAddr` to detect replication state changes ignoring IP address changes due to e.g. member restarts. #464
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/model.go
+++ b/ring/model.go
@@ -14,12 +14,12 @@ import (
 	"github.com/grafana/dskit/loser"
 )
 
-// ByAddr is a sortable list of InstanceDesc.
-type ByAddr []InstanceDesc
+// ByID is a sortable list of InstanceDesc.
+type ByID []InstanceDesc
 
-func (ts ByAddr) Len() int           { return len(ts) }
-func (ts ByAddr) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
-func (ts ByAddr) Less(i, j int) bool { return ts[i].Addr < ts[j].Addr }
+func (ts ByID) Len() int           { return len(ts) }
+func (ts ByID) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
+func (ts ByID) Less(i, j int) bool { return ts[i].Id < ts[j].Id }
 
 // ProtoDescFactory makes new Descs
 func ProtoDescFactory() proto.Message {

--- a/ring/model.go
+++ b/ring/model.go
@@ -14,6 +14,13 @@ import (
 	"github.com/grafana/dskit/loser"
 )
 
+// ByAddr is a sortable list of InstanceDesc.
+type ByAddr []InstanceDesc
+
+func (ts ByAddr) Len() int           { return len(ts) }
+func (ts ByAddr) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
+func (ts ByAddr) Less(i, j int) bool { return ts[i].Addr < ts[j].Addr }
+
 // ByID is a sortable list of InstanceDesc.
 type ByID []InstanceDesc
 

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -468,6 +468,17 @@ func HasReplicationSetChangedWithoutState(before, after ReplicationSet) bool {
 	})
 }
 
+// Has HasReplicationSetChangedWithoutStateOrAddr returns false if two replications sets
+// are the same (with possibly different timestamps, instance states, and ip addresses),
+// true if they differ in any other way (number of instances, tokens, zones, ...).
+func HasReplicationSetChangedWithoutStateOrAddr(before, after ReplicationSet) bool {
+	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
+		i.Timestamp = 0
+		i.State = PENDING
+		i.Addr = ""
+	})
+}
+
 // Do comparison of replicasets, but apply a function first
 // to be able to exclude (reset) some values
 func hasReplicationSetChangedExcluding(before, after ReplicationSet, exclude func(*InstanceDesc)) bool {
@@ -478,8 +489,8 @@ func hasReplicationSetChangedExcluding(before, after ReplicationSet, exclude fun
 		return true
 	}
 
-	sort.Sort(ByAddr(beforeInstances))
-	sort.Sort(ByAddr(afterInstances))
+	sort.Sort(ByID(beforeInstances))
+	sort.Sort(ByID(afterInstances))
 
 	for i := 0; i < len(beforeInstances); i++ {
 		b := beforeInstances[i]

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -204,7 +204,7 @@ func addInstancesPeriodically(ring *Ring) chan struct{} {
 				ring.mtx.Lock()
 				ringDesc := ring.ringDesc
 				instanceID := fmt.Sprintf("127.0.0.%d", len(ringDesc.Ingesters)+1)
-				ringDesc.Ingesters[instanceID] = InstanceDesc{Addr: instanceID, State: ACTIVE, Timestamp: time.Now().Unix()}
+				ringDesc.Ingesters[instanceID] = InstanceDesc{Id: instanceID, Addr: instanceID, State: ACTIVE, Timestamp: time.Now().Unix()}
 				ring.ringDesc = ringDesc
 				ring.ringTokens = ringDesc.GetTokens()
 				ring.ringTokensByZone = ringDesc.getTokensByZone()

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -278,7 +278,9 @@ func changeStatePeriodically(ring *Ring) chan struct{} {
 				stateIdx++
 				ring.mtx.Lock()
 				ringDesc := ring.ringDesc
-				desc := InstanceDesc{Addr: "127.0.0.1", State: states[stateIdx%len(states)], Timestamp: time.Now().Unix()}
+				desc := ringDesc.Ingesters[instanceToMutate]
+				desc.State = states[stateIdx%len(states)]
+				desc.Timestamp = time.Now().Unix()
 				ringDesc.Ingesters[instanceToMutate] = desc
 				ring.mtx.Unlock()
 			}

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -74,11 +74,11 @@ func (r *RingMock) GetTokenRangesForInstance(_ string) (TokenRanges, error) {
 func createStartingRing() *Ring {
 	// Init the ring.
 	ringDesc := &Desc{Ingesters: map[string]InstanceDesc{
-		"instance-1": {Addr: "127.0.0.1", State: ACTIVE, Timestamp: time.Now().Unix()},
-		"instance-2": {Addr: "127.0.0.2", State: PENDING, Timestamp: time.Now().Unix()},
-		"instance-3": {Addr: "127.0.0.3", State: JOINING, Timestamp: time.Now().Unix()},
-		"instance-4": {Addr: "127.0.0.4", State: LEAVING, Timestamp: time.Now().Unix()},
-		"instance-5": {Addr: "127.0.0.5", State: ACTIVE, Timestamp: time.Now().Unix()},
+		"instance-1": {Id: "instance-1", Addr: "127.0.0.1", State: ACTIVE, Timestamp: time.Now().Unix()},
+		"instance-2": {Id: "instance-2", Addr: "127.0.0.2", State: PENDING, Timestamp: time.Now().Unix()},
+		"instance-3": {Id: "instance-3", Addr: "127.0.0.3", State: JOINING, Timestamp: time.Now().Unix()},
+		"instance-4": {Id: "instance-4", Addr: "127.0.0.4", State: LEAVING, Timestamp: time.Now().Unix()},
+		"instance-5": {Id: "instance-5", Addr: "127.0.0.5", State: ACTIVE, Timestamp: time.Now().Unix()},
 	}}
 
 	ring := &Ring{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The existing `ring.HasReplicationSetChangedWithoutState` function will detect a replication state change if a member was rebooted and rejoins the ring with a different IP address. In Mimir we want to ignore these changes as, in some cases, we only care about the distribution of the tokens in the ring changing.

This PR:
1. changes the sorting of the replication sets in `ring.hasReplicationSetChangedExcluding` from `ByAddr` to `ByID`, since we want to ignore the `Addr` field in some situations.
2. adds `ring.HasReplicationSetChangedWithoutStateOrAddr` to detect replication set changes ignoring the State and Addr fields.

**Which issue(s) this PR fixes**:

Fixes N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
