### PR TITLE
Expose InstancesInZoneCount and ZonesCount from ring.ReadRing.

### DIFF
--- a/ring/model.go
+++ b/ring/model.go
@@ -518,6 +518,16 @@ func (d *Desc) getOldestRegisteredTimestamp() int64 {
 	return result
 }
 
+func (d *Desc) instancesCountPerZone() map[string]int {
+	instancesCountPerZone := map[string]int{}
+	if d != nil {
+		for _, ingester := range d.Ingesters {
+			instancesCountPerZone[ingester.Zone]++
+		}
+	}
+	return instancesCountPerZone
+}
+
 type CompareResult int
 
 // CompareResult responses

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -71,6 +71,14 @@ func (r *RingMock) GetTokenRangesForInstance(_ string) (TokenRanges, error) {
 	return []uint32{0, math.MaxUint32}, nil
 }
 
+func (r *RingMock) InstancesInZoneCount(zone string) int {
+	return 0
+}
+
+func (r *RingMock) ZonesCount() int {
+	return 0
+}
+
 func createStartingRing() *Ring {
 	// Init the ring.
 	ringDesc := &Desc{Ingesters: map[string]InstanceDesc{


### PR DESCRIPTION
**What this PR does**:

This PR adds `InstancesInZoneCount` and `ZonesCount` methods to `ring.ReadRing` interface and `*ring.Ring` implementation. These methods are already available via lifecycler, but we would like to switch Mimir's limiter from using lifecycler to using `ring.ReadRing` instead in https://github.com/grafana/mimir/pull/7411 (to avoid a bug caused by starting lifecycler after the `ownedSeriesService`), so we are exposing some necessary methods.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
