### PR TITLE
Neater string-to-byteslice conversions

### DIFF
--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -311,12 +311,7 @@ func (c *RedisClient) Name() string {
 	return c.name
 }
 
-// stringToBytes converts string to byte slice (copied from vendor/github.com/go-redis/redis/v8/internal/util/unsafe.go).
+// stringToBytes converts string to byte slice.
 func stringToBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(
-		&struct {
-			string
-			Cap int
-		}{s, len(s)},
-	))
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/ring/shard/shard.go
+++ b/ring/shard/shard.go
@@ -41,5 +41,5 @@ func ShuffleShardExpectedInstances(shardSize, numZones int) int {
 
 // yoloBuf will return an unsafe pointer to a string, as the name yolo.yoloBuf implies use at your own risk.
 func yoloBuf(s string) []byte {
-	return *((*[]byte)(unsafe.Pointer(&s)))
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }


### PR DESCRIPTION
`unsafe.Slice` and `unsafe.StringData` were added in Go 1.20

`yoloBuf` previously did not fill in the `cap` member, which didn't matter in the way it was used but was potentially risky in future.