### PR TITLE
Add option to force partition state change from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493 #496 #498
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493 #496 #497 #498
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495

--- a/ring/partition_instance_lifecycler.go
+++ b/ring/partition_instance_lifecycler.go
@@ -154,20 +154,7 @@ func (l *PartitionInstanceLifecycler) GetPartitionState(ctx context.Context) (Pa
 func (l *PartitionInstanceLifecycler) ChangePartitionState(ctx context.Context, toState PartitionState) error {
 	return l.runOnLifecyclerLoop(func() error {
 		err := l.updateRing(ctx, func(ring *PartitionRingDesc) (bool, error) {
-			partition, exists := ring.Partitions[l.cfg.PartitionID]
-			if !exists {
-				return false, ErrPartitionDoesNotExist
-			}
-
-			if partition.State == toState {
-				return false, nil
-			}
-
-			if !isPartitionStateChangeAllowed(partition.State, toState) {
-				return false, errors.Wrapf(ErrPartitionStateChangeNotAllowed, "change partition state from %s to %s", partition.State.CleanName(), toState.CleanName())
-			}
-
-			return ring.UpdatePartitionState(l.cfg.PartitionID, toState, time.Now()), nil
+			return changePartitionState(ring, l.cfg.PartitionID, toState)
 		})
 
 		if err != nil {

--- a/ring/partition_instance_lifecycler_test.go
+++ b/ring/partition_instance_lifecycler_test.go
@@ -324,6 +324,14 @@ func getPartitionRingFromStore(t *testing.T, store kv.Client, key string) *Parti
 	return GetOrCreatePartitionRingDesc(in)
 }
 
+func getPartitionStateFromStore(t *testing.T, store kv.Client, key string, partitionID int32) PartitionState {
+	partition, ok := getPartitionRingFromStore(t, store, key).GetPartitions()[partitionID]
+	if !ok {
+		return PartitionUnknown
+	}
+	return partition.State
+}
+
 func createTestPartitionInstanceLifecyclerConfig(partitionID int32, instanceID string) PartitionInstanceLifecyclerConfig {
 	return PartitionInstanceLifecyclerConfig{
 		PartitionID:                          partitionID,

--- a/ring/partition_ring_editor.go
+++ b/ring/partition_ring_editor.go
@@ -1,0 +1,60 @@
+package ring
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/grafana/dskit/kv"
+)
+
+// PartitionRingEditor is standalone component that can be used to modify the partitions ring.
+// If you want to implement the partition lifecycle you should use PartitionInstanceLifecycler instead.
+type PartitionRingEditor struct {
+	ringKey string
+	store   kv.Client
+}
+
+func NewPartitionRingEditor(ringKey string, store kv.Client) *PartitionRingEditor {
+	return &PartitionRingEditor{
+		ringKey: ringKey,
+		store:   store,
+	}
+}
+
+// ChangePartitionState changes the partition state to toState.
+// This function returns ErrPartitionDoesNotExist if the partition doesn't exist,
+// and ErrPartitionStateChangeNotAllowed if the state change is not allowed.
+func (l *PartitionRingEditor) ChangePartitionState(ctx context.Context, partitionID int32, toState PartitionState) error {
+	return l.updateRing(ctx, func(ring *PartitionRingDesc) (bool, error) {
+		partition, exists := ring.Partitions[partitionID]
+		if !exists {
+			return false, ErrPartitionDoesNotExist
+		}
+
+		if partition.State == toState {
+			return false, nil
+		}
+
+		if !isPartitionStateChangeAllowed(partition.State, toState) {
+			return false, errors.Wrapf(ErrPartitionStateChangeNotAllowed, "change partition state from %s to %s", partition.State.CleanName(), toState.CleanName())
+		}
+
+		return ring.UpdatePartitionState(partitionID, toState, time.Now()), nil
+	})
+}
+
+func (l *PartitionRingEditor) updateRing(ctx context.Context, update func(ring *PartitionRingDesc) (bool, error)) error {
+	return l.store.CAS(ctx, l.ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := GetOrCreatePartitionRingDesc(in)
+
+		if changed, err := update(ringDesc); err != nil {
+			return nil, false, err
+		} else if !changed {
+			return nil, false, nil
+		}
+
+		return ringDesc, true, nil
+	})
+}

--- a/ring/partition_ring_editor_test.go
+++ b/ring/partition_ring_editor_test.go
@@ -1,0 +1,50 @@
+package ring
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/kv/consul"
+)
+
+func TestPartitionRingEditor_ChangePartitionState(t *testing.T) {
+	ctx := context.Background()
+
+	store, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	// Init the ring.
+	require.NoError(t, store.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := GetOrCreatePartitionRingDesc(in)
+		desc.AddPartition(1, PartitionActive, time.Now())
+		desc.AddPartition(2, PartitionActive, time.Now())
+		return desc, true, nil
+	}))
+
+	// Start editor.
+	editor := NewPartitionRingEditor(ringKey, store)
+
+	// Pre-condition: ensure the partitions are in the expected state at the beginning of the test.
+	require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 1))
+	require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 2))
+
+	// A request to switch to state whose transition is not allowed should return error.
+	require.ErrorIs(t, editor.ChangePartitionState(ctx, 1, PartitionPending), ErrPartitionStateChangeNotAllowed)
+	require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 1))
+	require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 2))
+
+	// Switch to inactive.
+	require.NoError(t, editor.ChangePartitionState(ctx, 1, PartitionInactive))
+	require.Equal(t, PartitionInactive, getPartitionStateFromStore(t, store, ringKey, 1))
+	require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 2))
+
+	// A request to switch to the same state should be a no-op.
+	require.NoError(t, editor.ChangePartitionState(ctx, 1, PartitionInactive))
+	require.Equal(t, PartitionInactive, getPartitionStateFromStore(t, store, ringKey, 1))
+	require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 2))
+}

