### PR TITLE
Service.AddListener now returns function to unregister listener from the service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@
 * [CHANGE] Cache: Remove superfluous `cache.RemoteCacheClient` interface and unify all caches using the `cache.Cache` interface. #520
 * [CHANGE] Updated the minimum required Go version to 1.21. #540
 * [CHANGE] memberlist: Metric `memberlist_client_messages_in_broadcast_queue` is now split into `queue="local"` and `queue="gossip"` values. #539
-* [CHANGE] `Service.AddListener` now returns function for stopping the listener. #564
+* [CHANGE] `Service.AddListener` and `Manager.AddListener` now return function for stopping the listener. #564
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338
@@ -222,6 +222,7 @@
 * [EHNANCEMENT] crypto/tls: Support reloading client certificates #537 #552
 * [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554
 * [ENHANCEMENT] Added new ring methods to expose number of writable instances with tokens per zone, and overall. #560 #562
+* [ENHANCEMENT] `services.FailureWatcher` can now be closed, which unregisters all service and manager listeners, and closes channel used to receive errors. #564 
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * [CHANGE] Cache: Remove superfluous `cache.RemoteCacheClient` interface and unify all caches using the `cache.Cache` interface. #520
 * [CHANGE] Updated the minimum required Go version to 1.21. #540
 * [CHANGE] memberlist: Metric `memberlist_client_messages_in_broadcast_queue` is now split into `queue="local"` and `queue="gossip"` values. #539
+* [CHANGE] `Service.AddListener` now returns function for stopping the listener. #564
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/grpcutil/health_check_test.go
+++ b/grpcutil/health_check_test.go
@@ -170,8 +170,9 @@ func (s *mockService) State() services.State {
 	return s.state
 }
 
-func (s *mockService) AddListener(listener services.Listener) {
+func (s *mockService) AddListener(listener services.Listener) func() {
 	s.listeners = append(s.listeners, listener)
+	return func() {}
 }
 
 func (s *mockService) StartAsync(_ context.Context) error      { return nil }

--- a/services/failure_watch_test.go
+++ b/services/failure_watch_test.go
@@ -107,6 +107,9 @@ func TestServiceFailureWatcherClose(t *testing.T) {
 	require.Panics(t, func() {
 		w.WatchManager(m)
 	})
+
+	// Repeated call to Close doesn't panic.
+	w.Close()
 }
 
 // Creates service which will return first error passed to the channel.

--- a/services/failure_watch_test.go
+++ b/services/failure_watch_test.go
@@ -3,10 +3,12 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	e2 "github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 func TestNilServiceFailureWatcher(t *testing.T) {
@@ -30,6 +32,9 @@ func TestNilServiceFailureWatcher(t *testing.T) {
 	require.Panics(t, func() {
 		w.WatchManager(m)
 	})
+
+	// Closing nil watcher doesn't panic.
+	w.Close()
 }
 
 func TestServiceFailureWatcher(t *testing.T) {
@@ -48,4 +53,73 @@ func TestServiceFailureWatcher(t *testing.T) {
 	e := <-w.Chan()
 	require.NotNil(t, e)
 	require.Equal(t, err, e2.Cause(e))
+}
+
+func TestServiceFailureWatcherClose(t *testing.T) {
+	s1 := serviceThatDoesntDoAnything()
+	s2 := serviceThatDoesntDoAnything()
+	m, err := NewManager(s1, s2)
+	require.NoError(t, err)
+
+	s3, errorsS3 := errorReturningService()
+	s4, errorsS4 := errorReturningService()
+
+	require.NoError(t, StartManagerAndAwaitHealthy(context.Background(), m))
+	require.NoError(t, StartAndAwaitRunning(context.Background(), s3))
+	require.NoError(t, StartAndAwaitRunning(context.Background(), s4))
+
+	// All goroutines created until now are unrelated to failure watcher.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent(), goleak.Cleanup(func(_ int) {
+		require.NoError(t, StopManagerAndAwaitStopped(context.Background(), m))
+		// These services are expected to errors.
+		require.Error(t, StopAndAwaitTerminated(context.Background(), s3))
+		require.Error(t, StopAndAwaitTerminated(context.Background(), s4))
+
+		goleak.VerifyNone(t)
+	}))
+
+	// Watch manager and both services
+	w := NewFailureWatcher()
+	w.WatchManager(m)
+	w.WatchService(s3)
+	w.WatchService(s4)
+
+	ch := w.Chan()
+
+	// Verify that we receive error from s3.
+	err = fmt.Errorf("service3 error")
+	errorsS3 <- err
+
+	require.ErrorIs(t, <-ch, err)
+
+	// After closing failure watcher, we don't receive any more errors.
+	w.Close()
+	require.Nil(t, <-ch)
+
+	// Even sending error from service 4 doesn't make it to failure watcher.
+	errorsS4 <- fmt.Errorf("service4 error")
+	require.Nil(t, <-ch)
+
+	// Since watcher is now closed, it cannot be used to watch services or managers.
+	require.Panics(t, func() {
+		w.WatchService(s3)
+	})
+	require.Panics(t, func() {
+		w.WatchManager(m)
+	})
+}
+
+// Creates service which will return first error passed to the channel.
+func errorReturningService() (*BasicService, chan<- error) {
+	errCh := make(chan error)
+	return NewBasicService(nil, func(ctx context.Context) error {
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case e := <-errCh:
+				return e
+			}
+		}
+	}, nil), errCh
 }

