### PR TITLE
Add concurrency to the memberlist transport's `WriteTo` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,7 +233,7 @@
 * [ENHANCEMENT] Adapt `metrics.SendSumOfGaugesPerTenant` to use `metrics.MetricOption`. #584
 * [ENHANCEMENT] Cache: Add `.Add()` and `.Set()` methods to cache clients. #591
 * [ENHANCEMENT] Cache: Add `.Advance()` methods to mock cache clients for easier testing of TTLs. #601
-* [ENHANCEMENT] Memberlist: Make `WriteTo` non-blocking. #525
+* [ENHANCEMENT] Memberlist: Add concurrency to the transport's WriteTo method. #525
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@
 * [ENHANCEMENT] Adapt `metrics.SendSumOfGaugesPerTenant` to use `metrics.MetricOption`. #584
 * [ENHANCEMENT] Cache: Add `.Add()` and `.Set()` methods to cache clients. #591
 * [ENHANCEMENT] Cache: Add `.Advance()` methods to mock cache clients for easier testing of TTLs. #601
+* [ENHANCEMENT] Memberlist: Make `WriteTo` non-blocking. #525
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -76,11 +76,16 @@ func (cfg *TCPTransportConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix s
 	f.IntVar(&cfg.BindPort, prefix+"memberlist.bind-port", 7946, "Port to listen on for gossip messages.")
 	f.DurationVar(&cfg.PacketDialTimeout, prefix+"memberlist.packet-dial-timeout", 2*time.Second, "Timeout used when connecting to other nodes to send packet.")
 	f.DurationVar(&cfg.PacketWriteTimeout, prefix+"memberlist.packet-write-timeout", 5*time.Second, "Timeout for writing 'packet' data.")
-	f.IntVar(&cfg.MaxConcurrentWrites, prefix+"memberlist.max-concurrent-writes", 1, "Maximum number of concurrent writes to other nodes.")
+	f.IntVar(&cfg.MaxConcurrentWrites, prefix+"memberlist.max-concurrent-writes", 3, "Maximum number of concurrent writes to other nodes.")
 	f.BoolVar(&cfg.TransportDebug, prefix+"memberlist.transport-debug", false, "Log debug transport messages. Note: global log.level must be at debug level as well.")
 
 	f.BoolVar(&cfg.TLSEnabled, prefix+"memberlist.tls-enabled", false, "Enable TLS on the memberlist transport layer.")
 	cfg.TLS.RegisterFlagsWithPrefix(prefix+"memberlist", f)
+}
+
+type writeRequest struct {
+	b    []byte
+	addr string
 }
 
 // TCPTransport is a memberlist.Transport implementation that uses TCP for both packet and stream
