### PR TITLE
Add shuffle sharding support to partitions ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -111,7 +111,8 @@ func (r *PartitionRing) ShuffleShard(identifier string, size int) (*PartitionRin
 		return cached, nil
 	}
 
-	subring, err := r.shuffleShard(identifier, size, 0, time.Now())
+	// No need to pass the time if there's no lookback.
+	subring, err := r.shuffleShard(identifier, size, 0, time.Time{})
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +150,10 @@ func (r *PartitionRing) shuffleShard(identifier string, size int, lookbackPeriod
 		size = len(r.desc.Partitions)
 	}
 
-	lookbackUntil := now.Add(-lookbackPeriod).Unix()
+	var lookbackUntil int64
+	if lookbackPeriod > 0 {
+		lookbackUntil = now.Add(-lookbackPeriod).Unix()
+	}
 
 	// Initialise the random generator used to select instances in the ring.
 	// There are no zones

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -199,28 +199,10 @@ func (r *PartitionRing) shuffleShard(identifier string, size int, lookbackPeriod
 			}
 
 			var (
-				shouldInclude bool
-				shouldExtend  bool
+				withinLookbackPeriod = lookbackPeriod > 0 && p.GetStateTimestamp() >= lookbackUntil
+				shouldExtend         = withinLookbackPeriod
+				shouldInclude        = p.IsActive() || withinLookbackPeriod
 			)
-
-			// Check whether the partition should be included in the result and/or the result set extended.
-			if lookbackPeriod > 0 {
-				if p.IsActive() {
-					// The partition is active. We should include it. The result set is extended only
-					// if the partition became active within the lookback window.
-					shouldInclude = true
-					shouldExtend = p.GetStateTimestamp() >= lookbackUntil
-				} else {
-					// The partition is inactive. We should include it (and then extend the result set)
-					// only if became inactive within the lookback window.
-					shouldInclude = p.GetStateTimestamp() >= lookbackUntil
-					shouldExtend = shouldInclude
-				}
-			} else {
-				// No lookback was provided. We only include active partitions and don't lookback.
-				shouldInclude = p.IsActive()
-				shouldExtend = false
-			}
 
 			// Either include or exclude the found partition.
 			if shouldInclude {

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -195,8 +195,8 @@ func (r *PartitionRing) shuffleShard(identifier string, size int, lookbackPeriod
 			}
 
 			var (
-				shouldInclude = false
-				shouldExtend  = false
+				shouldInclude bool
+				shouldExtend  bool
 			)
 
 			// Check whether the partition should be included in the result and/or the result set extended.

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -122,7 +122,7 @@ func (r *PartitionRing) ShuffleShard(identifier string, size int) (*PartitionRin
 }
 
 // ShuffleShardWithLookback is like ShuffleShard() but the returned subring includes all instances
-// that have been part of the identifier's shard since "now - lookbackPeriod".
+// that have been part of the identifier's shard in [now - lookbackPeriod, now] time window.
 //
 // This function can return a mix of ACTIVE and INACTIVE partitions. INACTIVE partitions are only
 // included if they were part of the identifier's shard within the lookbackPeriod.

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -3,6 +3,12 @@ package ring
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
+	"time"
+
+	"golang.org/x/exp/slices"
+
+	shardUtil "github.com/grafana/dskit/ring/shard"
 )
 
 var ErrNoActivePartitionFound = fmt.Errorf("no active partition found")
@@ -27,6 +33,9 @@ type PartitionRing struct {
 
 	// ownersByPartition is a map where the key is the partition ID and the value is a list of owner IDs.
 	ownersByPartition map[int32][]string
+
+	// shuffleShardCache is used to cache subrings generated with shuffle sharding.
+	shuffleShardCache *partitionRingShuffleShardCache
 }
 
 func NewPartitionRing(desc PartitionRingDesc) *PartitionRing {
@@ -35,6 +44,7 @@ func NewPartitionRing(desc PartitionRingDesc) *PartitionRing {
 		ringTokens:        desc.tokens(),
 		partitionByToken:  desc.partitionByToken(),
 		ownersByPartition: desc.ownersByPartition(),
+		shuffleShardCache: newPartitionRingShuffleShardCache(),
 	}
 }
 
@@ -75,9 +85,225 @@ func (r *PartitionRing) ActivePartitionForKey(key uint32) (int32, error) {
 	return 0, ErrNoActivePartitionFound
 }
 
