### PR TITLE
Enable users of Server to wrap HTTP/gRPC listeners (e.g. add PROXY protocol support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Expose `HTTPListener` and `GRPCListener` to users of `Server` to enable wrapping in other listeners (e.g. `go-proxyprotocol`'s `Listener`).
 * [CHANGE] Add a new middleware to cancel http requests cleanly based on http.TimeoutHandler. #504
 * [CHANGE] Exemplar label changes from "traceID" to "trace_id". #487
 * [CHANGE] server: import godeltaprof/http/pprof adding /debug/pprof/delta_{heap,mutex,block} endpoints to DefaultServeMux #450

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -93,7 +93,7 @@ func TestTCPv4Network(t *testing.T) {
 			errChan <- srv.Run()
 		}()
 
-		require.NoError(t, srv.httpListener.Close())
+		require.NoError(t, srv.HTTPListener.Close())
 		require.NotNil(t, <-errChan)
 
 		// So that address is freed for further tests.
@@ -110,7 +110,7 @@ func TestTCPv4Network(t *testing.T) {
 			errChan <- srv.Run()
 		}()
 
-		require.NoError(t, srv.grpcListener.Close())
+		require.NoError(t, srv.GRPCListener.Close())
 		require.NotNil(t, <-errChan)
 	})
 }
@@ -466,7 +466,7 @@ func TestRunReturnsError(t *testing.T) {
 			errChan <- srv.Run()
 		}()
 
-		require.NoError(t, srv.httpListener.Close())
+		require.NoError(t, srv.HTTPListener.Close())
 		require.NotNil(t, <-errChan)
 
 		// So that address is freed for further tests.
@@ -483,7 +483,7 @@ func TestRunReturnsError(t *testing.T) {
 			errChan <- srv.Run()
 		}()
 
-		require.NoError(t, srv.grpcListener.Close())
+		require.NoError(t, srv.GRPCListener.Close())
 		require.NotNil(t, <-errChan)
 	})
 }


### PR DESCRIPTION
Exposing the listeners enables users of `Server` to wrap them in other listeners, such as `go-proxyproto`'s `Listener` to enable PROXY protocol support.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- makes `Server.httpListener` and `Server.grpcListener` public (e.g. `Server.HTTPListener` and `Server.GRPCListener`)

**Which issue(s) this PR fixes**:

Fixes #n/a

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
