### PR TITLE
Add PartitionInstanceRing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.

--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -50,11 +50,11 @@ func (r *PartitionInstanceRing) GetReplicationSetsForOperation(op Operation) ([]
 	result := make([]ReplicationSet, 0, len(partitionsRingDesc.Partitions))
 
 	for partitionID := range partitionsRingDesc.Partitions {
-		ownerIDs := partitionsRing.UnsafePartitionOwnerIDs(partitionID)
+		ownerIDs := partitionsRing.PartitionOwnerIDs(partitionID)
 		instances := make([]InstanceDesc, 0, len(ownerIDs))
 
 		for _, instanceID := range ownerIDs {
-			instance, err := r.instancesRing.UnsafeGetInstance(instanceID)
+			instance, err := r.instancesRing.GetInstance(instanceID)
 			if err != nil {
 				// If an instance doesn't exist in the instances ring we don't return an error
 				// but lookup for other instances of the partition.

--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -86,8 +86,9 @@ func (r *PartitionInstanceRing) GetReplicationSetsForOperation(op Operation) ([]
 		}
 
 		result = append(result, ReplicationSet{
-			Instances: instances,
-			MaxErrors: len(instances) - 1, // We need response from at least 1 owner.
+			Instances:            instances,
+			MaxUnavailableZones:  len(instances) - 1, // We need response from at least 1 owner.
+			ZoneAwarenessEnabled: true,               // Partitions has no concept of zone, but we enable it in order to support ring's requests minimization feature.
 		})
 	}
 	return result, nil

--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -1,0 +1,122 @@
+package ring
+
+import (
+	"fmt"
+	"time"
+)
+
+type PartitionRingReader interface {
+	PartitionRing() *PartitionRing
+}
+
+// PartitionInstanceRing holds a partitions ring and a instances ring, and provide functions
+// to look up the intersection of the two (e.g. healthy instances by partition).
+type PartitionInstanceRing struct {
+	// partitionsRingReader and partitionsRing are mutually exclusive.
+	partitionsRingReader PartitionRingReader
+	partitionsRing       *PartitionRing
+
+	instancesRing    *Ring
+	heartbeatTimeout time.Duration
+}
+
+func NewPartitionInstanceRing(partitionsRingWatcher PartitionRingReader, instancesRing *Ring, heartbeatTimeout time.Duration) *PartitionInstanceRing {
+	return &PartitionInstanceRing{
+		partitionsRingReader: partitionsRingWatcher,
+		instancesRing:        instancesRing,
+		heartbeatTimeout:     heartbeatTimeout,
+	}
+}
+
+func newStaticPartitionInstanceRing(partitionsRing *PartitionRing, instancesRing *Ring, heartbeatTimeout time.Duration) *PartitionInstanceRing {
+	return &PartitionInstanceRing{
+		partitionsRing:   partitionsRing,
+		instancesRing:    instancesRing,
+		heartbeatTimeout: heartbeatTimeout,
+	}
+}
+
+func (r *PartitionInstanceRing) PartitionRing() *PartitionRing {
+	if r.partitionsRingReader != nil {
+		return r.partitionsRingReader.PartitionRing()
+	}
+
+	return r.partitionsRing
+}
+
+func (r *PartitionInstanceRing) InstanceRing() *Ring {
+	return r.instancesRing
+}
+
+// GetReplicationSetsForOperation returns one ReplicationSet for each partition in the ring.
+// A ReplicationSet is returned for every partition in ring. If there are no healthy owners
+// for a partition, an error is returned.
+func (r *PartitionInstanceRing) GetReplicationSetsForOperation(op Operation) ([]ReplicationSet, error) {
+	partitionsRing := r.PartitionRing()
+	partitionsRingDesc := partitionsRing.desc
+
+	if len(partitionsRingDesc.Partitions) == 0 {
+		return nil, ErrEmptyRing
+	}
+
+	now := time.Now()
+	result := make([]ReplicationSet, 0, len(partitionsRingDesc.Partitions))
+
+	for partitionID := range partitionsRingDesc.Partitions {
+		ownerIDs := partitionsRing.UnsafePartitionOwnerIDs(partitionID)
+		instances := make([]InstanceDesc, 0, len(ownerIDs))
+
+		for _, instanceID := range ownerIDs {
+			instance, err := r.instancesRing.UnsafeGetInstance(instanceID)
+			if err != nil {
+				// If an instance doesn't exist in the instances ring we don't return an error
+				// but lookup for other instances of the partition.
+				continue
+			}
+
+			if !instance.IsHealthy(op, r.heartbeatTimeout, now) {
+				continue
+			}
+
+			instances = append(instances, instance)
+		}
+
+		if len(instances) == 0 {
+			return nil, fmt.Errorf("partition %d: %w", partitionID, ErrTooManyUnhealthyInstances)
+		}
+
+		result = append(result, ReplicationSet{
+			Instances: instances,
+			MaxErrors: len(instances) - 1, // We need response from at least 1 owner.
+		})
+	}
+	return result, nil
+}
+
+// ShuffleShard wraps PartitionRing.ShuffleShard().
+//
+// The PartitionRing embedded in the returned PartitionInstanceRing is based on a snapshot of the partitions ring
+// at the time this function gets called. This means that subsequent changes to the partitions ring will not
+// be reflected in the returned PartitionInstanceRing.
+func (r *PartitionInstanceRing) ShuffleShard(identifier string, size int) (*PartitionInstanceRing, error) {
+	partitionsSubring, err := r.PartitionRing().ShuffleShard(identifier, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return newStaticPartitionInstanceRing(partitionsSubring, r.instancesRing, r.heartbeatTimeout), nil
+}
+
+// ShuffleShardWithLookback wraps PartitionRing.ShuffleShardWithLookback().
+//
+// The PartitionRing embedded in the returned PartitionInstanceRing is based on a snapshot of the partitions ring
+// at the time this function gets called. This means that subsequent changes to the partitions ring will not
+// be reflected in the returned PartitionInstanceRing.
+func (r *PartitionInstanceRing) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) (*PartitionInstanceRing, error) {
+	partitionsSubring, err := r.PartitionRing().ShuffleShardWithLookback(identifier, size, lookbackPeriod, now)
+	if err != nil {
+		return nil, err
+	}
+
+	return newStaticPartitionInstanceRing(partitionsSubring, r.instancesRing, r.heartbeatTimeout), nil
+}

--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -6,6 +6,8 @@ import (
 )
 
 type PartitionRingReader interface {
+	// PartitionRing returns a snapshot of the PartitionRing. This function must never return nil.
+	// If the ring is empty or unknown, an empty PartitionRing can be returned.
 	PartitionRing() *PartitionRing
 }
 

--- a/ring/partition_instance_ring_test.go
+++ b/ring/partition_instance_ring_test.go
@@ -1,0 +1,198 @@
+package ring
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
+	now := time.Now()
+	op := NewOp([]InstanceState{ACTIVE}, nil)
+	heartbeatTimeout := time.Minute
+
+	tests := map[string]struct {
+		partitionsRing PartitionRingDesc
+		instancesRing  *Desc
+		expectedErr    error
+		expectedSets   [][]string
+	}{
+		"should return error on empty partitions ring": {
+			partitionsRing: PartitionRingDesc{},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-1": {Id: "instance-1", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-2": {Id: "instance-2", State: ACTIVE, Timestamp: now.Unix()},
+			}},
+			expectedErr: ErrEmptyRing,
+		},
+		"should return error on empty instances ring": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					"instance-1": {OwnedPartition: 1},
+					"instance-2": {OwnedPartition: 2},
+				},
+			},
+			instancesRing: &Desc{},
+			expectedErr:   ErrTooManyUnhealthyInstances,
+		},
+		"should return replication sets with at least 1 instance per partition, if every partition has at least 1 healthy instance": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					"instance-1-a": {OwnedPartition: 1},
+					"instance-2-a": {OwnedPartition: 2},
+					"instance-2-b": {OwnedPartition: 2},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Timestamp: now.Unix()},
+			}},
+			expectedSets: [][]string{{"instance-1-a"}, {"instance-2-a", "instance-2-b"}},
+		},
+		"should return error if there are no healthy instances for a partition": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					"instance-1-a": {OwnedPartition: 1},
+					"instance-2-a": {OwnedPartition: 2},
+					"instance-2-b": {OwnedPartition: 2},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy.
+			}},
+			expectedErr: ErrTooManyUnhealthyInstances,
+		},
+		"should return replication sets excluding unhealthy instances as long as there's at least 1 healthy instance per partition": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					"instance-1-a": {OwnedPartition: 1},
+					"instance-1-b": {OwnedPartition: 1},
+					"instance-2-a": {OwnedPartition: 2},
+					"instance-2-b": {OwnedPartition: 2},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-1-b": {Id: "instance-1-a", State: LEAVING, Timestamp: now.Unix()}, // Unhealthy because of the state.
+				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy because of the heartbeat.
+			}},
+			expectedSets: [][]string{{"instance-1-a"}, {"instance-2-a"}},
+		},
+		"should NOT return error if an instance is missing in the instances ring but there's another healthy instance for the partition": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					"instance-1-a": {OwnedPartition: 1},
+					"instance-1-b": {OwnedPartition: 1}, // Missing in the instances ring.
+					"instance-2-a": {OwnedPartition: 2}, // Missing in the instances ring.
+					"instance-2-b": {OwnedPartition: 2},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Timestamp: now.Unix()},
+			}},
+			expectedSets: [][]string{{"instance-1-a"}, {"instance-2-b"}},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			for _, staticPartitionsRing := range []bool{false, true} {
+				t.Run(fmt.Sprintf("static partitions ring: %t", staticPartitionsRing), func(t *testing.T) {
+					var r *PartitionInstanceRing
+
+					partitionsRing := NewPartitionRing(testData.partitionsRing)
+					instancesRing := &Ring{ringDesc: testData.instancesRing}
+
+					if staticPartitionsRing {
+						r = newStaticPartitionInstanceRing(partitionsRing, instancesRing, heartbeatTimeout)
+					} else {
+						r = NewPartitionInstanceRing(partitionRingReaderMock{ring: partitionsRing}, instancesRing, heartbeatTimeout)
+					}
+
+					sets, err := r.GetReplicationSetsForOperation(op)
+					require.ErrorIs(t, err, testData.expectedErr)
+
+					// Build the actual replication sets to compare with the expected ones.
+					actual := make([][]string, 0, len(sets))
+					for _, set := range sets {
+						instanceIDs := set.GetIDs()
+						slices.Sort(instanceIDs)
+						actual = append(actual, instanceIDs)
+					}
+
+					assert.ElementsMatch(t, testData.expectedSets, actual)
+				})
+			}
+		})
+	}
+}
+
+func TestPartitionInstanceRing_ShuffleShard(t *testing.T) {
+	now := time.Now()
+
+	partitionsRing := NewPartitionRingDesc()
+	partitionsRing.AddPartition(1, PartitionActive, now.Add(-120*time.Minute))
+	partitionsRing.AddPartition(2, PartitionActive, now.Add(-30*time.Minute))
+	partitionsRing.AddPartition(3, PartitionActive, now.Add(-30*time.Minute))
+	partitionsRing.AddOrUpdateOwner("instance-1", OwnerActive, 1, now.Add(-30*time.Minute))
+	partitionsRing.AddOrUpdateOwner("instance-2", OwnerActive, 2, now.Add(-30*time.Minute))
+	partitionsRing.AddOrUpdateOwner("instance-3", OwnerActive, 3, now.Add(-30*time.Minute))
+
+	instancesRing := &Desc{Ingesters: map[string]InstanceDesc{
+		"instance-1": {Id: "instance-1", State: ACTIVE, Timestamp: time.Now().Unix()},
+		"instance-2": {Id: "instance-2", State: ACTIVE, Timestamp: time.Now().Unix()},
+		"instance-3": {Id: "instance-3", State: ACTIVE, Timestamp: time.Now().Unix()},
+	}}
+
+	r := NewPartitionInstanceRing(partitionRingReaderMock{ring: NewPartitionRing(*partitionsRing)}, &Ring{ringDesc: instancesRing}, 0)
+
+	t.Run("ShuffleShard()", func(t *testing.T) {
+		actual, err := r.ShuffleShard("test", 2)
+		require.NoError(t, err)
+		assert.Equal(t, 2, actual.PartitionRing().PartitionsCount())
+		assert.Equal(t, 3, actual.InstanceRing().InstancesCount()) // Should be preserved.
+	})
+
+	t.Run("ShuffleShardWithLookback()", func(t *testing.T) {
+		actual, err := r.ShuffleShardWithLookback("test", 2, time.Hour, now)
+		require.NoError(t, err)
+		assert.Equal(t, 3, actual.PartitionRing().PartitionsCount())
+		assert.Equal(t, 3, actual.InstanceRing().InstancesCount()) // Should be preserved.
+	})
+}
+
+type partitionRingReaderMock struct {
+	ring *PartitionRing
+}
+
+func (m partitionRingReaderMock) PartitionRing() *PartitionRing {
+	return m.ring
+}

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -303,6 +303,12 @@ func (r *PartitionRing) PartitionOwnerIDs(partitionID int32) []string {
 	return slices.Clone(ids)
 }
 
