### PR TITLE
Removed unused time.Duration parameter from ShouldLog() function in middle.OptionalLogging interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [CHANGE] Expose `BuildHTTPMiddleware` to enable dskit `Server` instrumentation addition on external `*mux.Router`s. #459
 * [CHANGE] Remove `RouteHTTPToGRPC` option and related functionality #460
 * [CHANGE] Cache: Remove `MemcachedCache` and `RedisCache` structs in favor of `RemoteCacheAdapter` or using the underlying clients directly. #471
+* [CHANGE] Removed unused `time.Duration` parameter from `ShouldLog()` function in `middle.OptionalLogging` interface. #513
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -170,7 +170,7 @@ func TestServerHandleDoNotLogError(t *testing.T) {
 				var optional middleware.OptionalLogging
 				if testData.doNotLogError {
 					require.ErrorAs(t, err, &optional)
-					require.False(t, optional.ShouldLog(context.Background(), 0))
+					require.False(t, optional.ShouldLog(context.Background()))
 				} else {
 					require.False(t, errors.As(err, &optional))
 				}

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -37,9 +36,9 @@ func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
 
 type doNotLogError struct{ Err error }
 
-func (i doNotLogError) Error() string                                     { return i.Err.Error() }
-func (i doNotLogError) Unwrap() error                                     { return i.Err }
-func (i doNotLogError) ShouldLog(_ context.Context, _ time.Duration) bool { return false }
+func (i doNotLogError) Error() string                    { return i.Err.Error() }
+func (i doNotLogError) Unwrap() error                    { return i.Err }
+func (i doNotLogError) ShouldLog(_ context.Context) bool { return false }
 
 func TestGrpcLogging(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
**What this PR does**:

Yesterday I was working on conditional error logging in Mimir and I noticed that the duration parameter of `ShouldLog()` is not used anywhere. I talked to Bryan which mentioned it was originally added in `weaveworks/common` (before we forked it into `dskit`) "just in case". I propose to remove it since we still don't have a practical use case for it. Given `dskit` is under our control (and we don't mind breaking interfaces), we can always add it back if needed.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
