### PR TITLE
Filter out read-only instances, but skip filtering when it's not required.

### DIFF
--- a/ring/model.go
+++ b/ring/model.go
@@ -594,6 +594,29 @@ func (d *Desc) writableInstancesWithTokensCountPerZone() map[string]int {
 	return instancesCountPerZone
 }
 
+func (d *Desc) readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp() (int, int64) {
+	readOnlyInstances := 0
+	oldestReadOnlyUpdatedTimestamp := int64(0)
+	first := true
+
+	if d != nil {
+		for _, ingester := range d.Ingesters {
+			if !ingester.ReadOnly {
+				continue
+			}
+
+			readOnlyInstances++
+			if first {
+				oldestReadOnlyUpdatedTimestamp = ingester.ReadOnlyUpdatedTimestamp
+			} else {
+				oldestReadOnlyUpdatedTimestamp = min(oldestReadOnlyUpdatedTimestamp, ingester.ReadOnlyUpdatedTimestamp)
+			}
+			first = false
+		}
+	}
+	return readOnlyInstances, oldestReadOnlyUpdatedTimestamp
+}
+
 type CompareResult int
 
 // CompareResult responses

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -779,8 +779,9 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 		// may not return all instances.
 	}
 
-	if size <= 0 || len(r.ringDesc.Ingesters) <= size {
-		size = len(r.ringDesc.Ingesters)
+	if size <= 0 {
+		// Use all available instances in each zone.
+		size = math.MaxInt
 	}
 
 	var numInstancesPerZone int
@@ -794,7 +795,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 		actualZones = []string{""}
 	}
 
