### PR TITLE
Don't cancel other test jobs if one fails in CI workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -42,6 +42,7 @@ jobs:
         # We want to make sure dskit can support multiple golang versions
         # by ensuring the test would pass using all these supported versions.
         go-version: ['1.21.x', '1.22.x']
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go ${{ matrix.go-version }}


### PR DESCRIPTION
**What this PR does**:

This PR changes the CI workflow to not cancel all other test jobs if one fails.

This behaviour can be annoying when dealing with a flaky test.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
