### PR TITLE
Add read only support for computing shuffle shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,7 @@
 * [ENHANCEMENT] memberlist: Added `-<prefix>memberlist.broadcast-timeout-for-local-updates-on-shutdown` option to set timeout for sending locally-generated updates on shutdown, instead of previously hardcoded 10s (which is still the default). #539
 * [ENHANCEMENT] tracing: add ExtractTraceSpanID function.
 * [EHNANCEMENT] crypto/tls: Support reloading client certificates #537 #552
-* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553
+* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -706,6 +706,11 @@ func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 // This function supports caching, but the cache will only be effective if successive calls for the
 // same identifier are with the same lookbackPeriod and increasing values of now.
 func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ReadRing {
+	// Nothing to do if the shard size is not smaller than the actual ring.
+	if lookbackPeriod > 0 && (size <= 0 || r.InstancesCount() <= size) {
+		return r
+	}
+
 	if cached := r.getCachedShuffledSubringWithLookback(identifier, size, lookbackPeriod, now); cached != nil {
 		return cached
 	}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -35,6 +35,7 @@ const (
 )
 
 // ReadRing represents the read interface to the ring.
+// Support for read-only instances requires use of ShuffleShard or ShuffleShardWithLookback prior to getting a ReplicationSet.
 type ReadRing interface {
 	// Get returns n (or more) instances which form the replicas for the given key.
 	// bufDescs, bufHosts and bufZones are slices to be overwritten for the return value
@@ -166,6 +167,7 @@ type instanceInfo struct {
 }
 
 // Ring is a Service that maintains an in-memory copy of a ring and watches for changes.
+// Support for read-only instances requires use of ShuffleShard or ShuffleShardWithLookback prior to getting a ReplicationSet.
 type Ring struct {
 	services.Service
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -819,7 +819,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 				instanceID := info.InstanceID
 				instance := r.ringDesc.Ingesters[instanceID]
 
-				// On write path (lookbackPeriod == 0), read only instances are excluded.
+				// The lookbackPeriod is 0 when this function is called by ShuffleShard(). In this case, we want read only instances excluded.
 				if lookbackPeriod == 0 && instance.ReadOnly {
 					continue
 				}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -678,6 +678,8 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 //
 // - Shuffling: probabilistically, for a large enough cluster each identifier gets a different
 // set of instances, with a reduced number of overlapping instances between two identifiers.
+//
+// Subring returned by this method does not contain instances that have read-only field set.
 func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 	// Use all instances if shuffle sharding is disabled, or it covers all instances anyway.
 	// Reason for not returning entire ring directly is that we need to filter out read-only instances.

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -680,7 +680,7 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 // set of instances, with a reduced number of overlapping instances between two identifiers.
 func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 	// Use all instances if shuffle sharding is disabled, or it covers all instances anyway.
-	// Reason is that we need to filter out read-only instances.
+	// Reason for not returning entire ring directly is that we need to filter out read-only instances.
 	instances := r.InstancesCount()
 	if size <= 0 || instances <= size {
 		size = instances

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -722,11 +722,6 @@ func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPer
 func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Duration, now time.Time) *Ring {
 	lookbackUntil := now.Add(-lookbackPeriod).Unix()
 
-	includeReadOnly := false
-	if lookbackPeriod > 0 {
-		includeReadOnly = true
-	}
-
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
@@ -789,8 +784,8 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 				instanceID := info.InstanceID
 				instance := r.ringDesc.Ingesters[instanceID]
 
-				// If the instance is read only, do not include it in the shard.
-				if instance.ReadOnly && !includeReadOnly {
+				// If the instance is read only without a lookback, do not include it in the shard.
+				if lookbackPeriod == 0 && instance.ReadOnly {
 					continue
 				}
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -812,12 +812,12 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 					continue
 				}
 
-				// If the lookback is enabled, and this instance has switched its read-only state within the lookback period,
-				// then we should include it in the subring, but continue selecting more instances.
+				// If the lookback is enabled, and this instance is read only or has switched its read-only state
+				// within the lookback period, then we should include it in the subring, but continue selecting more instances.
 				//
 				// * If instance switched to read-only state within the lookback period, then next instance is currently receiving data that previously belonged to this instance.
 				// * If instance switched to read-write state (read-only=false) within the lookback period, then there was another instance that received data that now belongs back to this instance.
-				if lookbackPeriod > 0 && instance.ReadOnlyUpdatedTimestamp >= lookbackUntil {
+				if lookbackPeriod > 0 && (instance.ReadOnly || instance.ReadOnlyUpdatedTimestamp >= lookbackUntil) {
 					continue
 				}
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -807,11 +807,6 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 				if lookbackPeriod == 0 && instance.ReadOnly {
 					continue
 				}
-				// On read path (lookbackPeriod > 0), read only instances are only included if they have not changed read-only status in the lookback window.
-				// If ReadOnlyUpdatedTimestamp is not set, we include the instance, and extend the shard later.
-				if lookbackPeriod > 0 && instance.ReadOnly && (instance.ReadOnlyUpdatedTimestamp > 0 && instance.ReadOnlyUpdatedTimestamp < lookbackUntil) {
-					continue
-				}
 
 				// Include instance in the subring.
 				shard[instanceID] = instance

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -725,6 +725,16 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
+	// If all instances have RegisteredTimestamp within the lookback period,
+	// then all instances would be included in the resulting ring, so we can
+	// simply return this ring.
+	//
+	// If any instance had RegisteredTimestamp equal to 0 (it would not cause additional lookup of next instance),
+	// then r.oldestRegisteredTimestamp is zero too, and we skip this optimization.
+	if lookbackPeriod > 0 && r.oldestRegisteredTimestamp > 0 && r.oldestRegisteredTimestamp >= lookbackUntil {
+		return r
+	}
+
 	var numInstancesPerZone int
 	var actualZones []string
 
@@ -800,7 +810,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 				// If the lookback is enabled, and this instance has switched its read-only state within the lookback period,
 				// then we should include it in the subring, but continue selecting more instances.
 				//
-				// * If instance switched to read-only state within the lookback period, then next instance is currently receiving data that belonged to this instance before.
+				// * If instance switched to read-only state within the lookback period, then next instance is currently receiving data that previously belonged to this instance.
 				// * If instance switched to read-write state (read-only=false) within the lookback period, then there was another instance that received data that now belongs back to this instance.
 				if lookbackPeriod > 0 && instance.ReadOnlyUpdatedTimestamp >= lookbackUntil {
 					continue

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -727,7 +727,7 @@ func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 // same identifier are with the same lookbackPeriod and increasing values of now.
 func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ReadRing {
 	// Nothing to do if the shard size is not smaller than the actual ring.
-	if lookbackPeriod > 0 && (size <= 0 || r.InstancesCount() <= size) {
+	if size <= 0 || r.InstancesCount() <= size {
 		return r
 	}
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2264,7 +2264,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 							instanceID := fmt.Sprintf("instance-%d", nextInstanceID)
 							zoneID := fmt.Sprintf("zone-%d", nextInstanceID%numZones)
 							nextInstanceID++
-							ringDesc.Ingesters[instanceID] = generateRingInstanceWithInfo(instanceID, zoneID, gen.GenerateTokens(128, nil), currTime)
+							ringDesc.Ingesters[instanceID] = generateRingInstanceWithInfo(instanceID, zoneID, gen.GenerateTokens(128, ringDesc.GetTokens()), currTime)
 							updateRing()
 							t.Logf("%d: added instance %s", i, instanceID)
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1868,7 +1868,6 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 		instanceDesc InstanceDesc
 		shardSize    int
 		expected     []string
-		readOnly     bool
 		readOnlyTime time.Time
 	}
 
@@ -1974,7 +1973,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 			timeline: []event{
 				// instance 2 is included in addition to another instance
 				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(lookbackPeriod / 2)},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnlyTime: now.Add(lookbackPeriod / 2)},
 				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2", "instance-3"}},
 			},
@@ -1983,15 +1982,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 			timeline: []event{
 				// readOnlyTime is too old to matter
 				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(-2 * lookbackPeriod)},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-3"}},
-			},
-		},
-		"single zone, with read only instance, with unknown ReadOnlyUpdatedTimestamp": {
-			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnlyTime: now.Add(-2 * lookbackPeriod)},
 				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2", "instance-3"}},
 			},
@@ -2096,11 +2087,11 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 			timeline: []event{
 				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
 				// instance 2 and 4 are included in addition to other instances in the same zone
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(lookbackPeriod / 2)},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnlyTime: now.Add(lookbackPeriod / 2)},
 				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-b", []uint32{userToken(userID, "zone-b", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-c", []uint32{userToken(userID, "zone-c", 3) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-c", []uint32{userToken(userID, "zone-c", 4) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(lookbackPeriod / 2)},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-2*lookbackPeriod)), readOnlyTime: now.Add(lookbackPeriod / 2)},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3", "instance-4", "instance-6"}},
 			},
 		},
