### PR TITLE
Fix MaxUnavailableZones computed by PartitionInstanceRing.GetReplicationSetsForOperation()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444

--- a/ring/partition_instance_ring_test.go
+++ b/ring/partition_instance_ring_test.go
@@ -55,19 +55,19 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 					2: {State: PartitionInactive},
 				},
 				Owners: map[string]OwnerDesc{
-					"instance-1-a": {OwnedPartition: 1},
-					"instance-2-a": {OwnedPartition: 2},
-					"instance-2-b": {OwnedPartition: 2},
+					"instance-zone-a-1": {OwnedPartition: 1},
+					"instance-zone-a-2": {OwnedPartition: 2},
+					"instance-zone-b-2": {OwnedPartition: 2},
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
-				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
-				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-b-2": {Id: "instance-zone-b-2", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
 			}},
 			expectedSets: []comparableReplicationSet{
-				{instances: []string{"instance-1-a"}, maxUnavailableZones: 0},
-				{instances: []string{"instance-2-a", "instance-2-b"}, maxUnavailableZones: 1},
+				{instances: []string{"instance-zone-a-1"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-zone-a-2", "instance-zone-b-2"}, maxUnavailableZones: 1},
 			},
 		},
 		"should return error if there are no healthy instances for a partition": {
@@ -77,14 +77,14 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 					2: {State: PartitionInactive},
 				},
 				Owners: map[string]OwnerDesc{
-					"instance-1-a": {OwnedPartition: 1},
-					"instance-2-a": {OwnedPartition: 2},
-					"instance-2-b": {OwnedPartition: 2},
+					"instance-zone-a-1": {OwnedPartition: 1},
+					"instance-zone-a-2": {OwnedPartition: 2},
+					"instance-zone-b-2": {OwnedPartition: 2},
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
-				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "a", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy.
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "a", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy.
 			}},
 			expectedErr: ErrTooManyUnhealthyInstances,
 		},
@@ -95,21 +95,21 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 					2: {State: PartitionInactive},
 				},
 				Owners: map[string]OwnerDesc{
-					"instance-1-a": {OwnedPartition: 1},
-					"instance-1-b": {OwnedPartition: 1},
-					"instance-2-a": {OwnedPartition: 2},
-					"instance-2-b": {OwnedPartition: 2},
+					"instance-zone-a-1": {OwnedPartition: 1},
+					"instance-zone-b-1": {OwnedPartition: 1},
+					"instance-zone-a-2": {OwnedPartition: 2},
+					"instance-zone-b-2": {OwnedPartition: 2},
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
-				"instance-1-b": {Id: "instance-1-a", State: LEAVING, Zone: "a", Timestamp: now.Unix()}, // Unhealthy because of the state.
-				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
-				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "b", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy because of the heartbeat.
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-b-1": {Id: "instance-zone-a-1", State: LEAVING, Zone: "a", Timestamp: now.Unix()}, // Unhealthy because of the state.
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-b-2": {Id: "instance-zone-b-2", State: ACTIVE, Zone: "b", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy because of the heartbeat.
 			}},
 			expectedSets: []comparableReplicationSet{
-				{instances: []string{"instance-1-a"}, maxUnavailableZones: 0},
-				{instances: []string{"instance-2-a"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-zone-a-1"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-zone-a-2"}, maxUnavailableZones: 0},
 			},
 		},
 		"should NOT return error if an instance is missing in the instances ring but there's another healthy instance for the partition": {
@@ -119,19 +119,19 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 					2: {State: PartitionInactive},
 				},
 				Owners: map[string]OwnerDesc{
-					"instance-1-a": {OwnedPartition: 1},
-					"instance-1-b": {OwnedPartition: 1}, // Missing in the instances ring.
-					"instance-2-a": {OwnedPartition: 2}, // Missing in the instances ring.
-					"instance-2-b": {OwnedPartition: 2},
+					"instance-zone-a-1": {OwnedPartition: 1},
+					"instance-zone-b-1": {OwnedPartition: 1}, // Missing in the instances ring.
+					"instance-zone-a-2": {OwnedPartition: 2}, // Missing in the instances ring.
+					"instance-zone-b-2": {OwnedPartition: 2},
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
-				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-b-2": {Id: "instance-zone-b-2", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
 			}},
 			expectedSets: []comparableReplicationSet{
-				{instances: []string{"instance-1-a"}, maxUnavailableZones: 0},
-				{instances: []string{"instance-2-b"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-zone-a-1"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-zone-b-2"}, maxUnavailableZones: 0},
 			},
 		},
 		"should return replication sets with MaxUnavailableZones=0 if there are multiple instances per zone but all instances belong to the same zone": {
@@ -141,21 +141,21 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 					2: {State: PartitionInactive},
 				},
 				Owners: map[string]OwnerDesc{
-					"instance-1-a": {OwnedPartition: 1},
-					"instance-1-b": {OwnedPartition: 1},
-					"instance-2-a": {OwnedPartition: 2},
-					"instance-2-b": {OwnedPartition: 2},
+					"instance-zone-a-1": {OwnedPartition: 1},
+					"instance-zone-b-1": {OwnedPartition: 1},
+					"instance-zone-a-2": {OwnedPartition: 2},
+					"instance-zone-b-2": {OwnedPartition: 2},
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
-				"instance-1-b": {Id: "instance-1-b", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
-				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
-				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+				"instance-zone-b-1": {Id: "instance-zone-b-1", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+				"instance-zone-b-2": {Id: "instance-zone-b-2", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
 			}},
 			expectedSets: []comparableReplicationSet{
-				{instances: []string{"instance-1-a", "instance-1-b"}, maxUnavailableZones: 0},
-				{instances: []string{"instance-2-a", "instance-2-b"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-zone-a-1", "instance-zone-b-1"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-zone-a-2", "instance-zone-b-2"}, maxUnavailableZones: 0},
 			},
 		},
 	}

