### PR TITLE
Add ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation() and fix context cancellation in concurrency.ForEachJob() when there's 1 job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
+* [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274
@@ -192,6 +193,7 @@
 * [ENHANCEMENT] SpanLogger: Add `SetSpanAndLogTag` method. #467
 * [ENHANCEMENT] Add servicediscovery package. #469
 * [ENHANCEMENT] Expose `InstancesInZoneCount` and `ZonesCount` in `ring.ReadRing` interface. #494
+* [ENHANCEMENT] Add optimization to run `concurrency.ForEachJob()` with no parallelism when there's only 1 job. #486 #495
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	kitlog "github.com/go-kit/log"
@@ -386,6 +387,108 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 	}
 
 	return results, nil
+}
+
+// DoMultiUntilQuorumWithoutSuccessfulContextCancellation behaves similar to DoUntilQuorumWithoutSuccessfulContextCancellation
+// with the following exceptions:
+//
+//   - This function calls DoUntilQuorumWithoutSuccessfulContextCancellation for each input ReplicationSet and requires
+//     DoUntilQuorumWithoutSuccessfulContextCancellation to successfully run for each of them. Execution breaks on the
+//     first error returned by DoUntilQuorumWithoutSuccessfulContextCancellation on any ReplicationSet.
+//
+//   - This function requires that the callback function f always call context.CancelCauseFunc once done. Failing to
+//     cancel the context will leak resources.
+func DoMultiUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Context, sets []ReplicationSet, cfg DoUntilQuorumConfig, f func(context.Context, *InstanceDesc, context.CancelCauseFunc) (T, error), cleanupFunc func(T)) ([]T, error) {
+	if len(sets) == 0 {
+		return nil, errors.New("no replication sets")
+	}
+	if len(sets) == 1 {
+		return DoUntilQuorumWithoutSuccessfulContextCancellation[T](ctx, sets[0], cfg, f, cleanupFunc)
+	}
+
+	results, _, err := doMultiUntilQuorumWithoutSuccessfulContextCancellation[T](ctx, sets, cfg, f, cleanupFunc)
+	return results, err
+}
+
+func doMultiUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Context, sets []ReplicationSet, cfg DoUntilQuorumConfig, f func(context.Context, *InstanceDesc, context.CancelCauseFunc) (T, error), cleanupFunc func(T)) ([]T, context.Context, error) {
+	var (
+		returnResultsMx = sync.Mutex{}
+		returnResults   = make([]T, 0, len(sets)*len(sets[0].Instances)) // Assume all replication sets have the same number of instances.
+
+		returnErrOnce sync.Once
+		returnErr     error // The first error occurred.
+
+		workersGroup                 = sync.WaitGroup{}
+		workersCtx, cancelWorkersCtx = context.WithCancelCause(ctx)
+
+		inflightTracker = newInflightInstanceTracker(sets)
+	)
+
+	cancelWorkersCtxIfSafe := func() {
+		if inflightTracker.allInstancesCompleted() {
+			cancelWorkersCtx(errors.New("all requests completed"))
+		}
+	}
+
+	// Start a worker for each set. A worker is responsible to call DoUntilQuorumWithoutSuccessfulContextCancellation()
+	// for the given replication set and handle the result.
+	workersGroup.Add(len(sets))
+
+	for idx, set := range sets {
+		go func(idx int, set ReplicationSet) {
+			defer workersGroup.Done()
+
+			wrappedFn := func(ctx context.Context, instance *InstanceDesc, cancelCtx context.CancelCauseFunc) (T, error) {
+				// The callback function has been called, so we need to track it.
+				inflightTracker.addInstance(idx, instance)
+
+				// Inject custom logic in the context.CancelCauseFunc.
+				return f(ctx, instance, func(cause error) {
+					// Call the original one.
+					cancelCtx(cause)
+
+					// The callback has done, so we can remove it from tracker and then check if it's safe
+					// to cancel the workers context.
+					inflightTracker.removeInstance(idx, instance)
+					cancelWorkersCtxIfSafe()
+				})
+			}
+
+			setResults, setErr := DoUntilQuorumWithoutSuccessfulContextCancellation[T](workersCtx, set, cfg, wrappedFn, cleanupFunc)
+
+			if setErr != nil {
+				returnErrOnce.Do(func() {
+					returnErr = setErr
+
+					// Interrupt the execution of all workers.
+					cancelWorkersCtx(setErr)
+				})
+
+				return
+			}
+
+			// Keep track of the results.
+			returnResultsMx.Lock()
+			returnResults = append(returnResults, setResults...)
+			returnResultsMx.Unlock()
+		}(idx, set)
+	}
+
+	// Wait until all goroutines have terminated.
+	workersGroup.Wait()
+
+	// All workers completed, so it's guaranteed returnResults and returnErr won't be accessed by workers anymore,
+	// and it's safe to read them with no locking.
+	if returnErr != nil {
+		return nil, workersCtx, returnErr
+	}
+
+	// No error occurred. It means workers context hasn't been canceled yet, and we don't expect more callbacks
+	// to get tracked, so we can check if the cancelling condition has already been reached and eventually do it.
+	inflightTracker.allInstancesAdded()
+	cancelWorkersCtxIfSafe()
+
+	return returnResults, workersCtx, nil
 }
 
 type instanceResult[T any] struct {

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -410,6 +410,9 @@ func DoMultiUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.C
 	return results, err
 }
 