+// ShuffleShard returns a subring for the provided identifier (eg. a tenant ID)
+// and size (number of partitions).
+//
+// The algorithm used to build the subring is a shuffle sharder based on probabilistic
+// hashing. We pick N unique partitions, walking the ring starting from random but
+// predictable numbers. The random generator is initialised with a seed based on the
+// provided identifier.
+//
+// This function returns a subring containing ONLY ACTIVE partitions.
+//
+// This function supports caching.
+//
+// This implementation guarantees:
+//
+//   - Stability: given the same ring, two invocations returns the same result.
+//
+//   - Consistency: adding/removing 1 partition from the ring generates a resulting
+//     subring with no more then 1 difference.
+//
+//   - Shuffling: probabilistically, for a large enough cluster each identifier gets a different
+//     set of instances, with a reduced number of overlapping instances between two identifiers.
+func (r *PartitionRing) ShuffleShard(identifier string, size int) (*PartitionRing, error) {
+	if cached := r.shuffleShardCache.getSubring(identifier, size); cached != nil {
+		return cached, nil
+	}
+
+	subring, err := r.shuffleShard(identifier, size, 0, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	r.shuffleShardCache.setSubring(identifier, size, subring)
+	return subring, nil
+}
+
+// ShuffleShardWithLookback is like ShuffleShard() but the returned subring includes all instances
+// that have been part of the identifier's shard since "now - lookbackPeriod".
+//
+// This function can return a mix of ACTIVE and INACTIVE partitions. INACTIVE partitions are only
+// included if they were part of the identifier's shard within the lookbackPeriod.
+//
+// This function supports caching, but the cache will only be effective if successive calls for the
+// same identifier are with the same lookbackPeriod and increasing values of now.
+func (r *PartitionRing) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) (*PartitionRing, error) {
+	if cached := r.shuffleShardCache.getSubringWithLookback(identifier, size, lookbackPeriod, now); cached != nil {
+		return cached, nil
+	}
+
+	subring, err := r.shuffleShard(identifier, size, lookbackPeriod, now)
+	if err != nil {
+		return nil, err
+	}
+
+	r.shuffleShardCache.setSubringWithLookback(identifier, size, lookbackPeriod, now, subring)
+	return subring, nil
+}
+
+func (r *PartitionRing) shuffleShard(identifier string, size int, lookbackPeriod time.Duration, now time.Time) (*PartitionRing, error) {
+	// If the size is too small or too large, run with a size equal to the total number of partitions.
+	// We have to run the function anyway because the logic may filter out some INACTIVE partitions.
+	if size <= 0 || size >= len(r.desc.Partitions) {
+		size = len(r.desc.Partitions)
+	}
+
+	lookbackUntil := now.Add(-lookbackPeriod).Unix()
+
+	// Initialise the random generator used to select instances in the ring.
+	// There are no zones
+	random := rand.New(rand.NewSource(shardUtil.ShuffleShardSeed(identifier, "")))
+
+	// To select one more instance while guaranteeing the "consistency" property,
+	// we do pick a random value from the generator and resolve uniqueness collisions
+	// (if any) continuing walking the ring.
+	tokensCount := len(r.ringTokens)
+
+	result := make(map[int32]struct{}, size)
+	exclude := map[int32]struct{}{}
+
+	for len(result) < size {
+		start := searchToken(r.ringTokens, random.Uint32())
+		iterations := 0
+		found := false
+
+		for p := start; !found && iterations < tokensCount; p++ {
+			iterations++
+
+			// Wrap p around in the ring.
+			if p >= tokensCount {
+				p %= tokensCount
+			}
+
+			pid, ok := r.partitionByToken[Token(r.ringTokens[p])]
+			if !ok {
+				return nil, ErrInconsistentTokensInfo
+			}
+
+			// Ensure the partition has not already been included or excluded.
+			if _, ok := result[pid]; ok {
+				continue
+			}
+			if _, ok := exclude[pid]; ok {
+				continue
+			}
+
+			p, ok := r.desc.Partitions[pid]
+			if !ok {
+				return nil, ErrInconsistentTokensInfo
+			}
+
+			var (
+				shouldInclude = false
+				shouldExtend  = false
+			)
+
+			// Check whether the partition should be included in the result and/or the result set extended.
+			if lookbackPeriod > 0 {
+				if p.IsActive() {
+					// The partition is active. We should include it. The result set is extended only
+					// if the partition became active within the lookback window.
+					shouldInclude = true
+					shouldExtend = p.GetStateTimestamp() >= lookbackUntil
+				} else {
+					// The partition is inactive. We should include it (and then extend the result set)
+					// only if became inactive within the lookback window.
+					shouldInclude = p.GetStateTimestamp() >= lookbackUntil
+					shouldExtend = shouldInclude
+				}
+			} else {
+				// No lookback was provided. We only include active partitions and don't lookback.
+				shouldInclude = p.IsActive()
+				shouldExtend = false
+			}
+
+			// Either include or exclude the found partition.
+			if shouldInclude {
+				result[pid] = struct{}{}
+			} else {
+				exclude[pid] = struct{}{}
+			}
+
+			// Extend the shard, if requested.
+			if shouldExtend {
+				size++
+			}
+
+			// We can stop searching for other partitions only if this partition was included
+			// and no extension was requested, which means it's the "stop partition" for this cycle.
+			if shouldInclude && !shouldExtend {
+				found = true
+			}
+		}
+
+		// If we iterated over all tokens, and no new partition has been found, we can stop looking for more partitions.
+		if !found {
+			break
+		}
+	}
+
+	return NewPartitionRing(r.desc.WithPartitions(result)), nil
+}
+
 // PartitionsCount returns the number of partitions in the ring.
 func (r *PartitionRing) PartitionsCount() int {
 	return len(r.desc.Partitions)
+}
+
+// Partitions returns the partitions in the ring.
+// The returned slice is a deep copy, so the caller can freely manipulate it.
+func (r *PartitionRing) Partitions() []PartitionDesc {
+	res := make([]PartitionDesc, 0, len(r.desc.Partitions))
+
+	for _, partition := range r.desc.Partitions {
+		res = append(res, partition.Clone())
+	}
+
+	return res
+}
+
+// PartitionIDs returns a list of all partition IDs in the ring.
+// The returned slice is a copy, so the caller can freely manipulate it.
+func (r *PartitionRing) PartitionIDs() []int32 {
+	ids := make([]int32, 0, len(r.desc.Partitions))
+
+	for id := range r.desc.Partitions {
+		ids = append(ids, id)
+	}
+
+	slices.Sort(ids)
+	return ids
+}
+
+// ActivePartitionIDs returns a list of all ACTIVE partition IDs in the ring.
+// The returned slice is a copy, so the caller can freely manipulate it.
+func (r *PartitionRing) ActivePartitionIDs() []int32 {
+	ids := make([]int32, 0, len(r.desc.Partitions))
+
+	for id, partition := range r.desc.Partitions {
+		if partition.IsActive() {
+			ids = append(ids, id)
+		}
+	}
+
+	slices.Sort(ids)
+	return ids
+}
+
+// InactivePartitionIDs returns a list of all INACTIVE partition IDs in the ring.
+// The returned slice is a copy, so the caller can freely manipulate it.
+func (r *PartitionRing) InactivePartitionIDs() []int32 {
+	ids := make([]int32, 0, len(r.desc.Partitions))
+
+	for id, partition := range r.desc.Partitions {
+		if !partition.IsActive() {
+			ids = append(ids, id)
+		}
+	}
+
+	slices.Sort(ids)
+	return ids
 }
 
 func (r *PartitionRing) String() string {

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -1,11 +1,17 @@
 package ring
 
 import (
+	"fmt"
+	"math"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 func TestPartitionRing_ActivePartitionForKey(t *testing.T) {
@@ -143,6 +149,775 @@ func BenchmarkPartitionRing_ActivePartitionForKey(b *testing.B) {
 		}
 	}
 }
+func TestPartitionRing_ShuffleShard(t *testing.T) {
+	t.Run("should honor the shard size", func(t *testing.T) {
+		const numActivePartitions = 5
+
+		ring := createPartitionRingWithPartitions(numActivePartitions, 0)
+
+		// Request a shard size up to the number of existing partitions.
+		for shardSize := 1; shardSize <= numActivePartitions; shardSize++ {
+			subring, err := ring.ShuffleShard("tenant-id", shardSize)
+			require.NoError(t, err)
+			assert.Equal(t, shardSize, subring.PartitionsCount())
+		}
+
+		// Request a shard size greater than the number of existing partitions.
+		subring, err := ring.ShuffleShard("tenant-id", numActivePartitions+1)
+		require.NoError(t, err)
+		assert.Equal(t, numActivePartitions, subring.PartitionsCount())
+	})
+
+	t.Run("should never return INACTIVE partitions", func(t *testing.T) {
+		const (
+			numActivePartitions   = 5
+			numInactivePartitions = 5
+		)
+
+		ring := createPartitionRingWithPartitions(numActivePartitions, numInactivePartitions)
+
+		for shardSize := 1; shardSize <= numActivePartitions+numInactivePartitions; shardSize++ {
+			subring, err := ring.ShuffleShard("tenant-id", shardSize)
+			require.NoError(t, err)
+
+			for _, partition := range subring.Partitions() {
+				assert.Equal(t, PartitionActive, partition.State)
+			}
+		}
+	})
+}
+
+// This test asserts on shard stability across multiple invocations and given the same input ring.
+func TestPartitionRing_ShuffleShard_Stability(t *testing.T) {
+	var (
+		numTenants            = 100
+		numActivePartitions   = 50
+		numInactivePartitions = 10
+		numInvocations        = 10
+		shardSizes            = []int{3, 6, 9, 12, 15}
+	)
+
+	// Initialise the ring.
+	ring := createPartitionRingWithPartitions(numActivePartitions, numInactivePartitions)
+
+	for i := 1; i <= numTenants; i++ {
+		tenantID := fmt.Sprintf("%d", i)
+
+		for _, size := range shardSizes {
+			expectedSubring, err := ring.ShuffleShard(tenantID, size)
+			require.NoError(t, err)
+
+			// Assert that multiple invocations generate the same exact shard.
+			for n := 0; n < numInvocations; n++ {
+				actualSubring, err := ring.ShuffleShard(tenantID, size)
+				require.NoError(t, err)
+				assert.Equal(t, expectedSubring.desc, actualSubring.desc)
+			}
+		}
+	}
+}
+
+func TestPartitionRing_ShuffleShard_Shuffling(t *testing.T) {
+	var (
+		numTenants          = 1000
+		numActivePartitions = 90
+		shardSize           = 3
+
+		// This is the expected theoretical distribution of matching partitions
+		// between different shards, given the settings above. It has been computed
+		// using this spreadsheet:
+		// https://docs.google.com/spreadsheets/d/1FXbiWTXi6bdERtamH-IfmpgFq1fNL4GP_KX_yJvbRi4/edit
+		theoreticalMatchings = map[int]float64{
+			0: 90.2239,
+			1: 9.55312,
+			2: 0.22217,
+			3: 0.00085,
+		}
+	)
+
+	// Initialise the ring.
+	ring := createPartitionRingWithPartitions(numActivePartitions, 0)
+
+	// Compute the shard for each tenant.
+	partitionsByTenant := map[string][]int32{}
+
+	for i := 1; i <= numTenants; i++ {
+		tenantID := fmt.Sprintf("%d", i)
+
+		subring, err := ring.ShuffleShard(tenantID, shardSize)
+		require.NoError(t, err)
+
+		partitionsByTenant[tenantID] = subring.PartitionIDs()
+	}
+
+	// Compute the distribution of matching partitions between every combination of shards.
+	// The shards comparison is not optimized, but it's fine for a test.
+	distribution := map[int]int{}
+
+	for currTenant, currPartitions := range partitionsByTenant {
+		for otherTenant, otherPartitions := range partitionsByTenant {
+			if currTenant == otherTenant {
+				continue
+			}
+
+			numMatching := 0
+			for _, c := range currPartitions {
+				if slices.Contains(otherPartitions, c) {
+					numMatching++
+				}
+			}
+
+			distribution[numMatching]++
+		}
+	}
+
+	maxCombinations := int(math.Pow(float64(numTenants), 2)) - numTenants
+	for numMatching, probability := range theoreticalMatchings {
+		// We allow a max deviance of 10% compared to the theoretical probability,
+		// clamping it between 1% and 0.2% boundaries.
+		maxDeviance := math.Min(1, math.Max(0.2, probability*0.1))
+
+		actual := (float64(distribution[numMatching]) / float64(maxCombinations)) * 100
+		assert.InDelta(t, probability, actual, maxDeviance, "numMatching: %d", numMatching)
+	}
+}
+
+func TestPartitionRing_ShuffleShard_ConsistencyOnPartitionsTopologyChange(t *testing.T) {
+	type change string
+
+	type scenario struct {
+		name          string
+		numPartitions int
+		shardSize     int
+		ringChange    change
+	}
+
+	const (
+		numTenants              = 100
+		addActivePartition      = change("add-active-partition")
+		switchInactivePartition = change("switch-inactive-partition")
+		removeActivePartition   = change("remove-active-partition")
+		removeInactivePartition = change("remove-inactive-partition")
+	)
+
+	// Generate all test scenarios.
+	var scenarios []scenario
+	for _, numPartitions := range []int{20, 30, 40, 50} {
+		for _, shardSize := range []int{3, 6, 9, 12, 15} {
+			for _, c := range []change{addActivePartition, switchInactivePartition, removeActivePartition, removeInactivePartition} {
+				scenarios = append(scenarios, scenario{
+					name:          fmt.Sprintf("partitions = %d, shard size = %d, ring operation = %s", numPartitions, shardSize, c),
+					numPartitions: numPartitions,
+					shardSize:     shardSize,
+					ringChange:    c,
+				})
+			}
+		}
+	}
+
+	for _, s := range scenarios {
+		s := s
+
+		t.Run(s.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Always include 5 inactive partitions.
+			ring := createPartitionRingWithPartitions(s.numPartitions, 5)
+
+			// Compute the initial shard for each tenant.
+			initial := map[int][]int32{}
+			for id := 0; id < numTenants; id++ {
+				subring, err := ring.ShuffleShard(fmt.Sprintf("%d", id), s.shardSize)
+				require.NoError(t, err)
+				initial[id] = subring.PartitionIDs()
+			}
+
+			// Update the ring.
+			switch s.ringChange {
+			case addActivePartition:
+				desc := &(ring.desc)
+				desc.AddPartition(int32(s.numPartitions+1), PartitionActive, time.Now())
+				ring = NewPartitionRing(*desc)
+			case switchInactivePartition:
+				// Switch to first active partition to inactive.
+				desc := &(ring.desc)
+				desc.UpdatePartitionState(ring.ActivePartitionIDs()[0], PartitionInactive, time.Now())
+				ring = NewPartitionRing(*desc)
+			case removeActivePartition:
+				// Remove the first active partition.
+				desc := &(ring.desc)
+				desc.RemovePartition(ring.ActivePartitionIDs()[0])
+				ring = NewPartitionRing(*desc)
+			case removeInactivePartition:
+				// Remove the first inactive partition.
+				desc := &(ring.desc)
+				desc.RemovePartition(ring.InactivePartitionIDs()[0])
+				ring = NewPartitionRing(*desc)
+			}
+
+			// Compute the updated shard for each tenant and compare it with the initial one.
+			// If the "consistency" property is guaranteed, we expect no more than 1 different
+			// partition in the updated shard.
+			for id := 0; id < numTenants; id++ {
+				subring, err := ring.ShuffleShard(fmt.Sprintf("%d", id), s.shardSize)
+				require.NoError(t, err)
+				updated := subring.PartitionIDs()
+
+				added, removed := comparePartitionIDs(initial[id], updated)
+				assert.LessOrEqual(t, len(added), 1)
+				assert.LessOrEqual(t, len(removed), 1)
+			}
+		})
+	}
+}
+
+func TestPartitionRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
+	ring := createPartitionRingWithPartitions(30, 0)
+
+	// Get the replication set with shard size = 3.
+	firstShard, err := ring.ShuffleShard("tenant-id", 3)
+	require.NoError(t, err)
+	assert.Equal(t, 3, firstShard.PartitionsCount())
+	firstPartitions := firstShard.PartitionIDs()
+
+	// Increase shard size to 6.
+	secondShard, err := ring.ShuffleShard("tenant-id", 6)
+	require.NoError(t, err)
+	assert.Equal(t, 6, secondShard.PartitionsCount())
+	secondPartitions := secondShard.PartitionIDs()
+
+	for _, id := range firstPartitions {
+		assert.True(t, slices.Contains(secondPartitions, id), "new shard is expected to include previous partition %s", id)
+	}
+
+	// Increase shard size to 9.
+	thirdShard, err := ring.ShuffleShard("tenant-id", 9)
+	require.NoError(t, err)
+	assert.Equal(t, 9, thirdShard.PartitionsCount())
+	thirdPartitions := thirdShard.PartitionIDs()
+
+	for _, id := range secondPartitions {
+		assert.True(t, slices.Contains(thirdPartitions, id), "new shard is expected to include previous partition %s", id)
+	}
+
+	// Decrease shard size to 6.
+	fourthShard, err := ring.ShuffleShard("tenant-id", 6)
+	require.NoError(t, err)
+	assert.Equal(t, 6, fourthShard.PartitionsCount())
+	fourthPartitions := fourthShard.PartitionIDs()
+
+	// We expect to have the same exact instances we had when the shard size was 6.
+	assert.Equal(t, secondPartitions, fourthPartitions)
+
+	// Decrease shard size to 3.
+	fifthShard, err := ring.ShuffleShard("tenant-id", 3)
+	require.NoError(t, err)
+	assert.Equal(t, 3, fifthShard.PartitionsCount())
+	fifthPartitions := fifthShard.PartitionIDs()
+
+	// We expect to have the same exact instances we had when the shard size was 3.
+	assert.Equal(t, firstPartitions, fifthPartitions)
+}
+
+func TestPartitionRing_ShuffleShardWithLookback(t *testing.T) {
+	type eventType int
+
+	const (
+		add eventType = iota
+		update
+		remove
+		test
+
+		lookbackPeriod = time.Hour
+		userID         = "user-1"
+	)
+
+	now := time.Now()
+	outsideLookback := now.Add(-2 * lookbackPeriod)
+	withinLookback := now.Add(-lookbackPeriod / 2)
+
+	type event struct {
+		what          eventType
+		partitionID   int32
+		partitionDesc PartitionDesc
+		shardSize     int
+		expected      []int32
+	}
+
+	tests := map[string]struct {
+		partitionTokens map[int32][]uint32
+		timeline        []event
+	}{
+		"shard size > number of partitions": {
+			partitionTokens: map[int32][]uint32{
+				0: {userToken(userID, "", 0) + 1},
+				1: {userToken(userID, "", 1) + 1},
+				2: {userToken(userID, "", 2) + 1},
+			},
+			timeline: []event{
+				{what: add, partitionID: 0, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 1, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 4, expected: []int32{0, 1, 2}},
+			},
+		},
+		"shard size < number of partitions": {
+			partitionTokens: map[int32][]uint32{
+				0: {userToken(userID, "", 0) + 1},
+				1: {userToken(userID, "", 1) + 1},
+				2: {userToken(userID, "", 2) + 1},
+			},
+			timeline: []event{
+				{what: add, partitionID: 0, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 1, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 1, expected: []int32{0}},
+			},
+		},
+		"new partitions added": {
+			partitionTokens: map[int32][]uint32{
+				0: {userToken(userID, "", 0) + 1},
+				1: {userToken(userID, "", 2) + 1},
+				2: {userToken(userID, "", 1) + 1},
+			},
+			timeline: []event{
+				{what: add, partitionID: 0, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 1, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{0, 1}},
+				{what: add, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, withinLookback)},
+				{what: test, shardSize: 2, expected: []int32{0, 1, 2}},
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{0, 2}},
+			},
+		},
+		"shard size = 2, partition is marked as inactive then marked as active again": {
+			partitionTokens: map[int32][]uint32{
+				0: {userToken(userID, "", 1) + 1},
+				1: {userToken(userID, "", 2) + 1},
+				2: {userToken(userID, "", 0) + 1},
+			},
+			timeline: []event{
+				{what: add, partitionID: 0, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 1, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 0}},
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, withinLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
+				// Partition 2 still inactive, but now falls outside the lookback period, there's no need to look back to partition 1
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{1, 0}},
+				// Partition 2 becomes active again
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, withinLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
+				// Partition 2 still active, but now falls outside the lookback period, there's no need to look back to partition 1
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 0}},
+			},
+		},
+		"shard size = 2, partitions marked as inactive, deleted, and re-added": {
+			partitionTokens: map[int32][]uint32{
+				0: {userToken(userID, "", 1) + 1},
+				1: {userToken(userID, "", 2) + 1},
+				2: {userToken(userID, "", 0) + 1},
+			},
+			timeline: []event{
+				{what: add, partitionID: 0, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 1, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 0}},
+				// Partition 2 switches to inactive
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, withinLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
+				// Partition 2 still inactive, but now falls outside the lookback period, there's no need to look back to partition 1
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{1, 0}},
+				// Partition 2 now gone
+				{what: remove, partitionID: 2},
+				{what: test, shardSize: 2, expected: []int32{1, 0}},
+				// Partition 2 becomes active again
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, withinLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
+				// Partition 2 still active, but now falls outside the lookback period, there's no need to look back to partition 1
+				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 2, expected: []int32{2, 0}},
+			},
+		},
+		"increase shard size": {
+			partitionTokens: map[int32][]uint32{
+				0: {userToken(userID, "", 0) + 1},
+				1: {userToken(userID, "", 1) + 1},
+				2: {userToken(userID, "", 2) + 1},
+			},
+			timeline: []event{
+				{what: add, partitionID: 0, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 1, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: add, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
+				{what: test, shardSize: 1, expected: []int32{0}},
+				{what: test, shardSize: 2, expected: []int32{0, 1}},
+				{what: test, shardSize: 3, expected: []int32{0, 1, 2}},
+				{what: test, shardSize: 4, expected: []int32{0, 1, 2}},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ringDesc := NewPartitionRingDesc()
+
+			// Replay the events on the timeline.
+			for ix, event := range testData.timeline {
+				switch event.what {
+				case add, update:
+					var ok bool
+					event.partitionDesc.Tokens, ok = testData.partitionTokens[event.partitionID]
+					require.True(t, ok, "no tokens for partition %d", event.partitionID)
+					ringDesc.Partitions[event.partitionID] = event.partitionDesc
+				case remove:
+					delete(ringDesc.Partitions, event.partitionID)
+				case test:
+					// Create a new ring for every test so that it can create its own
+					ring := NewPartitionRing(*ringDesc)
+					shuffledRing, err := ring.ShuffleShardWithLookback(userID, event.shardSize, lookbackPeriod, now)
+					assert.NoError(t, err, "step %d", ix)
+					assert.ElementsMatch(t, event.expected, maps.Keys(shuffledRing.desc.Partitions), "step %d", ix)
+				}
+			}
+		})
+	}
+}
+
+func TestPartitionRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
+	// The goal of this test is NOT to ensure that the minimum required number of partitions
+	// are returned at any given time, BUT at least all required partitions are returned.
+	var (
+		numInitialPartitions = []int{9, 30, 60, 90}
+		numEvents            = 100
+		lookbackPeriod       = time.Hour
+		delayBetweenEvents   = 5 * time.Minute // 12 events / hour
+		userID               = "user-1"
+	)
+
+	for _, numPartitions := range numInitialPartitions {
+		numPartitions := numPartitions
+
+		t.Run(fmt.Sprintf("partitions: %d", numPartitions), func(t *testing.T) {
+			t.Parallel()
+
+			// Randomise the seed but log it in case we need to reproduce the test on failure.
+			seed := time.Now().UnixNano()
+			rnd := rand.New(rand.NewSource(seed))
+			t.Log("random generator seed:", seed)
+
+			// Initialise the ring.
+			ring := createPartitionRingWithPartitions(numPartitions, 0)
+
+			// The simulation starts with the minimum shard size. Random events can later increase it.
+			shardSize := 1
+
+			// Add the initial shard to the history.
+			currTime := time.Now()
+			subring, err := ring.shuffleShard(userID, shardSize, 0, currTime)
+			require.NoError(t, err)
+
+			history := map[time.Time][]int32{
+				currTime: subring.PartitionIDs(),
+			}
+
+			// Advance the time. The simulation assumes the initial ring contains partitions added
+			// since more than the lookback period.
+			currTime = currTime.Add(lookbackPeriod).Add(time.Minute)
+
+			// Simulate a progression of random events over the time and, at each iteration of the simuation,
+			// make sure the subring includes all non-removed partitions picked from previous versions of the
+			// ring up until the lookback period.
+			nextPartitionID := ring.PartitionsCount()
+
+			for i := 1; i <= numEvents; i++ {
+				currTime = currTime.Add(delayBetweenEvents)
+
+				switch r := rnd.Intn(100); {
+				case r < 70:
+					// Add a partition.
+					desc := &(ring.desc)
+					desc.AddPartition(int32(nextPartitionID), PartitionActive, currTime)
+					ring = NewPartitionRing(*desc)
+
+					nextPartitionID++
+				case r < 80:
+					// Switch an active partition to inactive.
+					activeIDs := ring.ActivePartitionIDs()
+					if len(activeIDs) > 0 {
+						// Tests are reproducible because the list of partition IDs is sorted and the random
+						// generator is initialised with a known seed.
+						idToSwitch := int32(rnd.Intn(len(activeIDs)))
+
+						desc := &(ring.desc)
+						desc.UpdatePartitionState(idToSwitch, PartitionInactive, currTime)
+						ring = NewPartitionRing(*desc)
+					}
+				case r < 90:
+					// Remove an inactive partition.
+					inactiveIDs := ring.InactivePartitionIDs()
+					if len(inactiveIDs) > 0 {
+						// Tests are reproducible because the list of partition IDs is sorted and the random
+						// generator is initialised with a known seed.
+						idToRemove := int32(rnd.Intn(len(inactiveIDs)))
+
+						desc := &(ring.desc)
+						desc.RemovePartition(idToRemove)
+						ring = NewPartitionRing(*desc)
+
+						// Remove the partition from the history.
+						for ringTime, partitionIDs := range history {
+							for idx, partitionID := range partitionIDs {
+								if partitionID != idToRemove {
+									continue
+								}
+
+								history[ringTime] = append(partitionIDs[:idx], partitionIDs[idx+1:]...)
+								break
+							}
+						}
+					}
+				default:
+					// Scale up shard size.
+					shardSize++
+				}
+
+				// Add the current shard to the history.
+				subring, err = ring.shuffleShard(userID, shardSize, 0, time.Now())
+				require.NoError(t, err)
+				history[currTime] = subring.PartitionIDs()
+
+				// Ensure the shard with lookback includes all partitions from previous states of the ring.
+				subringWithLookback, err := ring.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, currTime)
+				require.NoError(t, err)
+				subringWithLookbackPartitionIDs := subringWithLookback.PartitionIDs()
+
+				for ringTime, ringPartitionIDs := range history {
+					if ringTime.Before(currTime.Add(-lookbackPeriod)) {
+						// This entry from the history is obsolete, we can remove it.
+						delete(history, ringTime)
+						continue
+					}
+
+					for _, expectedPartitionID := range ringPartitionIDs {
+						if !slices.Contains(subringWithLookbackPartitionIDs, expectedPartitionID) {
+							t.Fatalf(
+								"subring generated after event %d is expected to include partition %d from ring state at time %s but it's missing (actual partitions are: %v)",
+								i, expectedPartitionID, ringTime.String(), subringWithLookbackPartitionIDs)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestPartitionRing_ShuffleShardWithLookback_Caching(t *testing.T) {
+	var (
+		tenantID      = "user-1"
+		otherTenantID = "user-2"
+		subringSize   = 3
+		now           = time.Now()
+	)
+
+	desc := NewPartitionRingDesc()
+	desc.AddPartition(1, PartitionActive, now.Add(-1*time.Hour))
+	desc.AddPartition(2, PartitionActive, now.Add(-90*time.Minute))
+	desc.AddPartition(3, PartitionActive, now.Add(-6*time.Hour))
+	desc.AddPartition(4, PartitionActive, now.Add(-6*time.Hour))
+	desc.AddPartition(5, PartitionActive, now.Add(-6*time.Hour))
+	desc.AddPartition(6, PartitionActive, now.Add(-6*time.Hour))
+	ring := NewPartitionRing(*desc)
+
+	t.Run("identical requests", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(tenantID, subringSize, time.Minute, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(tenantID, subringSize, time.Minute, now)
+		require.NoError(t, err)
+
+		require.Same(t, first, second)
+		require.Equal(t, []int32{2, 3, 5}, first.PartitionIDs())
+	})
+
+	t.Run("different shard size", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(tenantID, subringSize, time.Minute, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(tenantID, subringSize+1, time.Minute, now)
+		require.NoError(t, err)
+
+		require.NotSame(t, first, second)
+		require.Equal(t, []int32{2, 3, 5}, first.PartitionIDs())
+		require.Equal(t, []int32{1, 2, 3, 5}, second.PartitionIDs())
+	})
+
+	t.Run("different identifiers", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(tenantID, subringSize, time.Minute, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, time.Minute, now)
+		require.NoError(t, err)
+
+		require.NotSame(t, first, second)
+		require.Equal(t, []int32{2, 3, 5}, first.PartitionIDs())
+		require.Equal(t, []int32{1, 4, 6}, second.PartitionIDs())
+	})
+
+	t.Run("different lookback windows", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(tenantID, subringSize, 30*time.Minute, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(tenantID, subringSize, 80*time.Minute, now)
+		require.NoError(t, err)
+
+		third, err := ring.ShuffleShardWithLookback(tenantID, subringSize, 100*time.Minute, now)
+		require.NoError(t, err)
+
+		require.NotSame(t, first, second)
+		require.NotSame(t, first, third)
+		require.Equal(t, []int32{2, 3, 5}, first.PartitionIDs())
+		require.Equal(t, []int32{2, 3, 5}, second.PartitionIDs())
+		require.Equal(t, []int32{2, 3, 5, 6}, third.PartitionIDs())
+	})
+
+	t.Run("same lookback window at different times, both over a period touching the most recent partition state change", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 80*time.Minute, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 80*time.Minute, now.Add(5*time.Minute))
+		require.NoError(t, err)
+
+		require.Same(t, first, second)
+		require.Equal(t, []int32{1, 2, 4, 6}, first.PartitionIDs())
+		require.Equal(t, []int32{1, 2, 4, 6}, second.PartitionIDs())
+	})
+
+	t.Run("same lookback window at different times, crossing the period of the most recent partition state change", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 80*time.Minute, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 80*time.Minute, now.Add(30*time.Minute))
+		require.NoError(t, err)
+
+		require.NotSame(t, first, second)
+		require.Equal(t, []int32{1, 2, 4, 6}, first.PartitionIDs())
+		require.Equal(t, []int32{1, 4, 6}, second.PartitionIDs())
+	})
+
+	t.Run("same lookback window at different times, crossing the period of the 2 most recent partition state changes", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 100*time.Minute, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 100*time.Minute, now.Add(60*time.Minute))
+		require.NoError(t, err)
+
+		require.NotSame(t, first, second)
+		require.Equal(t, []int32{1, 2, 4, 5, 6}, first.PartitionIDs())
+		require.Equal(t, []int32{1, 4, 6}, second.PartitionIDs())
+	})
+
+	t.Run("same lookback window at different alternate times, crossing the period of the most recent partition state change", func(t *testing.T) {
+		firstEarly, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 62*time.Minute, now)
+		require.NoError(t, err)
+
+		firstLate, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 62*time.Minute, now.Add(5*time.Minute))
+		require.NoError(t, err)
+
+		require.NotSame(t, firstEarly, firstLate)
+		require.Equal(t, []int32{1, 2, 4, 6}, firstEarly.PartitionIDs())
+		require.Equal(t, []int32{1, 4, 6}, firstLate.PartitionIDs())
+
+		// Run again the same requests.
+		secondEarly, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 62*time.Minute, now)
+		require.NoError(t, err)
+
+		secondLate, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 62*time.Minute, now.Add(5*time.Minute))
+		require.NoError(t, err)
+
+		require.NotSame(t, secondEarly, secondLate)
+		require.Equal(t, firstEarly.PartitionIDs(), secondEarly.PartitionIDs())
+		require.Equal(t, firstLate.PartitionIDs(), secondLate.PartitionIDs())
+
+		// The early cached entry should have been invalidated.
+		require.NotSame(t, firstEarly, secondEarly)
+
+		// The late cached entry is preserved because cache skips caching an entry if its timestamp is older
+		// than the one already cached.
+		require.Same(t, firstLate, secondLate)
+	})
+
+	t.Run("a lookback window that effectively includes all partitions", func(t *testing.T) {
+		first, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 12*time.Hour, now)
+		require.NoError(t, err)
+
+		second, err := ring.ShuffleShardWithLookback(otherTenantID, subringSize, 12*time.Hour, now.Add(30*time.Minute))
+		require.NoError(t, err)
+
+		require.Same(t, first, second)
+		require.Equal(t, []int32{1, 2, 3, 4, 5, 6}, first.PartitionIDs())
+		require.Equal(t, []int32{1, 2, 3, 4, 5, 6}, second.PartitionIDs())
+	})
+}
+
+func TestPartitionRing_ShuffleShardWithLookback_CachingConcurrency(t *testing.T) {
+	const (
+		numWorkers            = 10
+		numRequestsPerWorker  = 1000
+		numActivePartitions   = 100
+		numInactivePartitions = 10
+		shardSize             = 3
+		lookback              = time.Hour
+	)
+
+	ring := createPartitionRingWithPartitions(numActivePartitions, numInactivePartitions)
+
+	// Since partitions are created at time.Now(), we to advance the test mocked time
+	// so that we're outside the lookback window (otherwise there's no caching involved).
+	now := time.Now().Add(2 * time.Hour)
+
+	// Start the workers.
+	wg := sync.WaitGroup{}
+	wg.Add(numWorkers)
+
+	for w := 0; w < numWorkers; w++ {
+		go func(workerID int) {
+			defer wg.Done()
+
+			// Get the subring once. This is the one expected from subsequent requests.
+			userID := fmt.Sprintf("user-%d", workerID)
+			expected, err := ring.ShuffleShardWithLookback(userID, shardSize, lookback, now)
+			require.NoError(t, err)
+
+			for r := 0; r < numRequestsPerWorker; r++ {
+				actual, err := ring.ShuffleShardWithLookback(userID, shardSize, lookback, now)
+				require.NoError(t, err)
+				require.Equal(t, expected, actual)
+
+				// Get the subring for a new user each time too, in order to stress the setter too
+				// (if we only read from the cache there's no read/write concurrent access).
+				_, err = ring.ShuffleShardWithLookback(fmt.Sprintf("stress-%d", r), 3, lookback, now)
+				require.NoError(t, err)
+			}
+		}(w)
+	}
+
+	// Wait until all workers have done.
+	wg.Wait()
+
+	// Ensure the cache was populated.
+	assert.NotEmpty(t, ring.shuffleShardCache.cacheWithLookback)
+	assert.Empty(t, ring.shuffleShardCache.cacheWithoutLookback)
+}
+
+func generatePartitionWithInfo(state PartitionState, stateTS time.Time) PartitionDesc {
+	return PartitionDesc{
+		State:          state,
+		StateTimestamp: stateTS.Unix(),
+	}
+}
 
 func createPartitionRingWithPartitions(numActive, numInactive int) *PartitionRing {
 	desc := NewPartitionRingDesc()
@@ -155,4 +930,21 @@ func createPartitionRingWithPartitions(numActive, numInactive int) *PartitionRin
 	}
 
 	return NewPartitionRing(*desc)