+// UnsafePartitionOwnerIDs is like PartitionOwnerIDs() but the returned slice is NOT a copy and
+// should be never modified by the caller.
+func (r *PartitionRing) UnsafePartitionOwnerIDs(partitionID int32) []string {
+	return r.ownersByPartition[partitionID]
+}
+
 func (r *PartitionRing) String() string {
 	buf := bytes.Buffer{}
 	for pid, pd := range r.desc.Partitions {

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -293,20 +293,20 @@ func (r *PartitionRing) InactivePartitionIDs() []int32 {
 }
 
 // PartitionOwnerIDs returns a list of owner IDs for the given partitionID.
-// The returned slice is a copy, so the caller can freely manipulate it.
-func (r *PartitionRing) PartitionOwnerIDs(partitionID int32) []string {
+// The returned slice is NOT a copy and should be never modified by the caller.
+func (r *PartitionRing) PartitionOwnerIDs(partitionID int32) (doNotModify []string) {
+	return r.ownersByPartition[partitionID]
+}
+
+// PartitionOwnerIDsCopy is like PartitionOwnerIDs(), but the returned slice is a copy,
+// so the caller can freely manipulate it.
+func (r *PartitionRing) PartitionOwnerIDsCopy(partitionID int32) []string {
 	ids := r.ownersByPartition[partitionID]
 	if len(ids) == 0 {
 		return nil
 	}
 
 	return slices.Clone(ids)
-}
-
-// UnsafePartitionOwnerIDs is like PartitionOwnerIDs() but the returned slice is NOT a copy and
-// should be never modified by the caller.
-func (r *PartitionRing) UnsafePartitionOwnerIDs(partitionID int32) []string {
-	return r.ownersByPartition[partitionID]
 }
 
 func (r *PartitionRing) String() string {

--- a/ring/partition_ring_http.go
+++ b/ring/partition_ring_http.go
@@ -21,10 +21,6 @@ var partitionRingPageTemplate = template.Must(template.New("webpage").Funcs(temp
 	},
 }).Parse(partitionRingPageContent))
 
-type PartitionRingReader interface {
-	PartitionRing() *PartitionRing
-}
-
 type PartitionRingPageHandler struct {
 	ring PartitionRingReader
 }

--- a/ring/partition_ring_http.go
+++ b/ring/partition_ring_http.go
@@ -40,7 +40,7 @@ func (h *PartitionRingPageHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 	// Prepare the data to render partitions in the page.
 	partitionsData := make([]partitionPageData, 0, len(ringDesc.Partitions))
 	for id, partition := range ringDesc.Partitions {
-		owners := ring.PartitionOwnerIDs(id)
+		owners := ring.PartitionOwnerIDsCopy(id)
 		slices.Sort(owners)
 
 		partitionsData = append(partitionsData, partitionPageData{

--- a/ring/partition_ring_http_test.go
+++ b/ring/partition_ring_http_test.go
@@ -48,17 +48,3 @@ func TestPartitionRingPageHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, "text/html", recorder.Header().Get("Content-Type"))
 }
-
-type staticPartitionRingReader struct {
-	ring *PartitionRing
-}
-
-func newStaticPartitionRingReader(ring *PartitionRing) *staticPartitionRingReader {
-	return &staticPartitionRingReader{
-		ring: ring,
-	}
-}
-
-func (r *staticPartitionRingReader) PartitionRing() *PartitionRing {
-	return r.ring
-}

--- a/ring/partition_ring_watcher.go
+++ b/ring/partition_ring_watcher.go
@@ -34,6 +34,7 @@ func NewPartitionRingWatcher(name, key string, kv kv.Client, logger log.Logger, 
 		key:    key,
 		kv:     kv,
 		logger: logger,
+		ring:   NewPartitionRing(*NewPartitionRingDesc()),
 		numPartitionsGaugeVec: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "partition_ring_partitions",
 			Help:        "Number of partitions by state in the partitions ring.",
@@ -56,8 +57,6 @@ func (w *PartitionRingWatcher) starting(ctx context.Context) error {
 
 	if value == nil {
 		level.Info(w.logger).Log("msg", "partition ring doesn't exist in KV store yet")
-
-		// Initialise the watcher with an empty ring.
 		value = NewPartitionRingDesc()
 	}
 

--- a/ring/partition_ring_watcher.go
+++ b/ring/partition_ring_watcher.go
@@ -91,9 +91,9 @@ func (w *PartitionRingWatcher) updatePartitionRing(desc *PartitionRingDesc) {
 	}
 }
 
-// GetRing returns the most updated snapshot of the PartitionRing. The returned instance
+// PartitionRing returns the most updated snapshot of the PartitionRing. The returned instance
 // is immutable and will not be updated if new changes are done to the ring.
-func (w *PartitionRingWatcher) GetRing() *PartitionRing {
+func (w *PartitionRingWatcher) PartitionRing() *PartitionRing {
 	w.ringMx.Lock()
 	defer w.ringMx.Unlock()
 

--- a/ring/partition_ring_watcher_test.go
+++ b/ring/partition_ring_watcher_test.go
@@ -28,6 +28,9 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	watcher := NewPartitionRingWatcher("test", ringKey, store, logger, reg)
 
+	// PartitionRing should never return nil, even if the watcher hasn't been started yet.
+	assert.NotNil(t, watcher.PartitionRing())
+
 	// Start the watcher with an empty ring.
 	require.NoError(t, services.StartAndAwaitRunning(ctx, watcher))
 	t.Cleanup(func() {

--- a/ring/partition_ring_watcher_test.go
+++ b/ring/partition_ring_watcher_test.go
@@ -34,7 +34,7 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, watcher))
 	})
 
-	assert.Equal(t, 0, watcher.GetRing().PartitionsCount())
+	assert.Equal(t, 0, watcher.PartitionRing().PartitionsCount())
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP partition_ring_partitions Number of partitions by state in the partitions ring.
 		# TYPE partition_ring_partitions gauge
@@ -50,7 +50,7 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	}))
 
 	require.Eventually(t, func() bool {
-		return watcher.GetRing().PartitionsCount() == 1
+		return watcher.PartitionRing().PartitionsCount() == 1
 	}, time.Second, 10*time.Millisecond)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
@@ -68,7 +68,7 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	}))
 
 	require.Eventually(t, func() bool {
-		return watcher.GetRing().PartitionsCount() == 2
+		return watcher.PartitionRing().PartitionsCount() == 2
 	}, time.Second, 10*time.Millisecond)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -405,6 +405,16 @@ func (r ReplicationSet) Includes(addr string) bool {
 	return false
 }
 
