### PR TITLE
native histograms: add common defaults for latency metrics

### DIFF
--- a/cache/client.go
+++ b/cache/client.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/dskit/instrument/nativehistogram"
 )
 
 const (
@@ -104,9 +106,9 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Help:    "Duration of operations against cache.",
 		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 3, 6, 10},
 		// Use defaults recommended by Prometheus for native histograms.
-		NativeHistogramBucketFactor:     1.1,
-		NativeHistogramMaxBucketNumber:  100,
-		NativeHistogramMinResetDuration: time.Hour,
+		NativeHistogramBucketFactor:     nativehistogram.LatencyBucketFactor,
+		NativeHistogramMaxBucketNumber:  nativehistogram.LatencyMaxBucketNumber,
+		NativeHistogramMinResetDuration: nativehistogram.LatencyMinResetDuration,
 	}, []string{"operation"})
 	cm.duration.WithLabelValues(opGetMulti)
 	cm.duration.WithLabelValues(opSet)

--- a/gate/gate.go
+++ b/gate/gate.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/dskit/instrument/nativehistogram"
 )
 
 var ErrMaxConcurrent = errors.New("max concurrent requests inflight")
@@ -69,9 +71,9 @@ func NewInstrumented(reg prometheus.Registerer, maxConcurrent int, gate Gate) Ga
 			Help:    "How many seconds it took for queries to wait at the gate.",
 			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720},
 			// Use defaults recommended by Prometheus for native histograms.
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
+			NativeHistogramBucketFactor:     nativehistogram.LatencyBucketFactor,
+			NativeHistogramMaxBucketNumber:  nativehistogram.LatencyMaxBucketNumber,
+			NativeHistogramMinResetDuration: nativehistogram.LatencyMinResetDuration,
 		}, []string{"outcome"}),
 	}
 

--- a/instrument/nativehistogram/native_histogram.go
+++ b/instrument/nativehistogram/native_histogram.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package nativehistogram
+
+import "time"
+
+const (
+	// Define the default values for latency related native histogram configuration.
+	LatencyBucketFactor     = 1.1
+	LatencyMaxBucketNumber  = 100
+	LatencyMinResetDuration = time.Hour
+)

--- a/kv/metrics.go
+++ b/kv/metrics.go
@@ -3,13 +3,13 @@ package kv
 import (
 	"context"
 	"strconv"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/instrument"
+	"github.com/grafana/dskit/instrument/nativehistogram"
 )
 
 // RegistererWithKVName wraps the provided Registerer with the KV name label. If a nil reg
@@ -55,9 +55,9 @@ func newMetricsClient(backend string, c Client, reg prometheus.Registerer) Clien
 				Help:    "Time spent on kv store requests.",
 				Buckets: prometheus.DefBuckets,
 				// Use defaults recommended by Prometheus for native histograms.
-				NativeHistogramBucketFactor:     1.1,
-				NativeHistogramMaxBucketNumber:  100,
-				NativeHistogramMinResetDuration: time.Hour,
+				NativeHistogramBucketFactor:     nativehistogram.LatencyBucketFactor,
+				NativeHistogramMaxBucketNumber:  nativehistogram.LatencyMaxBucketNumber,
+				NativeHistogramMinResetDuration: nativehistogram.LatencyMinResetDuration,
 				ConstLabels: prometheus.Labels{
 					"type": backend,
 				},

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -5,12 +5,11 @@
 package server
 
 import (
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/dskit/instrument"
+	"github.com/grafana/dskit/instrument/nativehistogram"
 	"github.com/grafana/dskit/middleware"
 )
 
@@ -43,8 +42,8 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Help:                            "Time (in seconds) spent serving HTTP requests.",
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
+			NativeHistogramMaxBucketNumber:  nativehistogram.LatencyMaxBucketNumber,
+			NativeHistogramMinResetDuration: nativehistogram.LatencyMinResetDuration,
 		}, []string{"method", "route", "status_code", "ws"}),
 		ReceivedMessageSize: reg.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,


### PR DESCRIPTION
**What this PR does**:

native histograms: add common defaults for latency metrics
To be reused in Mimir and GEM and possibly more.

**Which issue(s) this PR fixes**:

Related to : https://github.com/grafana/mimir/issues/5020

**Checklist**
- N/A Tests updated
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