-	shard := make(map[string]InstanceDesc, size)
+	shard := make(map[string]InstanceDesc, min(r.InstancesCount(), size))
 
 	// We need to iterate zones always in the same order to guarantee stability.
 	for _, zone := range actualZones {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -706,11 +706,11 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 //
 // Subring returned by this method does not contain instances that have read-only field set.
 func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
-	if cached := r.getCachedShuffledSubring(identifier, size); cached != nil {
-		return cached
-	}
 	if size <= 0 {
 		size = math.MaxInt
+	}
+	if cached := r.getCachedShuffledSubring(identifier, size); cached != nil {
+		return cached
 	}
 	result := r.shuffleShard(identifier, size, 0, time.Now())
 
@@ -734,12 +734,11 @@ func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 // Subring returned by this method does not contain read-only instances that have changed their state
 // before the lookback period.
 func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ReadRing {
-	if cached := r.getCachedShuffledSubringWithLookback(identifier, size, lookbackPeriod, now); cached != nil {
-		return cached
-	}
-
 	if size <= 0 {
 		size = math.MaxInt
+	}
+	if cached := r.getCachedShuffledSubringWithLookback(identifier, size, lookbackPeriod, now); cached != nil {
+		return cached
 	}
 	result := r.shuffleShard(identifier, size, lookbackPeriod, now)
 	if result != r {

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -874,8 +874,9 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 	return r.buildReadOnlyRingForTheShard(shard)
 }
 
-// filterOutReadOnlyInstances removes all read-only instances from the ring, and returns the result.
-// When lookback period > 0, only read-only instances that have changed state within the lookback period are returned, to be consistent with shuffleShard function.
+// filterOutReadOnlyInstances removes all read-only instances from the ring, and returns the resulting ring.
+// When lookback period > 0, only read-only instances that have changed state within outside of the lookback window are filtered,
+// to be consistent with shuffleShard function.
 func (r *Ring) filterOutReadOnlyInstances(lookbackPeriod time.Duration, now time.Time) *Ring {
 	lookbackUntil := now.Add(-lookbackPeriod).Unix()
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -193,9 +193,9 @@ type Ring struct {
 
 	readOnlyInstancesUpdated bool // True, if readOnlyInstances was actually updated. False if 0 is because of default value.
 	readOnlyInstances        int  // Number of instances with ReadOnly flag set. Only valid if readOnlyInstancesUpdated is set.
-
 	// Oldest value of ReadOnlyUpdatedTimestamp for read-only instances. If any read-only instance
 	// has ReadOnlyUpdatedTimestamp == 0 (which should not happen), then this value will be 0.
+	// Only valid if readOnlyInstancesUpdated is set.
 	oldestReadOnlyUpdatedTimestamp int64
 
 	// Maps a token with the information of the instance holding it. This map is immutable and

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2336,8 +2336,9 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 								ring.oldestRegisteredTimestamp = ringDesc.getOldestRegisteredTimestamp()
 							}
 							if updateReadOnlyInstances {
-								ring.readOnlyInstancesUpdated = true
-								ring.readOnlyInstances, ring.oldestReadOnlyUpdatedTimestamp = ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+								readOnlyInstances, oldestReadOnlyUpdatedTimestamp := ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+								ring.readOnlyInstances = &readOnlyInstances
+								ring.oldestReadOnlyUpdatedTimestamp = &oldestReadOnlyUpdatedTimestamp
 							}
 						case remove:
 							delete(ringDesc.Ingesters, event.instanceID)
@@ -2350,8 +2351,9 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 								ring.oldestRegisteredTimestamp = ringDesc.getOldestRegisteredTimestamp()
 							}
 							if updateReadOnlyInstances {
-								ring.readOnlyInstancesUpdated = true
-								ring.readOnlyInstances, ring.oldestReadOnlyUpdatedTimestamp = ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+								readOnlyInstances, oldestReadOnlyUpdatedTimestamp := ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+								ring.readOnlyInstances = &readOnlyInstances
+								ring.oldestReadOnlyUpdatedTimestamp = &oldestReadOnlyUpdatedTimestamp
 							}
 						case test:
 							rs, err := ring.ShuffleShardWithLookback(userID, event.shardSize, lookbackPeriod, now).GetAllHealthy(Read)
@@ -2423,8 +2425,9 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 								ring.oldestRegisteredTimestamp = ringDesc.getOldestRegisteredTimestamp()
 							}
 							if updateReadOnlyInstances {
-								ring.readOnlyInstancesUpdated = true
-								ring.readOnlyInstances, ring.oldestReadOnlyUpdatedTimestamp = ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+								readOnlyInstances, oldestReadOnlyUpdatedTimestamp := ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+								ring.readOnlyInstances = &readOnlyInstances
+								ring.oldestReadOnlyUpdatedTimestamp = &oldestReadOnlyUpdatedTimestamp
 							}
 
 							if len(ring.ringZones) != numZones {
@@ -3310,8 +3313,9 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, s
 		strategy:             NewDefaultReplicationStrategy(),
 		lastTopologyChange:   time.Now(),
 	}
-	ring.readOnlyInstances, ring.oldestReadOnlyUpdatedTimestamp = ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
-	ring.readOnlyInstancesUpdated = true
+	readOnlyInstances, oldestReadOnlyUpdatedTimestamp := ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+	ring.readOnlyInstances = &readOnlyInstances
+	ring.oldestReadOnlyUpdatedTimestamp = &oldestReadOnlyUpdatedTimestamp
 
 	b.ResetTimer()
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2437,6 +2437,8 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 									instanceDesc.ReadOnly = true
 									instanceDesc.ReadOnlyUpdatedTimestamp = currTime.Unix()
 									ringDesc.Ingesters[instanceID] = instanceDesc
+									updateRing()
+
 									readOnlyInstances[instanceID] = instanceDesc
 									t.Logf("%d: switched instance %s to read-only", i, instanceID)
 								} else {
@@ -2451,6 +2453,8 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 									instanceDesc.ReadOnly = false
 									instanceDesc.ReadOnlyUpdatedTimestamp = currTime.Unix()
 									ringDesc.Ingesters[instanceID] = instanceDesc
+									updateRing()
+
 									delete(readOnlyInstances, instanceID)
 									t.Logf("%d: switched instance %s to read-write", i, instanceID)
 								} else {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -2396,7 +2396,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 								nextInstanceID++
 								ringDesc.Ingesters[instanceID] = generateRingInstanceWithInfo(instanceID, zoneID, gen.GenerateTokens(128, ringDesc.GetTokens()), currTime)
 								updateRing()
-								t.Logf("%d (%v): added instance %s", eventID, currTime.Format("03:04"), instanceID)
+								t.Logf("%d (%v): added instance %s, total instances %d", eventID, currTime.Format("03:04"), instanceID, len(ringDesc.Ingesters))
 
 							case r < 70:
 								// Scale down instances by 1.
@@ -2411,7 +2411,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 
 								delete(ringDesc.Ingesters, idToRemove)
 								updateRing()
-								t.Logf("%d (%v): removed instance %s", eventID, currTime.Format("03:04"), idToRemove)
+								t.Logf("%d (%v): removed instance %s, total instances %d", eventID, currTime.Format("03:04"), idToRemove, len(ringDesc.Ingesters))
 
 								// Remove the terminated instance from the history.
 								for eid, ringState := range history {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -3218,6 +3218,8 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, s
 		strategy:             NewDefaultReplicationStrategy(),
 		lastTopologyChange:   time.Now(),
 	}
+	ring.readOnlyInstances, ring.oldestReadOnlyUpdatedTimestamp = ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+	ring.readOnlyInstancesUpdated = true
 
 	b.ResetTimer()
 

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -215,14 +215,15 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 			SubringCacheDisabled: true,
 			ReplicationFactor:    numZones,
 		},
