### PR TITLE
instrumented gate: observe permitted and non-permitted queries separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@
   * `gate_duration_seconds`
   * `kv_request_duration_seconds`
   * `operation_duration_seconds`
+* [ENHANCEMENT] Add `outcome` label to `gate_duration_seconds` metric. Possible values are `rejected_canceled`, `rejected_deadline_exceeded`, `rejected_other`, and `permitted`. #512
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/gate/gate.go
+++ b/gate/gate.go
@@ -64,7 +64,7 @@ func NewInstrumented(reg prometheus.Registerer, maxConcurrent int, gate Gate) Ga
 			Name: "gate_queries_in_flight",
 			Help: "Number of queries that are currently in flight.",
 		}),
-		duration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		duration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "gate_duration_seconds",
 			Help:    "How many seconds it took for queries to wait at the gate.",
 			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
@@ -72,7 +72,7 @@ func NewInstrumented(reg prometheus.Registerer, maxConcurrent int, gate Gate) Ga
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
-		}),
+		}, []string{"outcome"}),
 	}
 
 	g.max.Set(float64(maxConcurrent))
@@ -84,20 +84,19 @@ type instrumentedGate struct {
 
 	max      prometheus.Gauge
 	inflight prometheus.Gauge
-	duration prometheus.Histogram
+	duration *prometheus.HistogramVec
 }
 
 func (g *instrumentedGate) Start(ctx context.Context) error {
 	start := time.Now()
-	defer func() {
-		g.duration.Observe(time.Since(start).Seconds())
-	}()
 
 	err := g.gate.Start(ctx)
 	if err != nil {
+		g.duration.WithLabelValues("not_permitted").Observe(time.Since(start).Seconds())
 		return err
 	}
 
+	g.duration.WithLabelValues("permitted").Observe(time.Since(start).Seconds())
 	g.inflight.Inc()
 	return nil
 }

--- a/gate/gate.go
+++ b/gate/gate.go
@@ -173,37 +173,3 @@ func (g *blockingGate) Done() {
 		panic("gate.Done: more operations done than started")
 	}
 }
-
-// WithTimeout returns a Gate implementation that returns ErrTimeout if the
-// waiting time exceeds the given timeout.
-// If timeout is 0, the gate will not enforce any timeout.
-func WithTimeout(gate Gate, timeout time.Duration) Gate {
-	if timeout == 0 {
-		return gate
-	}
-	return timeoutGate{
-		delegate: gate,
-		timeout:  timeout,
-	}
-}
-
-type timeoutGate struct {
-	delegate Gate
-	timeout  time.Duration
-}
-
-func (t timeoutGate) Start(ctx context.Context) error {
-	if t.timeout == 0 {
-		return t.delegate.Start(ctx)
-	}
-	ctx, cancel := context.WithCancelCause(ctx)
-	time.AfterFunc(t.timeout, func() {
-		cancel(ErrTimeout)
-	})
-
-	return t.delegate.Start(ctx)
-}
-
-func (t timeoutGate) Done() {
-	t.delegate.Done()
-}

--- a/gate/gate.go
+++ b/gate/gate.go
@@ -10,10 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var (
-	ErrMaxConcurrent = errors.New("max concurrent requests inflight")
-	ErrTimeout       = errors.New("concurrency gate waiting timeout")
-)
+var ErrMaxConcurrent = errors.New("max concurrent requests inflight")
 
 // Gate controls the maximum number of concurrently running and waiting queries.
 //


### PR DESCRIPTION
This distinction helps when debugging increased congestion on a gate.


**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