+// GetIDs returns the IDs of all instances within the replication set. Returned slice
+// order is not guaranteed.
+func (r ReplicationSet) GetIDs() []string {
+	ids := make([]string, 0, len(r.Instances))
+	for _, desc := range r.Instances {
+		ids = append(ids, desc.Id)
+	}
+	return ids
+}
+
 // GetAddresses returns the addresses of all instances within the replication set. Returned slice
 // order is not guaranteed.
 func (r ReplicationSet) GetAddresses() []string {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -866,10 +866,10 @@ func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
 	return merged
 }
 
-// UnsafeGetInstance return the InstanceDesc for the given instanceID or an error
+// GetInstance return the InstanceDesc for the given instanceID or an error
 // if the instance doesn't exist in the ring. The returned InstanceDesc is NOT a
 // deep copy, so the caller should never modify it.
-func (r *Ring) UnsafeGetInstance(instanceID string) (InstanceDesc, error) {
+func (r *Ring) GetInstance(instanceID string) (doNotModify InstanceDesc, _ error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
@@ -889,7 +889,7 @@ func (r *Ring) UnsafeGetInstance(instanceID string) (InstanceDesc, error) {
 // GetInstanceState returns the current state of an instance or an error if the
 // instance does not exist in the ring.
 func (r *Ring) GetInstanceState(instanceID string) (InstanceState, error) {
-	instance, err := r.UnsafeGetInstance(instanceID)
+	instance, err := r.GetInstance(instanceID)
 	if err != nil {
 		return PENDING, err
 	}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -866,16 +866,32 @@ func mergeTokenGroups(groupsByName map[string][]uint32) []uint32 {
 	return merged
 }
 
-// GetInstanceState returns the current state of an instance or an error if the
-// instance does not exist in the ring.
-func (r *Ring) GetInstanceState(instanceID string) (InstanceState, error) {
+// UnsafeGetInstance return the InstanceDesc for the given instanceID or an error
+// if the instance doesn't exist in the ring. The returned InstanceDesc is NOT a
+// deep copy, so the caller should never modify it.
+func (r *Ring) UnsafeGetInstance(instanceID string) (InstanceDesc, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
 	instances := r.ringDesc.GetIngesters()
+	if instances == nil {
+		return InstanceDesc{}, ErrInstanceNotFound
+	}
+
 	instance, ok := instances[instanceID]
 	if !ok {
-		return PENDING, ErrInstanceNotFound
+		return InstanceDesc{}, ErrInstanceNotFound
+	}
+
+	return instance, nil
+}
+
+// GetInstanceState returns the current state of an instance or an error if the
+// instance does not exist in the ring.
+func (r *Ring) GetInstanceState(instanceID string) (InstanceState, error) {
+	instance, err := r.UnsafeGetInstance(instanceID)
+	if err != nil {
+		return PENDING, err
 	}
 
 	return instance.GetState(), nil


### PR DESCRIPTION
**What this PR does**:

This PR is another piece of the work we're doing on the experimental partitions ring support. In this PR I'm introducing `PartitionInstanceRing`, which is a component holding a partitions ring and instances ring, and then provides functions to lookup the intersection of the two.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