@@ -92,9 +97,12 @@ type TCPTransport struct {
 	packetCh     chan *memberlist.Packet
 	connCh       chan net.Conn
 	wg           sync.WaitGroup
-	writeCh      chan struct{}
 	tcpListeners []net.Listener
 	tlsConfig    *tls.Config
+
+	writeMu sync.RWMutex
+	writeCh chan writeRequest
+	writeWG sync.WaitGroup
 
 	shutdown atomic.Int32
 
@@ -124,12 +132,20 @@ func NewTCPTransport(config TCPTransportConfig, logger log.Logger, registerer pr
 
 	// Build out the new transport.
 	var ok bool
+	concurrentWrites := config.MaxConcurrentWrites
+	if concurrentWrites <= 0 {
+		concurrentWrites = 1
+	}
 	t := TCPTransport{
 		cfg:      config,
 		logger:   log.With(logger, "component", "memberlist TCPTransport"),
 		packetCh: make(chan *memberlist.Packet),
 		connCh:   make(chan net.Conn),
-		writeCh:  make(chan struct{}, config.MaxConcurrentWrites),
+		writeCh:  make(chan writeRequest),
+	}
+
+	for i := 0; i < concurrentWrites; i++ {
+		go t.writeWorker()
 	}
 
 	var err error
@@ -430,31 +446,34 @@ func (t *TCPTransport) getAdvertisedAddr() string {
 // WriteTo is a packet-oriented interface that fires off the given
 // payload to the given address.
 func (t *TCPTransport) WriteTo(b []byte, addr string) (time.Time, error) {
-	t.sentPackets.Inc()
-	t.sentPacketsBytes.Add(float64(len(b)))
-	t.writeCh <- struct{}{}
-	go func() {
-		defer func() { <-t.writeCh }()
-		t.writeToAsync(b, addr)
-	}()
+	if t.shutdown.Load() == 1 {
+		return time.Time{}, errors.New("transport is shutting down")
+	}
+	t.writeMu.RLock()
+	defer t.writeMu.RUnlock()
+	t.writeWG.Add(1)
+	t.writeCh <- writeRequest{b: b, addr: addr}
 	return time.Now(), nil
 }
 
-func (t *TCPTransport) writeToAsync(b []byte, addr string) {
-	err := t.writeTo(b, addr)
-	if err != nil {
-		t.sentPacketsErrors.Inc()
+func (t *TCPTransport) writeWorker() {
+	for req := range t.writeCh {
+		b, addr := req.b, req.addr
+		t.sentPackets.Inc()
+		t.sentPacketsBytes.Add(float64(len(b)))
+		err := t.writeTo(b, addr)
+		if err != nil {
+			t.sentPacketsErrors.Inc()
 
-		logLevel := level.Warn(t.logger)
-		if strings.Contains(err.Error(), "connection refused") {
-			// The connection refused is a common error that could happen during normal operations when a node
-			// shutdown (or crash). It shouldn't be considered a warning condition on the sender side.
-			logLevel = t.debugLog()
+			logLevel := level.Warn(t.logger)
+			if strings.Contains(err.Error(), "connection refused") {
+				// The connection refused is a common error that could happen during normal operations when a node
+				// shutdown (or crash). It shouldn't be considered a warning condition on the sender side.
+				logLevel = t.debugLog()
+			}
+			logLevel.Log("msg", "WriteTo failed", "addr", addr, "err", err)
 		}
-		logLevel.Log("msg", "WriteTo failed", "addr", addr, "err", err)
-
-		// WriteTo is used to send "UDP" packets. Since we use TCP, we can detect more errors,
-		// but memberlist library doesn't seem to cope with that very well. That is why we return nil instead.
+		t.writeWG.Done()
 	}
 }
 
@@ -570,9 +589,12 @@ func (t *TCPTransport) StreamCh() <-chan net.Conn {
 
 // Shutdown is called when memberlist is shutting down; this gives the
 // transport a chance to clean up any listeners.
+// This will avoid log spam about errors when we shut down.
 func (t *TCPTransport) Shutdown() error {
 	// This will avoid log spam about errors when we shut down.
-	t.shutdown.Store(1)
+	if old := t.shutdown.Swap(1); old == 1 {
+		return nil // already shut down
+	}
 
 	// Rip through all the connections and shut them down.
 	for _, conn := range t.tcpListeners {
@@ -581,6 +603,12 @@ func (t *TCPTransport) Shutdown() error {
 
 	// Block until all the listener threads have died.
 	t.wg.Wait()
+
+	// Wait until the write channel is empty and close it (to end the writeWorker goroutines).
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+	t.writeWG.Wait()
+	close(t.writeCh)
 	return nil
 }
 

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -3,6 +3,7 @@ package memberlist
 import (
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -78,10 +79,7 @@ func TestTCPTransportWriteToUnreachableAddr(t *testing.T) {
 	writeCt := 50
 
 	// Listen for TCP connections on a random port
-	freePorts, err := getFreePorts(1)
-	require.NoError(t, err)
-	addr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: freePorts[0]}
-	listener, err := net.ListenTCP("tcp", addr)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer listener.Close()
 
@@ -107,7 +105,7 @@ func TestTCPTransportWriteToUnreachableAddr(t *testing.T) {
 	timeStart := time.Now()
 
 	for i := 0; i < writeCt; i++ {
-		_, err = transport.WriteTo([]byte("test"), addr.String())
+		_, err = transport.WriteTo([]byte("test"), listener.Addr().String())
 		require.NoError(t, err)
 	}
 
@@ -117,6 +115,39 @@ func TestTCPTransportWriteToUnreachableAddr(t *testing.T) {
 	assert.Equal(t, writeCt, gotErrorCt, "expected %d errors, got %d", writeCt, gotErrorCt)
 	assert.GreaterOrEqual(t, time.Since(timeStart), 500*time.Millisecond, "expected to take at least 500ms (timeout duration)")
 	assert.LessOrEqual(t, time.Since(timeStart), 2*time.Second, "expected to take less than 2s (timeout + a good margin), writing to unreachable addresses should not block")
+}
+
+func TestTCPTransportWriterAcquireTimeout(t *testing.T) {
+	// Listen for TCP connections on a random port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	logs := &concurrency.SyncBuffer{}
+	logger := log.NewLogfmtLogger(logs)
+
+	cfg := TCPTransportConfig{}
+	flagext.DefaultValues(&cfg)
+	cfg.MaxConcurrentWrites = 1
+	cfg.AcquireWriterTimeout = 1 * time.Millisecond // very short timeout
+	transport, err := NewTCPTransport(cfg, logger, nil)
+	require.NoError(t, err)
+
+	writeCt := 100
+	var reqWg sync.WaitGroup
+	for i := 0; i < writeCt; i++ {
+		reqWg.Add(1)
+		go func() {
+			defer reqWg.Done()
+			transport.WriteTo([]byte("test"), listener.Addr().String()) // nolint:errcheck
+		}()
+	}
+	reqWg.Wait()
+
+	require.NoError(t, transport.Shutdown())
+	gotErrorCt := strings.Count(logs.String(), "WriteTo failed to acquire a writer. Dropping message")
+	assert.Less(t, gotErrorCt, writeCt, "expected to have less errors (%d) than total writes (%d). Some writes should pass.", gotErrorCt, writeCt)
+	assert.NotZero(t, gotErrorCt, "expected errors, got none")
 }
 
 func TestFinalAdvertiseAddr(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
This PR adds concurrency to the WriteTo function with a configurable maximum writes parameter to control the number of goroutines.

This allows the memberlist to keep working if one of the addresses it's trying to write to is unreachable

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/dskit/issues/192

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
