### PR TITLE
Return sampling frequency from ShouldLog()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 * [CHANGE] Remove `RouteHTTPToGRPC` option and related functionality #460
 * [CHANGE] Cache: Remove `MemcachedCache` and `RedisCache` structs in favor of `RemoteCacheAdapter` or using the underlying clients directly. #471
 * [CHANGE] Removed unused `time.Duration` parameter from `ShouldLog()` function in `middle.OptionalLogging` interface. #513
-* [CHANGE] Changed `ShouldLog()` function signature in `middle.OptionalLogging` interface to `ShouldLog(context.Context) (bool, string)`: the returned `string` contains an optional reason. When reason is valued, `GRPCServerLog` adds `(<reason>)` suffix to the error. #513
+* [CHANGE] Changed `ShouldLog()` function signature in `middle.OptionalLogging` interface to `ShouldLog(context.Context) (bool, string)`: the returned `string` contains an optional reason. When reason is valued, `GRPCServerLog` adds `(<reason>)` suffix to the error. #514
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 * [CHANGE] Remove `RouteHTTPToGRPC` option and related functionality #460
 * [CHANGE] Cache: Remove `MemcachedCache` and `RedisCache` structs in favor of `RemoteCacheAdapter` or using the underlying clients directly. #471
 * [CHANGE] Removed unused `time.Duration` parameter from `ShouldLog()` function in `middle.OptionalLogging` interface. #513
-* [CHANGE] Changed `ShouldLog()` function signature in `middle.OptionalLogging` interface to `ShouldLog(context.Context) (bool, int)`: the returned `int` is the sampled frequency. When a log is sampled, `GRPCServerLog` now wraps the error adding `(sampled 1/<frequency>)`. #513
+* [CHANGE] Changed `ShouldLog()` function signature in `middle.OptionalLogging` interface to `ShouldLog(context.Context) (bool, string)`: the returned `string` contains an optional reason. When reason is valued, `GRPCServerLog` adds `(<reason>)` suffix to the error. #513
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,8 @@
 * [CHANGE] Expose `BuildHTTPMiddleware` to enable dskit `Server` instrumentation addition on external `*mux.Router`s. #459
 * [CHANGE] Remove `RouteHTTPToGRPC` option and related functionality #460
 * [CHANGE] Cache: Remove `MemcachedCache` and `RedisCache` structs in favor of `RemoteCacheAdapter` or using the underlying clients directly. #471
-* [CHANGE] Removed unused `time.Duration` parameter from `ShouldLog()` function in `middle.OptionalLogging` interface. #513
-* [CHANGE] Changed `ShouldLog()` function signature in `middle.OptionalLogging` interface to `ShouldLog(context.Context) (bool, string)`: the returned `string` contains an optional reason. When reason is valued, `GRPCServerLog` adds `(<reason>)` suffix to the error. #514
+* [CHANGE] Removed unused `time.Duration` parameter from `ShouldLog()` function in `middleware.OptionalLogging` interface. #513
+* [CHANGE] Changed `ShouldLog()` function signature in `middleware.OptionalLogging` interface to `ShouldLog(context.Context) (bool, string)`: the returned `string` contains an optional reason. When reason is valued, `GRPCServerLog` adds `(<reason>)` suffix to the error. #514
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * [CHANGE] Remove `RouteHTTPToGRPC` option and related functionality #460
 * [CHANGE] Cache: Remove `MemcachedCache` and `RedisCache` structs in favor of `RemoteCacheAdapter` or using the underlying clients directly. #471
 * [CHANGE] Removed unused `time.Duration` parameter from `ShouldLog()` function in `middle.OptionalLogging` interface. #513
