### PR TITLE
Move requests/hits metrics to cache clients

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -121,13 +121,13 @@ func CreateClient(cacheName string, cfg BackendConfig, logger log.Logger, reg pr
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create memcached client")
 		}
-		return NewMemcachedCache(cacheName, logger, client, reg), nil
+		return NewMemcachedCache(cacheName, logger, client), nil
 	case BackendRedis:
 		client, err := NewRedisClient(logger, cacheName, cfg.Redis, reg)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create redis client")
 		}
-		return NewRedisCache(cacheName, logger, client, reg), nil
+		return NewRedisCache(cacheName, logger, client), nil
 	default:
 		return nil, errors.Errorf("unsupported cache type for cache %s: %s", cacheName, cfg.Backend)
 	}

--- a/cache/client.go
+++ b/cache/client.go
@@ -38,6 +38,10 @@ type clientMetrics struct {
 	dataSize   *prometheus.HistogramVec
 }
 
+// newClientMetrics creates a new bundle of metrics about an instance of a cache client. Note
+// that there may be multiple cache clients at any given time so the prometheus.Registerer passed
+// to this method should include labels unique to this particular client (e.g. a name for each
+// different cache being used).
 func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 	cm := &clientMetrics{}
 

--- a/cache/client.go
+++ b/cache/client.go
@@ -29,6 +29,8 @@ const (
 )
 
 type clientMetrics struct {
+	requests   prometheus.Counter
+	hits       prometheus.Counter
 	operations *prometheus.CounterVec
 	failures   *prometheus.CounterVec
 	skipped    *prometheus.CounterVec
@@ -39,6 +41,14 @@ type clientMetrics struct {
 func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 	cm := &clientMetrics{}
 
+	cm.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "requests_total",
+		Help: "Total number of items requests to cache.",
+	})
+	cm.hits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "hits_total",
+		Help: "Total number of items requests to the cache that were a hit.",
+	})
 	cm.operations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "operations_total",
 		Help: "Total number of operations against cache.",

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -338,6 +338,7 @@ func (c *MemcachedClient) GetMulti(ctx context.Context, keys []string, opts ...O
 		return nil
 	}
 
+	c.metrics.requests.Add(float64(len(keys)))
 	options := toMemcacheOptions(opts...)
 	batches, err := c.getMultiBatched(ctx, keys, options...)
 	if err != nil {
@@ -362,6 +363,7 @@ func (c *MemcachedClient) GetMulti(ctx context.Context, keys []string, opts ...O
 		}
 	}
 
+	c.metrics.hits.Add(float64(len(hits)))
 	return hits
 }
 

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -237,6 +237,7 @@ func (c *RedisClient) GetMulti(ctx context.Context, keys []string, _ ...Option) 
 	}
 	var mu sync.Mutex
 	results := make(map[string][]byte, len(keys))
+	c.metrics.requests.Add(float64(len(keys)))
 
 	err := doWithBatch(ctx, len(keys), c.config.MaxGetMultiBatchSize, c.getMultiGate, func(startIndex, endIndex int) error {
 		start := time.Now()
@@ -272,6 +273,8 @@ func (c *RedisClient) GetMulti(ctx context.Context, keys []string, _ ...Option) 
 		level.Warn(c.logger).Log("msg", "failed to mget items from redis", "err", err, "items", len(keys))
 		return nil
 	}
+
+	c.metrics.hits.Add(float64(len(results)))
 	return results
 }
 


### PR DESCRIPTION
**What this PR does**:

Move tracking of keys requested and hits from the `remoteCache` to each respective cache client (Memcached and Redis). This is part of a refactor that will eventually remove `remoteCache` since it doesn't provide enough value to justify itself.

**Which issue(s) this PR fixes**:

Related #452

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
