### PR TITLE
Expose IngestersWithTokensCount and IngestersWithTokensInZone count from ring.ReadRing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@
   * `kv_request_duration_seconds`
   * `operation_duration_seconds`
 * [ENHANCEMENT] Add `outcome` label to `gate_duration_seconds` metric. Possible values are `rejected_canceled`, `rejected_deadline_exceeded`, `rejected_other`, and `permitted`. #512
+* [ENHANCEMENT] Expose `InstancesWithTokensCount` and `InstancesWithTokensInZoneCount` in `ring.ReadRing` interface. #516
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/ring/model.go
+++ b/ring/model.go
@@ -518,11 +518,35 @@ func (d *Desc) getOldestRegisteredTimestamp() int64 {
 	return result
 }
 
+func (d *Desc) instancesWithTokensCount() int {
+	count := 0
+	if d != nil {
+		for _, ingester := range d.Ingesters {
+			if len(ingester.Tokens) > 0 {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 func (d *Desc) instancesCountPerZone() map[string]int {
 	instancesCountPerZone := map[string]int{}
 	if d != nil {
 		for _, ingester := range d.Ingesters {
 			instancesCountPerZone[ingester.Zone]++
+		}
+	}
+	return instancesCountPerZone
+}
+
+func (d *Desc) instancesWithTokensCountPerZone() map[string]int {
+	instancesCountPerZone := map[string]int{}
+	if d != nil {
+		for _, ingester := range d.Ingesters {
+			if len(ingester.Tokens) > 0 {
+				instancesCountPerZone[ingester.Zone]++
+			}
 		}
 	}
 	return instancesCountPerZone

--- a/ring/replication_strategy.go
+++ b/ring/replication_strategy.go
@@ -109,11 +109,3 @@ func (r *Ring) IsHealthy(instance *InstanceDesc, op Operation, now time.Time) bo
 func (r *Ring) ReplicationFactor() int {
 	return r.cfg.ReplicationFactor
 }
-
-// InstancesCount returns the number of instances in the ring.
-func (r *Ring) InstancesCount() int {
-	r.mtx.RLock()
-	c := len(r.ringDesc.Ingesters)
-	r.mtx.RUnlock()
-	return c
-}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -58,6 +58,9 @@ type ReadRing interface {
 	// InstancesCount returns the number of instances in the ring.
 	InstancesCount() int
 
+	// InstancesWithTokensCount returns the number of instances in the ring that have tokens.
+	InstancesWithTokensCount() int
+
 	// ShuffleShard returns a subring for the provided identifier (eg. a tenant ID)
 	// and size (number of instances).
 	ShuffleShard(identifier string, size int) ReadRing
@@ -81,6 +84,9 @@ type ReadRing interface {
 
 	// InstancesInZoneCount returns the number of instances in the ring that are registered in given zone.
 	InstancesInZoneCount(zone string) int
+
+	// InstancesWithTokensInZoneCount returns the number of instances in the ring that are registered in given zone and have tokens.
+	InstancesWithTokensInZoneCount(zone string) int
 
 	// ZonesCount returns the number of zones for which there's at least 1 instance registered in the ring.
 	ZonesCount() int
@@ -190,8 +196,14 @@ type Ring struct {
 	// to be sorted alphabetically.
 	ringZones []string
 
+	// Number of registered instances with tokens.
+	instancesWithTokensCount int
+
 	// Number of registered instances per zone.
 	instancesCountPerZone map[string]int
+
+	// Nubmber of registered instances with tokens per zone.
+	instancesWithTokensCountPerZone map[string]int
 
 	// Cache of shuffle-sharded subrings per identifier. Invalidated when topology changes.
 	// If set to nil, no caching is done (used by tests, and subrings).
@@ -342,7 +354,9 @@ func (r *Ring) updateRingState(ringDesc *Desc) {
 	ringInstanceByToken := ringDesc.getTokensInfo()
 	ringZones := getZones(ringTokensByZone)
 	oldestRegisteredTimestamp := ringDesc.getOldestRegisteredTimestamp()
+	instancesWithTokensCount := ringDesc.instancesWithTokensCount()
 	instancesCountPerZone := ringDesc.instancesCountPerZone()
+	instancesWithTokensCountPerZone := ringDesc.instancesWithTokensCountPerZone()
 
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
@@ -351,7 +365,9 @@ func (r *Ring) updateRingState(ringDesc *Desc) {
 	r.ringTokensByZone = ringTokensByZone
 	r.ringInstanceByToken = ringInstanceByToken
 	r.ringZones = ringZones
+	r.instancesWithTokensCount = instancesWithTokensCount
 	r.instancesCountPerZone = instancesCountPerZone
+	r.instancesWithTokensCountPerZone = instancesWithTokensCountPerZone
 	r.oldestRegisteredTimestamp = oldestRegisteredTimestamp
 	r.lastTopologyChange = now
 
@@ -808,13 +824,15 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 	shardTokens := mergeTokenGroups(shardTokensByZone)
 
 	return &Ring{
-		cfg:                   r.cfg,
-		strategy:              r.strategy,
-		ringDesc:              shardDesc,
-		ringTokens:            shardTokens,
-		ringTokensByZone:      shardTokensByZone,
-		ringZones:             getZones(shardTokensByZone),
-		instancesCountPerZone: shardDesc.instancesCountPerZone(),
+		cfg:                             r.cfg,
+		strategy:                        r.strategy,
+		ringDesc:                        shardDesc,
+		ringTokens:                      shardTokens,
+		ringTokensByZone:                shardTokensByZone,
+		ringZones:                       getZones(shardTokensByZone),
+		instancesWithTokensCount:        shardDesc.instancesWithTokensCount(),
+		instancesCountPerZone:           shardDesc.instancesCountPerZone(),
+		instancesWithTokensCountPerZone: shardDesc.instancesWithTokensCountPerZone(),
 
 		oldestRegisteredTimestamp: shardDesc.getOldestRegisteredTimestamp(),
 
@@ -1099,12 +1117,28 @@ func (r *Ring) InstancesCount() int {
 	return c
 }
 
+// InstancesWithTokensCount returns the number of instances in the ring that have tokens.
+func (r *Ring) InstancesWithTokensCount() int {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	return r.instancesWithTokensCount
+}
+
 // InstancesInZoneCount returns the number of instances in the ring that are registered in given zone.
 func (r *Ring) InstancesInZoneCount(zone string) int {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
 	return r.instancesCountPerZone[zone]
+}
+
+// InstancesWithTokensInZoneCount returns the number of instances in the ring that are registered in given zone and have tokens.
+func (r *Ring) InstancesWithTokensInZoneCount(zone string) int {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	return r.instancesWithTokensCountPerZone[zone]
 }
 
 func (r *Ring) ZonesCount() int {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -1091,6 +1091,14 @@ func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	newRingPageHandler(r, r.cfg.HeartbeatTimeout).handle(w, req)
 }
 
+// InstancesCount returns the number of instances in the ring.
+func (r *Ring) InstancesCount() int {
+	r.mtx.RLock()
+	c := len(r.ringDesc.Ingesters)
+	r.mtx.RUnlock()
+	return c
+}
+
 // InstancesInZoneCount returns the number of instances in the ring that are registered in given zone.
 func (r *Ring) InstancesInZoneCount(zone string) int {
 	r.mtx.RLock()

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1172,6 +1172,86 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 	}
 }
 
+func TestRing_GetInstancesWithTokensCounts(t *testing.T) {
+	gen := initTokenGenerator(t)
+
+	tests := map[string]struct {
+		ringInstances                          map[string]InstanceDesc
+		expectedInstancesWithTokensCount       int
+		expectedInstancesWithTokensInZoneCount map[string]int
+	}{
+		"empty ring": {
+			ringInstances:                          nil,
+			expectedInstancesWithTokensCount:       0,
+			expectedInstancesWithTokensInZoneCount: map[string]int{},
+		},
+		"single zone, no tokens": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", State: ACTIVE, Tokens: []uint32{}},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", State: LEAVING, Tokens: []uint32{}},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", State: PENDING, Tokens: []uint32{}},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-a", State: JOINING, Tokens: []uint32{}},
+			},
+			expectedInstancesWithTokensCount:       0,
+			expectedInstancesWithTokensInZoneCount: map[string]int{"zone-a": 0},
+		},
+		"single zone, some tokens": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", State: ACTIVE, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", State: ACTIVE, Tokens: []uint32{}},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", State: LEAVING, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-a", State: LEAVING, Tokens: []uint32{}},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-a", State: PENDING, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-a", State: PENDING, Tokens: []uint32{}},
+				"instance-7": {Addr: "127.0.0.7", Zone: "zone-a", State: JOINING, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-8": {Addr: "127.0.0.8", Zone: "zone-a", State: JOINING, Tokens: []uint32{}},
+			},
+			expectedInstancesWithTokensCount:       4,
+			expectedInstancesWithTokensInZoneCount: map[string]int{"zone-a": 4},
+		},
+		"multiple zones": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", State: ACTIVE, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", State: ACTIVE, Tokens: []uint32{}},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", State: LEAVING, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", State: LEAVING, Tokens: []uint32{}},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", State: PENDING, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-d", State: PENDING, Tokens: []uint32{}},
+				"instance-7": {Addr: "127.0.0.7", Zone: "zone-c", State: JOINING, Tokens: gen.GenerateTokens(128, nil)},
+				"instance-8": {Addr: "127.0.0.8", Zone: "zone-d", State: JOINING, Tokens: []uint32{}},
+			},
+			expectedInstancesWithTokensCount:       4,
+			expectedInstancesWithTokensInZoneCount: map[string]int{"zone-a": 1, "zone-b": 1, "zone-c": 2, "zone-d": 0},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// Init the ring.
+			ringDesc := &Desc{Ingesters: testData.ringInstances}
+			for id, instance := range ringDesc.Ingesters {
+				instance.Timestamp = time.Now().Unix()
+				ringDesc.Ingesters[id] = instance
+			}
+
+			ring := Ring{
+				cfg: Config{
+					HeartbeatTimeout:     time.Hour,
+					ZoneAwarenessEnabled: true,
+				},
+				ringDesc:                        ringDesc,
+				instancesWithTokensCount:        ringDesc.instancesWithTokensCount(),
+				instancesWithTokensCountPerZone: ringDesc.instancesWithTokensCountPerZone(),
+			}
+
+			assert.Equal(t, testData.expectedInstancesWithTokensCount, ring.InstancesWithTokensCount())
+			for z, instances := range testData.expectedInstancesWithTokensInZoneCount {
+				assert.Equal(t, instances, ring.InstancesWithTokensInZoneCount(z))
+			}
+		})
+	}
+}
+
 func TestRing_ShuffleShard(t *testing.T) {
 	gen := initTokenGenerator(t)
 

--- a/ring/util_test.go
+++ b/ring/util_test.go
@@ -46,6 +46,10 @@ func (r *RingMock) InstancesCount() int {
 	return 0
 }
 
+func (r *RingMock) InstancesWithTokensCount() int {
+	return 0
+}
+
 func (r *RingMock) ShuffleShard(identifier string, size int) ReadRing {
 	args := r.Called(identifier, size)
 	return args.Get(0).(ReadRing)
@@ -72,6 +76,10 @@ func (r *RingMock) GetTokenRangesForInstance(_ string) (TokenRanges, error) {
 }
 
 func (r *RingMock) InstancesInZoneCount(_ string) int {
+	return 0
+}
+
+func (r *RingMock) InstancesWithTokensInZoneCount(_ string) int {
 	return 0
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds `InstancesWithTokensCount` and `InstancesWithTokensInZoneCount` methods to the `ring.ReadRing` interface and `*ring.Ring` implementation. These methods provide global and per-zone counts of registered instances that have some tokens in the ring, regardless of instance state. In Mimir we need these to exclude instances with no tokens when calculating limits (since these instances won't actually handle a portion of the global limit).

This PR also moves the `InstancesCount` implementation to `ring.go`, with the other instance counting functions.

**Which issue(s) this PR fixes**:

Relates to https://github.com/grafana/mimir/issues/7847

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