-		ringDesc:             desc,
-		ringTokens:           desc.GetTokens(),
-		ringTokensByZone:     desc.getTokensByZone(),
-		ringInstanceByToken:  desc.getTokensInfo(),
-		ringZones:            getZones(desc.getTokensByZone()),
-		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		strategy:             NewDefaultReplicationStrategy(),
-		lastTopologyChange:   time.Now(),
+		ringDesc:              desc,
+		ringTokens:            desc.GetTokens(),
+		ringTokensByZone:      desc.getTokensByZone(),
+		ringInstanceByToken:   desc.getTokensInfo(),
+		ringZones:             getZones(desc.getTokensByZone()),
+		instancesCountPerZone: desc.instancesCountPerZone(),
+		shuffledSubringCache:  map[subringCacheKey]*Ring{},
+		strategy:              NewDefaultReplicationStrategy(),
+		lastTopologyChange:    time.Now(),
 	}
 	// Measure how long does it take for a call to succeed.
 	t0 := time.Now()
@@ -1743,12 +1744,13 @@ func TestRing_ShuffleShard_Shuffling(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.GetTokens(),
-		ringTokensByZone:    ringDesc.getTokensByZone(),
-		ringInstanceByToken: ringDesc.getTokensInfo(),
-		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(),
+		ringDesc:              ringDesc,
+		ringTokens:            ringDesc.GetTokens(),
+		ringTokensByZone:      ringDesc.getTokensByZone(),
+		ringInstanceByToken:   ringDesc.getTokensInfo(),
+		ringZones:             getZones(ringDesc.getTokensByZone()),
+		instancesCountPerZone: ringDesc.instancesCountPerZone(),
+		strategy:              NewDefaultReplicationStrategy(),
 	}
 
 	// Compute the shard for each tenant.
@@ -1857,12 +1859,13 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 					HeartbeatTimeout:     time.Hour,
 					ZoneAwarenessEnabled: true,
 				},
-				ringDesc:            ringDesc,
-				ringTokens:          ringDesc.GetTokens(),
-				ringTokensByZone:    ringDesc.getTokensByZone(),
-				ringInstanceByToken: ringDesc.getTokensInfo(),
-				ringZones:           getZones(ringDesc.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(),
+				ringDesc:              ringDesc,
+				ringTokens:            ringDesc.GetTokens(),
+				ringTokensByZone:      ringDesc.getTokensByZone(),
+				ringInstanceByToken:   ringDesc.getTokensInfo(),
+				ringZones:             getZones(ringDesc.getTokensByZone()),
+				instancesCountPerZone: ringDesc.instancesCountPerZone(),
+				strategy:              NewDefaultReplicationStrategy(),
 			}
 
 			// Compute the initial shard for each tenant.
@@ -1906,6 +1909,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 			ring.ringTokensByZone = ringDesc.getTokensByZone()
 			ring.ringInstanceByToken = ringDesc.getTokensInfo()
 			ring.ringZones = getZones(ringDesc.getTokensByZone())
+			ring.instancesCountPerZone = ringDesc.instancesCountPerZone()
 
 			// Compute the update shard for each tenant and compare it with the initial one.
 			// If the "consistency" property is guaranteed, we expect no more then 1 different instance
@@ -1937,12 +1941,13 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.GetTokens(),
-		ringTokensByZone:    ringDesc.getTokensByZone(),
-		ringInstanceByToken: ringDesc.getTokensInfo(),
-		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(),
+		ringDesc:              ringDesc,
+		ringTokens:            ringDesc.GetTokens(),
+		ringTokensByZone:      ringDesc.getTokensByZone(),
+		ringInstanceByToken:   ringDesc.getTokensInfo(),
+		ringZones:             getZones(ringDesc.getTokensByZone()),
+		instancesCountPerZone: ringDesc.instancesCountPerZone(),
+		strategy:              NewDefaultReplicationStrategy(),
 	}
 
 	// Get the replication set with shard size = 3.
@@ -2014,12 +2019,13 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.GetTokens(),
-		ringTokensByZone:    ringDesc.getTokensByZone(),
-		ringInstanceByToken: ringDesc.getTokensInfo(),
-		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(),
+		ringDesc:              ringDesc,
+		ringTokens:            ringDesc.GetTokens(),
+		ringTokensByZone:      ringDesc.getTokensByZone(),
+		ringInstanceByToken:   ringDesc.getTokensInfo(),
+		ringZones:             getZones(ringDesc.getTokensByZone()),
+		instancesCountPerZone: ringDesc.instancesCountPerZone(),
+		strategy:              NewDefaultReplicationStrategy(),
 	}
 
 	// Get the replication set with shard size = 2.
@@ -2051,6 +2057,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	ring.ringTokensByZone = ringDesc.getTokensByZone()
 	ring.ringInstanceByToken = ringDesc.getTokensInfo()
 	ring.ringZones = getZones(ringDesc.getTokensByZone())
