### PR TITLE
consul mock: respect context cancellations in Get

### DIFF
--- a/kv/consul/mock.go
+++ b/kv/consul/mock.go
@@ -181,6 +181,10 @@ func (m *mockKV) Get(key string, q *consul.QueryOptions) (*consul.KVPair, *consu
 			if value != nil {
 				valueModifyIndex = value.ModifyIndex
 			}
+			if err := q.Context().Err(); err != nil {
+				level.Debug(m.logger).Log("msg", "Get - context error", "key", key)
+				return nil, &consul.QueryMeta{LastIndex: q.WaitIndex}, nil
+			}
 		}
 		if time.Now().After(deadline) {
 			level.Debug(m.logger).Log("msg", "Get - deadline exceeded", "key", key)


### PR DESCRIPTION
**What this PR does**:

What this PR does:

This makes tearing down tests faster. The *consul.Client will wait until *consul.mockKV.Get returns. However, *mockKV.Get will wait 1.5s on average (two broadcasts of the shared sync.Cond) before returning because it's waiting for a new update of the key, which will never come because the test is shutting down. However, in tests that is usually close to 2s because the test started recently.

I tried waiting for the sync.Cond and the context in a separate goroutine, but that becomes more complicated with the mutex and the sync.Cond.

After this change the test will finish after the first sync.Cond broadcast, so 500ms on average and 1s in tests instead of the previous 1.5s and 2s.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
