### PR TITLE
Implement per tenant duration

### DIFF
--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -32,11 +32,11 @@ type RouteMatcher interface {
 // PerTenantCallback is a function that returns a tenant ID for a given request. When the returned tenant ID is not empty, it is used to label the duration histogram.
 type PerTenantCallback func(context.Context) string
 
-func (f PerTenantCallback) shouldInstrument(ctx context.Context) (tenantID string, ok bool) {
+func (f PerTenantCallback) shouldInstrument(ctx context.Context) (string, bool) {
 	if f == nil {
 		return "", false
 	}
-	tenantID = f(ctx)
+	tenantID := f(ctx)
 	if tenantID == "" {
 		return "", false
 	}

--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -5,6 +5,7 @@
 package middleware
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"regexp"
@@ -28,13 +29,29 @@ type RouteMatcher interface {
 	Match(*http.Request, *mux.RouteMatch) bool
 }
 
+// PerTenantCallback is a function that returns a tenant ID for a given request. When the returned tenant ID is not empty, it is used to label the duration histogram.
+type PerTenantCallback func(context.Context) string
+
+func (f PerTenantCallback) shouldInstrument(ctx context.Context) (tenantID string, ok bool) {
+	if f == nil {
+		return "", false
+	}
+	tenantID = f(ctx)
+	if tenantID == "" {
+		return "", false
+	}
+	return tenantID, true
+}
+
 // Instrument is a Middleware which records timings for every HTTP request
 type Instrument struct {
-	RouteMatcher     RouteMatcher
-	Duration         *prometheus.HistogramVec
-	RequestBodySize  *prometheus.HistogramVec
-	ResponseBodySize *prometheus.HistogramVec
-	InflightRequests *prometheus.GaugeVec
+	RouteMatcher      RouteMatcher
+	Duration          *prometheus.HistogramVec
+	PerTenantDuration *prometheus.HistogramVec
+	PerTenantCallback PerTenantCallback
+	RequestBodySize   *prometheus.HistogramVec
+	ResponseBodySize  *prometheus.HistogramVec
+	InflightRequests  *prometheus.GaugeVec
 }
 
 // IsWSHandshakeRequest returns true if the given request is a websocket handshake request.
@@ -77,7 +94,19 @@ func (i Instrument) Wrap(next http.Handler) http.Handler {
 		i.RequestBodySize.WithLabelValues(r.Method, route).Observe(float64(rBody.read))
 		i.ResponseBodySize.WithLabelValues(r.Method, route).Observe(float64(respMetrics.Written))
 
-		instrument.ObserveWithExemplar(r.Context(), i.Duration.WithLabelValues(r.Method, route, strconv.Itoa(respMetrics.Code), isWS), respMetrics.Duration.Seconds())
+		labelValues := []string{
+			r.Method,
+			route,
+			strconv.Itoa(respMetrics.Code),
+			isWS,
+			"", // this is a placeholder for the tenant ID
+		}
+		labelValues = labelValues[:len(labelValues)-1]
+		instrument.ObserveWithExemplar(r.Context(), i.Duration.WithLabelValues(labelValues...), respMetrics.Duration.Seconds())
+		if tenantID, ok := i.PerTenantCallback.shouldInstrument(r.Context()); ok {
+			labelValues = append(labelValues, tenantID)
+			instrument.ObserveWithExemplar(r.Context(), i.PerTenantDuration.WithLabelValues(labelValues...), respMetrics.Duration.Seconds())
+		}
 	})
 }
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -15,12 +15,13 @@ import (
 )
 
 type Metrics struct {
-	TCPConnections      *prometheus.GaugeVec
-	TCPConnectionsLimit *prometheus.GaugeVec
-	RequestDuration     *prometheus.HistogramVec
-	ReceivedMessageSize *prometheus.HistogramVec
-	SentMessageSize     *prometheus.HistogramVec
-	InflightRequests    *prometheus.GaugeVec
+	TCPConnections           *prometheus.GaugeVec
+	TCPConnectionsLimit      *prometheus.GaugeVec
+	RequestDuration          *prometheus.HistogramVec
+	PerTenantRequestDuration *prometheus.HistogramVec
+	ReceivedMessageSize      *prometheus.HistogramVec
+	SentMessageSize          *prometheus.HistogramVec
+	InflightRequests         *prometheus.GaugeVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
@@ -46,6 +47,15 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route", "status_code", "ws"}),
+		PerTenantRequestDuration: reg.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       cfg.MetricsNamespace,
+			Name:                            "per_tenant_request_duration_seconds",
+			Help:                            "Time (in seconds) spent serving HTTP requests for a particular tenant.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"method", "route", "status_code", "ws", "tenant"}),
 		ReceivedMessageSize: reg.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "request_message_bytes",

--- a/server/server.go
+++ b/server/server.go
@@ -100,6 +100,8 @@ type Config struct {
 	ExcludeRequestInLog                      bool `yaml:"-"`
 	DisableRequestSuccessLog                 bool `yaml:"-"`
 
+	PerTenantDurationInstrumentation middleware.PerTenantCallback `yaml:"-"`
+
 	ServerGracefulShutdownTimeout time.Duration `yaml:"graceful_shutdown_timeout"`
 	HTTPServerReadTimeout         time.Duration `yaml:"http_server_read_timeout"`
 	HTTPServerReadHeaderTimeout   time.Duration `yaml:"http_server_read_header_timeout"`
@@ -366,22 +368,29 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		WithRequest:              !cfg.ExcludeRequestInLog,
 		DisableRequestSuccessLog: cfg.DisableRequestSuccessLog,
 	}
-	var reportGRPCStatusesOptions []middleware.InstrumentationOption
+	var grpcInstrumentationOptions []middleware.InstrumentationOption
 	if cfg.ReportGRPCCodesInInstrumentationLabel {
-		reportGRPCStatusesOptions = []middleware.InstrumentationOption{middleware.ReportGRPCStatusOption}
+		grpcInstrumentationOptions = append(grpcInstrumentationOptions, middleware.ReportGRPCStatusOption)
+	}
+	if cfg.PerTenantDurationInstrumentation != nil {
+		grpcInstrumentationOptions = append(grpcInstrumentationOptions,
+			middleware.WithPerTenantInstrumentation(
+				metrics.PerTenantRequestDuration,
+				cfg.PerTenantDurationInstrumentation,
+			))
 	}
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,
 		otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer()),
 		middleware.HTTPGRPCTracingInterceptor(router), // This must appear after the OpenTracingServerInterceptor.
-		middleware.UnaryServerInstrumentInterceptor(metrics.RequestDuration, reportGRPCStatusesOptions...),
+		middleware.UnaryServerInstrumentInterceptor(metrics.RequestDuration, grpcInstrumentationOptions...),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 
 	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
 		serverLog.StreamServerInterceptor,
 		otgrpc.OpenTracingStreamServerInterceptor(opentracing.GlobalTracer()),
-		middleware.StreamServerInstrumentInterceptor(metrics.RequestDuration, reportGRPCStatusesOptions...),
+		middleware.StreamServerInstrumentInterceptor(metrics.RequestDuration, grpcInstrumentationOptions...),
 	}
 	grpcStreamMiddleware = append(grpcStreamMiddleware, cfg.GRPCStreamMiddleware...)
 
@@ -500,11 +509,13 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 		},
 		defaultLogMiddleware,
 		middleware.Instrument{
-			RouteMatcher:     router,
-			Duration:         metrics.RequestDuration,
-			RequestBodySize:  metrics.ReceivedMessageSize,
-			ResponseBodySize: metrics.SentMessageSize,
-			InflightRequests: metrics.InflightRequests,
+			RouteMatcher:      router,
+			Duration:          metrics.RequestDuration,
+			PerTenantDuration: metrics.PerTenantRequestDuration,
+			PerTenantCallback: cfg.PerTenantDurationInstrumentation,
+			RequestBodySize:   metrics.ReceivedMessageSize,
+			ResponseBodySize:  metrics.SentMessageSize,
+			InflightRequests:  metrics.InflightRequests,
 		},
 	}
 	var httpMiddleware []middleware.Interface


### PR DESCRIPTION
This will allow a per tenant metric request duration collection, based on an injected callback.

I have an example of this (in the private PR https://github.com/grafana/backend-enterprise/pull/5933, GL emplyoees only)


