### PR TITLE
grpcclient: rename backoff retry middleware

### DIFF
--- a/grpcclient/backoff_retry.go
+++ b/grpcclient/backoff_retry.go
@@ -2,6 +2,7 @@ package grpcclient
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -10,22 +11,27 @@ import (
 	"github.com/grafana/dskit/backoff"
 )
 
-// NewBackoffRetry gRPC middleware.
-func NewBackoffRetry(cfg backoff.Config) grpc.UnaryClientInterceptor {
+// NewRateLimitRetrier creates a UnaryClientInterceptor which retries with backoff
+// the calls from invoker when the executed RPC is rate limited.
+func NewRateLimitRetrier(cfg backoff.Config) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		backoff := backoff.New(ctx, cfg)
+		var err error
 		for backoff.Ongoing() {
-			err := invoker(ctx, method, req, reply, cc, opts...)
+			err = invoker(ctx, method, req, reply, cc, opts...)
 			if err == nil {
 				return nil
 			}
 
+			// Only ResourceExhausted statuses are handled as signals of being rate limited,
+			// following the implementation of package's RateLimiter interceptor.
+			// All other errors are propogated as-is upstream.
 			if status.Code(err) != codes.ResourceExhausted {
 				return err
 			}
 
 			backoff.Wait()
 		}
-		return backoff.Err()
+		return errors.Join(err, backoff.Err())
 	}
 }

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -108,7 +108,7 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 	streamClientInterceptors = append(streamClientInterceptors, cfg.StreamMiddleware...)
 
 	if cfg.BackoffOnRatelimits {
-		unaryClientInterceptors = append([]grpc.UnaryClientInterceptor{NewBackoffRetry(cfg.BackoffConfig)}, unaryClientInterceptors...)
+		unaryClientInterceptors = append([]grpc.UnaryClientInterceptor{NewRateLimitRetrier(cfg.BackoffConfig)}, unaryClientInterceptors...)
 	}
 
 	if cfg.RateLimit > 0 {


### PR DESCRIPTION
**What this PR does**:

The changes rename the `grpcclient.NewBackoffRetry` to `grpcclient.NewRateLimitRetrier`. The later is more obvious in term of signaliing to the (potencial) user, and a reader of the code, that the middleware is not a common-case retrier. That is, the middleware specifically retries RPC that were rate limited (see the discussion below https://github.com/grafana/dskit/pull/470#issuecomment-1910571457).

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