+	ring.instancesCountPerZone = ringDesc.instancesCountPerZone()
 
 	// Increase shard size to 6.
 	thirdShard := ring.ShuffleShard("tenant-id", 6)
@@ -2477,12 +2484,13 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 							HeartbeatTimeout:     time.Hour,
 							ZoneAwarenessEnabled: true,
 						},
-						ringDesc:            ringDesc,
-						ringTokens:          ringDesc.GetTokens(),
-						ringTokensByZone:    ringDesc.getTokensByZone(),
-						ringInstanceByToken: ringDesc.getTokensInfo(),
-						ringZones:           getZones(ringDesc.getTokensByZone()),
-						strategy:            NewDefaultReplicationStrategy(),
+						ringDesc:              ringDesc,
+						ringTokens:            ringDesc.GetTokens(),
+						ringTokensByZone:      ringDesc.getTokensByZone(),
+						ringInstanceByToken:   ringDesc.getTokensInfo(),
+						ringZones:             getZones(ringDesc.getTokensByZone()),
+						instancesCountPerZone: ringDesc.instancesCountPerZone(),
+						strategy:              NewDefaultReplicationStrategy(),
 					}
 
 					// Replay the events on the timeline.
@@ -2497,6 +2505,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 							ring.ringTokensByZone = ringDesc.getTokensByZone()
 							ring.ringInstanceByToken = ringDesc.getTokensInfo()
 							ring.ringZones = getZones(ringDesc.getTokensByZone())
+							ring.instancesCountPerZone = ringDesc.instancesCountPerZone()
 							if updateRegisteredTimestampCache {
 								ring.oldestRegisteredTimestamp = ringDesc.getOldestRegisteredTimestamp()
 							}
@@ -2512,6 +2521,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 							ring.ringTokensByZone = ringDesc.getTokensByZone()
 							ring.ringInstanceByToken = ringDesc.getTokensInfo()
 							ring.ringZones = getZones(ringDesc.getTokensByZone())
+							ring.instancesCountPerZone = ringDesc.instancesCountPerZone()
 							if updateRegisteredTimestampCache {
 								ring.oldestRegisteredTimestamp = ringDesc.getOldestRegisteredTimestamp()
 							}
