### PR TITLE
Add `PartitionRing.ShuffleShardSize`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -97,7 +97,6 @@ func (r *PartitionRing) ShuffleShardSize(size int) int {
 		return r.activePartitionsCount
 	}
 
-	// return min(size, r.activePartitionsCount)
 	if size < r.activePartitionsCount {
 		return size
 	}

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -38,15 +38,19 @@ type PartitionRing struct {
 
 	// shuffleShardCache is used to cache subrings generated with shuffle sharding.
 	shuffleShardCache *partitionRingShuffleShardCache
+
+	// activePartitionsCount is a saved count of active partitions to avoid recomputing it.
+	activePartitionsCount int
 }
 
 func NewPartitionRing(desc PartitionRingDesc) *PartitionRing {
 	return &PartitionRing{
-		desc:              desc,
-		ringTokens:        desc.tokens(),
-		partitionByToken:  desc.partitionByToken(),
-		ownersByPartition: desc.ownersByPartition(),
-		shuffleShardCache: newPartitionRingShuffleShardCache(),
+		desc:                  desc,
+		ringTokens:            desc.tokens(),
+		partitionByToken:      desc.partitionByToken(),
+		ownersByPartition:     desc.ownersByPartition(),
+		activePartitionsCount: desc.activePartitionsCount(),
+		shuffleShardCache:     newPartitionRingShuffleShardCache(),
 	}
 }
 
@@ -85,6 +89,19 @@ func (r *PartitionRing) ActivePartitionForKey(key uint32) (int32, error) {
 	}
 
 	return 0, ErrNoActivePartitionFound
+}
+
+// ShuffleShardSize returns number of partitions that would be in the result of ShuffleShard call with the same size.
+func (r *PartitionRing) ShuffleShardSize(size int) int {
+	if size <= 0 || size > r.activePartitionsCount {
+		return r.activePartitionsCount
+	}
+
+	// return min(size, r.activePartitionsCount)
+	if size < r.activePartitionsCount {
+		return size
+	}
+	return r.activePartitionsCount
 }
 
 // ShuffleShard returns a subring for the provided identifier (eg. a tenant ID)
@@ -249,13 +266,7 @@ func (r *PartitionRing) PartitionsCount() int {
 
 // ActivePartitionsCount returns the number of active partitions in the ring.
 func (r *PartitionRing) ActivePartitionsCount() int {
-	count := 0
-	for _, partition := range r.desc.Partitions {
-		if partition.IsActive() {
-			count++
-		}
-	}
-	return count
+	return r.activePartitionsCount
 }
 
 // Partitions returns the partitions in the ring.

--- a/ring/partition_ring_model.go
+++ b/ring/partition_ring_model.go
@@ -102,6 +102,16 @@ func (m *PartitionRingDesc) countPartitionsByState() map[PartitionState]int {
 	return out
 }
 
+func (m *PartitionRingDesc) activePartitionsCount() int {
+	count := 0
+	for _, partition := range m.Partitions {
+		if partition.IsActive() {
+			count++
+		}
+	}
+	return count
+}
+
 // WithPartitions returns a new PartitionRingDesc with only the specified partitions and their owners included.
 func (m *PartitionRingDesc) WithPartitions(partitions map[int32]struct{}) PartitionRingDesc {
 	newPartitions := make(map[int32]PartitionDesc, len(partitions))

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -199,7 +199,8 @@ func TestPartitionRing_ShuffleShard(t *testing.T) {
 
 		ring := createPartitionRingWithPartitions(numActivePartitions, numInactivePartitions, numPendingPartitions)
 
-		for shardSize := 0; shardSize <= ring.PartitionsCount()+5; shardSize++ {
+		// We test negative values of shardSize as well as sizes above current number of partition count.
+		for shardSize := -5; shardSize <= ring.PartitionsCount()+5; shardSize++ {
 			subring, err := ring.ShuffleShard("tenant-id", shardSize)
 			require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does**:

This PR adds `PartitionRing.ShuffleShardSize` method that returns number of partitions that would be in the shuffle shard with the same size. This is useful when this count is needed, but actual partitions are not. In that case, we can simplify the calculation.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