@@ -2108,23 +2099,11 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 			timeline: []event{
 				// readOnlyTime is too old to matter
 				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(-2 * lookbackPeriod)},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnlyTime: now.Add(-2 * lookbackPeriod)},
 				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-b", []uint32{userToken(userID, "zone-b", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-c", []uint32{userToken(userID, "zone-c", 3) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-c", []uint32{userToken(userID, "zone-c", 4) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-3", "instance-6"}},
-			},
-		},
-		"multi zone, with read only instance, with unknown ReadOnlyUpdatedTimestamp": {
-			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
-				// instance 2 and 4 are included in addition to other instances in the same zone
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-b", []uint32{userToken(userID, "zone-b", 2) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-c", []uint32{userToken(userID, "zone-c", 3) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-c", []uint32{userToken(userID, "zone-c", 4) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-2*lookbackPeriod)), readOnlyTime: now.Add(-2 * lookbackPeriod)},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3", "instance-4", "instance-6"}},
 			},
 		},
@@ -2152,8 +2131,10 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				for ix, event := range testData.timeline {
 					switch event.what {
 					case add:
-						event.instanceDesc.ReadOnly = event.readOnly
-						event.instanceDesc.ReadOnlyUpdatedTimestamp = timeToUnixSecons(event.readOnlyTime)
+						if !event.readOnlyTime.IsZero() {
+							event.instanceDesc.ReadOnly = true
+							event.instanceDesc.ReadOnlyUpdatedTimestamp = timeToUnixSecons(event.readOnlyTime)
+						}
 						ringDesc.Ingesters[event.instanceID] = event.instanceDesc
 
 						ring.ringTokens = ringDesc.GetTokens()

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1670,6 +1670,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 			case disableReadOnly:
 				for id, desc := range ringDesc.Ingesters {
 					desc.ReadOnly = false
+					desc.ReadOnlyUpdatedTimestamp = time.Now().Unix()
 					ringDesc.Ingesters[id] = desc
 					break
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This is PR 2 of 2 (following #553) to add read only support for ingesters. This PR integrates read only ingester support with shuffle shard computation. 

On the write path, read only ingesters are excluded from shuffle shards. On the read path, ingesters with a read only timestamp within the lookback period are included in addition to another ingesters, similar to how recently registered ingesters are handled.

This PR also updates shuffle shard caching with lookback to consider the read only timestamp.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
