### PR TITLE
Log correct caller information when `SpanLogger` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,3 +248,4 @@
 * [BUGFIX] httpgrpc: store headers in canonical form when converting from gRPC to HTTP. #518
 * [BUGFIX] Memcached: Don't truncate sub-second TTLs to 0 which results in them being cached forever. #530 
 * [BUGFIX] Cache: initialise the `operation_failures_total{reason="connect-timeout"}` metric to 0 for each cache operation type on startup. #545
+* [BUGFIX] spanlogger: include correct caller information in log messages logged through a `SpanLogger`. #547

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -2124,7 +2124,7 @@ func (l *testLogger) Log(keyvals ...interface{}) error {
 		key := keyvals[i]
 		value := keyvals[i+1]
 
-		if key == "user" || key == "method" {
+		if key == "user" || key == "method" || key == "caller" {
 			// These keys are added automatically by spanlogger, but they're not interesting for our tests.
 			continue
 		}

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -2,6 +2,8 @@ package spanlogger
 
 import (
 	"context"
+	"runtime"
+	"strings"
 
 	"go.uber.org/atomic" // Really just need sync/atomic but there is a lint rule preventing it.
 
@@ -160,6 +162,10 @@ func (s *SpanLogger) getLogger() log.Logger {
 	if ok {
 		logger = log.With(logger, "trace_id", traceID)
 	}
+
+	// Replace the default valuer for the 'caller' attribute with one that gets the caller of the methods in this file.
+	logger = log.With(logger, "caller", spanLoggerAwareCaller())
+
 	// If the value has been set by another goroutine, fetch that other value and discard the one we made.
 	if !s.logger.CompareAndSwap(nil, &logger) {
 		pLogger := s.logger.Load()
@@ -180,4 +186,48 @@ func (s *SpanLogger) SetSpanAndLogTag(key string, value interface{}) {
 	logger := s.getLogger()
 	wrappedLogger := log.With(logger, key, value)
 	s.logger.Store(&wrappedLogger)
+}
+
+// spanLoggerAwareCaller is like log.Caller, but ensures that the caller information is
+// that of the caller to SpanLogger, not SpanLogger itself.
+func spanLoggerAwareCaller() log.Valuer {
+	valuer := atomic.NewPointer[log.Valuer](nil)
+
+	return func() interface{} {
+		// If we've already determined the correct stack depth, use it.
+		existingValuer := valuer.Load()
+		if existingValuer != nil {
+			return (*existingValuer)()
+		}
+
+		// We haven't been called before, determine the correct stack depth to
+		// skip the configured logger's internals and the SpanLogger's internals too.
+		//
+		// Note that we can't do this in spanLoggerAwareCaller() directly because we
+		// need to do this when invoked by the configured logger - otherwise we cannot
+		// measure the stack depth of the logger's internals.
+
+		stackDepth := 3 // log.DefaultCaller uses a stack depth of 3, so start searching for the correct stack depth there.
+
+		for {
+			_, file, _, ok := runtime.Caller(stackDepth)
+			if !ok {
+				// We've run out of possible stack frames. Give up.
+				valuer.Store(&unknownCaller)
+				return unknownCaller()
+			}
+
+			if strings.HasSuffix(file, "spanlogger/spanlogger.go") {
+				stackValuer := log.Caller(stackDepth + 2) // Add one to skip the stack frame for the SpanLogger method, and another to skip the stack frame for the valuer which we'll invoke below.
+				valuer.Store(&stackValuer)
+				return stackValuer()
+			}
+
+			stackDepth++
+		}
+	}
+}
+
+var unknownCaller log.Valuer = func() interface{} {
+	return "<unknown>"
 }

--- a/spanlogger/spanlogger_test.go
+++ b/spanlogger/spanlogger_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -296,7 +297,7 @@ func TestSpanLogger_CallerInfo(t *testing.T) {
 }
 
 func toCallerInfo(path string, lineNumber int) string {
-	fileName := path[strings.LastIndex(path, "/")+1:]
+	fileName := filepath.Base(path)
 
 	return fmt.Sprintf("%s:%v", fileName, lineNumber)
 }


### PR DESCRIPTION
**What this PR does**:

This PR ensures that correct caller information is logged when `SpanLogger` is used.

Previously, messages logged with `SpanLogger` would have `caller=spanlogger.go:xxx`.

Unfortunately we can't retrieve the existing `Caller` instance configured in the logger and replace it with another with an increased stack depth, as there's no way to retrieve existing key/value pairs associated with a logger. So instead I've created a `spanLoggerAwareCaller` that determines the correct stack depth when it is first used.

For similar reasons, this also makes it difficult to only add caller information when the logger is configured to provide caller information, and so `SpanLogger`s will now unconditionally add caller information to all messages logged. Given all of the applications I checked (Mimir, Loki and Tempo) configure their loggers to include caller information, this doesn't seem to be a big issue, but it did require some changes to some tests that assert on log messages emitted through a `SpanLogger`.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
