### PR TITLE
Memcached: Fix issue where non-zero TTLs were trunctated to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,3 +243,4 @@
 * [BUGFIX] ring: don't mark trace spans as failed if `DoUntilQuorum` terminates due to cancellation. #449
 * [BUGFIX] middleware: fix issue where applications that used the httpgrpc tracing middleware would generate duplicate spans for incoming HTTP requests. #451
 * [BUGFIX] httpgrpc: store headers in canonical form when converting from gRPC to HTTP. #518
+* [BUGFIX] Memcached: Don't truncate sub-second TTLs to 0 which results in them being cached forever. #530 


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where if a non-zero TTL smaller than a full second was passed to the `SetAsync` or `SetMultiAsync` methods, the TTL would be truncated to zero seconds which results in the item being cached forever.

Specifically, this fixes an issue in Mimir where items that were supposed to have a several minute TTL computed as `$ttl - time.Since($start)` ended up being cached forever. They were never evicted by Memcached because there was no need to free space in this particular cache due to low usage.

**Which issue(s) this PR fixes**:

Internal postmortem

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