--- a/ring/partition_instance_ring_test.go
+++ b/ring/partition_instance_ring_test.go
@@ -1,6 +1,7 @@
 package ring
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -14,11 +15,16 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 	op := NewOp([]InstanceState{ACTIVE}, nil)
 	heartbeatTimeout := time.Minute
 
+	type comparableReplicationSet struct {
+		instances           []string
+		maxUnavailableZones int
+	}
+
 	tests := map[string]struct {
 		partitionsRing PartitionRingDesc
 		instancesRing  *Desc
 		expectedErr    error
-		expectedSets   [][]string
+		expectedSets   []comparableReplicationSet
 	}{
 		"should return error on empty partitions ring": {
 			partitionsRing: PartitionRingDesc{},
@@ -55,11 +61,14 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
-				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Timestamp: now.Unix()},
-				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
 			}},
-			expectedSets: [][]string{{"instance-1-a"}, {"instance-2-a", "instance-2-b"}},
+			expectedSets: []comparableReplicationSet{
+				{instances: []string{"instance-1-a"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-2-a", "instance-2-b"}, maxUnavailableZones: 1},
+			},
 		},
 		"should return error if there are no healthy instances for a partition": {
 			partitionsRing: PartitionRingDesc{
@@ -74,8 +83,8 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
-				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy.
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "a", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy.
 			}},
 			expectedErr: ErrTooManyUnhealthyInstances,
 		},
@@ -93,12 +102,15 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
-				"instance-1-b": {Id: "instance-1-a", State: LEAVING, Timestamp: now.Unix()}, // Unhealthy because of the state.
-				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Timestamp: now.Unix()},
-				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy because of the heartbeat.
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-1-b": {Id: "instance-1-a", State: LEAVING, Zone: "a", Timestamp: now.Unix()}, // Unhealthy because of the state.
+				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "b", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy because of the heartbeat.
 			}},
-			expectedSets: [][]string{{"instance-1-a"}, {"instance-2-a"}},
+			expectedSets: []comparableReplicationSet{
+				{instances: []string{"instance-1-a"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-2-a"}, maxUnavailableZones: 0},
+			},
 		},
 		"should NOT return error if an instance is missing in the instances ring but there's another healthy instance for the partition": {
 			partitionsRing: PartitionRingDesc{
@@ -114,10 +126,37 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 				},
 			},
 			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
-				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Timestamp: now.Unix()},
-				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Timestamp: now.Unix()},
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
 			}},