+// See DoMultiUntilQuorumWithoutSuccessfulContextCancellation().
+//
+// The returned context.Context is the internal context used by workers and it's used for testing purposes.
 func doMultiUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Context, sets []ReplicationSet, cfg DoUntilQuorumConfig, f func(context.Context, *InstanceDesc, context.CancelCauseFunc) (T, error), cleanupFunc func(T)) ([]T, context.Context, error) {
 	var (
 		returnResultsMx = sync.Mutex{}

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -1631,7 +1631,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 					// Successful callbacks wait a bit to ensure context is NOT cancelled in the meanwhile.
 					select {
 					case <-ctx.Done():
-						t.Fatal("expected the context to not get canceled but it was")
+						t.Error("expected the context to not get canceled but it was")
 						return "", ctx.Err()
 					case <-time.After(time.Second):
 						return instance.Addr, nil
@@ -1679,7 +1679,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 						assert.Contains(t, []string{errMock.Error(), "context canceled: quorum cannot be reached"}, context.Cause(ctx).Error())
 						return "", ctx.Err()
 					case <-time.After(time.Second):
-						t.Fatal("expected the context to get canceled but it wasn't")
+						t.Error("expected the context to get canceled but it wasn't")
 						return "", nil
 					}
 				}
@@ -1720,7 +1720,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 					assert.EqualError(t, context.Cause(ctx), expectedErr)
 					return "", ctx.Err()
 				case <-time.After(time.Second):
-					t.Fatal("expected the context to get canceled but it wasn't")
+					t.Error("expected the context to get canceled but it wasn't")
 					return "", nil
 				}
 			}
@@ -1753,7 +1753,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 				assert.ErrorIs(t, ctx.Err(), context.Canceled)
 				return "", ctx.Err()
 			case <-time.After(time.Second):
-				t.Fatal("expected the context to get canceled but it wasn't")
+				t.Error("expected the context to get canceled but it wasn't")
 				return "", nil
 			}
 		}

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"sync"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -464,4 +465,75 @@ func (t *zoneAwareContextTracker) cancelAllContexts(cause error) {
 		delete(t.contexts, instance)
 		delete(t.cancelFuncs, instance)
 	}
+}
+
+type inflightInstanceTracker struct {
+	mx       sync.Mutex
+	inflight []map[*InstanceDesc]struct{}
+
+	// expectMoreInstances is true if more instances are expected to be added to the tracker.
+	expectMoreInstances bool
+}
+
+func newInflightInstanceTracker(sets []ReplicationSet) *inflightInstanceTracker {
+	// Init the inflight tracker.
+	inflight := make([]map[*InstanceDesc]struct{}, len(sets))
+	for idx, set := range sets {
+		inflight[idx] = make(map[*InstanceDesc]struct{}, len(set.Instances))
+	}
+
+	return &inflightInstanceTracker{
+		inflight:            inflight,
+		expectMoreInstances: true,
+	}
+}
+
+// addInstance adds the instance for replicationSetIdx to the tracker.
+//
+// addInstance is idempotent.
+func (t *inflightInstanceTracker) addInstance(replicationSetIdx int, instance *InstanceDesc) {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	t.inflight[replicationSetIdx][instance] = struct{}{}
+}
+
+// removeInstance removes the instance for replicationSetIdx from the tracker.
+//
+// removeInstance is idempotent.
+func (t *inflightInstanceTracker) removeInstance(replicationSetIdx int, instance *InstanceDesc) {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	delete(t.inflight[replicationSetIdx], instance)
+}
+
+// allInstancesAdded signals the tracker that all expected instances have been added.
+func (t *inflightInstanceTracker) allInstancesAdded() {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	t.expectMoreInstances = false
+}
+
+// allInstancesCompleted returns true if and only if no more instances are expected to be
+// added to the tracker and all previously tracked instances have been removed calling removeInstance().
+func (t *inflightInstanceTracker) allInstancesCompleted() bool {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	// We can't assert all instances have completed if it's still possible
+	// to add new ones to the tracker.
+	if t.expectMoreInstances {
+		return false
+	}
+
+	// Ensure there are no inflight instances for any replication set.
+	for _, instances := range t.inflight {
+		if len(instances) > 0 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -509,6 +509,8 @@ func (t *inflightInstanceTracker) removeInstance(replicationSetIdx int, instance
 }
 
 // allInstancesAdded signals the tracker that all expected instances have been added.
+//
+// allInstancesAdded is idempotent.
 func (t *inflightInstanceTracker) allInstancesAdded() {
 	t.mx.Lock()
 	defer t.mx.Unlock()


### PR DESCRIPTION
**What this PR does**:

In this PR:

1. Fix context cancellation in `concurrency.ForEachJob()` when there's 1 job
   - In https://github.com/grafana/dskit/pull/486 I've introduced an optimization to `concurrency.ForEachJob()` to shortcut the invocation when there's only 1 job. However, this introduced a behavior change in how context is handled: the function is expected to cancel the context passed to the callback. This PR fixes it.
3. Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`
   - `DoMultiUntilQuorumWithoutSuccessfulContextCancellation()` is a wrapper around `DoUntilQuorumWithoutSuccessfulContextCancellation()` which allows to call it for multiple `ReplicationSet` and collect the results.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
