### PR TITLE
Change exemplar label from "traceID" to "trace_id"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Exemplar label changes from "traceID" to "trace_id". #487
 * [CHANGE] server: import godeltaprof/http/pprof adding /debug/pprof/delta_{heap,mutex,block} endpoints to DefaultServeMux #450
 * [CHANGE] Move httpgrpc request & response utils up from httpgrpc/server to httpgrpc package #434, #435
 * [CHANGE] Updated the minimum required Go version to 1.20 and update Drone config #420

--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -75,7 +75,7 @@ func ObserveWithExemplar(ctx context.Context, histogram prometheus.Observer, sec
 	if traceID, ok := tracing.ExtractSampledTraceID(ctx); ok {
 		histogram.(prometheus.ExemplarObserver).ObserveWithExemplar(
 			seconds,
-			prometheus.Labels{"trace_id": traceID},
+			prometheus.Labels{"trace_id": traceID, "traceID": traceID},
 		)
 		return
 	}

--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -75,7 +75,7 @@ func ObserveWithExemplar(ctx context.Context, histogram prometheus.Observer, sec
 	if traceID, ok := tracing.ExtractSampledTraceID(ctx); ok {
 		histogram.(prometheus.ExemplarObserver).ObserveWithExemplar(
 			seconds,
-			prometheus.Labels{"traceID": traceID},
+			prometheus.Labels{"trace_id": traceID},
 		)
 		return
 	}

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -58,7 +58,7 @@ func (l Log) logWithRequest(r *http.Request) log.Logger {
 	localLog := l.Log
 	traceID, ok := tracing.ExtractTraceID(r.Context())
 	if ok {
-		localLog = log.With(localLog, "traceID", traceID)
+		localLog = log.With(localLog, "trace_id", traceID)
 	}
 
 	if l.SourceIPs != nil {

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -158,7 +158,7 @@ func (s *SpanLogger) getLogger() log.Logger {
 
 	traceID, ok := tracing.ExtractSampledTraceID(s.ctx)
 	if ok {
-		logger = log.With(logger, "traceID", traceID)
+		logger = log.With(logger, "trace_id", traceID)
 	}
 	// If the value has been set by another goroutine, fetch that other value and discard the one we made.
 	if !s.logger.CompareAndSwap(nil, &logger) {


### PR DESCRIPTION
**What this PR does**:

Change exemplar label from "traceID" to "trace_id".

This is consistent with [the OpenTelemetry standard](https://github.com/open-telemetry/opentelemetry-specification/blob/89aa01348139/specification/metrics/data-model.md#exemplars), and [an example in OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/138654493130/specification/OpenMetrics.md#exemplars-1).

~Sorry it is a breaking change.~  I believe it was me that picked the wrong string in the first place.
EDIT: not a breaking change until we remove the old one.

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
