### PR TITLE
memberlist: Remove noisy debug log message

### DIFF
--- a/kv/memberlist/broadcast.go
+++ b/kv/memberlist/broadcast.go
@@ -1,10 +1,7 @@
 package memberlist
 
 import (
-	"fmt"
-
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/hashicorp/memberlist"
 )
 
@@ -45,7 +42,6 @@ func (r ringBroadcast) Invalidates(old memberlist.Broadcast) bool {
 		// otherwise, we may be invalidating some older messages, which however covered different
 		// ingesters
 		if r.version >= oldb.version {
-			level.Debug(r.logger).Log("msg", "Invalidating forwarded broadcast", "key", r.key, "version", r.version, "oldVersion", oldb.version, "content", fmt.Sprintf("%v", r.content), "oldContent", fmt.Sprintf("%v", oldb.content))
 			return true
 		}
 	}


### PR DESCRIPTION
**What this PR does**:
This PR removes noisy log message: Invalidating previous messages that are still in the queue by new messages is a common case, we don't need to log a message each time it happens.

Found while watching https://www.youtube.com/watch?v=iH0Ufv2bD1U, where it shows up as most frequent log message in the demo.

**Checklist**
- [na] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