+* [CHANGE] Changed `ShouldLog()` function signature in `middle.OptionalLogging` interface to `ShouldLog(context.Context) (bool, int)`: the returned `int` is the sampled frequency. When a log is sampled, `GRPCServerLog` now wraps the error adding `(sampled 1/<frequency>)`. #513
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -170,7 +170,9 @@ func TestServerHandleDoNotLogError(t *testing.T) {
 				var optional middleware.OptionalLogging
 				if testData.doNotLogError {
 					require.ErrorAs(t, err, &optional)
-					require.False(t, optional.ShouldLog(context.Background()))
+
+					actual, _ := optional.ShouldLog(context.Background())
+					require.False(t, actual)
 				} else {
 					require.False(t, errors.As(err, &optional))
 				}

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -59,14 +59,14 @@ func TestGrpcLogging(t *testing.T) {
 		expectedErr: DoNotLogError{Err: errors.New("yolo")},
 		logContains: nil,
 	}, {
-		inputErr:    sampledError{err: errors.New("yolo"), shouldLog: true, frequency: 10},
-		expectedErr: fmt.Errorf("%w (sampled 1/10)", sampledError{err: errors.New("yolo"), shouldLog: true, frequency: 10}),
+		inputErr:    sampledError{err: errors.New("yolo"), shouldLog: true, reason: "sampled 1/10"},
+		expectedErr: fmt.Errorf("%w (sampled 1/10)", sampledError{err: errors.New("yolo"), shouldLog: true, reason: "sampled 1/10"}),
 		logContains: []string{`err="yolo (sampled 1/10)"`},
 	}, {
-		inputErr: sampledError{err: errors.New("yolo"), shouldLog: false, frequency: 10},
+		inputErr: sampledError{err: errors.New("yolo"), shouldLog: false, reason: "sampled 1/10"},
 
 		// The returned error should have the "sampled" suffix because it has been effectively sampled even if not logged.
-		expectedErr: fmt.Errorf("%w (sampled 1/10)", sampledError{err: errors.New("yolo"), shouldLog: false, frequency: 10}),
+		expectedErr: fmt.Errorf("%w (sampled 1/10)", sampledError{err: errors.New("yolo"), shouldLog: false, reason: "sampled 1/10"}),
 		logContains: nil,
 	}} {
 		t.Run("", func(t *testing.T) {
@@ -102,9 +102,9 @@ func TestGrpcLogging(t *testing.T) {
 type sampledError struct {
 	err       error
 	shouldLog bool
-	frequency int
+	reason    string
 }
 
-func (e sampledError) Error() string                           { return e.err.Error() }
-func (e sampledError) Unwrap() error                           { return e.err }
-func (e sampledError) ShouldLog(_ context.Context) (bool, int) { return e.shouldLog, e.frequency }
+func (e sampledError) Error() string                              { return e.err.Error() }
+func (e sampledError) Unwrap() error                              { return e.err }
+func (e sampledError) ShouldLog(_ context.Context) (bool, string) { return e.shouldLog, e.reason }

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -34,29 +35,38 @@ func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
 	}
 }
 
-type doNotLogError struct{ Err error }
-
-func (i doNotLogError) Error() string                    { return i.Err.Error() }
-func (i doNotLogError) Unwrap() error                    { return i.Err }
-func (i doNotLogError) ShouldLog(_ context.Context) bool { return false }
-
 func TestGrpcLogging(t *testing.T) {
 	ctx := context.Background()
 	info := &grpc.UnaryServerInfo{FullMethod: "Test"}
 	for _, tc := range []struct {
-		err         error
+		inputErr    error
+		expectedErr error
 		logContains []string
 	}{{
-		err:         context.Canceled,
+		inputErr:    context.Canceled,
+		expectedErr: context.Canceled,
 		logContains: []string{"level=debug", "context canceled"},
 	}, {
-		err:         errors.New("yolo"),
+		inputErr:    errors.New("yolo"),
+		expectedErr: errors.New("yolo"),
 		logContains: []string{"level=warn", "err=yolo"},
 	}, {
-		err:         nil,
+		inputErr:    nil,
+		expectedErr: nil,
 		logContains: []string{"level=debug", "method=Test"},
 	}, {
-		err:         doNotLogError{Err: errors.New("yolo")},
+		inputErr:    DoNotLogError{Err: errors.New("yolo")},
+		expectedErr: DoNotLogError{Err: errors.New("yolo")},
+		logContains: nil,
+	}, {
+		inputErr:    sampledError{err: errors.New("yolo"), shouldLog: true, frequency: 10},
+		expectedErr: fmt.Errorf("%w (sampled 1/10)", sampledError{err: errors.New("yolo"), shouldLog: true, frequency: 10}),
+		logContains: []string{`err="yolo (sampled 1/10)"`},
+	}, {
+		inputErr: sampledError{err: errors.New("yolo"), shouldLog: false, frequency: 10},
+
+		// The returned error should have the "sampled" suffix because it has been effectively sampled even if not logged.
+		expectedErr: fmt.Errorf("%w (sampled 1/10)", sampledError{err: errors.New("yolo"), shouldLog: false, frequency: 10}),
 		logContains: nil,
 	}} {
 		t.Run("", func(t *testing.T) {
@@ -65,11 +75,19 @@ func TestGrpcLogging(t *testing.T) {
 			l := GRPCServerLog{Log: logger, WithRequest: true, DisableRequestSuccessLog: false}
 
 			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, tc.err
+				return nil, tc.inputErr
 			}
 
 			_, err := l.UnaryServerInterceptor(ctx, nil, info, handler)
-			require.ErrorIs(t, tc.err, err)
+
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			// The input error should be preserved in the chain.
+			require.ErrorIs(t, err, tc.inputErr)
 
 			if len(tc.logContains) == 0 {
 				require.Empty(t, buf)
@@ -80,3 +98,13 @@ func TestGrpcLogging(t *testing.T) {
 		})
 	}
 }
+
+type sampledError struct {
+	err       error
+	shouldLog bool
+	frequency int
+}
+
+func (e sampledError) Error() string                           { return e.err.Error() }
+func (e sampledError) Unwrap() error                           { return e.err }
+func (e sampledError) ShouldLog(_ context.Context) (bool, int) { return e.shouldLog, e.frequency }


### PR DESCRIPTION
**What this PR does**:

In order to address https://github.com/grafana/mimir/issues/7690, I propose to push down the "sampled" suffix to `GRPCServerLog`. In order to do it, `GRPCServerLog` needs to know the extra information to add to the logged error, so I've modified `ShouldLog()` to also return a textual "reason" (optional).

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