@@ -3407,7 +3417,7 @@ func TestRing_ShuffleShardWithLookback_CachingConcurrency(t *testing.T) {
 func BenchmarkRing_ShuffleShard(b *testing.B) {
 	for _, numInstances := range []int{50, 100, 1000} {
 		for _, numZones := range []int{1, 3} {
-			for _, shardSize := range []int{0, 3, 10, 30} {
+			for _, shardSize := range []int{0, 3, 10, 30, 100, 1000} {
 				b.Run(fmt.Sprintf("num instances = %d, num zones = %d, shard size = %d", numInstances, numZones, shardSize), func(b *testing.B) {
 					benchmarkShuffleSharding(b, numInstances, numZones, 128, shardSize, false)
 				})
@@ -3419,7 +3429,7 @@ func BenchmarkRing_ShuffleShard(b *testing.B) {
 func BenchmarkRing_ShuffleShardCached(b *testing.B) {
 	for _, numInstances := range []int{50, 100, 1000} {
 		for _, numZones := range []int{1, 3} {
-			for _, shardSize := range []int{0, 3, 10, 30} {
+			for _, shardSize := range []int{0, 3, 10, 30, 100, 1000} {
 				b.Run(fmt.Sprintf("num instances = %d, num zones = %d, shard size = %d", numInstances, numZones, shardSize), func(b *testing.B) {
 					benchmarkShuffleSharding(b, numInstances, numZones, 128, shardSize, true)
 				})
@@ -3468,15 +3478,16 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, s
 	// Initialise the ring.
 	ringDesc := &Desc{Ingesters: generateRingInstances(initTokenGenerator(b), numInstances, numZones, numTokens)}
 	ring := Ring{
-		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: !cache},
-		ringDesc:             ringDesc,
-		ringTokens:           ringDesc.GetTokens(),
-		ringTokensByZone:     ringDesc.getTokensByZone(),
-		ringInstanceByToken:  ringDesc.getTokensInfo(),
-		ringZones:            getZones(ringDesc.getTokensByZone()),
-		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		strategy:             NewDefaultReplicationStrategy(),
-		lastTopologyChange:   time.Now(),
+		cfg:                   Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: !cache},
+		ringDesc:              ringDesc,
+		ringTokens:            ringDesc.GetTokens(),
+		ringTokensByZone:      ringDesc.getTokensByZone(),
+		ringInstanceByToken:   ringDesc.getTokensInfo(),
+		ringZones:             getZones(ringDesc.getTokensByZone()),
+		instancesCountPerZone: ringDesc.instancesCountPerZone(),
+		shuffledSubringCache:  map[subringCacheKey]*Ring{},
+		strategy:              NewDefaultReplicationStrategy(),
+		lastTopologyChange:    time.Now(),
 	}
 	readOnlyInstances, oldestReadOnlyUpdatedTimestamp := ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
 	ring.readOnlyInstances = &readOnlyInstances
@@ -3527,14 +3538,15 @@ func BenchmarkRing_Get(b *testing.B) {
 				SubringCacheDisabled: true,
 				ReplicationFactor:    benchCase.replicationFactor,
 			},
-			ringDesc:             ringDesc,
-			ringTokens:           ringDesc.GetTokens(),
-			ringTokensByZone:     ringDesc.getTokensByZone(),
-			ringInstanceByToken:  ringDesc.getTokensInfo(),
-			ringZones:            getZones(ringDesc.getTokensByZone()),
-			shuffledSubringCache: map[subringCacheKey]*Ring{},
-			strategy:             NewDefaultReplicationStrategy(),
-			lastTopologyChange:   time.Now(),
+			ringDesc:              ringDesc,
+			ringTokens:            ringDesc.GetTokens(),
+			ringTokensByZone:      ringDesc.getTokensByZone(),
+			ringInstanceByToken:   ringDesc.getTokensInfo(),
+			ringZones:             getZones(ringDesc.getTokensByZone()),
+			instancesCountPerZone: ringDesc.instancesCountPerZone(),
+			shuffledSubringCache:  map[subringCacheKey]*Ring{},
+			strategy:              NewDefaultReplicationStrategy(),
+			lastTopologyChange:    time.Now(),
 		}
 
 		buf, bufHosts, bufZones := MakeBuffersForGet()
@@ -3559,15 +3571,16 @@ func TestRing_Get_NoMemoryAllocations(t *testing.T) {
 	// Initialise the ring.
 	ringDesc := &Desc{Ingesters: generateRingInstances(initTokenGenerator(t), 3, 3, 128)}
 	ring := Ring{
-		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: true, ReplicationFactor: 3},
-		ringDesc:             ringDesc,
-		ringTokens:           ringDesc.GetTokens(),
-		ringTokensByZone:     ringDesc.getTokensByZone(),
-		ringInstanceByToken:  ringDesc.getTokensInfo(),
-		ringZones:            getZones(ringDesc.getTokensByZone()),
-		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		strategy:             NewDefaultReplicationStrategy(),
-		lastTopologyChange:   time.Now(),
+		cfg:                   Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: true, ReplicationFactor: 3},
+		ringDesc:              ringDesc,
+		ringTokens:            ringDesc.GetTokens(),
+		ringTokensByZone:      ringDesc.getTokensByZone(),
+		ringInstanceByToken:   ringDesc.getTokensInfo(),
+		ringZones:             getZones(ringDesc.getTokensByZone()),
+		instancesCountPerZone: ringDesc.instancesCountPerZone(),
+		shuffledSubringCache:  map[subringCacheKey]*Ring{},
+		strategy:              NewDefaultReplicationStrategy(),
+		lastTopologyChange:    time.Now(),
 	}
 
 	buf, bufHosts, bufZones := MakeBuffersForGet()

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1499,7 +1499,7 @@ func TestRing_ShuffleShard(t *testing.T) {
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
 				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil)},
 			},
-			shardSize:                    3,
+			shardSize:                    6,
 			zoneAwarenessEnabled:         true,
 			expectedSize:                 3,
 			expectedDistribution:         []int{1, 1, 1},
@@ -2031,7 +2031,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 		userID         = "user-1"
 	)
 
-	now := time.Now()
+	now := time.Now().Truncate(time.Second)
 
 	type event struct {
 		what         eventType
@@ -2159,6 +2159,15 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-3"}},
 			},
 		},
+		"single zone, with read only instance, at lookback boundary": {
+			timeline: []event{
+				// readOnlyTime is too old to matter
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(lookbackPeriod)},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2", "instance-3"}},
+			},
+		},
 		"single zone, with read only instance, with unknown ReadOnlyUpdatedTimestamp": {
 			timeline: []event{
 				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
@@ -2273,6 +2282,18 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-c", []uint32{userToken(userID, "zone-c", 4) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(lookbackPeriod / 2)},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3", "instance-4", "instance-6"}},
+			},
+		},
+		"multi zone, with read only instance, at lookback boundary": {
+			timeline: []event{
+				// readOnlyTime is too old to matter
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod)), readOnly: true, readOnlyTime: now.Add(lookbackPeriod)},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-b", []uint32{userToken(userID, "zone-b", 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-c", []uint32{userToken(userID, "zone-c", 3) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-c", []uint32{userToken(userID, "zone-c", 4) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3", "instance-6"}},
 			},
 		},
 		"multi zone, with read only instance, not within lookback": {
@@ -4066,6 +4087,117 @@ func TestCountTokensMultiZones(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			assert.Equal(t, testData.expected, testData.ring.CountTokens())
 		})
