### PR TITLE
Store headers in canonical form when converting from gRPC to HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,3 +237,4 @@
 * [BUGFIX] Services: moduleService could drop stop signals to its underlying service. #409 #417
 * [BUGFIX] ring: don't mark trace spans as failed if `DoUntilQuorum` terminates due to cancellation. #449
 * [BUGFIX] middleware: fix issue where applications that used the httpgrpc tracing middleware would generate duplicate spans for incoming HTTP requests. #451
+* [BUGFIX] httpgrpc: store headers in canonical form when converting from gRPC to HTTP. #518

--- a/httpgrpc/httpgrpc.go
+++ b/httpgrpc/httpgrpc.go
@@ -89,7 +89,9 @@ func WriteError(w http.ResponseWriter, err error) {
 
 func ToHeader(hs []*Header, header http.Header) {
 	for _, h := range hs {
-		header[h.Key] = h.Values
+		// http.Header expects header to be stored in canonical form,
+		// otherwise they are inaccessible with Get() on a http.Header struct.
+		header[http.CanonicalHeaderKey(h.Key)] = h.Values
 	}
 }
 

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -3,6 +3,7 @@ package httpgrpc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/gogo/status"
@@ -27,6 +28,21 @@ func TestAppendMessageSizeToOutgoingContext(t *testing.T) {
 
 	require.Equal(t, []string{"GET"}, md.Get(MetadataMethod))
 	require.Equal(t, []string{"/test"}, md.Get(MetadataURL))
+}
+
+func TestToHeader(t *testing.T) {
+	grpcHeaders := []*Header{
+		{Key: "X-Header", Values: []string{"a", "b", "c"}},
+		{Key: "traceparent", Values: []string{"01234"}},
+	}
+	httpHeaders := http.Header{}
+	ToHeader(grpcHeaders, httpHeaders)
+
+	require.Equal(t, http.Header{
+		"X-Header":    []string{"a", "b", "c"},
+		"Traceparent": []string{"01234"},
+	}, httpHeaders)
+	require.Equal(t, "01234", httpHeaders.Get("traceparent"))
 }
 
 func TestErrorf(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
When applications access the HTTP header via Get() on a http.Header struct, the key is canonicalized before accessing the map [1]. Therefore, if a header is stored in a not canonicalized form, the header is inaccessible.

The Go http.Server converts header names to their canonicalized form when reading incoming HTTP requests to avoid the above issue, and make them effectively case-insensitive [2].

[1] https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/net/textproto/header.go;l=34
[2] https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/net/textproto/reader.go;l=548

**Which issue(s) this PR fixes**:
I ran into the above problem when debugging broken context propagation: OTEL reads the traceparent header with Get() on the http.Header struct [3,4]. If the traceparent header is all-lowercase in the gRPC header and is copied as-is to the http.Header, it effectively is inaccessible via the Get() function on http.Header.

The w3c trace context spec mentions vendors must accept the traceparent header name in any case (upper, lower, mixed).

[3] https://github.com/open-telemetry/opentelemetry-go/blob/dbfc75817a8486891f5b9e461b8a746129533e37/propagation/trace_context.go#L81
[4] https://github.com/open-telemetry/opentelemetry-go/blob/dbfc75817a8486891f5b9e461b8a746129533e37/propagation/propagation.go#L63

**Checklist**
- [X] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
