### PR TITLE
spanprofiler: do less work on unsampled traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@
 * [ENHANCEMENT] Add `outcome` label to `gate_duration_seconds` metric. Possible values are `rejected_canceled`, `rejected_deadline_exceeded`, `rejected_other`, and `permitted`. #512
 * [ENHANCEMENT] Expose `InstancesWithTokensCount` and `InstancesWithTokensInZoneCount` in `ring.ReadRing` interface. #516
 * [ENHANCEMENT] Middleware: determine route name in a single place, and add `middleware.ExtractRouteName()` method to allow consuming applications to retrieve the route name. #527
+* [ENHANCEMENT] SpanProfiler: do less work on unsampled traces. #528
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/spanprofiler/spanprofiler_test.go
+++ b/spanprofiler/spanprofiler_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSpanProfiler_pprof_labels_propagation(t *testing.T) {
-	tt := initTestTracer(t)
+	tt := initTestTracer(t, 1)
 	defer func() { require.NoError(t, tt.Close()) }()
 
 	t.Run("pprof labels are not propagated to child spans", func(t *testing.T) {

--- a/spanprofiler/tracer.go
+++ b/spanprofiler/tracer.go
@@ -41,6 +41,9 @@ func (t *tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOp
 	if !ok {
 		return span
 	}
+	if !spanCtx.IsSampled() {
+		return span
+	}
 	// pprof labels are attached only once, at the span root level.
 	if !isRootSpan(opts...) {
 		return span


### PR DESCRIPTION
**What this PR does**:

Skip the work to examine the span and decorate it, if the whole trace is not sampled hence the data is going nowhere.
This is 4% of all garbage in one production Mimir installation I looked at, maybe 2% of all CPU.

```
BenchmarkTracer/unsampled-28             2866868               405.6 ns/op           979 B/op         10 allocs/op
BenchmarkTracer/sampled-28               1000000              1024 ns/op            2346 B/op         25 allocs/op
```

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated
