### PR TITLE
Add PROXY protocol support to `Server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Add support for PROXY protocol to Server. #508
 * [CHANGE] Add a new middleware to cancel http requests cleanly based on http.TimeoutHandler. #504
 * [CHANGE] Exemplar label changes from "traceID" to "trace_id". #487
 * [CHANGE] server: import godeltaprof/http/pprof adding /debug/pprof/delta_{heap,mutex,block} endpoints to DefaultServeMux #450

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0
+	github.com/pires/go-proxyproto v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,8 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pires/go-proxyproto v0.7.0 h1:IukmRewDQFWC7kfnb66CSomk2q/seBuilHBYFwyq0Hs=
+github.com/pires/go-proxyproto v0.7.0/go.mod h1:Vz/1JPY/OACxWGQNIRY2BeyDmpoaWmEP40O9LbuiFR4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/server/PROXYPROTOCOL.md
+++ b/server/PROXYPROTOCOL.md
@@ -1,0 +1,28 @@
+# PROXY protocol support
+
+> **Note:** enabling PROXY protocol support does not break existing setups (e.g. non-PROXY connections are still accepted), however it does add a small overhead to the connection handling.
+ 
+To enable PROXY protocol support, set `Config.ProxyProtocolEnabled` to `true` before initializing a `Server` in your application. This enables PROXY protocol for both HTTP and gRPC servers.
+
+```go
+cfg := &Config{
+    ProxyProtocolEnabled: true,
+    // ...
+}
+
+server := NewServer(cfg)
+// ...
+```
+
+PROXY protocol is supported by using [go-proxyproto](https://github.com/pires/go-proxyproto).
+Both PROXY v1 and PROXY v2 are supported out of the box.
+
+When enabled, incoming connections are checked for the PROXY header, and if present, the connection information is updated to reflect the original source address.
+Most commonly, you will use the source address via [Request.RemoteAddr](https://pkg.go.dev/net/http#Request.RemoteAddr).
+
+```go
+server.HTTP.HandleFunc("/your-endpoint", func(w http.ResponseWriter, r *http.Request) {
+    ip, _, err := net.SplitHostPort(r.RemoteAddr)
+    // ...
+})
+```

--- a/server/fake_server.pb.go
+++ b/server/fake_server.pb.go
@@ -29,6 +29,49 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+type ProxyProtoIPResponse struct {
+	IP string `protobuf:"bytes,1,opt,name=IP,proto3" json:"IP,omitempty"`
+}
+
+func (m *ProxyProtoIPResponse) Reset()      { *m = ProxyProtoIPResponse{} }
+func (*ProxyProtoIPResponse) ProtoMessage() {}
+func (*ProxyProtoIPResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a932e7b7b9f5c118, []int{0}
+}
+func (m *ProxyProtoIPResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ProxyProtoIPResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ProxyProtoIPResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ProxyProtoIPResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ProxyProtoIPResponse.Merge(m, src)
+}
+func (m *ProxyProtoIPResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *ProxyProtoIPResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ProxyProtoIPResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ProxyProtoIPResponse proto.InternalMessageInfo
+
+func (m *ProxyProtoIPResponse) GetIP() string {
+	if m != nil {
+		return m.IP
+	}
+	return ""
+}
+
 type FailWithHTTPErrorRequest struct {
 	Code int32 `protobuf:"varint,1,opt,name=Code,proto3" json:"Code,omitempty"`
 }
@@ -36,7 +79,7 @@ type FailWithHTTPErrorRequest struct {
 func (m *FailWithHTTPErrorRequest) Reset()      { *m = FailWithHTTPErrorRequest{} }
 func (*FailWithHTTPErrorRequest) ProtoMessage() {}
 func (*FailWithHTTPErrorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a932e7b7b9f5c118, []int{0}
+	return fileDescriptor_a932e7b7b9f5c118, []int{1}
 }
 func (m *FailWithHTTPErrorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -73,32 +116,61 @@ func (m *FailWithHTTPErrorRequest) GetCode() int32 {
 }
 
 func init() {
+	proto.RegisterType((*ProxyProtoIPResponse)(nil), "server.ProxyProtoIPResponse")
 	proto.RegisterType((*FailWithHTTPErrorRequest)(nil), "server.FailWithHTTPErrorRequest")
 }
 
 func init() { proto.RegisterFile("fake_server.proto", fileDescriptor_a932e7b7b9f5c118) }
 
 var fileDescriptor_a932e7b7b9f5c118 = []byte{
-	// 265 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4c, 0x4b, 0xcc, 0x4e,
-	0x8d, 0x2f, 0x4e, 0x2d, 0x2a, 0x4b, 0x2d, 0xd2, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x83,
-	0xf0, 0xa4, 0xa4, 0xd3, 0xf3, 0xf3, 0xd3, 0x73, 0x52, 0xf5, 0xc1, 0xa2, 0x49, 0xa5, 0x69, 0xfa,
-	0xa9, 0xb9, 0x05, 0x25, 0x95, 0x10, 0x45, 0x4a, 0x7a, 0x5c, 0x12, 0x6e, 0x89, 0x99, 0x39, 0xe1,
-	0x99, 0x25, 0x19, 0x1e, 0x21, 0x21, 0x01, 0xae, 0x45, 0x45, 0xf9, 0x45, 0x41, 0xa9, 0x85, 0xa5,
-	0xa9, 0xc5, 0x25, 0x42, 0x42, 0x5c, 0x2c, 0xce, 0xf9, 0x29, 0xa9, 0x12, 0x8c, 0x0a, 0x8c, 0x1a,
-	0xac, 0x41, 0x60, 0xb6, 0xd1, 0x6d, 0x26, 0x2e, 0x2e, 0xb7, 0xc4, 0xec, 0xd4, 0x60, 0xb0, 0xd9,
-	0x42, 0xd6, 0x5c, 0xec, 0xc1, 0xa5, 0xc9, 0xc9, 0xa9, 0xa9, 0x29, 0x42, 0x62, 0x7a, 0x10, 0x7b,
-	0xf4, 0x60, 0xf6, 0xe8, 0xb9, 0x82, 0xec, 0x91, 0xc2, 0x21, 0xae, 0xc4, 0x20, 0xe4, 0xc8, 0xc5,
-	0x0b, 0xb3, 0x1b, 0x6c, 0x2f, 0x19, 0x46, 0xf8, 0x73, 0x09, 0x62, 0x38, 0x5f, 0x48, 0x41, 0x0f,
-	0x1a, 0x0e, 0xb8, 0x7c, 0x86, 0xc7, 0x40, 0x4b, 0x2e, 0xd6, 0xe0, 0x9c, 0xd4, 0xd4, 0x02, 0xb2,
-	0xbc, 0xc3, 0x1d, 0x5c, 0x52, 0x94, 0x9a, 0x98, 0x4b, 0xa6, 0x01, 0x06, 0x8c, 0x4e, 0x26, 0x17,
-	0x1e, 0xca, 0x31, 0xdc, 0x78, 0x28, 0xc7, 0xf0, 0xe1, 0xa1, 0x1c, 0x63, 0xc3, 0x23, 0x39, 0xc6,
-	0x15, 0x8f, 0xe4, 0x18, 0x4f, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1, 0xc1, 0x23, 0x39,
-	0xc6, 0x17, 0x8f, 0xe4, 0x18, 0x3e, 0x3c, 0x92, 0x63, 0x9c, 0xf0, 0x58, 0x8e, 0xe1, 0xc2, 0x63,
-	0x39, 0x86, 0x1b, 0x8f, 0xe5, 0x18, 0x92, 0xd8, 0xc0, 0x26, 0x19, 0x03, 0x02, 0x00, 0x00, 0xff,
-	0xff, 0x43, 0x2b, 0x71, 0x6d, 0x04, 0x02, 0x00, 0x00,
+	// 330 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x91, 0xb1, 0x4e, 0x02, 0x41,
+	0x10, 0x86, 0x77, 0x51, 0x30, 0xae, 0xd1, 0x84, 0x8d, 0x31, 0x04, 0xcd, 0x84, 0x5c, 0x61, 0xac,
+	0x0e, 0xa3, 0x36, 0xc6, 0x4a, 0x09, 0xc4, 0xab, 0xdc, 0xdc, 0x91, 0x58, 0x9a, 0x03, 0x06, 0x24,
+	0x1c, 0xec, 0xb9, 0x77, 0x67, 0xa4, 0xf3, 0x11, 0x7c, 0x0c, 0x3b, 0x5f, 0xc3, 0x92, 0x92, 0x52,
+	0x96, 0xc6, 0x92, 0x47, 0x30, 0x2c, 0x12, 0x0b, 0xc5, 0xe2, 0xba, 0x9d, 0xc9, 0xe4, 0xff, 0xbf,
+	0x7f, 0x7f, 0x96, 0x6f, 0xfb, 0x3d, 0xbc, 0x8b, 0x50, 0x3d, 0xa2, 0xb2, 0x43, 0x25, 0x63, 0xc9,
+	0x73, 0x8b, 0xa9, 0xb8, 0xdf, 0x91, 0xb2, 0x13, 0x60, 0xd9, 0x6c, 0x1b, 0x49, 0xbb, 0x8c, 0xfd,
+	0x30, 0x1e, 0x2e, 0x8e, 0xac, 0x43, 0xb6, 0x2b, 0x94, 0x7c, 0x1a, 0x8a, 0xf9, 0xe4, 0x08, 0x17,
+	0xa3, 0x50, 0x0e, 0x22, 0xe4, 0x3b, 0x2c, 0xe3, 0x88, 0x02, 0x2d, 0xd1, 0xa3, 0x4d, 0x37, 0xe3,
+	0x08, 0xcb, 0x66, 0x85, 0x9a, 0xdf, 0x0d, 0x6e, 0xbb, 0xf1, 0xfd, 0x75, 0xbd, 0x2e, 0xaa, 0x4a,
+	0x49, 0xe5, 0xe2, 0x43, 0x82, 0x51, 0xcc, 0x39, 0x5b, 0xaf, 0xc8, 0x16, 0x9a, 0xeb, 0xac, 0x6b,
+	0xde, 0x27, 0x6f, 0x6b, 0x8c, 0xd5, 0xfc, 0x1e, 0x7a, 0x86, 0x81, 0x5f, 0xb0, 0x0d, 0x2f, 0x69,
+	0x36, 0x11, 0x5b, 0x7c, 0xcf, 0x5e, 0xf0, 0xd8, 0x4b, 0x1e, 0xbb, 0x3a, 0xe7, 0x29, 0xae, 0xd8,
+	0x5b, 0x84, 0x5f, 0xb2, 0xed, 0xa5, 0xb7, 0xf1, 0x4d, 0x21, 0x71, 0xc3, 0xf2, 0xbf, 0xf0, 0x79,
+	0xc9, 0xfe, 0xfe, 0xaf, 0x55, 0xc9, 0xfe, 0x11, 0x3c, 0x67, 0x59, 0x2f, 0x40, 0x0c, 0x53, 0xc5,
+	0xd9, 0xf2, 0x62, 0x85, 0x7e, 0x3f, 0xa5, 0xc0, 0x31, 0xe5, 0x2e, 0x2b, 0xb8, 0x18, 0x27, 0x6a,
+	0xf0, 0xd3, 0x5d, 0xc5, 0x0f, 0x02, 0x54, 0x8e, 0x58, 0xa9, 0x77, 0xb0, 0x4c, 0xfb, 0x57, 0xdf,
+	0x16, 0xb9, 0x3a, 0x1b, 0x4d, 0x80, 0x8c, 0x27, 0x40, 0x66, 0x13, 0xa0, 0xcf, 0x1a, 0xe8, 0xab,
+	0x06, 0xfa, 0xae, 0x81, 0x8e, 0x34, 0xd0, 0x0f, 0x0d, 0xf4, 0x53, 0x03, 0x99, 0x69, 0xa0, 0x2f,
+	0x53, 0x20, 0xa3, 0x29, 0x90, 0xf1, 0x14, 0x48, 0x23, 0x67, 0x5c, 0x4e, 0xbf, 0x02, 0x00, 0x00,
+	0xff, 0xff, 0xf3, 0x3d, 0xce, 0x89, 0x80, 0x02, 0x00, 0x00,
 }
 
+func (this *ProxyProtoIPResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ProxyProtoIPResponse)
+	if !ok {
+		that2, ok := that.(ProxyProtoIPResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.IP != that1.IP {
+		return false
+	}
+	return true
+}
 func (this *FailWithHTTPErrorRequest) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -122,6 +194,16 @@ func (this *FailWithHTTPErrorRequest) Equal(that interface{}) bool {
 		return false
 	}
 	return true
+}
+func (this *ProxyProtoIPResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&server.ProxyProtoIPResponse{")
+	s = append(s, "IP: "+fmt.Sprintf("%#v", this.IP)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
 }
 func (this *FailWithHTTPErrorRequest) GoString() string {
 	if this == nil {
@@ -159,6 +241,7 @@ type FakeServerClient interface {
 	FailWithHTTPError(ctx context.Context, in *FailWithHTTPErrorRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	Sleep(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*empty.Empty, error)
 	StreamSleep(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (FakeServer_StreamSleepClient, error)
+	ReturnProxyProtoCallerIP(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*ProxyProtoIPResponse, error)
 }
 
 type fakeServerClient struct {
@@ -237,6 +320,15 @@ func (x *fakeServerStreamSleepClient) Recv() (*empty.Empty, error) {
 	return m, nil
 }
 
+func (c *fakeServerClient) ReturnProxyProtoCallerIP(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*ProxyProtoIPResponse, error) {
+	out := new(ProxyProtoIPResponse)
+	err := c.cc.Invoke(ctx, "/server.FakeServer/ReturnProxyProtoCallerIP", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // FakeServerServer is the server API for FakeServer service.
 type FakeServerServer interface {
 	Succeed(context.Context, *empty.Empty) (*empty.Empty, error)
@@ -244,6 +336,7 @@ type FakeServerServer interface {
 	FailWithHTTPError(context.Context, *FailWithHTTPErrorRequest) (*empty.Empty, error)
 	Sleep(context.Context, *empty.Empty) (*empty.Empty, error)
 	StreamSleep(*empty.Empty, FakeServer_StreamSleepServer) error
+	ReturnProxyProtoCallerIP(context.Context, *empty.Empty) (*ProxyProtoIPResponse, error)
 }
 
 // UnimplementedFakeServerServer can be embedded to have forward compatible implementations.
@@ -264,6 +357,9 @@ func (*UnimplementedFakeServerServer) Sleep(ctx context.Context, req *empty.Empt
 }
 func (*UnimplementedFakeServerServer) StreamSleep(req *empty.Empty, srv FakeServer_StreamSleepServer) error {
 	return status.Errorf(codes.Unimplemented, "method StreamSleep not implemented")
+}
+func (*UnimplementedFakeServerServer) ReturnProxyProtoCallerIP(ctx context.Context, req *empty.Empty) (*ProxyProtoIPResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReturnProxyProtoCallerIP not implemented")
 }
 
 func RegisterFakeServerServer(s *grpc.Server, srv FakeServerServer) {
@@ -363,6 +459,24 @@ func (x *fakeServerStreamSleepServer) Send(m *empty.Empty) error {
 	return x.ServerStream.SendMsg(m)
 }
 
+func _FakeServer_ReturnProxyProtoCallerIP_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(empty.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FakeServerServer).ReturnProxyProtoCallerIP(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/server.FakeServer/ReturnProxyProtoCallerIP",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FakeServerServer).ReturnProxyProtoCallerIP(ctx, req.(*empty.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _FakeServer_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "server.FakeServer",
 	HandlerType: (*FakeServerServer)(nil),
@@ -383,6 +497,10 @@ var _FakeServer_serviceDesc = grpc.ServiceDesc{
 			MethodName: "Sleep",
 			Handler:    _FakeServer_Sleep_Handler,
 		},
+		{
+			MethodName: "ReturnProxyProtoCallerIP",
+			Handler:    _FakeServer_ReturnProxyProtoCallerIP_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -392,6 +510,36 @@ var _FakeServer_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Metadata: "fake_server.proto",
+}
+
+func (m *ProxyProtoIPResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ProxyProtoIPResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ProxyProtoIPResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.IP) > 0 {
+		i -= len(m.IP)
+		copy(dAtA[i:], m.IP)
+		i = encodeVarintFakeServer(dAtA, i, uint64(len(m.IP)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *FailWithHTTPErrorRequest) Marshal() (dAtA []byte, err error) {
@@ -433,6 +581,19 @@ func encodeVarintFakeServer(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+func (m *ProxyProtoIPResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.IP)
+	if l > 0 {
+		n += 1 + l + sovFakeServer(uint64(l))
+	}
+	return n
+}
+
 func (m *FailWithHTTPErrorRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -451,6 +612,16 @@ func sovFakeServer(x uint64) (n int) {
 func sozFakeServer(x uint64) (n int) {
 	return sovFakeServer(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+func (this *ProxyProtoIPResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ProxyProtoIPResponse{`,
