### PR TITLE
Add Backoff.ErrCause()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@
 * [ENHANCEMENT] SpanProfiler: do less work on unsampled traces. #528
 * [ENHANCEMENT] Log Middleware: if the trace is not sampled, log its ID as `trace_id_unsampled` instead of `trace_id`. #529
 * [EHNANCEMENT] httpgrpc: httpgrpc Server can now use error message from special HTTP header when converting HTTP response to an error. This is useful when HTTP response body contains binary data that doesn't form valid utf-8 string, otherwise grpc would fail to marshal returned error. #531
+* [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -55,16 +55,23 @@ func (b *Backoff) Ongoing() bool {
 }
 
 // Err returns the reason for terminating the backoff, or nil if it didn't terminate.
-// If backoff is terminated because the context has been canceled, then this function
-// returns the context cancellation cause.
 func (b *Backoff) Err() error {
 	if b.ctx.Err() != nil {
-		return context.Cause(b.ctx)
+		return b.ctx.Err()
 	}
 	if b.cfg.MaxRetries != 0 && b.numRetries >= b.cfg.MaxRetries {
 		return fmt.Errorf("terminated after %d retries", b.numRetries)
 	}
 	return nil
+}
+
+// ErrCause is like Err() but returns the context cause if backoff is terminated because the
+// context has been canceled.
+func (b *Backoff) ErrCause() error {
+	if b.ctx.Err() != nil {
+		return context.Cause(b.ctx)
+	}
+	return b.Err()
 }
 
 // NumRetries returns the number of retries so far

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -54,10 +54,12 @@ func (b *Backoff) Ongoing() bool {
 	return b.ctx.Err() == nil && (b.cfg.MaxRetries == 0 || b.numRetries < b.cfg.MaxRetries)
 }
 
-// Err returns the reason for terminating the backoff, or nil if it didn't terminate
+// Err returns the reason for terminating the backoff, or nil if it didn't terminate.
+// If backoff is terminated because the context has been canceled, then this function
+// returns the context cancellation cause.
 func (b *Backoff) Err() error {
 	if b.ctx.Err() != nil {
-		return b.ctx.Err()
+		return context.Cause(b.ctx)
 	}
 	if b.cfg.MaxRetries != 0 && b.numRetries >= b.cfg.MaxRetries {
 		return fmt.Errorf("terminated after %d retries", b.numRetries)

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -105,7 +105,7 @@ func TestBackoff_NextDelay(t *testing.T) {
 	}
 }
 
-func TestBackoff_Err(t *testing.T) {
+func TestBackoff_ErrAndErrCause(t *testing.T) {
 	cause := errors.New("my cause")
 
 	tests := map[string]struct {


### PR DESCRIPTION
**What this PR does**:

In this PR I propose a add `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
