### PR TITLE
Initialise `reason="connect-timeout"` series for cache `operation_failures_total` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,3 +247,4 @@
 * [BUGFIX] middleware: fix issue where applications that used the httpgrpc tracing middleware would generate duplicate spans for incoming HTTP requests. #451
 * [BUGFIX] httpgrpc: store headers in canonical form when converting from gRPC to HTTP. #518
 * [BUGFIX] Memcached: Don't truncate sub-second TTLs to 0 which results in them being cached forever. #530 
+* [BUGFIX] Cache: initialise the `operation_failures_total{reason="connect-timeout"}` metric to 0 for each cache operation type on startup. #545

--- a/cache/client.go
+++ b/cache/client.go
@@ -86,6 +86,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Help: "Total number of operations against cache that failed.",
 	}, []string{"operation", "reason"})
 	for _, op := range []string{opGetMulti, opSet, opDelete, opIncrement, opFlush, opTouch, opCompareAndSwap} {
+		cm.failures.WithLabelValues(op, reasonConnectTimeout)
 		cm.failures.WithLabelValues(op, reasonTimeout)
 		cm.failures.WithLabelValues(op, reasonMalformedKey)
 		cm.failures.WithLabelValues(op, reasonServerError)


### PR DESCRIPTION
**What this PR does**:

This PR adds the missing initialisation of the value of the `operation_failures_total{reason="connect-timeout"}` metric series for each cache operation type.

This ensures that the first failure due to connection timeout after a restart is observable with the `rate()` PromQL function.

All of the other `reason` values emitted by `baseClient.trackError()` are initialised to 0 at startup, this was the only missing one.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