+	}
+}
+
+func TestRing_filterOutReadOnlyInstances(t *testing.T) {
+	gen := initTokenGenerator(t)
+	now := time.Now().Truncate(time.Second)
+
+	tests := map[string]struct {
+		ringInstances     map[string]InstanceDesc
+		lookbackPeriod    time.Duration
+		expectedInstances []string
+	}{
+		"empty ring": {
+			ringInstances:     nil,
+			expectedInstances: nil,
+		},
+		"no readonly instances, no lookback": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil)},
+			},
+			lookbackPeriod:    0,
+			expectedInstances: []string{"instance-1", "instance-2", "instance-3"},
+		},
+		"no readonly instances, with lookback": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil)},
+			},
+			lookbackPeriod:    1 * time.Hour,
+			expectedInstances: []string{"instance-1", "instance-2", "instance-3"},
+		},
+		"one readonly instance, no lookback": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil), ReadOnly: true, ReadOnlyUpdatedTimestamp: now.Unix()},
+			},
+			lookbackPeriod:    0,
+			expectedInstances: []string{"instance-1", "instance-2"},
+		},
+		"one readonly instance, switched inside lookback window": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil), ReadOnly: true, ReadOnlyUpdatedTimestamp: now.Unix()},
+			},
+			lookbackPeriod:    1 * time.Hour,
+			expectedInstances: []string{"instance-1", "instance-2", "instance-3"},
+		},
+		"one readonly instance, switched exactly at the lookback window boundary": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil), ReadOnly: true, ReadOnlyUpdatedTimestamp: now.Add(-time.Hour).Unix()},
+			},
+			lookbackPeriod:    1 * time.Hour,
+			expectedInstances: []string{"instance-1", "instance-2", "instance-3"},
+		},
+		"one readonly instance, switched before the lookback window boundary": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil), ReadOnly: true, ReadOnlyUpdatedTimestamp: now.Add(-2 * time.Hour).Unix()},
+			},
+			lookbackPeriod:    1 * time.Hour,
+			expectedInstances: []string{"instance-1", "instance-2"},
+		},
+	}
+
+	for testName, testData := range tests {
+		for _, updateReadOnlyInstances := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s, updateReadOnlyInstances=%v", testName, updateReadOnlyInstances), func(t *testing.T) {
+				// Init the ring.
+				ringDesc := &Desc{Ingesters: testData.ringInstances}
+				for id, instance := range ringDesc.Ingesters {
+					instance.Timestamp = time.Now().Unix()
+					instance.State = ACTIVE
+					ringDesc.Ingesters[id] = instance
+				}
+
+				ring := Ring{
+					cfg: Config{
+						HeartbeatTimeout: time.Hour,
+					},
+					ringDesc:              ringDesc,
+					ringTokens:            ringDesc.GetTokens(),
+					ringTokensByZone:      ringDesc.getTokensByZone(),
+					ringInstanceByToken:   ringDesc.getTokensInfo(),
+					ringZones:             getZones(ringDesc.getTokensByZone()),
+					instancesCountPerZone: ringDesc.instancesCountPerZone(),
+					strategy:              NewDefaultReplicationStrategy(),
+				}
+
+				if updateReadOnlyInstances {
+					readOnlyInstances, oldestReadOnlyUpdatedTimestamp := ringDesc.readOnlyInstancesAndOldestReadOnlyUpdatedTimestamp()
+					ring.readOnlyInstances = &readOnlyInstances
+					ring.oldestReadOnlyUpdatedTimestamp = &oldestReadOnlyUpdatedTimestamp
+				}
+
+				shardRing := ring.filterOutReadOnlyInstances(testData.lookbackPeriod, now)
+				var instances []string
+				for id, _ := range shardRing.ringDesc.Ingesters {
+					instances = append(instances, id)
+				}
+
+				assert.ElementsMatch(t, testData.expectedInstances, instances)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

This PR updates shuffle-sharding to 1) filter out read-only instances on shuffle shard with lookback, if instance changed its state before lookback window, 2) avoid computing shuffle shard if no filtering is required.

