### PR TITLE
Optimize inflightInstanceTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493 #496
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493 #496 #498
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -469,7 +469,7 @@ func (t *zoneAwareContextTracker) cancelAllContexts(cause error) {
 
 type inflightInstanceTracker struct {
 	mx       sync.Mutex
-	inflight []map[*InstanceDesc]struct{}
+	inflight [][]*InstanceDesc
 
 	// expectMoreInstances is true if more instances are expected to be added to the tracker.
 	expectMoreInstances bool
@@ -477,9 +477,9 @@ type inflightInstanceTracker struct {
 
 func newInflightInstanceTracker(sets []ReplicationSet) *inflightInstanceTracker {
 	// Init the inflight tracker.
-	inflight := make([]map[*InstanceDesc]struct{}, len(sets))
+	inflight := make([][]*InstanceDesc, len(sets))
 	for idx, set := range sets {
-		inflight[idx] = make(map[*InstanceDesc]struct{}, len(set.Instances))
+		inflight[idx] = make([]*InstanceDesc, 0, len(set.Instances))
 	}
 
 	return &inflightInstanceTracker{
@@ -495,7 +495,14 @@ func (t *inflightInstanceTracker) addInstance(replicationSetIdx int, instance *I
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	t.inflight[replicationSetIdx][instance] = struct{}{}
+	// Check if the instance has already been added.
+	for i, instances := 0, t.inflight[replicationSetIdx]; i < len(instances); i++ {
+		if instances[i] == instance {
+			return
+		}
+	}
+
+	t.inflight[replicationSetIdx] = append(t.inflight[replicationSetIdx], instance)
 }
 
 // removeInstance removes the instance for replicationSetIdx from the tracker.
@@ -505,7 +512,14 @@ func (t *inflightInstanceTracker) removeInstance(replicationSetIdx int, instance
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	delete(t.inflight[replicationSetIdx], instance)
+	for i, instances := 0, t.inflight[replicationSetIdx]; i < len(instances); i++ {
+		if instances[i] == instance {
+			t.inflight[replicationSetIdx] = append(instances[:i], instances[i+1:]...)
+
+			// We can safely break the loop because we don't expect multiple occurrences of the same instance.
+			return
+		}
+	}
 }
 
 // allInstancesAdded signals the tracker that all expected instances have been added.

--- a/ring/replication_set_tracker.go
+++ b/ring/replication_set_tracker.go
@@ -496,8 +496,8 @@ func (t *inflightInstanceTracker) addInstance(replicationSetIdx int, instance *I
 	defer t.mx.Unlock()
 
 	// Check if the instance has already been added.
-	for i, instances := 0, t.inflight[replicationSetIdx]; i < len(instances); i++ {
-		if instances[i] == instance {
+	for _, curr := range t.inflight[replicationSetIdx] {
+		if curr == instance {
 			return
 		}
 	}
@@ -512,8 +512,9 @@ func (t *inflightInstanceTracker) removeInstance(replicationSetIdx int, instance
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	for i, instances := 0, t.inflight[replicationSetIdx]; i < len(instances); i++ {
-		if instances[i] == instance {
+	for i, curr := range t.inflight[replicationSetIdx] {
+		if curr == instance {
+			instances := t.inflight[replicationSetIdx]
 			t.inflight[replicationSetIdx] = append(instances[:i], instances[i+1:]...)
 
 			// We can safely break the loop because we don't expect multiple occurrences of the same instance.


### PR DESCRIPTION
**What this PR does**:

Following up a [suggestion received here](https://github.com/grafana/dskit/pull/495#discussion_r1499277214), I've tried to replace the `map` used in `inflightInstanceTracker` with a slice and the performance impact is significative.

```
goos: darwin
goarch: amd64
pkg: github.com/grafana/dskit/ring
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                                                                                    │  before.txt  │             after.txt              │
                                                                                    │    sec/op    │   sec/op     vs base               │
InflightInstanceTracker/few_replication_sets,_many_instances_per_replication_set-12   29.29µ ± 11%   31.08µ ± 7%        ~ (p=0.065 n=6)
InflightInstanceTracker/many_replication_sets,_few_instances_per_replication_set-12   49.89µ ±  8%   33.73µ ± 8%  -32.39% (p=0.002 n=6)
geomean                                                                               38.23µ         32.38µ       -15.31%

                                                                                    │  before.txt   │              after.txt              │
                                                                                    │     B/op      │     B/op      vs base               │
InflightInstanceTracker/few_replication_sets,_many_instances_per_replication_set-12    9.281Ki ± 0%   2.750Ki ± 0%  -70.37% (p=0.002 n=6)
InflightInstanceTracker/many_replication_sets,_few_instances_per_replication_set-12   13.422Ki ± 0%   5.016Ki ± 0%  -62.63% (p=0.002 n=6)
geomean                                                                                11.16Ki        3.714Ki       -66.72%

                                                                                    │ before.txt  │             after.txt             │
                                                                                    │  allocs/op  │ allocs/op   vs base               │
InflightInstanceTracker/few_replication_sets,_many_instances_per_replication_set-12   11.000 ± 0%   5.000 ± 0%  -54.55% (p=0.002 n=6)
InflightInstanceTracker/many_replication_sets,_few_instances_per_replication_set-12    202.0 ± 0%   102.0 ± 0%  -49.50% (p=0.002 n=6)
geomean                                                                                47.14        22.58       -52.09%
```

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
