### PR TITLE
Add `SpanLogger.SetSpanAndLogTag()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@
 * [ENHANCEMENT] SpanProfiler: add spanprofiler package. #448
 * [ENHANCEMENT] Server: Add support for `ReportHTTP4XXCodesInInstrumentationLabel`, which specifies whether HTTP 4xx status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that HTTP 4xx status codes are represented with `success` value. Moreover, when `ReportHTTP4XXCodesInInstrumentationLabel` is set to true, responses with HTTP status code `4xx` are returned as errors. #457
 * [ENHANCEMENT] Ring: Add `HasReplicationSetChangedWithoutStateOrAddr` to detect replication state changes ignoring IP address changes due to e.g. member restarts. #464
+* [ENHANCEMENT] SpanLogger: Add `SetSpanAndLogTag` method. #467
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -167,3 +167,17 @@ func (s *SpanLogger) getLogger() log.Logger {
 	}
 	return logger
 }
+
+// SetSpanAndLogTag sets a tag on the span used by this SpanLogger, and appends a key/value pair to the logger used for
+// future log lines emitted by this SpanLogger.
+//
+// It is not safe to call this method from multiple goroutines simultaneously.
+// It is safe to call this method at the same time as calling other SpanLogger methods, however, this may produce
+// inconsistent results (eg. some log lines may be emitted with the provided key/value pair, and others may not).
+func (s *SpanLogger) SetSpanAndLogTag(key string, value interface{}) {
+	s.Span.SetTag(key, value)
+
+	logger := s.getLogger()
+	wrappedLogger := log.With(logger, key, value)
+	s.logger.Store(&wrappedLogger)
+}


### PR DESCRIPTION
**What this PR does**:

This PR adds a `SetSpanAndLogTag` method to `SpanLogger`.

This is useful for situations where you want to add a tag to a span, and also have this information included in log lines as well.

See https://github.com/grafana/rollout-operator/pull/114#discussion_r1448257480 for the discussion that motivated this functionality.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