--- a/ring/partition_ring_http_test.go
+++ b/ring/partition_ring_http_test.go
@@ -1,19 +1,26 @@
 package ring
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/services"
 )
 
-func TestPartitionRingPageHandler(t *testing.T) {
+func TestPartitionRingPageHandler_ViewPage(t *testing.T) {
 	handler := NewPartitionRingPageHandler(
 		newStaticPartitionRingReader(
 			NewPartitionRing(PartitionRingDesc{
@@ -48,6 +55,7 @@ func TestPartitionRingPageHandler(t *testing.T) {
 				},
 			}),
 		),
+		nil,
 	)
 
 	recorder := httptest.NewRecorder()
@@ -76,4 +84,117 @@ func TestPartitionRingPageHandler(t *testing.T) {
 		"<td>", "N/A", "</td>",
 		"<td>", "ingester-zone-b-2", "<br />", "</td>",
 	}, `\s*`))), recorder.Body.String())
+}
+
+func TestPartitionRingPageHandler_ChangePartitionState(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	store, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	// Init the ring.
+	require.NoError(t, store.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := GetOrCreatePartitionRingDesc(in)
+		desc.AddPartition(1, PartitionActive, time.Now())
+		desc.AddPartition(2, PartitionActive, time.Now())
+		return desc, true, nil
+	}))
+
+	// Init the watcher.
+	watcher := NewPartitionRingWatcher(testRingName, ringKey, store, logger, nil)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, watcher))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, watcher))
+	})
+
+	// Init the handler.
+	editor := NewPartitionRingEditor(ringKey, store)
+	handler := NewPartitionRingPageHandler(watcher, editor)
+
+	t.Run("should fail if the partition ID is invalid", func(t *testing.T) {
+		data := url.Values{}
+		data.Set("action", "change_state")
+		data.Set("partition_id", "xxx")
+		data.Set("partition_state", PartitionActive.String())
+
+		req := httptest.NewRequest(http.MethodPost, "/partition-ring", strings.NewReader(data.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "invalid partition ID")
+	})
+
+	t.Run("should fail if the partition does not exist", func(t *testing.T) {
+		data := url.Values{}
+		data.Set("action", "change_state")
+		data.Set("partition_id", "100")
+		data.Set("partition_state", PartitionActive.String())
+
+		req := httptest.NewRequest(http.MethodPost, "/partition-ring", strings.NewReader(data.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), ErrPartitionDoesNotExist.Error())
+	})
+
+	t.Run("should fail if the state is invalid", func(t *testing.T) {
+		data := url.Values{}
+		data.Set("action", "change_state")
+		data.Set("partition_id", "1")
+		data.Set("partition_state", "xxx")
+
+		req := httptest.NewRequest(http.MethodPost, "/partition-ring", strings.NewReader(data.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "invalid partition state")
+	})
+
+	t.Run("should fail if the state change is not allowed", func(t *testing.T) {
+		data := url.Values{}
+		data.Set("action", "change_state")
+		data.Set("partition_id", "1")
+		data.Set("partition_state", PartitionPending.String())
+
+		req := httptest.NewRequest(http.MethodPost, "/partition-ring", strings.NewReader(data.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), ErrPartitionStateChangeNotAllowed.Error())
+	})
+
+	t.Run("should succeed if the state change is allowed", func(t *testing.T) {
+		data := url.Values{}
+		data.Set("action", "change_state")
+		data.Set("partition_id", "1")
+		data.Set("partition_state", PartitionInactive.String())
+
+		req := httptest.NewRequest(http.MethodPost, "/partition-ring", strings.NewReader(data.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		recorder := httptest.NewRecorder()
+
+		// Pre-condition check.
+		require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 1))
+		require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 2))
+
+		handler.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusFound, recorder.Code)
+
+		require.Equal(t, PartitionInactive, getPartitionStateFromStore(t, store, ringKey, 1))
+		require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 2))
+	})
 }

