### PR TITLE
Use builtin min function

### DIFF
--- a/concurrency/runner.go
+++ b/concurrency/runner.go
@@ -7,7 +7,6 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/grafana/dskit/internal/math"
 	"github.com/grafana/dskit/multierror"
 )
 
@@ -31,7 +30,7 @@ func ForEachUser(ctx context.Context, userIDs []string, concurrency int, userFun
 	errsMx := sync.Mutex{}
 
 	wg := sync.WaitGroup{}
-	for ix := 0; ix < math.Min(concurrency, len(userIDs)); ix++ {
+	for ix := 0; ix < min(concurrency, len(userIDs)); ix++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -108,7 +107,7 @@ func ForEachJob(ctx context.Context, jobs int, concurrency int, jobFunc func(ctx
 
 	// Start workers to process jobs.
 	g, ctx := errgroup.WithContext(ctx)
-	for ix := 0; ix < math.Min(concurrency, jobs); ix++ {
+	for ix := 0; ix < min(concurrency, jobs); ix++ {
 		g.Go(func() error {
 			for ctx.Err() == nil {
 				idx := int(indexes.Inc())

--- a/internal/math/math.go
+++ b/internal/math/math.go
@@ -1,9 +1,0 @@
-package math
-
-// Min returns the minimum of two ints.
-func Min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/dskit/flagext"
-	dsmath "github.com/grafana/dskit/internal/math"
 	"github.com/grafana/dskit/internal/slices"
 	"github.com/grafana/dskit/kv"
 	shardUtil "github.com/grafana/dskit/ring/shard"
@@ -423,7 +422,7 @@ func (r *Ring) findInstancesForKey(key uint32, op Operation, bufDescs []Instance
 		distinctHosts = bufHosts[:0]
 		distinctZones = bufZones[:0]
 	)
-	for i := start; len(distinctHosts) < dsmath.Min(maxInstances, n) && len(distinctZones) < maxZones && iterations < len(r.ringTokens); i++ {
+	for i := start; len(distinctHosts) < min(maxInstances, n) && len(distinctZones) < maxZones && iterations < len(r.ringTokens); i++ {
 		iterations++
 		// Wrap i around in the ring.
 		i %= len(r.ringTokens)
@@ -528,7 +527,7 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 		// Given data is replicated to RF different zones, we can tolerate a number of
 		// RF/2 failing zones. However, we need to protect from the case the ring currently
 		// contains instances in a number of zones < RF.
-		numReplicatedZones := dsmath.Min(len(r.ringZones), r.cfg.ReplicationFactor)
+		numReplicatedZones := min(len(r.ringZones), r.cfg.ReplicationFactor)
 		minSuccessZones := (numReplicatedZones / 2) + 1
 		maxUnavailableZones = minSuccessZones - 1
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
-	dsmath "github.com/grafana/dskit/internal/math"
 	"github.com/grafana/dskit/internal/slices"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/kv/consul"
@@ -2953,9 +2952,9 @@ func BenchmarkRing_Get(b *testing.B) {
 		buf, bufHosts, bufZones := MakeBuffersForGet()
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-		expectedInstances := dsmath.Min(benchCase.numInstances, benchCase.replicationFactor)
+		expectedInstances := min(benchCase.numInstances, benchCase.replicationFactor)
 		if ring.cfg.ZoneAwarenessEnabled {
-			expectedInstances = dsmath.Min(benchCase.numZones, benchCase.replicationFactor)
+			expectedInstances = min(benchCase.numZones, benchCase.replicationFactor)
 		}
 
 		b.Run(benchName, func(b *testing.B) {


### PR DESCRIPTION
Replaces a few usages of `math.Min` with the builtin `min` that was [added in Go 1.21](https://tip.golang.org/doc/go1.21#language), and removes `Math.min` since it was internal.