### PR TITLE
Upgrade golangci-lint to v1.59.1 and faillint to v1.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,10 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 	GOPATH=$(CURDIR)/.tools go install github.com/client9/misspell/cmd/misspell@v0.3.4
 
 .tools/bin/faillint: .tools
-	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.11.0
+	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.13.0
 
 .tools/bin/golangci-lint: .tools
-	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
+	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
 
 .tools/bin/protoc: .tools
 ifeq ("$(wildcard .tools/protoc/bin/protoc)","")

--- a/concurrency/limited_concurrency_singleflight_test.go
+++ b/concurrency/limited_concurrency_singleflight_test.go
@@ -34,7 +34,7 @@ func TestLimitedConcurrencySingleFlight_ForEachNotInFlight_ConcurrencyLimit(t *t
 		require.NoError(t, sf.ForEachNotInFlight(ctx, tokens, f))
 	}
 
-	busyWorker := func(ctx context.Context, s string) error {
+	busyWorker := func(context.Context, string) error {
 		workersToStart.Done()
 		<-workersWait
 		return nil
@@ -49,7 +49,7 @@ func TestLimitedConcurrencySingleFlight_ForEachNotInFlight_ConcurrencyLimit(t *t
 	workersToStart.Wait()
 
 	extraWorkerInvoked := make(chan struct{})
-	go forEachNotInFlight(func(ctx context.Context, s string) error {
+	go forEachNotInFlight(func(context.Context, string) error {
 		close(extraWorkerInvoked)
 		return nil
 	}, "10")
@@ -77,7 +77,7 @@ func TestLimitedConcurrencySingleFlight_ForEachNotInFlight_ReturnsWhenAllTokensA
 
 	workersToStart.Add(1)
 	go func() {
-		require.NoError(t, sf.ForEachNotInFlight(ctx, []string{token}, func(ctx context.Context, s string) error {
+		require.NoError(t, sf.ForEachNotInFlight(ctx, []string{token}, func(context.Context, string) error {
 			workersToStart.Done()
 			<-workersWait
 			return nil
@@ -87,7 +87,7 @@ func TestLimitedConcurrencySingleFlight_ForEachNotInFlight_ReturnsWhenAllTokensA
 	workersToStart.Wait()
 
 	duplicatedTokenInvoked := false
-	require.NoError(t, sf.ForEachNotInFlight(ctx, []string{token}, func(ctx context.Context, s string) error {
+	require.NoError(t, sf.ForEachNotInFlight(ctx, []string{token}, func(context.Context, string) error {
 		duplicatedTokenInvoked = true
 		return nil
 	}))
@@ -114,7 +114,7 @@ func TestLimitedConcurrencySingleFlight_ForEachNotInFlight_CallsOnlyNotInFlightT
 
 	workersToStart.Add(1)
 	go func() {
-		require.NoError(t, sf.ForEachNotInFlight(ctx, []string{tokenA}, func(ctx context.Context, s string) error {
+		require.NoError(t, sf.ForEachNotInFlight(ctx, []string{tokenA}, func(context.Context, string) error {
 			workersToStart.Done()
 			<-workersWait
 			return nil
@@ -123,7 +123,7 @@ func TestLimitedConcurrencySingleFlight_ForEachNotInFlight_CallsOnlyNotInFlightT
 
 	workersToStart.Wait()
 	var invocations atomic.Int64
-	assert.NoError(t, sf.ForEachNotInFlight(ctx, []string{tokenA, tokenB}, func(ctx context.Context, s string) error {
+	assert.NoError(t, sf.ForEachNotInFlight(ctx, []string{tokenA, tokenB}, func(_ context.Context, s string) error {
 		assert.Equal(t, tokenB, s)
 		invocations.Inc()
 		return nil
@@ -136,7 +136,7 @@ func TestLimitedConcurrencySingleFlight_ForEachNotInFlight_ReturnsWhenTokensAreE
 	t.Parallel()
 
 	var invocations atomic.Int64
-	assert.NoError(t, NewLimitedConcurrencySingleFlight(10).ForEachNotInFlight(context.Background(), []string{}, func(ctx context.Context, s string) error {
+	assert.NoError(t, NewLimitedConcurrencySingleFlight(10).ForEachNotInFlight(context.Background(), []string{}, func(context.Context, string) error {
 		invocations.Inc()
 		return nil
 	}))

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -102,7 +102,7 @@ func newIntegrationClientServer(
 	serv, err := server.New(cfg)
 	require.NoError(t, err)
 
-	serv.HTTP.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+	serv.HTTP.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "OK")
 	})
 

--- a/grpcclient/ratelimit_test.go
+++ b/grpcclient/ratelimit_test.go
@@ -18,7 +18,7 @@ func TestRateLimiterFailureResultsInResourceExhaustedError(t *testing.T) {
 		RateLimit:      0,
 	}
 	conn := grpc.ClientConn{}
-	invoker := func(currentCtx context.Context, currentMethod string, currentReq, currentRepl interface{}, currentConn *grpc.ClientConn, currentOpts ...grpc.CallOption) error {
+	invoker := func(context.Context, string, interface{}, interface{}, *grpc.ClientConn, ...grpc.CallOption) error {
 		return nil
 	}
 

--- a/grpcutil/health_check.go
+++ b/grpcutil/health_check.go
@@ -16,7 +16,7 @@ type Check func(ctx context.Context) bool
 
 // WithManager returns a new Check that tests if the managed services are healthy.
 func WithManager(manager *services.Manager) Check {
-	return func(ctx context.Context) bool {
+	return func(context.Context) bool {
 		states := manager.ServicesByState()
 
 		// Given this is a health check endpoint for the whole instance, we should consider
@@ -33,7 +33,7 @@ func WithManager(manager *services.Manager) Check {
 
 // WithShutdownRequested returns a new Check that returns false when shutting down.
 func WithShutdownRequested(requested *atomic.Bool) Check {
-	return func(ctx context.Context) bool {
+	return func(context.Context) bool {
 		return !requested.Load()
 	}
 }

--- a/hedging/hedging_test.go
+++ b/hedging/hedging_test.go
@@ -35,7 +35,7 @@ func TestHedging(t *testing.T) {
 	}
 	count := atomic.NewInt32(0)
 	client, err := Client(cfg, &http.Client{
-		Transport: RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		Transport: RoundTripperFunc(func(*http.Request) (*http.Response, error) {
 			count.Inc()
 			time.Sleep(200 * time.Millisecond)
 			return &http.Response{
@@ -70,7 +70,7 @@ func TestHedgingRateLimit(t *testing.T) {
 	}
 	count := atomic.NewInt32(0)
 	client, err := Client(cfg, &http.Client{
-		Transport: RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		Transport: RoundTripperFunc(func(*http.Request) (*http.Response, error) {
 			count.Inc()
 			time.Sleep(200 * time.Millisecond)
 			return &http.Response{

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestReturn4XXErrorsOption(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprint(w, "test")
 		require.NoError(t, err)
 	})
@@ -69,7 +69,7 @@ func newTestServer(t *testing.T, handler http.Handler) (*testServer, error) {
 }
 
 func TestBasic(t *testing.T) {
-	server, err := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server, err := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprint(w, "world")
 		require.NoError(t, err)
 	}))
@@ -97,7 +97,7 @@ func TestError(t *testing.T) {
 			stat = "not "
 		}
 		t.Run(fmt.Sprintf("test header when DoNotLogErrorHeaderKey is %spresent", stat), func(t *testing.T) {
-			server, err := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server, err := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if doNotLog {
 					w.Header().Set(DoNotLogErrorHeaderKey, "true")
 				}
@@ -152,7 +152,7 @@ func TestServerHandleDoNotLogError(t *testing.T) {
 	errMsg := "this is an error"
 	for testName, testData := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if testData.doNotLogError {
 					w.Header().Set(DoNotLogErrorHeaderKey, "true")
 				}
@@ -227,7 +227,7 @@ func TestServerHandleReturn4XXErrors(t *testing.T) {
 	errMsg := "this is an error"
 	for testName, testData := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				http.Error(w, errMsg, testData.errorCode)
 			})
 
@@ -351,7 +351,7 @@ func TestGrpcErrorsHaveCorrectMessage(t *testing.T) {
 	}
 	for testName, testData := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if testData.errorMessageInHeader != "" {
 					w.Header().Set(ErrorMessageHeaderKey, testData.errorMessageInHeader)
 				}

--- a/kv/client_test.go
+++ b/kv/client_test.go
@@ -195,12 +195,12 @@ func TestMultipleInMemoryClient(t *testing.T) {
 	}, stringCodec{value: "bar"}, prometheus.NewRegistry(), logger)
 	require.NoError(t, err)
 
-	require.NoError(t, foo.CAS(context.TODO(), "foo", func(in interface{}) (out interface{}, retry bool, err error) { return "foo", false, nil }))
+	require.NoError(t, foo.CAS(context.TODO(), "foo", func(interface{}) (out interface{}, retry bool, err error) { return "foo", false, nil }))
 	fooKey, err := foo.Get(ctx, "foo")
 	require.NoError(t, err)
 	require.Equal(t, "foo", fooKey.(string))
 
-	require.NoError(t, bar.CAS(context.TODO(), "bar", func(in interface{}) (out interface{}, retry bool, err error) { return "bar", false, nil }))
+	require.NoError(t, bar.CAS(context.TODO(), "bar", func(interface{}) (out interface{}, retry bool, err error) { return "bar", false, nil }))
 	barKey, err := bar.Get(ctx, "bar")
 	require.NoError(t, err)
 	require.Equal(t, "bar", barKey.(string))

--- a/kv/consul/client.go
+++ b/kv/consul/client.go
@@ -116,7 +116,7 @@ func (c *Client) Put(ctx context.Context, key string, value interface{}) error {
 		return err
 	}
 
-	return instrument.CollectedRequest(ctx, "Put", c.consulMetrics.consulRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	return instrument.CollectedRequest(ctx, "Put", c.consulMetrics.consulRequestDuration, instrument.ErrorCode, func(context.Context) error {
 		_, err := c.kv.Put(&consul.KVPair{
 			Key:   key,
 			Value: bytes,
@@ -376,16 +376,18 @@ func checkLastIndex(index, metaLastIndex uint64) (newIndex uint64, skip bool) {
 		// Don't just keep using index=0.
 		// After blocking request, returned index must be at least 1.
 		return 1, false
-	} else if metaLastIndex < index {
+	}
+	if metaLastIndex < index {
 		// Index reset.
 		return 0, false
-	} else if index == metaLastIndex {
+	}
+	if index == metaLastIndex {
 		// Skip if the index is the same as last time, because the key value is
 		// guaranteed to be the same as last time
 		return metaLastIndex, true
-	} else {
-		return metaLastIndex, false
 	}
+
+	return metaLastIndex, false
 }
 
 func (c *Client) createRateLimiter() *rate.Limiter {

--- a/kv/consul/client_test.go
+++ b/kv/consul/client_test.go
@@ -170,7 +170,7 @@ func TestWatchKeyWithNoStartValue(t *testing.T) {
 	defer fn()
 
 	reported := 0
-	c.WatchKey(ctx, key, func(i interface{}) bool {
+	c.WatchKey(ctx, key, func(interface{}) bool {
 		reported++
 		return reported != 2
 	})

--- a/kv/etcd/mock.go
+++ b/kv/etcd/mock.go
@@ -234,15 +234,17 @@ func (m *mockKV) Do(_ context.Context, op clientv3.Op) (clientv3.OpResponse, err
 func (m *mockKV) doInternal(op clientv3.Op) (clientv3.OpResponse, error) {
 	if op.IsGet() {
 		return m.doGet(op)
-	} else if op.IsPut() {
-		return m.doPut(op)
-	} else if op.IsDelete() {
-		return m.doDelete(op)
-	} else if op.IsTxn() {
-		return m.doTxn(op)
-	} else {
-		panic(fmt.Sprintf("unsupported operation: %+v", op))
 	}
+	if op.IsPut() {
+		return m.doPut(op)
+	}
+	if op.IsDelete() {
+		return m.doDelete(op)
+	}
+	if op.IsTxn() {
+		return m.doTxn(op)
+	}
+	panic(fmt.Sprintf("unsupported operation: %+v", op))
 }
 
 func (m *mockKV) doGet(op clientv3.Op) (clientv3.OpResponse, error) {

--- a/kv/etcd/mock_test.go
+++ b/kv/etcd/mock_test.go
@@ -340,7 +340,7 @@ func TestMockKV_Watch(t *testing.T) {
 		return kv, cancel, ch, &complete
 	}
 
-	t.Run("watch stopped by context", func(t *testing.T) {
+	t.Run("watch stopped by context", func(*testing.T) {
 		// Ensure we can use the cancel method of the context given to the watch
 		// to stop the watch
 		_, cancel, _, complete := setupWatchTest("/bar", false)
@@ -348,7 +348,7 @@ func TestMockKV_Watch(t *testing.T) {
 		complete.Wait()
 	})
 
-	t.Run("watch stopped by close", func(t *testing.T) {
+	t.Run("watch stopped by close", func(*testing.T) {
 		// Ensure we can use the Close method of the mockKV given to the watch
 		// to stop the watch
 		kv, _, _, complete := setupWatchTest("/bar", false)

--- a/kv/kv_test.go
+++ b/kv/kv_test.go
@@ -52,7 +52,7 @@ var (
 func TestCAS(t *testing.T) {
 	withFixtures(t, func(t *testing.T, client Client) {
 		// Blindly set key to "0".
-		err := client.CAS(ctx, key, func(in interface{}) (interface{}, bool, error) {
+		err := client.CAS(ctx, key, func(interface{}) (interface{}, bool, error) {
 			return "0", true, nil
 		})
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestCAS(t *testing.T) {
 func TestNilCAS(t *testing.T) {
 	withFixtures(t, func(t *testing.T, client Client) {
 		// Blindly set key to "0".
-		err := client.CAS(ctx, key, func(in interface{}) (interface{}, bool, error) {
+		err := client.CAS(ctx, key, func(interface{}) (interface{}, bool, error) {
 			return "0", true, nil
 		})
 		require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestWatchKey(t *testing.T) {
 				// Start with sleeping, so that watching client see empty KV store at the beginning.
 				time.Sleep(sleep)
 
-				err := client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
+				err := client.CAS(ctx, key, func(interface{}) (out interface{}, retry bool, err error) {
 					return fmt.Sprintf("%d", i), true, nil
 				})
 
@@ -193,7 +193,7 @@ func TestWatchPrefix(t *testing.T) {
 			defer wg.Done()
 
 			// start watching before we even start generating values. values will be buffered
-			client.WatchPrefix(ctx, prefix, func(key string, val interface{}) bool {
+			client.WatchPrefix(ctx, prefix, func(key string, _ interface{}) bool {
 				observedKeysCh <- key
 				return true
 			})
@@ -208,7 +208,7 @@ func TestWatchPrefix(t *testing.T) {
 				time.Sleep(sleep)
 
 				key := fmt.Sprintf("%s%d", p, i)
-				err := client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
+				err := client.CAS(ctx, key, func(interface{}) (out interface{}, retry bool, err error) {
 					return key, true, nil
 				})
 
@@ -268,7 +268,7 @@ func TestList(t *testing.T) {
 
 	withFixtures(t, func(t *testing.T, client Client) {
 		for _, key := range keysToCreate {
-			err := client.CAS(context.Background(), key, func(in interface{}) (out interface{}, retry bool, err error) {
+			err := client.CAS(context.Background(), key, func(interface{}) (out interface{}, retry bool, err error) {
 				return key, false, nil
 			})
 			require.NoError(t, err)

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1171,7 +1171,7 @@ func (m *KV) queueBroadcast(key string, content []string, version uint, message 
 		content: content,
 		version: version,
 		msg:     message,
-		finished: func(b ringBroadcast) {
+		finished: func(ringBroadcast) {
 			m.totalSizeOfBroadcastMessagesInQueue.Sub(float64(l))
 		},
 		logger: m.logger,

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -339,7 +339,7 @@ func TestCASNoOutput(t *testing.T) {
 	withFixtures(t, func(t *testing.T, kv *Client) {
 		// should succeed with single call
 		calls := 0
-		err := cas(kv, key, func(d *data) (*data, bool, error) {
+		err := cas(kv, key, func(*data) (*data, bool, error) {
 			calls++
 			return nil, true, nil
 		})
@@ -352,7 +352,7 @@ func TestCASNoOutput(t *testing.T) {
 func TestCASErrorNoRetry(t *testing.T) {
 	withFixtures(t, func(t *testing.T, kv *Client) {
 		calls := 0
-		err := casWithErr(context.Background(), kv, key, func(d *data) (*data, bool, error) {
+		err := casWithErr(context.Background(), kv, key, func(*data) (*data, bool, error) {
 			calls++
 			return nil, false, errors.New("don't worry, be happy")
 		})
@@ -364,7 +364,7 @@ func TestCASErrorNoRetry(t *testing.T) {
 func TestCASErrorWithRetries(t *testing.T) {
 	withFixtures(t, func(t *testing.T, kv *Client) {
 		calls := 0
-		err := casWithErr(context.Background(), kv, key, func(d *data) (*data, bool, error) {
+		err := casWithErr(context.Background(), kv, key, func(*data) (*data, bool, error) {
 			calls++
 			return nil, true, errors.New("don't worry, be happy")
 		})
@@ -437,7 +437,7 @@ func TestCASNoChangeShortTimeout(t *testing.T) {
 
 func TestCASFailedBecauseOfVersionChanges(t *testing.T) {
 	withFixtures(t, func(t *testing.T, kv *Client) {
-		err := cas(kv, key, func(in *data) (*data, bool, error) {
+		err := cas(kv, key, func(*data) (*data, bool, error) {
 			return &data{Members: map[string]member{"nonempty": {Timestamp: time.Now().Unix()}}}, true, nil
 		})
 		require.NoError(t, err)
@@ -1540,7 +1540,7 @@ func TestMetricsRegistration(t *testing.T) {
 
 	reg := prometheus.NewPedanticRegistry()
 	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, reg)
-	err := kv.CAS(context.Background(), "test", c, func(in interface{}) (out interface{}, retry bool, err error) {
+	err := kv.CAS(context.Background(), "test", c, func(interface{}) (out interface{}, retry bool, err error) {
 		return &data{Members: map[string]member{
 			"member": {},
 		}}, true, nil

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -24,7 +24,7 @@ func TestTCPTransport_WriteTo_ShouldNotLogAsWarningExpectedFailures(t *testing.T
 			unexpectedLogs: "connection refused",
 		},
 		"should log 'connection refused' if debug log level is enabled": {
-			setup: func(t *testing.T, cfg *TCPTransportConfig) {
+			setup: func(_ *testing.T, cfg *TCPTransportConfig) {
 				cfg.TransportDebug = true
 			},
 			remoteAddr:   "127.0.0.1:12345",

--- a/kv/multi.go
+++ b/kv/multi.go
@@ -350,7 +350,7 @@ func (m *MultiClient) writeToSecondary(ctx context.Context, primary kvclient, ke
 		}
 
 		m.mirrorWritesCounter.Inc()
-		err := kvc.client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := kvc.client.CAS(ctx, key, func(interface{}) (out interface{}, retry bool, err error) {
 			// try once
 			return newValue, false, nil
 		})

--- a/middleware/grpc_instrumentation_test.go
+++ b/middleware/grpc_instrumentation_test.go
@@ -289,7 +289,7 @@ func setUpStreamClientInstrumentInterceptorTest(t *testing.T, serverStreams bool
 	t.Cleanup(cancelCtx)
 
 	mockStream := &mockGrpcStream{}
-	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	streamer := func(context.Context, *grpc.StreamDesc, *grpc.ClientConn, string, ...grpc.CallOption) (grpc.ClientStream, error) {
 		return mockStream, nil
 	}
 	desc := &grpc.StreamDesc{ServerStreams: serverStreams}

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -23,7 +23,7 @@ func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
 	ctx := context.Background()
 	info := &grpc.UnaryServerInfo{FullMethod: "Test"}
 
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(context.Context, interface{}) (interface{}, error) {
 		return nil, nil
 	}
 
@@ -74,7 +74,7 @@ func TestGrpcLogging(t *testing.T) {
 			logger := log.NewLogfmtLogger(buf)
 			l := GRPCServerLog{Log: logger, WithRequest: true, DisableRequestSuccessLog: false}
 
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler := func(context.Context, interface{}) (interface{}, error) {
 				return nil, tc.inputErr
 			}
 

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -38,7 +38,7 @@ func TestBadWriteLogging(t *testing.T) {
 		loggingMiddleware := Log{
 			Log: logger,
 		}
-		handler := func(w http.ResponseWriter, r *http.Request) {
+		handler := func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = io.WriteString(w, "<html><body>Hello World!</body></html>")
 		}
 		loggingHandler := loggingMiddleware.Wrap(http.HandlerFunc(handler))
@@ -80,7 +80,7 @@ func TestDisabledSuccessfulRequestsLogging(t *testing.T) {
 			DisableRequestSuccessLog: tc.disableLog,
 		}
 
-		handler := func(w http.ResponseWriter, r *http.Request) {
+		handler := func(w http.ResponseWriter, _ *http.Request) {
 			_, err := io.WriteString(w, "<html><body>Hello World!</body></html>")
 			require.NoError(t, err) //nolint:errcheck
 		}
@@ -122,7 +122,7 @@ func TestLoggingRequestsAtInfoLevel(t *testing.T) {
 			Log:                   log.NewGoKitWithWriter(log.LogfmtFormat, buf),
 			LogRequestAtInfoLevel: true,
 		}
-		handler := func(w http.ResponseWriter, r *http.Request) {
+		handler := func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = io.WriteString(w, "<html><body>Hello World!</body></html>")
 		}
 		loggingHandler := loggingMiddleware.Wrap(http.HandlerFunc(handler))
@@ -173,7 +173,7 @@ func TestLoggingRequestWithExcludedHeaders(t *testing.T) {
 
 			loggingMiddleware := NewLogMiddleware(log.NewGoKitWithWriter(log.LogfmtFormat, buf), true, false, nil, tc.excludeHeaderList)
 
-			handler := func(w http.ResponseWriter, r *http.Request) {
+			handler := func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = io.WriteString(w, "<html><body>Hello world!</body></html>")
 			}
 			loggingHandler := loggingMiddleware.Wrap(http.HandlerFunc(handler))

--- a/middleware/zero_response_test.go
+++ b/middleware/zero_response_test.go
@@ -18,7 +18,7 @@ func TestZeroResponseLogger(t *testing.T) {
 	const body = "Hello"
 
 	s := http.Server{
-		Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		Handler: http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 			_, _ = writer.Write([]byte(body))
 		}),
 		ReadTimeout:       0,

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -307,7 +307,7 @@ func TestModuleWaitsForAllDependencies(t *testing.T) {
 	var serviceA services.Service
 
 	initA := func() (services.Service, error) {
-		serviceA = services.NewIdleService(func(serviceContext context.Context) error {
+		serviceA = services.NewIdleService(func(context.Context) error {
 			// Slow-starting service. Delay is here to verify that service for C is not started before this service
 			// has finished starting.
 			time.Sleep(1 * time.Second)
@@ -318,7 +318,7 @@ func TestModuleWaitsForAllDependencies(t *testing.T) {
 	}
 
 	initC := func() (services.Service, error) {
-		return services.NewIdleService(func(serviceContext context.Context) error {
+		return services.NewIdleService(func(context.Context) error {
 			// At this point, serviceA should be Running, because "C" depends (indirectly) on "A".
 			if s := serviceA.State(); s != services.Running {
 				return fmt.Errorf("serviceA has invalid state: %v", s)
@@ -365,7 +365,7 @@ func TestModuleService_InterruptedFastStartup(t *testing.T) {
 	}, func(serviceContext context.Context) error {
 		<-serviceContext.Done()
 		return nil
-	}, func(failureCase error) error {
+	}, func(error) error {
 		subserviceStopped = true
 		return nil
 	})
@@ -401,10 +401,10 @@ func TestModuleService_InterruptedSlowStartup(t *testing.T) {
 		// Prolong the startup until we have to stop.
 		<-serviceContext.Done()
 		return nil
-	}, func(serviceContext context.Context) error {
+	}, func(context.Context) error {
 		require.Fail(t, "did not expect to enter running state; service should have been canceled while in starting Fn and go directly to stoppingFn")
 		return nil
-	}, func(failureCase error) error {
+	}, func(error) error {
 		subserviceStopped = true
 		return nil
 	})

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -121,7 +121,7 @@ func TestPrivateInterface(t *testing.T) {
 func TestPrivateInterfaceError(t *testing.T) {
 	interfaces := generateTestInterfaces([]string{"eth9"})
 	ipaddr := "not_a_parseable_ip_string"
-	getInterfaceAddrs = func(i *net.Interface) ([]net.Addr, error) {
+	getInterfaceAddrs = func(*net.Interface) ([]net.Addr, error) {
 		return []net.Addr{mockAddr{netAddr: ipaddr}}, nil
 	}
 	logger := log.NewLogfmtLogger(os.Stdout)

--- a/ring/basic_lifecycler_delegates_test.go
+++ b/ring/basic_lifecycler_delegates_test.go
@@ -45,7 +45,7 @@ func TestTokensPersistencyDelegate_ShouldSkipTokensLoadingIfFileDoesNotExist(t *
 	require.NoError(t, os.Remove(tokensFile.Name()))
 
 	testDelegate := &mockDelegate{
-		onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc InstanceDesc) (InstanceState, Tokens) {
+		onRegister: func(_ *BasicLifecycler, _ Desc, instanceExists bool, _ string, _ InstanceDesc) (InstanceState, Tokens) {
 			assert.False(t, instanceExists)
 			return JOINING, Tokens{1, 2, 3, 4, 5}
 		},
@@ -87,7 +87,7 @@ func TestTokensPersistencyDelegate_ShouldLoadTokensFromFileIfFileExist(t *testin
 	require.NoError(t, storedTokens.StoreToFile(tokensFile.Name()))
 
 	testDelegate := &mockDelegate{
-		onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc InstanceDesc) (InstanceState, Tokens) {
+		onRegister: func(_ *BasicLifecycler, _ Desc, instanceExists bool, _ string, instanceDesc InstanceDesc) (InstanceState, Tokens) {
 			assert.True(t, instanceExists)
 			assert.Equal(t, ACTIVE, instanceDesc.GetState())
 			assert.Equal(t, storedTokens, Tokens(instanceDesc.GetTokens()))
@@ -156,7 +156,7 @@ func TestTokensPersistencyDelegate_ShouldHandleTheCaseTheInstanceIsAlreadyInTheR
 			registeredAt := time.Now().Add(-time.Hour)
 
 			testDelegate := &mockDelegate{
-				onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc InstanceDesc) (InstanceState, Tokens) {
+				onRegister: func(_ *BasicLifecycler, _ Desc, _ bool, _ string, instanceDesc InstanceDesc) (InstanceState, Tokens) {
 					return instanceDesc.GetState(), instanceDesc.GetTokens()
 				},
 			}
@@ -170,7 +170,7 @@ func TestTokensPersistencyDelegate_ShouldHandleTheCaseTheInstanceIsAlreadyInTheR
 			defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
 
 			// Add the instance to the ring.
-			require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+			require.NoError(t, store.CAS(ctx, testRingKey, func(interface{}) (out interface{}, retry bool, err error) {
 				ringDesc := NewDesc()
 				ringDesc.AddIngester(cfg.ID, cfg.Addr, cfg.Zone, testData.initialTokens, testData.initialState, registeredAt)
 				return ringDesc, true, nil
@@ -197,7 +197,7 @@ func TestDelegatesChain(t *testing.T) {
 	// Chain delegates together.
 	var chain BasicLifecyclerDelegate
 	chain = &mockDelegate{
-		onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc InstanceDesc) (InstanceState, Tokens) {
+		onRegister: func(_ *BasicLifecycler, _ Desc, instanceExists bool, _ string, _ InstanceDesc) (InstanceState, Tokens) {
 			assert.False(t, instanceExists)
 			return JOINING, Tokens{1, 2, 3, 4, 5}
 		},
@@ -276,7 +276,7 @@ func TestAutoForgetDelegate(t *testing.T) {
 			require.NoError(t, err)
 
 			// Setup the initial state of the ring.
-			require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+			require.NoError(t, store.CAS(ctx, testRingKey, func(interface{}) (out interface{}, retry bool, err error) {
 				ringDesc := NewDesc()
 				testData.setup(ringDesc)
 				return ringDesc, true, nil

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -389,7 +389,7 @@ func TestBasicLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
 
 	// Now we delete it from the ring to simulate a ring storage reset and we expect the next heartbeat
 	// will restore it.
-	require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, store.CAS(ctx, testRingKey, func(interface{}) (out interface{}, retry bool, err error) {
 		return NewDesc(), true, nil
 	}))
 
@@ -495,13 +495,13 @@ func TestBasicLifecycler_updateInstance_ShouldAddInstanceToTheRingIfDoesNotExist
 	expectedRegisteredAt := lifecycler.GetRegisteredAt()
 
 	// Now we delete it from the ring to simulate a ring storage reset.
-	require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, store.CAS(ctx, testRingKey, func(interface{}) (out interface{}, retry bool, err error) {
 		return NewDesc(), true, nil
 	}))
 
 	// Run a noop update instance, but since the instance is not in the ring we do expect
 	// it will added back anyway.
-	require.NoError(t, lifecycler.updateInstance(ctx, func(_ *Desc, desc *InstanceDesc) bool {
+	require.NoError(t, lifecycler.updateInstance(ctx, func(*Desc, *InstanceDesc) bool {
 		return false
 	}))
 

--- a/ring/client/pool_test.go
+++ b/ring/client/pool_test.go
@@ -184,7 +184,7 @@ func TestRemoveClient(t *testing.T) {
 	}
 
 	clientHappy := true
-	factory := PoolAddrFunc(func(addr string) (PoolClient, error) {
+	factory := PoolAddrFunc(func(string) (PoolClient, error) {
 		return &mockClient{happy: clientHappy, status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 	})
 

--- a/ring/lifecycler_test.go
+++ b/ring/lifecycler_test.go
@@ -497,7 +497,7 @@ func TestLifecycler_HeartbeatAfterBackendReset(t *testing.T) {
 
 	// Now we delete it from the ring to simulate a ring storage reset and we expect the next heartbeat
 	// will restore it.
-	require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, store.CAS(ctx, testRingKey, func(interface{}) (out interface{}, retry bool, err error) {
 		return NewDesc(), true, nil
 	}))
 
@@ -546,7 +546,7 @@ func TestLifecycler_IncreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 
 	// Simulate ingester with 64 tokens left the ring in LEAVING state
 	origTokens := initTokenGenerator(t).GenerateTokens(64, nil)
-	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	err = r.KVClient.CAS(ctx, ringKey, func(interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
 		if err != nil {
@@ -622,7 +622,7 @@ func TestLifecycler_DecreasingTokensLeavingInstanceInTheRing(t *testing.T) {
 
 	// Simulate ingester with 128 tokens left the ring in LEAVING state
 	origTokens := initTokenGenerator(t).GenerateTokens(128, nil)
-	err = r.KVClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	err = r.KVClient.CAS(ctx, ringKey, func(interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := NewDesc()
 		addr, err := GetInstanceAddr(lifecyclerConfig.Addr, lifecyclerConfig.InfNames, nil, lifecyclerConfig.EnableInet6)
 		if err != nil {
@@ -891,8 +891,8 @@ func TestCheckReady_CheckRingHealth(t *testing.T) {
 
 			// Wait until both instances are registered in the ring. We expect them to be registered
 			// immediately and then switch to ACTIVE after the configured auto join delay.
-			waitRingInstance(t, 3*time.Second, l1, func(instance InstanceDesc) error { return nil })
-			waitRingInstance(t, 3*time.Second, l2, func(instance InstanceDesc) error { return nil })
+			waitRingInstance(t, 3*time.Second, l1, func(InstanceDesc) error { return nil })
+			waitRingInstance(t, 3*time.Second, l2, func(InstanceDesc) error { return nil })
 
 			// Poll the readiness check until ready and measure how much time it takes.
 			test.Poll(t, 5*time.Second, nil, func() interface{} {
@@ -1209,7 +1209,7 @@ func TestJoinInLeavingState(t *testing.T) {
 	cfg.MinReadyDuration = 1 * time.Nanosecond
 
 	// Set state as LEAVING
-	err = r.KVClient.CAS(context.Background(), ringKey, func(in interface{}) (interface{}, bool, error) {
+	err = r.KVClient.CAS(context.Background(), ringKey, func(interface{}) (interface{}, bool, error) {
 		r := &Desc{
 			Ingesters: map[string]InstanceDesc{
 				"ing1": {
@@ -1266,7 +1266,7 @@ func TestJoinInJoiningState(t *testing.T) {
 	instance2RegisteredAt := time.Now().Add(-2 * time.Hour)
 
 	// Set state as JOINING
-	err = r.KVClient.CAS(context.Background(), ringKey, func(in interface{}) (interface{}, bool, error) {
+	err = r.KVClient.CAS(context.Background(), ringKey, func(interface{}) (interface{}, bool, error) {
 		r := &Desc{
 			Ingesters: map[string]InstanceDesc{
 				"ing1": {
@@ -1321,7 +1321,7 @@ func TestWaitBeforeJoining(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	err = r.KVClient.CAS(context.Background(), ringKey, func(in interface{}) (interface{}, bool, error) {
+	err = r.KVClient.CAS(context.Background(), ringKey, func(interface{}) (interface{}, bool, error) {
 		r := &Desc{
 			Ingesters: map[string]InstanceDesc{
 				instanceName(0, 1): {
@@ -1531,7 +1531,7 @@ func TestRestoreOfZoneWhenOverwritten(t *testing.T) {
 	cfg := testLifecyclerConfig(ringConfig, "ing1")
 
 	// Set ing1 to not have a zone
-	err = r.KVClient.CAS(context.Background(), ringKey, func(in interface{}) (interface{}, bool, error) {
+	err = r.KVClient.CAS(context.Background(), ringKey, func(interface{}) (interface{}, bool, error) {
 		r := &Desc{
 			Ingesters: map[string]InstanceDesc{
 				"ing1": {

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -1163,7 +1163,7 @@ func benchmarkPartitionRingGetTokenRangesForInstance(b *testing.B, partitions in
 }
 
 func TestActivePartitionBatchRing(t *testing.T) {
-	t.Run("should implement DoBatchRing", func(t *testing.T) {
+	t.Run("should implement DoBatchRing", func(*testing.T) {
 		_ = DoBatchRing(&ActivePartitionBatchRing{})
 	})
 }

--- a/ring/replication_set_tracker_test.go
+++ b/ring/replication_set_tracker_test.go
@@ -1363,7 +1363,7 @@ func TestZoneAwareResultTracker_StartMinimumRequests_ZoneSorting(t *testing.T) {
 	mtx := sync.Mutex{}
 	released := []bool{false, false, false, false}
 
-	zoneSorter := func(zones []string) []string {
+	zoneSorter := func([]string) []string {
 		return []string{"zone-c", "zone-a", "zone-d", "zone-b"}
 	}
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -3180,7 +3180,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 	lc, err := NewLifecycler(lcCfg, &noopFlushTransferer{}, "test", "test", false, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
-	lc.AddListener(services.NewListener(nil, nil, nil, nil, func(from services.State, failure error) {
+	lc.AddListener(services.NewListener(nil, nil, nil, nil, func(_ services.State, failure error) {
 		t.Log("lifecycler", lifecyclerID, "failed:", failure)
 		t.Fail()
 	}))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -142,7 +142,7 @@ func TestDefaultAddresses(t *testing.T) {
 	fakeServer := FakeServer{}
 	RegisterFakeServerServer(server.GRPC, fakeServer)
 
-	server.HTTP.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(204)
 	})
 
@@ -181,15 +181,15 @@ func TestErrorInstrumentationMiddleware(t *testing.T) {
 	fakeServer := FakeServer{}
 	RegisterFakeServerServer(server.GRPC, fakeServer)
 
-	server.HTTP.HandleFunc("/succeed", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/succeed", func(http.ResponseWriter, *http.Request) {
 	})
-	server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(500)
 	})
-	server.HTTP.HandleFunc("/sleep10", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/sleep10", func(_ http.ResponseWriter, r *http.Request) {
 		_ = cancelableSleep(r.Context(), time.Second*10)
 	})
-	server.HTTP.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
@@ -322,13 +322,13 @@ func TestHTTPInstrumentationMetrics(t *testing.T) {
 	server, err := New(cfg)
 	require.NoError(t, err)
 
-	server.HTTP.HandleFunc("/succeed", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/succeed", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("OK"))
 	})
-	server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(500)
 	})
-	server.HTTP.HandleFunc("/sleep10", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/sleep10", func(_ http.ResponseWriter, r *http.Request) {
 		_, _ = io.Copy(io.Discard, r.Body) // Consume body, otherwise it's not counted.
 		_ = cancelableSleep(r.Context(), time.Second*10)
 	})
@@ -521,7 +521,7 @@ func TestMiddlewareLogging(t *testing.T) {
 	server, err := New(cfg)
 	require.NoError(t, err)
 
-	server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(500)
 	})
 
@@ -566,7 +566,7 @@ func TestTLSServer(t *testing.T) {
 	server, err := New(cfg)
 	require.NoError(t, err)
 
-	server.HTTP.HandleFunc("/testhttps", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/testhttps", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte("Hello World!"))
 		require.NoError(t, err)
 	})
@@ -661,7 +661,7 @@ func TestTLSServerWithInlineCerts(t *testing.T) {
 
 	require.NoError(t, err)
 
-	server.HTTP.HandleFunc("/testhttps", func(w http.ResponseWriter, r *http.Request) {
+	server.HTTP.HandleFunc("/testhttps", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte("Hello World!"))
 		require.NoError(t, err)
 	})
@@ -753,7 +753,7 @@ func TestLogSourceIPs(t *testing.T) {
 		server, err := New(cfg)
 		require.NoError(t, err)
 
-		server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, r *http.Request) {
+		server.HTTP.HandleFunc("/error500", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(500)
 		})
 
@@ -861,7 +861,7 @@ func (pc *proxyProtocolConn) Write(b []byte) (int, error) {
 }
 
 func proxyDialer(proxyHeader string) func(context.Context, string, string) (net.Conn, error) {
-	return func(ctx context.Context, network string, addr string) (net.Conn, error) {
+	return func(_ context.Context, network string, addr string) (net.Conn, error) {
 		conn, err := net.Dial(network, addr)
 		if err != nil {
 			return nil, err
@@ -955,7 +955,7 @@ func TestGrpcOverProxyProtocol(t *testing.T) {
 	fakeSourceIP := "1.2.3.4"
 
 	// Custom dialer that sends a PROXY header
-	customDialer := func(ctx context.Context, address string) (net.Conn, error) {
+	customDialer := func(_ context.Context, address string) (net.Conn, error) {
 		conn, err := net.Dial("tcp", address)
 		if err != nil {
 			return nil, err

--- a/server/server_tracing_test.go
+++ b/server/server_tracing_test.go
@@ -218,7 +218,7 @@ func TestHTTPGRPCTracing(t *testing.T) {
 
 			grpc_health_v1.RegisterHealthServer(server.GRPC, health.NewServer())
 
-			handlerFunc := func(w http.ResponseWriter, r *http.Request) {}
+			handlerFunc := func(http.ResponseWriter, *http.Request) {}
 			if test.routeName != "" {
 				// explicitly-named routes will be labeled using the provided route name
 				server.HTTP.NewRoute().Name(test.routeName).Path(test.routeTmpl).HandlerFunc(handlerFunc)

--- a/servicediscovery/ring_test.go
+++ b/servicediscovery/ring_test.go
@@ -34,7 +34,7 @@ func TestRingServiceDiscovery_WithoutMaxUsedInstances(t *testing.T) {
 
 	// Create an empty ring.
 	ctx := context.Background()
-	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(interface{}) (out interface{}, retry bool, err error) {
 		return ring.NewDesc(), true, nil
 	}))
 
@@ -136,7 +136,7 @@ func TestRingServiceDiscovery_WithMaxUsedInstances(t *testing.T) {
 
 	// Create an empty ring.
 	ctx := context.Background()
-	require.NoError(t, inmem.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, inmem.CAS(ctx, ringKey, func(interface{}) (out interface{}, retry bool, err error) {
 		return ring.NewDesc(), true, nil
 	}))
 

--- a/services/failure_watcher.go
+++ b/services/failure_watcher.go
@@ -35,7 +35,7 @@ func (w *FailureWatcher) WatchService(service Service) {
 		panic(errFailureWatcherNotInitialized)
 	}
 
-	service.AddListener(NewListener(nil, nil, nil, nil, func(from State, failure error) {
+	service.AddListener(NewListener(nil, nil, nil, nil, func(_ State, failure error) {
 		w.ch <- errors.Wrapf(failure, "service %s failed", DescribeService(service))
 	}))
 }

--- a/services/manager_test.go
+++ b/services/manager_test.go
@@ -274,7 +274,7 @@ func equalStatesMap(t *testing.T, m1, m2 map[State][]Service) {
 }
 
 func serviceThatFailsToStart() Service {
-	return NewBasicService(func(serviceContext context.Context) error {
+	return NewBasicService(func(context.Context) error {
 		return errors.New("failed to start")
 	}, nil, nil)
 }

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -16,7 +16,7 @@ func TestIdleService(t *testing.T) {
 	started := false
 	stopped := false
 
-	s := NewIdleService(func(ctx context.Context) error {
+	s := NewIdleService(func(context.Context) error {
 		started = true
 		return nil
 	}, func(_ error) error {
@@ -43,7 +43,7 @@ func TestTimerService(t *testing.T) {
 
 	var iterations atomic.Uint64
 
-	s := NewTimerService(100*time.Millisecond, nil, func(ctx context.Context) error {
+	s := NewTimerService(100*time.Millisecond, nil, func(context.Context) error {
 		iterations.Inc()
 		return nil
 	}, nil)
@@ -77,7 +77,7 @@ func TestHelperFunctionsStartError(t *testing.T) {
 	t.Parallel()
 
 	e := errors.New("some error")
-	s := NewIdleService(func(serviceContext context.Context) error { return e }, nil)
+	s := NewIdleService(func(context.Context) error { return e }, nil)
 
 	require.Equal(t, e, StartAndAwaitRunning(context.Background(), s))
 	require.Equal(t, e, StopAndAwaitTerminated(context.Background(), s))
@@ -86,7 +86,7 @@ func TestHelperFunctionsStartError(t *testing.T) {
 func TestHelperFunctionsStartTooSlow(t *testing.T) {
 	t.Parallel()
 
-	s := NewIdleService(func(serviceContext context.Context) error {
+	s := NewIdleService(func(context.Context) error {
 		// ignores context
 		time.Sleep(1 * time.Second)
 		return nil


### PR DESCRIPTION
**What this PR does**:
Upgrade golangci-lint to v1.59.1 and faillint to v1.13.0.

Fix a bunch of errors from golangci-lint.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