--- a/ring/partition_ring_status.gohtml
+++ b/ring/partition_ring_status.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/dskit/ring.httpResponse */ -}}
+{{- /*gotype: github.com/grafana/dskit/ring.partitionRingPageData */ -}}
 <!DOCTYPE html>
 <html>
 <head>
@@ -15,13 +15,21 @@
                 <th>State</th>
                 <th>State updated at</th>
                 <th>Owners</th>
+                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
+        {{ $stateChanges := .PartitionStateChanges }}
         {{ range $partition := .Partitions }}
-            <tr {{ if eq .State "Corrupt" }}bgcolor="#FFDEDE"{{ else if mod $partition.ID 2 }}bgcolor="#BEBEBE"{{ end }}>
+            <tr {{ if .Corrupted }}bgcolor="#FFDEDE"{{ else if mod $partition.ID 2 }}bgcolor="#BEBEBE"{{ end }}>
                 <td>{{ .ID }}</td>
-                <td>{{ .State }}</td>
+                <td>
+                    {{ if .Corrupted }}
+                        Corrupt
+                    {{ else }}
+                        {{ .State.CleanName }}
+                    {{ end }}
+                </td>
                 <td>
                     {{ if not .StateTimestamp.IsZero }}
                         {{ .StateTimestamp | formatTimestamp }}
@@ -32,6 +40,19 @@
                 <td>
                     {{ range $ownerID := $partition.OwnerIDs }}
                         {{$ownerID}} <br />
+                    {{ end }}
+                </td>
+                <td>
+                    <!-- Allow to force a state change -->
+                    {{ if and (not .Corrupted) (ne (index $stateChanges .State) 0) }}
+                        {{ $toState := index $stateChanges .State }}
+                        <form action="" method="POST" onsubmit="return confirm('Do you confirm you want to change the state to {{ $toState.CleanName }}?');">
+                            <input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
+                            <input type="hidden" name="partition_id" value="{{ .ID }}">
+                            <input type="hidden" name="partition_state" value="{{ $toState.String }}">
+
+                            <button name="action" value="change_state" type="submit">Change state to {{ $toState.CleanName }}</button>
+                        </form>
                     {{ end }}
                 </td>
             </tr>


### PR DESCRIPTION
**What this PR does**:

In this PR I'm proposing to add an option to force partition state change from the UI.

##### UX

- To keep the UI simple, I propose to only allow a single state switch based on the partition state:
  - PENDING -> ACTIVE
  - ACTIVE -> INACTIVE
  - INACTIVE -> ACTIVE
- Asks confirmation before proceeding (it's done in javascript)

https://github.com/grafana/dskit/assets/1701904/f405351e-ac2c-495c-b59c-ea4f42cbf583

##### Implementation

- We don't have a component that allows to easily manipulate the partition ring in the store, so I've introduced `PartitionRingEditor`

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