Benchmark compared to `main` (updated after https://github.com/grafana/dskit/pull/565/commits/95e95648d2c85553387565584c8e394ec79eaf0f):

```
benchstat main-new-bench.txt final2.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/ring
                                                                                  │ main-new-bench.txt │              final2.txt              │
                                                                                  │       sec/op       │    sec/op     vs base                │
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_0-10                657443.00n ± ∞ ¹   59.71n ± ∞ ¹   -99.99% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_3-10                    19.83µ ± ∞ ¹   19.34µ ± ∞ ¹         ~ (p=0.151 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_10-10                   53.21µ ± ∞ ¹   53.59µ ± ∞ ¹         ~ (p=0.841 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_30-10                   163.3µ ± ∞ ¹   163.5µ ± ∞ ¹         ~ (p=0.310 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_100-10                  651.8µ ± ∞ ¹   272.4µ ± ∞ ¹   -58.21% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_1000-10                 652.2µ ± ∞ ¹   271.9µ ± ∞ ¹   -58.31% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_0-10                680198.00n ± ∞ ¹   58.80n ± ∞ ¹   -99.99% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_3-10                    45.55µ ± ∞ ¹   45.19µ ± ∞ ¹    -0.78% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_10-10                   87.33µ ± ∞ ¹   89.49µ ± ∞ ¹    +2.47% (p=0.016 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_30-10                   200.8µ ± ∞ ¹   203.2µ ± ∞ ¹         ~ (p=0.222 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_100-10                  677.0µ ± ∞ ¹   293.9µ ± ∞ ¹   -56.59% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_1000-10                 671.4µ ± ∞ ¹   291.4µ ± ∞ ¹   -56.60% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_0-10              1395995.00n ± ∞ ¹   59.98n ± ∞ ¹  -100.00% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_3-10                   19.45µ ± ∞ ¹   19.35µ ± ∞ ¹         ~ (p=0.310 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_10-10                  53.32µ ± ∞ ¹   55.47µ ± ∞ ¹    +4.02% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_30-10                  162.9µ ± ∞ ¹   168.1µ ± ∞ ¹    +3.19% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_100-10                 654.3µ ± ∞ ¹   635.1µ ± ∞ ¹    -2.93% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_1000-10               1366.3µ ± ∞ ¹   628.9µ ± ∞ ¹   -53.97% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_0-10              1377139.00n ± ∞ ¹   60.41n ± ∞ ¹  -100.00% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_3-10                   45.29µ ± ∞ ¹   46.29µ ± ∞ ¹    +2.22% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_10-10                  86.79µ ± ∞ ¹   91.29µ ± ∞ ¹    +5.18% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_30-10                  200.1µ ± ∞ ¹   208.0µ ± ∞ ¹    +3.94% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_100-10                1147.1µ ± ∞ ¹   672.6µ ± ∞ ¹   -41.36% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_1000-10               1383.6µ ± ∞ ¹   671.2µ ± ∞ ¹   -51.49% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_0-10            17568050.00n ± ∞ ¹   61.36n ± ∞ ¹  -100.00% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_3-10                  17.58µ ± ∞ ¹   18.28µ ± ∞ ¹    +3.96% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_10-10                 50.52µ ± ∞ ¹   52.53µ ± ∞ ¹    +3.99% (p=0.016 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_30-10                 157.3µ ± ∞ ¹   163.3µ ± ∞ ¹    +3.82% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_100-10                626.2µ ± ∞ ¹   651.5µ ± ∞ ¹    +4.04% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_1000-10               8.996m ± ∞ ¹   8.596m ± ∞ ¹    -4.44% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_0-10            17422654.00n ± ∞ ¹   61.11n ± ∞ ¹  -100.00% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_3-10                  41.42µ ± ∞ ¹   43.73µ ± ∞ ¹    +5.59% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_10-10                 80.49µ ± ∞ ¹   86.60µ ± ∞ ¹    +7.60% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_30-10                 191.4µ ± ∞ ¹   200.6µ ± ∞ ¹    +4.80% (p=0.008 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_100-10                692.7µ ± ∞ ¹   719.2µ ± ∞ ¹         ~ (p=0.151 n=5)
Ring_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_1000-10              17.892m ± ∞ ¹   8.968m ± ∞ ¹   -49.87% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_1,_shard_size_=_0-10            1688.00n ± ∞ ¹   68.99n ± ∞ ¹   -95.91% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_1,_shard_size_=_3-10              149.4n ± ∞ ¹   148.7n ± ∞ ¹         ~ (p=0.802 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_1,_shard_size_=_10-10             366.3n ± ∞ ¹   357.0n ± ∞ ¹    -2.54% (p=0.032 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_1,_shard_size_=_30-10             1.027µ ± ∞ ¹   1.008µ ± ∞ ¹         ~ (p=0.151 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_1,_shard_size_=_100-10            1.671µ ± ∞ ¹   1.693µ ± ∞ ¹         ~ (p=0.548 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_1,_shard_size_=_1000-10           1.700µ ± ∞ ¹   1.648µ ± ∞ ¹    -3.06% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_3,_shard_size_=_0-10            1698.00n ± ∞ ¹   69.67n ± ∞ ¹   -95.90% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_3,_shard_size_=_3-10              149.1n ± ∞ ¹   148.5n ± ∞ ¹         ~ (p=0.968 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_3,_shard_size_=_10-10             431.9n ± ∞ ¹   426.0n ± ∞ ¹         ~ (p=0.310 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_3,_shard_size_=_30-10             1.015µ ± ∞ ¹   1.009µ ± ∞ ¹         ~ (p=0.103 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_3,_shard_size_=_100-10            1.691µ ± ∞ ¹   1.648µ ± ∞ ¹         ~ (p=0.151 n=5)
Ring_ShuffleShardCached/num_instances_=_50,_num_zones_=_3,_shard_size_=_1000-10           1.630µ ± ∞ ¹   1.668µ ± ∞ ¹         ~ (p=0.421 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_1,_shard_size_=_0-10           3602.00n ± ∞ ¹   69.57n ± ∞ ¹   -98.07% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_1,_shard_size_=_3-10             147.5n ± ∞ ¹   147.0n ± ∞ ¹         ~ (p=0.690 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_1,_shard_size_=_10-10            360.3n ± ∞ ¹   365.2n ± ∞ ¹         ~ (p=0.222 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_1,_shard_size_=_30-10            1.027µ ± ∞ ¹   1.031µ ± ∞ ¹         ~ (p=0.690 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_1,_shard_size_=_100-10           3.604µ ± ∞ ¹   3.577µ ± ∞ ¹         ~ (p=1.000 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_1,_shard_size_=_1000-10          3.570µ ± ∞ ¹   3.581µ ± ∞ ¹         ~ (p=1.000 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_3,_shard_size_=_0-10           3608.00n ± ∞ ¹   69.46n ± ∞ ¹   -98.07% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_3,_shard_size_=_3-10             149.9n ± ∞ ¹   150.3n ± ∞ ¹         ~ (p=0.421 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_3,_shard_size_=_10-10            424.4n ± ∞ ¹   429.2n ± ∞ ¹         ~ (p=0.841 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_3,_shard_size_=_30-10            1.014µ ± ∞ ¹   1.028µ ± ∞ ¹         ~ (p=1.000 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_3,_shard_size_=_100-10           3.606µ ± ∞ ¹   3.580µ ± ∞ ¹    -0.72% (p=0.032 n=5)
Ring_ShuffleShardCached/num_instances_=_100,_num_zones_=_3,_shard_size_=_1000-10          3.682µ ± ∞ ¹   3.545µ ± ∞ ¹    -3.72% (p=0.016 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_1,_shard_size_=_0-10         56902.00n ± ∞ ¹   69.58n ± ∞ ¹   -99.88% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_1,_shard_size_=_3-10            146.5n ± ∞ ¹   145.9n ± ∞ ¹         ~ (p=0.690 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_1,_shard_size_=_10-10           357.9n ± ∞ ¹   358.4n ± ∞ ¹         ~ (p=0.421 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_1,_shard_size_=_30-10           1.023µ ± ∞ ¹   1.021µ ± ∞ ¹         ~ (p=0.889 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_1,_shard_size_=_100-10          3.604µ ± ∞ ¹   3.604µ ± ∞ ¹         ~ (p=1.000 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_1,_shard_size_=_1000-10         56.92µ ± ∞ ¹   57.21µ ± ∞ ¹         ~ (p=0.841 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_3,_shard_size_=_0-10         57481.00n ± ∞ ¹   69.66n ± ∞ ¹   -99.88% (p=0.008 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_3,_shard_size_=_3-10            144.6n ± ∞ ¹   144.6n ± ∞ ¹         ~ (p=0.817 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_3,_shard_size_=_10-10           423.3n ± ∞ ¹   417.6n ± ∞ ¹         ~ (p=0.310 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_3,_shard_size_=_30-10           1.023µ ± ∞ ¹   1.032µ ± ∞ ¹         ~ (p=0.738 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_3,_shard_size_=_100-10          3.747µ ± ∞ ¹   3.627µ ± ∞ ¹         ~ (p=0.151 n=5)
Ring_ShuffleShardCached/num_instances_=_1000,_num_zones_=_3,_shard_size_=_1000-10         57.83µ ± ∞ ¹   56.68µ ± ∞ ¹    -1.99% (p=0.032 n=5)
Ring_ShuffleShard_512Tokens-10                                                            173.9µ ± ∞ ¹   173.3µ ± ∞ ¹    -0.35% (p=0.032 n=5)
Ring_ShuffleShard_LargeShardSize-10                                                       8.231m ± ∞ ¹   8.217m ± ∞ ¹         ~ (p=0.095 n=5)
Ring_ShuffleShard_ShardSize_0-10                                                     5152882.00n ± ∞ ¹   61.14n ± ∞ ¹  -100.00% (p=0.008 n=5)
geomean                                                                                   26.13µ         6.128µ         -76.54%
¹ need >= 6 samples for confidence interval at level 0.95
```

**Which issue(s) this PR fixes**:

Follow up to https://github.com/grafana/dskit/pull/560.

**Checklist**
- [x] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
