### PR TITLE
crypto/tls.ClientConfig: Set Config.Certificates for backwards compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,7 @@
 * [ENHANCEMENT] memberlist: use separate queue for broadcast messages that are result of local updates, and prioritize locally-generated messages when sending broadcasts. On stopping, only wait for queue with locally-generated messages to be empty. #539
 * [ENHANCEMENT] memberlist: Added `-<prefix>memberlist.broadcast-timeout-for-local-updates-on-shutdown` option to set timeout for sending locally-generated updates on shutdown, instead of previously hardcoded 10s (which is still the default). #539
 * [ENHANCEMENT] tracing: add ExtractTraceSpanID function.
-* [EHNANCEMENT] crypto/tls: Support reloading client certificates #537
+* [EHNANCEMENT] crypto/tls: Support reloading client certificates #537 #552
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
@@ -251,6 +251,6 @@
 * [BUGFIX] ring: don't mark trace spans as failed if `DoUntilQuorum` terminates due to cancellation. #449
 * [BUGFIX] middleware: fix issue where applications that used the httpgrpc tracing middleware would generate duplicate spans for incoming HTTP requests. #451
 * [BUGFIX] httpgrpc: store headers in canonical form when converting from gRPC to HTTP. #518
-* [BUGFIX] Memcached: Don't truncate sub-second TTLs to 0 which results in them being cached forever. #530 
+* [BUGFIX] Memcached: Don't truncate sub-second TTLs to 0 which results in them being cached forever. #530
 * [BUGFIX] Cache: initialise the `operation_failures_total{reason="connect-timeout"}` metric to 0 for each cache operation type on startup. #545
 * [BUGFIX] spanlogger: include correct caller information in log messages logged through a `SpanLogger`. #547

--- a/crypto/tls/tls_test.go
+++ b/crypto/tls/tls_test.go
@@ -111,6 +111,8 @@ func TestGetTLSConfig_ClientCerts(t *testing.T) {
 	assert.Equal(t, false, tlsConfig.InsecureSkipVerify, "make sure we default to not skip verification")
 	require.NotNil(t, tlsConfig.GetClientCertificate, "ensure GetClientCertificate is set")
 	cert, err := tlsConfig.GetClientCertificate(nil)
+	require.Equal(t, []tls.Certificate{*cert}, tlsConfig.Certificates,
+		"Certificates should be set for backwards compatibility with callers using client config for servers")
 	require.NoError(t, err)
 	assert.NotNil(t, cert, "ensure GetClientCertificate returns a certificate")
 


### PR DESCRIPTION
**What this PR does**:
A [recent change](https://github.com/grafana/dskit/pull) in `crypto/tls.ClientConfig.GetTLSConfig` that allows for reloading of client certs, turned out to [break](https://github.com/grafana/dskit/pull/537#issuecomment-2254953303) `memberlist/kv.NewTCPTransport`. Apparently the latter uses `ClientConfig` for a server, which then fails since there's no longer any certificate config for servers.

I propose working around the problem by again setting `crypto/tls.Config.Certificates`, as it used to be prior to the aforementioned change. However, since we now also set `GetClientCertificate`, _clients will prefer the latter_:

```golang
// GetClientCertificate, if not nil, is called when a server requests a
// certificate from a client. If set, the contents of Certificates will
// be ignored.
```

I've tested that this change fixes the broken integration test in Mimir (`TestSingleBinaryWithMemberlist/tls`).

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
