### PR TITLE
Add `GetTokenRangesForPartition` method for partition ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -354,6 +354,9 @@ func (r *PartitionRing) String() string {
 	return fmt.Sprintf("PartitionRing{ownersCount: %d, partitionsCount: %d, partitions: {%s}}", len(r.desc.Owners), len(r.desc.Partitions), buf.String())
 }
 
+// GetTokenRangesForPartition returns token-range owned by given partition. Note that this
+// method does NOT take partition state into account, so if only active partitions should be
+// considered, then PartitionRing with only active partitions must be created first (e.g. using ShuffleShard method).
 func (r *PartitionRing) GetTokenRangesForPartition(partitionID int32) (TokenRanges, error) {
 	partition, ok := r.desc.Partitions[partitionID]
 	if !ok {

--- a/ring/partition_ring_model.go
+++ b/ring/partition_ring_model.go
@@ -54,7 +54,7 @@ func (m *PartitionRingDesc) tokens() Tokens {
 	return allTokens
 }
 
-// partitionByToken returns the a map where they key is a registered token and the value is ID of the partition
+// partitionByToken returns a map where they key is a registered token and the value is ID of the partition
 // that registered that token.
 func (m *PartitionRingDesc) partitionByToken() map[Token]int32 {
 	out := make(map[Token]int32, len(m.Partitions)*optimalTokensPerInstance)

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -966,7 +966,7 @@ func TestPartitionRing_ShuffleShardWithLookback_CachingConcurrency(t *testing.T)
 	assert.Empty(t, ring.shuffleShardCache.cacheWithoutLookback)
 }
 
-func TestPartitionRingGetTokenRangesForInstance(t *testing.T) {
+func TestPartitionRingGetTokenRangesForPartition(t *testing.T) {
 	gen := initTokenGenerator(t)
 
 	tests := map[string]struct {
@@ -1075,7 +1075,7 @@ func preparePartitionRingForBenchmarks(partitions int) *PartitionRing {
 	return pr
 }
 
-func BenchmarkPartitionRingGetTokenRangesForInstance(b *testing.B) {
+func BenchmarkPartitionRingGetTokenRangesForPartition(b *testing.B) {
 	partitionsCount := []int{1, 3, 9, 27, 81, 243, 729}
 
 	for _, n := range partitionsCount {


### PR DESCRIPTION
**What this PR does**:

To support "owned series" with partitions ring in Mimir we need to compute token ranges that belong to the partition. This PR adds such method.

At first I've reused code from original `GetTokenRangesForInstance` implementation. After that I've tried to implement suggestion from original review https://github.com/grafana/dskit/pull/433#discussion_r1400325576, and that improved benchmarks considerably (as expected by @pracucci in the comment):

```console
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/ring
                                                         │    orig.txt     │             better.txt              │
                                                         │     sec/op      │    sec/op     vs base               │
PartitionRingGetTokenRangesForInstance/1_partitions-10        4.220µ ± ∞ ¹   7.413µ ± ∞ ¹  +75.66% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/3_partitions-10       14.074µ ± ∞ ¹   8.085µ ± ∞ ¹  -42.55% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/9_partitions-10       72.631µ ± ∞ ¹   8.517µ ± ∞ ¹  -88.27% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/27_partitions-10      297.23µ ± ∞ ¹   10.71µ ± ∞ ¹  -96.40% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/81_partitions-10      999.92µ ± ∞ ¹   14.04µ ± ∞ ¹  -98.60% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/243_partitions-10    2994.87µ ± ∞ ¹   17.35µ ± ∞ ¹  -99.42% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/729_partitions-10   10174.34µ ± ∞ ¹   21.63µ ± ∞ ¹  -99.79% (p=0.008 n=5)
geomean                                                       234.6µ         11.63µ        -95.04%
¹ need >= 6 samples for confidence interval at level 0.95
```

After that I've added one more optimization: making `ringTokens` slice with all tokens smaller and smaller, as we go through subsequent tokens. That also made the method bit faster, especially for high number of partitions and tokens:

```console
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/ring
                                                         │  better.txt   │              best.txt               │
                                                         │    sec/op     │    sec/op     vs base               │
PartitionRingGetTokenRangesForInstance/1_partitions-10      7.413µ ± ∞ ¹   5.429µ ± ∞ ¹  -26.76% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/3_partitions-10      8.085µ ± ∞ ¹   6.120µ ± ∞ ¹  -24.30% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/9_partitions-10      8.517µ ± ∞ ¹   7.095µ ± ∞ ¹  -16.70% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/27_partitions-10    10.710µ ± ∞ ¹   8.277µ ± ∞ ¹  -22.72% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/81_partitions-10    14.037µ ± ∞ ¹   9.038µ ± ∞ ¹  -35.61% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/243_partitions-10    17.35µ ± ∞ ¹   10.52µ ± ∞ ¹  -39.40% (p=0.008 n=5)
PartitionRingGetTokenRangesForInstance/729_partitions-10    21.63µ ± ∞ ¹   13.19µ ± ∞ ¹  -39.01% (p=0.008 n=5)
geomean                                                     11.63µ         8.178µ        -29.69%
¹ need >= 6 samples for confidence interval at level 0.95
```

I've kept only this last ("best") version in the PR.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