+}
+
+// comparePartitionIDs returns the list of partition IDs which differ between the two lists.
+func comparePartitionIDs(first, second []int32) (added, removed []int32) {
+	for _, id := range first {
+		if !slices.Contains(second, id) {
+			removed = append(removed, id)
+		}
+	}
+
+	for _, id := range second {
+		if !slices.Contains(first, id) {
+			added = append(added, id)
+		}
+	}
+
+	return
 }

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -503,13 +503,13 @@ func TestPartitionRing_ShuffleShardWithLookback(t *testing.T) {
 				{what: test, shardSize: 2, expected: []int32{2, 0}},
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, withinLookback)},
 				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
-				// Partition 2 still inactive, but now falls outside the lookback period, there's no need to look back to partition 1
+				// Partition 2 still inactive, but now falls outside the lookback period, there's no need to include partition 1
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, outsideLookback)},
 				{what: test, shardSize: 2, expected: []int32{1, 0}},
 				// Partition 2 becomes active again
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, withinLookback)},
 				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
-				// Partition 2 still active, but now falls outside the lookback period, there's no need to look back to partition 1
+				// Partition 2 still active, but now falls outside the lookback period, there's no need to include partition 1
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
 				{what: test, shardSize: 2, expected: []int32{2, 0}},
 			},
