### PR TITLE
Fix PartitionRingDesc merge panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493 #496
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444


### PR DESCRIPTION
**What this PR does**:

Yesterday, in the local dev env I've experienced the following panic when running the dskit at [this commit](https://github.com/grafana/dskit/tree/d6732a3418c27fac5c4f8bce2bdde080d9a88b23):

```
panic: assignment to entry in nil map

goroutine 3226 [running]:
github.com/grafana/dskit/ring.(*PartitionRingDesc).mergeWithTime(0xc0033ac240, {0x431bf68, 0xc0033ac350}, 0x0, {0xc16da058af617d42, 0xddd4bd58, 0x5729640})
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/ring/partition_ring_model.go:290 +0x565
github.com/grafana/dskit/ring.(*PartitionRingDesc).Merge(0xc0033ac240, {0x431bf68, 0xc0033ac350}, 0x0)
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/ring/partition_ring_model.go:243 +0xac
github.com/grafana/dskit/kv/memberlist.computeNewValue({0x431bf68, 0xc0033ac350}, {0x431bf68, 0xc0033ac240}, 0x0)
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1426 +0xa7
github.com/grafana/dskit/kv/memberlist.(*KV).mergeValueForKey(0xc001954000, {0xc001bb01c0, 0x1e}, {0x431bf68, 0xc0033ac350}, 0x0, {0x4310d78, 0xc0004aa9d8})
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1377 +0x28a
github.com/grafana/dskit/kv/memberlist.(*KV).mergeBytesValueForKey(0xc001954000, {0xc001bb01c0, 0x1e}, {0xc0033f6000, 0x83a, 0x900}, {0x4310d78, 0xc0004aa9d8})
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1358 +0x385
github.com/grafana/dskit/kv/memberlist.(*KV).processValueUpdate(0xc001954000, 0xc002846b40, {0xc001bb01c0, 0x1e})
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1131 +0x1b8
created by github.com/grafana/dskit/kv/memberlist.(*KV).getKeyWorkerChannel in goroutine 538
	/Users/marco/workspace/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1119 +0x24f
```

The panic happened at startup of `mimir-read` and occurred because it pull the memberlist state from another pod which had an empty partitions ring at that time. When the ring is empty, `PartitionRingDesc.Partitions` and `PartitionRingDesc.Owners` are empty maps in the remote endpoint, but decoded as `nil` by `codec.Codec.Decode()`.

At first I addressed the issue handling the case of `nil` maps in `PartitionRingDesc.Merge()` but then I realised we access these maps in multiple places and having to check if they're `nil` is quite annoying. I think it's easier to assume that when we work with `PartitionRingDesc` in dskit these maps are never nil. `NewPartitionRingDesc()` already did for this purpose.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
