### PR TITLE
Fix TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests flakyness

### DIFF
--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -290,8 +290,10 @@ func TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests(t *testing.
 
 	// With 1000 iterations, 4 instances and max 1 error, we'd expect each instance to receive
 	// 750 calls each (each instance has a 3-in-4 chance of being called in each iteration).
+	const expectedAverageCallsPerInstance = 750
+	const tolerancePerc = 0.2
 	for _, instanceRequestCount := range instanceRequestCounts {
-		require.InDeltaf(t, 750, instanceRequestCount.Load(), 50, "expected roughly even distribution of requests across all instances, but got %v", instanceRequestCounts)
+		require.InDeltaf(t, expectedAverageCallsPerInstance, instanceRequestCount.Load(), expectedAverageCallsPerInstance*tolerancePerc, "expected roughly even distribution of requests across all instances, but got %v", instanceRequestCounts)
 	}
 }
 
@@ -970,8 +972,10 @@ func TestZoneAwareResultTracker_StartMinimumRequests_NoFailingRequests(t *testin
 
 	// With 900 iterations, 3 zones and max 1 failing zone, we'd expect each zone to receive
 	// 600 calls each (each zone has a 2-in-3 chance of being called in each iteration).
+	const expectedAverageCallsPerZone = 600
+	const tolerancePerc = 0.2
 	for _, zoneRequestCount := range zoneRequestCounts {
-		require.InDeltaf(t, 600, zoneRequestCount, 50, "expected roughly even distribution of requests across all zones, but got %v", zoneRequestCount)
+		require.InDeltaf(t, expectedAverageCallsPerZone, zoneRequestCount, expectedAverageCallsPerZone*tolerancePerc, "expected roughly even distribution of requests across all zones, but got %v", zoneRequestCount)
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

In [this CI run](https://drone.grafana.net/grafana/dskit/4023/1/5) we've seen `TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests` being flaky:

```
--- FAIL: TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests (20.67s)
    replication_set_tracker_test.go:294: 
        	Error Trace:	/drone/src/ring/replication_set_tracker_test.go:294
        	Error:      	Max difference between 750 and 695 allowed is 50, but difference was 55
        	Test:       	TestDefaultResultTracker_StartMinimumRequests_NoFailingRequests
        	Messages:   	expected roughly even distribution of requests across all instances, but got [{[] 769} {[] 772} {[] 764} {[] 695}]
FAIL
```

The test checks whether each instance got roughly the same number of requests. The selection of instances getting the "minimum requests" is generated randomly. Since there's no perfect random distribution, the actual difference may be greater than the `50` delta configured for the assertion.

In this PR I've just increased the delta to reduce the likelihood of flaky executions.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
