### PR TITLE
Add native histograms to the main latency histogram metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,10 @@
 * [ENHANCEMENT] Add servicediscovery package. #469
 * [ENHANCEMENT] Expose `InstancesInZoneCount` and `ZonesCount` in `ring.ReadRing` interface. #494
 * [ENHANCEMENT] Add optimization to run `concurrency.ForEachJob()` with no parallelism when there's only 1 job. #486 #495
+* [ENHANCEMENT] Add native histogram version of some metrics: #501
+  * `gate_duration_seconds`
+  * `kv_request_duration_seconds`
+  * `operation_duration_seconds`
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/cache/client.go
+++ b/cache/client.go
@@ -103,6 +103,10 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Name:    "operation_duration_seconds",
 		Help:    "Duration of operations against cache.",
 		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 3, 6, 10},
+		// Use defaults recommended by Prometheus for native histograms.
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
 	}, []string{"operation"})
 	cm.duration.WithLabelValues(opGetMulti)
 	cm.duration.WithLabelValues(opSet)

--- a/gate/gate.go
+++ b/gate/gate.go
@@ -68,6 +68,10 @@ func NewInstrumented(reg prometheus.Registerer, maxConcurrent int, gate Gate) Ga
 			Name:    "gate_duration_seconds",
 			Help:    "How many seconds it took for queries to wait at the gate.",
 			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
+			// Use defaults recommended by Prometheus for native histograms.
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
 		}),
 	}
 

--- a/kv/metrics.go
+++ b/kv/metrics.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -53,6 +54,10 @@ func newMetricsClient(backend string, c Client, reg prometheus.Registerer) Clien
 				Name:    "kv_request_duration_seconds",
 				Help:    "Time spent on kv store requests.",
 				Buckets: prometheus.DefBuckets,
+				// Use defaults recommended by Prometheus for native histograms.
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  100,
+				NativeHistogramMinResetDuration: time.Hour,
 				ConstLabels: prometheus.Labels{
 					"type": backend,
 				},


### PR DESCRIPTION
**What this PR does**:

Add native histograms to the main latency histogram metrics
This helps downstream projects like Mimir transition to using native histograms.

**Which issue(s) this PR fixes**:

Related to: https://github.com/grafana/mimir/issues/5020

**Checklist**
- N/A Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