@@ -528,7 +528,7 @@ func TestPartitionRing_ShuffleShardWithLookback(t *testing.T) {
 				// Partition 2 switches to inactive
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, withinLookback)},
 				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
-				// Partition 2 still inactive, but now falls outside the lookback period, there's no need to look back to partition 1
+				// Partition 2 still inactive, but now falls outside the lookback period, there's no need to include partition 1
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionInactive, outsideLookback)},
 				{what: test, shardSize: 2, expected: []int32{1, 0}},
 				// Partition 2 now gone
@@ -537,7 +537,7 @@ func TestPartitionRing_ShuffleShardWithLookback(t *testing.T) {
 				// Partition 2 becomes active again
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, withinLookback)},
 				{what: test, shardSize: 2, expected: []int32{2, 1, 0}},
-				// Partition 2 still active, but now falls outside the lookback period, there's no need to look back to partition 1
+				// Partition 2 still active, but now falls outside the lookback period, there's no need to include partition 1
 				{what: update, partitionID: 2, partitionDesc: generatePartitionWithInfo(PartitionActive, outsideLookback)},
 				{what: test, shardSize: 2, expected: []int32{2, 0}},
 			},

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -624,7 +624,7 @@ func TestPartitionRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.
 			}
 
 			// Advance the time. The simulation assumes the initial ring contains partitions added
