### PR TITLE
Add DoBatch() support for partitions ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -49,9 +49,22 @@ func isHTTPStatus4xx(err error) bool {
 	return code/100 == 4
 }
 
+// DoBatchRing defines the interface required by a ring implementation to use DoBatch() and DoBatchWithOptions().
+type DoBatchRing interface {
+	// Get returns a ReplicationSet containing the instances to which the input key should be sharded to
+	// for the input Operation.
+	Get(key uint32, op Operation, bufInstances []InstanceDesc, bufStrings1, bufStrings2 []string) (ReplicationSet, error)
+
+	// ReplicationFactor returns the number of instances each key is expected to be sharded to.
+	ReplicationFactor() int
+
+	// InstancesCount returns the number of instances in the ring eligible to get any key sharded to.
+	InstancesCount() int
+}
+
 // DoBatch is a deprecated version of DoBatchWithOptions where grpc errors containing status codes 4xx are treated as client errors.
 // Deprecated. Use DoBatchWithOptions instead.
-func DoBatch(ctx context.Context, op Operation, r ReadRing, keys []uint32, callback func(InstanceDesc, []int) error, cleanup func()) error {
+func DoBatch(ctx context.Context, op Operation, r DoBatchRing, keys []uint32, callback func(InstanceDesc, []int) error, cleanup func()) error {
 	return DoBatchWithOptions(ctx, op, r, keys, callback, DoBatchOptions{
 		Cleanup:       cleanup,
 		IsClientError: isHTTPStatus4xx,
@@ -94,14 +107,14 @@ func (o *DoBatchOptions) replaceZeroValuesWithDefaults() {
 // See comments on DoBatchOptions for available options for this call.
 //
 // Not implemented as a method on Ring, so we can test separately.
-func DoBatchWithOptions(ctx context.Context, op Operation, r ReadRing, keys []uint32, callback func(InstanceDesc, []int) error, o DoBatchOptions) error {
+func DoBatchWithOptions(ctx context.Context, op Operation, r DoBatchRing, keys []uint32, callback func(InstanceDesc, []int) error, o DoBatchOptions) error {
 	o.replaceZeroValuesWithDefaults()
 
 	if r.InstancesCount() <= 0 {
 		o.Cleanup()
 		return fmt.Errorf("DoBatch: InstancesCount <= 0")
 	}
-	expectedTrackers := len(keys) * (r.ReplicationFactor() + 1) / r.InstancesCount()
+	expectedTrackersPerInstance := len(keys) * (r.ReplicationFactor() + 1) / r.InstancesCount()
 	itemTrackers := make([]itemTracker, len(keys))
 	instances := make(map[string]instance, r.InstancesCount())
 
@@ -132,8 +145,8 @@ func DoBatchWithOptions(ctx context.Context, op Operation, r ReadRing, keys []ui
 		for _, desc := range replicationSet.Instances {
 			curr, found := instances[desc.Addr]
 			if !found {
-				curr.itemTrackers = make([]*itemTracker, 0, expectedTrackers)
-				curr.indexes = make([]int, 0, expectedTrackers)
+				curr.itemTrackers = make([]*itemTracker, 0, expectedTrackersPerInstance)
+				curr.indexes = make([]int, 0, expectedTrackersPerInstance)
 			}
 			instances[desc.Addr] = instance{
 				desc:         desc,

--- a/ring/batch.go
+++ b/ring/batch.go
@@ -53,6 +53,10 @@ func isHTTPStatus4xx(err error) bool {
 type DoBatchRing interface {
 	// Get returns a ReplicationSet containing the instances to which the input key should be sharded to
 	// for the input Operation.
+	//
+	// The input buffers may be referenced in the returned ReplicationSet. This means that it's unsafe to call
+	// Get() multiple times passing the same buffers if ReplicationSet is retained between two different Get()
+	// calls. In this cas, you can pass nil buffers.
 	Get(key uint32, op Operation, bufInstances []InstanceDesc, bufStrings1, bufStrings2 []string) (ReplicationSet, error)
 
 	// ReplicationFactor returns the number of instances each key is expected to be sharded to.


### PR DESCRIPTION
**What this PR does**:

As part of the experimental partitions ring support, in this PR I'm adding `DoBatch()` and `DoBatchWithOptions()` support for the partitions ring.

`DoBatch()` and `DoBatchWithOptions()` currently takes in input `ReadRing` interface, which is quite a big interface with several methods that don't make sense for partitions ring. However, `DoBatch()` and `DoBatchWithOptions()` only require 3 methods which I've defined into a new interface `DoBatchRing`.

Then I've created `ActivePartitionBatchRing`, which is a `PartitionRing` wrapper implementing `DoBatchRing`. Why didn't I added `DoBatchRing` methods directly to `PartitionRing`? The reason is that `DoBatchRing` methods behaviour needs to be contextualised based on what you really want to "batch" (in Mimir will be used on the write path where we need to write to ACTIVE partitions only). To keep a cleaner design, I've created `ActivePartitionBatchRing` which is the specific `DoBatchRing` implementation which lookup keys only among ACTIVE partitions.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