--- a/services/failure_watch_test.go
+++ b/services/failure_watch_test.go
@@ -23,6 +23,9 @@ func TestNilServiceFailureWatcher(t *testing.T) {
 	// Ensure WatchManager() panics.
 	m, err := NewManager(NewIdleService(nil, nil))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, StopManagerAndAwaitStopped(context.Background(), m))
+	})
 
 	require.Panics(t, func() {
 		w.WatchManager(m)

--- a/services/failure_watcher.go
+++ b/services/failure_watcher.go
@@ -1,16 +1,22 @@
 package services
 
 import (
+	"sync"
+
 	"github.com/pkg/errors"
 )
 
 var (
 	errFailureWatcherNotInitialized = errors.New("FailureWatcher has not been initialized")
+	errFailureWatcherClosed         = errors.New("FailureWatcher has been stopped")
 )
 
 // FailureWatcher waits for service failures, and passed them to the channel.
 type FailureWatcher struct {
-	ch chan error
+	mu                  sync.Mutex
+	ch                  chan error
+	closed              bool
+	unregisterListeners []func()
 }
 
 func NewFailureWatcher() *FailureWatcher {
@@ -35,9 +41,17 @@ func (w *FailureWatcher) WatchService(service Service) {
 		panic(errFailureWatcherNotInitialized)
 	}
 
-	service.AddListener(NewListener(nil, nil, nil, nil, func(_ State, failure error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		panic(errFailureWatcherClosed)
+	}
+
+	stop := service.AddListener(NewListener(nil, nil, nil, nil, func(_ State, failure error) {
 		w.ch <- errors.Wrapf(failure, "service %s failed", DescribeService(service))
 	}))
+	w.unregisterListeners = append(w.unregisterListeners, stop)
 }
 
 func (w *FailureWatcher) WatchManager(manager *Manager) {
@@ -47,7 +61,39 @@ func (w *FailureWatcher) WatchManager(manager *Manager) {
 		panic(errFailureWatcherNotInitialized)
 	}
 
-	manager.AddListener(NewManagerListener(nil, nil, func(service Service) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		panic(errFailureWatcherClosed)
+	}
+
+	stop := manager.AddListener(NewManagerListener(nil, nil, func(service Service) {
 		w.ch <- errors.Wrapf(service.FailureCase(), "service %s failed", DescribeService(service))
 	}))
+	w.unregisterListeners = append(w.unregisterListeners, stop)
+}
+
+// Close stops this failure watcher and closes channel returned by Chan() method. After closing failure watcher,
+// it cannot be used to watch additional services or managers.
+func (w *FailureWatcher) Close() {
+	// Graceful handle the case FailureWatcher has not been initialized,
+	// to simplify the code in the components using it.
+	if w == nil {
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return
+	}
+	for _, stop := range w.unregisterListeners {
+		stop()
+	}
+
+	// All listeners are now stopped, and can't receive more notifications. We can close the channel.
+	close(w.ch)
+	w.closed = true
 }

--- a/services/failure_watcher.go
+++ b/services/failure_watcher.go
@@ -76,6 +76,7 @@ func (w *FailureWatcher) WatchManager(manager *Manager) {
 
 // Close stops this failure watcher and closes channel returned by Chan() method. After closing failure watcher,
 // it cannot be used to watch additional services or managers.
+// Repeated calls to Close() do nothing.
 func (w *FailureWatcher) Close() {
 	// Graceful handle the case FailureWatcher has not been initialized,
 	// to simplify the code in the components using it.

--- a/services/service.go
+++ b/services/service.go
@@ -91,7 +91,10 @@ type Service interface {
 	// as the service enters those states. Additionally, at most one of the listener's callbacks will execute
 	// at once. However, multiple listeners' callbacks may execute concurrently, and listeners may execute
 	// in an order different from the one in which they were registered.
-	AddListener(listener Listener)
+	//
+	// Returned function can be used to stop the listener from receiving additional events from the service,
+	// and release resources used by the listener (e.g. goroutine, if it was started by adding listener).
+	AddListener(listener Listener) func()
 }
 
 // NamedService extends Service with a name.

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -8,7 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestIdleService(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
**What this PR does**:

This PR modifies `Service.AddListener` and `Manager.AddListener` to return a function to unregister listener from the service.

This PR also adds `FailureWatcher.Close` method which unregisters all listeners to services and manager, and closes channel used to pass errors. This is useful eg. in tests when you want the tests to not leak any goroutines.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/dskit/issues/563

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
