### PR TITLE
Do not allow partition state change from inactive to pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@
 * [FEATURE] Add `middleware.HTTPGRPCTracer` for more detailed server-side tracing spans and tags on `httpgrpc.HTTP/Handle` requests
 * [FEATURE] Server: Add support for `GrpcInflightMethodLimiter` -- limiting gRPC requests before reading full request into the memory. This can be used to implement global or method-specific inflight limits for gRPC methods. #377 #392
 * [FEATURE] Server: Add `-grpc.server.num-workers` flag that configures the `grpc.NumStreamWorkers()` option. This can be used to start a fixed base amount of workers to process gRPC requests and avoid stack allocation for each call. #400
-* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493 #496 #497 #498 #503
+* [FEATURE] Add `PartitionRing`. The partitions ring is hash ring to shard data between partitions. #474 #476 #478 #479 #481 #483 #484 #485 #488 #489 #493 #496 #497 #498 #503 #509
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495

--- a/ring/partition_instance_lifecycler.go
+++ b/ring/partition_instance_lifecycler.go
@@ -23,7 +23,7 @@ var (
 	allowedPartitionStateChanges = map[PartitionState][]PartitionState{
 		PartitionPending:  {PartitionActive, PartitionInactive},
 		PartitionActive:   {PartitionInactive},
-		PartitionInactive: {PartitionPending, PartitionActive},
+		PartitionInactive: {PartitionActive},
 	}
 )
 


### PR DESCRIPTION
**What this PR does**:

It's not safe to change a partition from inactive to pending because of:

```
	// Should NOT allow changing from inactive to pending. The reason is that due to async ring changes propagation
	// (via memberlist) there's no guarantee that the partition was already switched from inactive to active in the
	// meanwhile by another instance, and the switch from active to pending is not allowed in order to guarantee
	// read consistency.
```

Initially we wanted to allow it, but then we decided to not do it. Mimir is not doing it.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