-			expectedSets: [][]string{{"instance-1-a"}, {"instance-2-b"}},
+			expectedSets: []comparableReplicationSet{
+				{instances: []string{"instance-1-a"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-2-b"}, maxUnavailableZones: 0},
+			},
+		},
+		"should return replication sets with MaxUnavailableZones=0 if there are multiple instances per zone but all instances belong to the same zone": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					"instance-1-a": {OwnedPartition: 1},
+					"instance-1-b": {OwnedPartition: 1},
+					"instance-2-a": {OwnedPartition: 2},
+					"instance-2-b": {OwnedPartition: 2},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-1-a": {Id: "instance-1-a", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+				"instance-1-b": {Id: "instance-1-b", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+				"instance-2-a": {Id: "instance-2-a", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+				"instance-2-b": {Id: "instance-2-b", State: ACTIVE, Zone: "fixed", Timestamp: now.Unix()},
+			}},
+			expectedSets: []comparableReplicationSet{
+				{instances: []string{"instance-1-a", "instance-1-b"}, maxUnavailableZones: 0},
+				{instances: []string{"instance-2-a", "instance-2-b"}, maxUnavailableZones: 0},
+			},
 		},
 	}
 
@@ -131,15 +170,51 @@ func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {
 			require.ErrorIs(t, err, testData.expectedErr)
 
 			// Build the actual replication sets to compare with the expected ones.
-			actual := make([][]string, 0, len(sets))
+			actual := make([]comparableReplicationSet, 0, len(sets))
 			for _, set := range sets {
 				instanceIDs := set.GetIDs()
 				slices.Sort(instanceIDs)
-				actual = append(actual, instanceIDs)
+				actual = append(actual, comparableReplicationSet{instances: instanceIDs, maxUnavailableZones: set.MaxUnavailableZones})
 			}
 
 			assert.ElementsMatch(t, testData.expectedSets, actual)
 		})
+	}
+}
+
+func BenchmarkPartitionInstanceRing_GetReplicationSetsForOperation(b *testing.B) {
+	var (
+		numActivePartitions = 100
+		zones               = []string{"a", "b", "c"}
+		now                 = time.Now()
+	)
+
+	// Create the instances and partitions ring.
+	partitionsRing := NewPartitionRingDesc()
+	instancesRing := &Ring{ringDesc: &Desc{}}
+
+	for partitionID := 0; partitionID < numActivePartitions; partitionID++ {
+		partitionsRing.AddPartition(int32(partitionID), PartitionActive, now)
+
+		for _, zone := range zones {
+			instanceID := fmt.Sprintf("instance-zone-%s-%d", zone, partitionID)
+			instancesRing.ringDesc.AddIngester(instanceID, instanceID, zone, nil, ACTIVE, now)
+			partitionsRing.AddOrUpdateOwner(instanceID, OwnerActive, int32(partitionID), now)
+		}
+	}
+
+	r := NewPartitionInstanceRing(newStaticPartitionRingReader(NewPartitionRing(*partitionsRing)), instancesRing, time.Hour)
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		sets, err := r.GetReplicationSetsForOperation(Read)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(sets) != numActivePartitions {
+			b.Fatalf("expected %d replication sets but got %d", numActivePartitions, len(sets))
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

`PartitionInstanceRing.GetReplicationSetsForOperation()` currently returns `ReplicationSet` with `MaxUnavailableZones` computed as `len(instances) - 1`. This works fine if all instances are in different zones, but we have some (or all) instances in the same zone it will not work as expected because `MaxUnavailableZones` will be >= the actual number of zones among `instances`. For example, when that's the case, the `zoneAwareResultTracker` will not issue any request at all because if `MaxUnavailableZones` is >= the actual number of zones... well the quorum is reached even without sending any request.

In this PR I propose to change `MaxUnavailableZones` to `len(zones) - 1`. Naturally this has an impact on quorum if some (or all instances) run in the same zone, but we expect not to be the case when using the partitions ring. However, if that will happen (e.g. local dev env, a demo, ...) after this change the system will keep working as expected, instead of weird bugs being surfaced (e.g. no requests sent to instances at all).

Benchmark:

```
goos: darwin
goarch: amd64
pkg: github.com/grafana/dskit/ring
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                                                        │ before.txt  │             after.txt              │
                                                        │   sec/op    │   sec/op     vs base               │
PartitionInstanceRing_GetReplicationSetsForOperation-12   37.99µ ± 1%   41.91µ ± 1%  +10.33% (p=0.002 n=6)

                                                        │  before.txt  │            after.txt            │
                                                        │     B/op     │     B/op      vs base           │
PartitionInstanceRing_GetReplicationSetsForOperation-12   32.88Ki ± 0%   32.88Ki ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal

                                                        │ before.txt │           after.txt           │
                                                        │ allocs/op  │ allocs/op   vs base           │
PartitionInstanceRing_GetReplicationSetsForOperation-12   101.0 ± 0%   101.0 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal
```

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
