### PR TITLE
Add more methods to memcachedClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
 * [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478
+* [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -628,3 +628,83 @@ func (c *MemcachedClient) FlushAll(ctx context.Context) error {
 		return err
 	})
 }
+
+func (c *MemcachedClient) touch(ctx context.Context, key string, ttl time.Duration, f func(ctx context.Context, key string, ttl time.Duration) error) error {
+	start := time.Now()
+	c.metrics.operations.WithLabelValues(opTouch).Inc()
+
+	err := f(ctx, key, ttl)
+	if err != nil {
+		level.Debug(c.logger).Log(
+			"msg", "failed to touch cache item",
+			"key", key,
+			"err", err,
+		)
+		c.trackError(opTouch, err)
+	} else {
+		c.metrics.duration.WithLabelValues(opTouch).Observe(time.Since(start).Seconds())
+	}
+
+	return err
+}
+
+func (c *MemcachedClient) increment(ctx context.Context, key string, delta uint64, f func(ctx context.Context, key string, delta uint64) (uint64, error)) (uint64, error) {
+	var (
+		newValue uint64
+		err      error
+	)
+	start := time.Now()
+	c.metrics.operations.WithLabelValues(opIncrement).Inc()
+
+	newValue, err = f(ctx, key, delta)
+	if err != nil {
+		level.Debug(c.logger).Log(
+			"msg", "failed to increment cache item",
+			"key", key,
+			"err", err,
+		)
+		c.trackError(opIncrement, err)
+	} else {
+		c.metrics.duration.WithLabelValues(opIncrement).Observe(time.Since(start).Seconds())
+	}
+
+	return newValue, err
+}
+
+func (c *MemcachedClient) compareAndSwap(ctx context.Context, key string, value []byte, ttl time.Duration, f func(ctx context.Context, key string, value []byte, ttl time.Duration) error) error {
+	start := time.Now()
+	c.metrics.operations.WithLabelValues(opCompareAndSwap).Inc()
+
+	err := f(ctx, key, value, ttl)
+	if err != nil {
+		level.Debug(c.logger).Log(
+			"msg", "failed to compareAndSwap cache item",
+			"key", key,
+			"err", err,
+		)
+		c.trackError(opCompareAndSwap, err)
+	} else {
+		c.metrics.dataSize.WithLabelValues(opCompareAndSwap).Observe(float64(len(value)))
+		c.metrics.duration.WithLabelValues(opCompareAndSwap).Observe(time.Since(start).Seconds())
+	}
+
+	return err
+}
+
+func (c *MemcachedClient) flushAll(ctx context.Context, f func(ctx context.Context) error) error {
+	start := time.Now()
+	c.metrics.operations.WithLabelValues(opFlush).Inc()
+
+	err := f(ctx)
+	if err != nil {
+		level.Debug(c.logger).Log(
+			"msg", "failed to flush all cache",
+			"err", err,
+		)
+		c.trackError(opFlush, err)
+	} else {
+		c.metrics.duration.WithLabelValues(opFlush).Observe(time.Since(start).Seconds())
+	}
+
+	return err
+}

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -44,8 +44,8 @@ type memcachedClientBackend interface {
 	GetMulti(keys []string, opts ...memcache.Option) (map[string]*memcache.Item, error)
 	Set(item *memcache.Item) error
 	Delete(key string) error
-	Increment(key string, delta uint64) (newValue uint64, err error)
-	Touch(key string, seconds int32) (err error)
+	Increment(key string, delta uint64) (uint64, error)
+	Touch(key string, seconds int32) error
 	Close()
 	CompareAndSwap(item *memcache.Item) error
 	FlushAll() error
@@ -333,7 +333,7 @@ func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 	})
 }
 
-func (c *MemcachedClient) Increment(ctx context.Context, key string, delta uint64) (newValue uint64, err error) {
+func (c *MemcachedClient) Increment(ctx context.Context, key string, delta uint64) (uint64, error) {
 	return c.increment(ctx, key, delta, func(ctx context.Context, key string, delta uint64) (uint64, error) {
 		var (
 			err      error
@@ -349,7 +349,7 @@ func (c *MemcachedClient) Increment(ctx context.Context, key string, delta uint6
 	})
 }
 
-func (c *MemcachedClient) Touch(ctx context.Context, key string, ttl time.Duration) (err error) {
+func (c *MemcachedClient) Touch(ctx context.Context, key string, ttl time.Duration) error {
 	return c.touch(ctx, key, ttl, func(ctx context.Context, key string, ttl time.Duration) error {
 		var err error
 		select {

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -291,24 +291,24 @@ func (m *mockMemcachedClientBackend) Delete(key string) error {
 	return nil
 }
 
-func (m *mockMemcachedClientBackend) Touch(key string, seconds int32) (err error) {
+func (m *mockMemcachedClientBackend) Touch(key string, seconds int32) error {
 	m.values[key].Expiration = seconds
 	return nil
 }
 
-func (m *mockMemcachedClientBackend) Increment(key string, delta uint64) (newValue uint64, err error) {
+func (m *mockMemcachedClientBackend) Increment(key string, delta uint64) (uint64, error) {
 	value, _ := strconv.ParseUint(string(m.values[key].Value), 10, 64)
 	value += delta
 	m.values[key].Value = []byte(strconv.FormatUint(value, 10))
 	return value, nil
 }
 
-func (m *mockMemcachedClientBackend) CompareAndSwap(item *memcache.Item) (err error) {
+func (m *mockMemcachedClientBackend) CompareAndSwap(item *memcache.Item) error {
 	m.values[item.Key] = item
 	return nil
 }
 
-func (m *mockMemcachedClientBackend) FlushAll() (err error) {
+func (m *mockMemcachedClientBackend) FlushAll() error {
 	m.values = make(map[string]*memcache.Item)
 	return nil
 }


### PR DESCRIPTION
Add Increment, Touch, CompareAndSwap, and FlushAll methods to the underlying Memcache client.

Include associated wrappers for the exported MemcachedClient object.

**What this PR does**:
Increase the number of MemcachedClient methods accessible to consumers.

**Which issue(s) this PR fixes**:
This pull request addresses an issue in a private repository, so it may not be directly linkable. 

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
