### PR TITLE
golangci-lint: Enable loggercheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - gofmt
     - misspell
     - revive
+    - loggercheck
 
 linters-settings:
   errcheck:

--- a/grpcutil/dns_resolver.go
+++ b/grpcutil/dns_resolver.go
@@ -208,7 +208,7 @@ func (w *dnsWatcher) lookupSRV() map[string]*Update {
 		for _, a := range addrs {
 			a, ok := formatIP(a)
 			if !ok {
-				level.Error(w.logger).Log("failed IP parsing", "err", err)
+				level.Error(w.logger).Log("msg", "failed IP parsing", "err", err)
 				continue
 			}
 			addr := a + ":" + strconv.Itoa(int(s.Port))

--- a/log/buffered_test.go
+++ b/log/buffered_test.go
@@ -111,9 +111,12 @@ func TestOnFlushCallback(t *testing.T) {
 	)
 
 	l := log.NewLogfmtLogger(bufLog)
+	//nolint: loggercheck
 	require.NoError(t, l.Log("line"))
+	//nolint: loggercheck
 	require.NoError(t, l.Log("line"))
 	// first flush
+	//nolint: loggercheck
 	require.NoError(t, l.Log("line"))
 
 	// pre-condition check: the last Log() call should have flushed previous entries.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Enable `loggercheck` linter in golangci-lint, and fix caught errors. `loggercheck` makes sure that arguments to logging calls are paired.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