-			// since more than the lookback period.
+			// outside of the lookback period.
 			currTime = currTime.Add(lookbackPeriod).Add(time.Minute)
 
 			// Simulate a progression of random events over the time and, at each iteration of the simuation,

--- a/ring/partitions_ring_shuffle_shard_cache.go
+++ b/ring/partitions_ring_shuffle_shard_cache.go
@@ -1,0 +1,96 @@
+package ring
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+type partitionRingShuffleShardCache struct {
+	mtx                  sync.RWMutex
+	cacheWithoutLookback map[subringCacheKey]*PartitionRing
+	cacheWithLookback    map[subringCacheKey]cachedSubringWithLookback[*PartitionRing]
+}
+
+func newPartitionRingShuffleShardCache() *partitionRingShuffleShardCache {
+	return &partitionRingShuffleShardCache{
+		cacheWithoutLookback: map[subringCacheKey]*PartitionRing{},
+		cacheWithLookback:    map[subringCacheKey]cachedSubringWithLookback[*PartitionRing]{},
+	}
+}
+
+func (r *partitionRingShuffleShardCache) setSubring(identifier string, size int, subring *PartitionRing) {
+	if subring == nil {
+		return
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	r.cacheWithoutLookback[subringCacheKey{identifier: identifier, shardSize: size}] = subring
+}
+
+func (r *partitionRingShuffleShardCache) getSubring(identifier string, size int) *PartitionRing {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	cached := r.cacheWithoutLookback[subringCacheKey{identifier: identifier, shardSize: size}]
+	if cached == nil {
+		return nil
+	}
+
+	return cached
+}
+
+func (r *partitionRingShuffleShardCache) setSubringWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time, subring *PartitionRing) {
+	if subring == nil {
+		return
+	}
+
+	var (
+		lookbackWindowStart                   = now.Add(-lookbackPeriod).Unix()
+		validForLookbackWindowsStartingBefore = int64(math.MaxInt64)
+	)
+
+	for _, partition := range subring.desc.Partitions {
+		stateChangedDuringLookbackWindow := partition.StateTimestamp >= lookbackWindowStart
+
+		if stateChangedDuringLookbackWindow && partition.StateTimestamp < validForLookbackWindowsStartingBefore {
+			validForLookbackWindowsStartingBefore = partition.StateTimestamp
+		}
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	// Only update cache if subring's lookback window starts later than the previously cached subring for this identifier,
+	// if there is one. This prevents cache thrashing due to different calls competing if their lookback windows start
+	// before and after the time a partition state has changed.
+	key := subringCacheKey{identifier: identifier, shardSize: size, lookbackPeriod: lookbackPeriod}
+
+	if existingEntry, haveCached := r.cacheWithLookback[key]; !haveCached || existingEntry.validForLookbackWindowsStartingAfter < lookbackWindowStart {
+		r.cacheWithLookback[key] = cachedSubringWithLookback[*PartitionRing]{
+			subring:                               subring,
+			validForLookbackWindowsStartingAfter:  lookbackWindowStart,
+			validForLookbackWindowsStartingBefore: validForLookbackWindowsStartingBefore,
+		}
+	}
+}
+
+func (r *partitionRingShuffleShardCache) getSubringWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) *PartitionRing {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	cached, ok := r.cacheWithLookback[subringCacheKey{identifier: identifier, shardSize: size, lookbackPeriod: lookbackPeriod}]
+	if !ok {
+		return nil
+	}
+
+	lookbackWindowStart := now.Add(-lookbackPeriod).Unix()
+	if lookbackWindowStart < cached.validForLookbackWindowsStartingAfter || lookbackWindowStart > cached.validForLookbackWindowsStartingBefore {
+		// The cached subring is not valid for the lookback window that has been requested.
+		return nil
+	}
+
+	return cached.subring
+}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -187,7 +187,7 @@ type Ring struct {
 	// Cache of shuffle-sharded subrings per identifier. Invalidated when topology changes.
 	// If set to nil, no caching is done (used by tests, and subrings).
 	shuffledSubringCache             map[subringCacheKey]*Ring
-	shuffledSubringWithLookbackCache map[subringCacheKey]cachedSubringWithLookback
+	shuffledSubringWithLookbackCache map[subringCacheKey]cachedSubringWithLookback[*Ring]
 
 	numMembersGaugeVec      *prometheus.GaugeVec
 	totalTokensGauge        prometheus.Gauge
@@ -202,8 +202,8 @@ type subringCacheKey struct {
 	lookbackPeriod time.Duration
 }
 
-type cachedSubringWithLookback struct {
-	subring                               *Ring
+type cachedSubringWithLookback[R any] struct {
+	subring                               R
 	validForLookbackWindowsStartingAfter  int64 // if the lookback window is from T to S, validForLookbackWindowsStartingAfter is the earliest value of T this cache entry is valid for
 	validForLookbackWindowsStartingBefore int64 // if the lookback window is from T to S, validForLookbackWindowsStartingBefore is the latest value of T this cache entry is valid for
 }
@@ -237,7 +237,7 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 		strategy:                         strategy,
 		ringDesc:                         &Desc{},
 		shuffledSubringCache:             map[subringCacheKey]*Ring{},
-		shuffledSubringWithLookbackCache: map[subringCacheKey]cachedSubringWithLookback{},
+		shuffledSubringWithLookbackCache: map[subringCacheKey]cachedSubringWithLookback[*Ring]{},
 		numMembersGaugeVec: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "ring_members",
 			Help:        "Number of members in the ring",
@@ -349,7 +349,7 @@ func (r *Ring) updateRingState(ringDesc *Desc) {
 		r.shuffledSubringCache = make(map[subringCacheKey]*Ring)
 	}
 	if r.shuffledSubringWithLookbackCache != nil {
-		r.shuffledSubringWithLookbackCache = make(map[subringCacheKey]cachedSubringWithLookback)
+		r.shuffledSubringWithLookbackCache = make(map[subringCacheKey]cachedSubringWithLookback[*Ring])
 	}
 
 	r.updateRingMetrics(rc)
@@ -676,7 +676,7 @@ func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 // operations (read only).
 //
 // This function supports caching, but the cache will only be effective if successive calls for the
-// same identifier are for increasing values of (now-lookbackPeriod).
+// same identifier are with the same lookbackPeriod and increasing values of now.
 func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ReadRing {
 	// Nothing to do if the shard size is not smaller then the actual ring.
 	if size <= 0 || r.InstancesCount() <= size {
@@ -1017,7 +1017,7 @@ func (r *Ring) setCachedShuffledSubringWithLookback(identifier string, size int,
 	key := subringCacheKey{identifier: identifier, shardSize: size, lookbackPeriod: lookbackPeriod}
 
 	if existingEntry, haveCached := r.shuffledSubringWithLookbackCache[key]; !haveCached || existingEntry.validForLookbackWindowsStartingAfter < lookbackWindowStart {
-		r.shuffledSubringWithLookbackCache[key] = cachedSubringWithLookback{
+		r.shuffledSubringWithLookbackCache[key] = cachedSubringWithLookback[*Ring]{
 			subring:                               subring,
 			validForLookbackWindowsStartingAfter:  lookbackWindowStart,
 			validForLookbackWindowsStartingBefore: validForLookbackWindowsStartingBefore,


### PR DESCRIPTION
**What this PR does**:

In #474 I've introduced the experimental `PartitionRing`. In this I'm adding support for shuffle sharding. The shuffle sharding implementation follows what we've already done in `Ring`. The main differences are:

- Partitions ring has no concept of zones (cause owners will be deployed cross zones, but that's another story)
- Partitions can either be in ACTIVE or INACTIVE state. This change the logic around which partitions are eligible to be picked by the shuffle sharding (see comments to `ShardSize()` and `ShardSizeWithLookback()` functions).
- Implementing cache for `PartitionRing` subrings is easier. `PartitionRing` is immutable by design, so we can just cache subrings inside it.

Note to reviewers:
- I haven't unit tested `partitionRingShuffleShardCache` because it's tested at an upper level by `TestPartitionRing_ShuffleShardWithLookback_Caching` and `TestPartitionRing_ShuffleShardWithLookback_CachingConcurrency`. I'm open to feedback here. I can also unit tests for `partitionRingShuffleShardCache` if desired.
- Most of the new tests added in `partition_ring_test.go` are an adaptation of existing shuffle sharding tests from `ring_test.go`. These tests have been very useful, in particular `TestPartitionRing_ShuffleShardWithLookback_CorrectnessWithFuzzy` which allowed me to spot a bug in the first `shuffleShard()` implementation, which was detected by other (simpler) unit tests.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