+		`IP:` + fmt.Sprintf("%v", this.IP) + `,`,
+		`}`,
+	}, "")
+	return s
+}
 func (this *FailWithHTTPErrorRequest) String() string {
 	if this == nil {
 		return "nil"
@@ -468,6 +639,91 @@ func valueToStringFakeServer(v interface{}) string {
 	}
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("*%v", pv)
+}
+func (m *ProxyProtoIPResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowFakeServer
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ProxyProtoIPResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ProxyProtoIPResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IP", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFakeServer
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthFakeServer
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthFakeServer
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.IP = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipFakeServer(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthFakeServer
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthFakeServer
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *FailWithHTTPErrorRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)

--- a/server/fake_server.proto
+++ b/server/fake_server.proto
@@ -10,6 +10,11 @@ service FakeServer {
     rpc FailWithHTTPError(FailWithHTTPErrorRequest) returns (google.protobuf.Empty) {};
     rpc Sleep(google.protobuf.Empty) returns (google.protobuf.Empty) {};
     rpc StreamSleep(google.protobuf.Empty) returns (stream google.protobuf.Empty) {};
+    rpc ReturnProxyProtoCallerIP(google.protobuf.Empty) returns (ProxyProtoIPResponse) {};
+}
+
+message ProxyProtoIPResponse {
+    string IP = 1;
 }
 
 message FailWithHTTPErrorRequest {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -78,7 +78,7 @@ func cancelableSleep(ctx context.Context, sleep time.Duration) error {
 	return ctx.Err()
 }
 
-func (f FakeServer) ReturnProxyProtoCallerIP(ctx context.Context, empty *protobuf.Empty) (*ProxyProtoIPResponse, error) {
+func (f FakeServer) ReturnProxyProtoCallerIP(ctx context.Context, _ *protobuf.Empty) (*ProxyProtoIPResponse, error) {
 	p, _ := peer.FromContext(ctx)
 	ip, _, err := net.SplitHostPort(p.Addr.String())
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -781,7 +781,7 @@ func TestLogSourceIPs(t *testing.T) {
 		logger.assertContains(t, "sourceIPs=127.0.0.1")
 	})
 
-	t.Run("without PROXY protocol", func(t *testing.T) {
+	t.Run("with PROXY protocol", func(t *testing.T) {
 		logger := newFakeLogger()
 		cfg.Log = logger
 		cfg.ProxyProtocolEnabled = true


### PR DESCRIPTION
**What this PR does**:
Adds support for PROXY protocol to `Server`, by using `go-proxyproto` package.

**Which issue(s) this PR fixes**:

Fixes N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
