### PR TITLE
Fix computation of shuffle shard when shard size is <= 0, or higher than number of ring instances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,3 +258,4 @@
 * [BUGFIX] Memcached: Don't truncate sub-second TTLs to 0 which results in them being cached forever. #530
 * [BUGFIX] Cache: initialise the `operation_failures_total{reason="connect-timeout"}` metric to 0 for each cache operation type on startup. #545
 * [BUGFIX] spanlogger: include correct caller information in log messages logged through a `SpanLogger`. #547
+* [BUGFIX] Ring: shuffle shard without lookback no longer returns entire ring when shard size >= number of instances. Instead proper subring is computed, with correct number of instances in each zone. Returning entire ring was a bug, and such ring can contain instances that were not supposed to be used, if zones are not balanced. #554 #556

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,7 +220,7 @@
 * [ENHANCEMENT] memberlist: Added `-<prefix>memberlist.broadcast-timeout-for-local-updates-on-shutdown` option to set timeout for sending locally-generated updates on shutdown, instead of previously hardcoded 10s (which is still the default). #539
 * [ENHANCEMENT] tracing: add ExtractTraceSpanID function.
 * [EHNANCEMENT] crypto/tls: Support reloading client certificates #537 #552
-* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554
+* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554 #556
 * [ENHANCEMENT] Added new ring methods to expose number of writable instances with tokens per zone, and overall. #560 #562
 * [ENHANCEMENT] `services.FailureWatcher` can now be closed, which unregisters all service and manager listeners, and closes channel used to receive errors. #564 
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -698,7 +698,7 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 // Subring returned by this method does not contain instances that have read-only field set.
 func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 	// Use all possible instances if shuffle sharding is disabled. We don't set size to r.InstancesCount(), because
-	// that could lead to wrong instances being returned when ring zones are unbalanced.
+	// that could lead to not all instances being returned when ring zones are unbalanced.
 	// Reason for not returning entire ring directly is that we need to filter out read-only instances.
 	if size <= 0 {
 		size = math.MaxInt

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -697,7 +697,8 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 //
 // Subring returned by this method does not contain instances that have read-only field set.
 func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
-	// Use all instances if shuffle sharding is disabled, or it covers all instances anyway.
+	// Use all possible instances if shuffle sharding is disabled. We don't set size to r.InstancesCount(), because
+	// that could lead to wrong instances being returned when ring zones are unbalanced.
 	// Reason for not returning entire ring directly is that we need to filter out read-only instances.
 	if size <= 0 {
 		size = math.MaxInt

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1614,13 +1614,12 @@ func TestRing_ShuffleShard_Stability(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:              ringDesc,
-		ringTokens:            ringDesc.GetTokens(),
-		ringTokensByZone:      ringDesc.getTokensByZone(),
-		ringInstanceByToken:   ringDesc.getTokensInfo(),
-		instancesCountPerZone: ringDesc.instancesCountPerZone(),
-		ringZones:             getZones(ringDesc.getTokensByZone()),
-		strategy:              NewDefaultReplicationStrategy(),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.GetTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	for i := 1; i <= numTenants; i++ {
@@ -1689,13 +1688,12 @@ func TestRing_ShuffleShard_Shuffling(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:              ringDesc,
-		ringTokens:            ringDesc.GetTokens(),
-		ringTokensByZone:      ringDesc.getTokensByZone(),
-		ringInstanceByToken:   ringDesc.getTokensInfo(),
-		ringZones:             getZones(ringDesc.getTokensByZone()),
-		instancesCountPerZone: ringDesc.instancesCountPerZone(),
-		strategy:              NewDefaultReplicationStrategy(),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.GetTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Compute the shard for each tenant.
@@ -1804,13 +1802,12 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 					HeartbeatTimeout:     time.Hour,
 					ZoneAwarenessEnabled: true,
 				},
-				ringDesc:              ringDesc,
-				ringTokens:            ringDesc.GetTokens(),
-				ringTokensByZone:      ringDesc.getTokensByZone(),
-				ringInstanceByToken:   ringDesc.getTokensInfo(),
-				ringZones:             getZones(ringDesc.getTokensByZone()),
-				instancesCountPerZone: ringDesc.instancesCountPerZone(),
-				strategy:              NewDefaultReplicationStrategy(),
+				ringDesc:            ringDesc,
+				ringTokens:          ringDesc.GetTokens(),
+				ringTokensByZone:    ringDesc.getTokensByZone(),
+				ringInstanceByToken: ringDesc.getTokensInfo(),
+				ringZones:           getZones(ringDesc.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			// Compute the initial shard for each tenant.
@@ -1885,13 +1882,12 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:              ringDesc,
-		ringTokens:            ringDesc.GetTokens(),
-		ringTokensByZone:      ringDesc.getTokensByZone(),
-		ringInstanceByToken:   ringDesc.getTokensInfo(),
-		ringZones:             getZones(ringDesc.getTokensByZone()),
-		instancesCountPerZone: ringDesc.instancesCountPerZone(),
-		strategy:              NewDefaultReplicationStrategy(),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.GetTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Get the replication set with shard size = 3.
@@ -1963,13 +1959,12 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:              ringDesc,
-		ringTokens:            ringDesc.GetTokens(),
-		ringTokensByZone:      ringDesc.getTokensByZone(),
-		ringInstanceByToken:   ringDesc.getTokensInfo(),
-		ringZones:             getZones(ringDesc.getTokensByZone()),
-		instancesCountPerZone: ringDesc.instancesCountPerZone(),
-		strategy:              NewDefaultReplicationStrategy(),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.GetTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Get the replication set with shard size = 2.
@@ -2001,7 +1996,6 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	ring.ringTokensByZone = ringDesc.getTokensByZone()
 	ring.ringInstanceByToken = ringDesc.getTokensInfo()
 	ring.ringZones = getZones(ringDesc.getTokensByZone())
-	ring.instancesCountPerZone = ringDesc.instancesCountPerZone()
 
 	// Increase shard size to 6.
 	thirdShard := ring.ShuffleShard("tenant-id", 6)
@@ -2297,13 +2291,12 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 						HeartbeatTimeout:     time.Hour,
 						ZoneAwarenessEnabled: true,
 					},
-					ringDesc:              ringDesc,
-					ringTokens:            ringDesc.GetTokens(),
-					ringTokensByZone:      ringDesc.getTokensByZone(),
-					ringInstanceByToken:   ringDesc.getTokensInfo(),
-					ringZones:             getZones(ringDesc.getTokensByZone()),
-					instancesCountPerZone: ringDesc.instancesCountPerZone(),
-					strategy:              NewDefaultReplicationStrategy(),
+					ringDesc:            ringDesc,
+					ringTokens:          ringDesc.GetTokens(),
+					ringTokensByZone:    ringDesc.getTokensByZone(),
+					ringInstanceByToken: ringDesc.getTokensInfo(),
+					ringZones:           getZones(ringDesc.getTokensByZone()),
+					strategy:            NewDefaultReplicationStrategy(),
 				}
 
 				// Replay the events on the timeline.
@@ -2320,7 +2313,6 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 						ring.ringTokensByZone = ringDesc.getTokensByZone()
 						ring.ringInstanceByToken = ringDesc.getTokensInfo()
 						ring.ringZones = getZones(ringDesc.getTokensByZone())
-						ring.instancesCountPerZone = ringDesc.instancesCountPerZone()
 						if updateRegisteredTimestampCache {
 							ring.oldestRegisteredTimestamp = ringDesc.getOldestRegisteredTimestamp()
 						}
@@ -2331,7 +2323,6 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 						ring.ringTokensByZone = ringDesc.getTokensByZone()
 						ring.ringInstanceByToken = ringDesc.getTokensInfo()
 						ring.ringZones = getZones(ringDesc.getTokensByZone())
-						ring.instancesCountPerZone = ringDesc.instancesCountPerZone()
 						if updateRegisteredTimestampCache {
 							ring.oldestRegisteredTimestamp = ringDesc.getOldestRegisteredTimestamp()
 						}
@@ -3252,16 +3243,15 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, s
 	// Initialise the ring.
 	ringDesc := &Desc{Ingesters: generateRingInstances(initTokenGenerator(b), numInstances, numZones, numTokens)}
 	ring := Ring{
-		cfg:                   Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: !cache},
-		ringDesc:              ringDesc,
-		ringTokens:            ringDesc.GetTokens(),
-		ringTokensByZone:      ringDesc.getTokensByZone(),
-		ringInstanceByToken:   ringDesc.getTokensInfo(),
-		ringZones:             getZones(ringDesc.getTokensByZone()),
-		instancesCountPerZone: ringDesc.instancesCountPerZone(),
-		shuffledSubringCache:  map[subringCacheKey]*Ring{},
-		strategy:              NewDefaultReplicationStrategy(),
-		lastTopologyChange:    time.Now(),
+		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: !cache},
+		ringDesc:             ringDesc,
+		ringTokens:           ringDesc.GetTokens(),
+		ringTokensByZone:     ringDesc.getTokensByZone(),
+		ringInstanceByToken:  ringDesc.getTokensInfo(),
+		ringZones:            getZones(ringDesc.getTokensByZone()),
+		shuffledSubringCache: map[subringCacheKey]*Ring{},
+		strategy:             NewDefaultReplicationStrategy(),
+		lastTopologyChange:   time.Now(),
 	}
 
 	b.ResetTimer()

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1462,6 +1462,38 @@ func TestRing_ShuffleShard(t *testing.T) {
 			expectedZoneCount:            2,
 			expectedInstancesInZoneCount: map[string]int{"zone-a": 1, "zone-b": 1, "zone-c": 0},
 		},
+		"multiple zones, shard size == num instances, balanced zones": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil)},
+			},
+			shardSize:                    6,
+			zoneAwarenessEnabled:         true,
+			expectedSize:                 6,
+			expectedDistribution:         []int{2, 2, 2},
+			expectedZoneCount:            3,
+			expectedInstancesInZoneCount: map[string]int{"zone-a": 2, "zone-b": 2, "zone-c": 2},
+		},
+		"multiple zones, shard size == num instances, unbalanced zones": {
+			ringInstances: map[string]InstanceDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-b", Tokens: gen.GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: gen.GenerateTokens(128, nil)},
+			},
+			shardSize:                    6,
+			zoneAwarenessEnabled:         true,
+			expectedSize:                 5,
+			expectedDistribution:         []int{2, 2, 1},
+			expectedZoneCount:            3,
+			expectedInstancesInZoneCount: map[string]int{"zone-a": 2, "zone-b": 2, "zone-c": 1},
+		},
 		"multiple zones, shard size > num instances, balanced zones": {
 			ringInstances: map[string]InstanceDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: gen.GenerateTokens(128, nil)},

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -3194,7 +3194,7 @@ func TestRing_ShuffleShardWithLookback_CachingConcurrency(t *testing.T) {
 func BenchmarkRing_ShuffleShard(b *testing.B) {
 	for _, numInstances := range []int{50, 100, 1000} {
 		for _, numZones := range []int{1, 3} {
-			for _, shardSize := range []int{3, 10, 30} {
+			for _, shardSize := range []int{0, 3, 10, 30} {
 				b.Run(fmt.Sprintf("num instances = %d, num zones = %d, shard size = %d", numInstances, numZones, shardSize), func(b *testing.B) {
 					benchmarkShuffleSharding(b, numInstances, numZones, 128, shardSize, false)
 				})
@@ -3206,7 +3206,7 @@ func BenchmarkRing_ShuffleShard(b *testing.B) {
 func BenchmarkRing_ShuffleShardCached(b *testing.B) {
 	for _, numInstances := range []int{50, 100, 1000} {
 		for _, numZones := range []int{1, 3} {
-			for _, shardSize := range []int{3, 10, 30} {
+			for _, shardSize := range []int{0, 3, 10, 30} {
 				b.Run(fmt.Sprintf("num instances = %d, num zones = %d, shard size = %d", numInstances, numZones, shardSize), func(b *testing.B) {
 					benchmarkShuffleSharding(b, numInstances, numZones, 128, shardSize, true)
 				})
@@ -3233,6 +3233,18 @@ func BenchmarkRing_ShuffleShard_LargeShardSize(b *testing.B) {
 		numZones     = 3
 		numTokens    = 512
 		shardSize    = 270 // = 90 per zone
+		cacheEnabled = false
+	)
+
+	benchmarkShuffleSharding(b, numInstances, numZones, numTokens, shardSize, cacheEnabled)
+}
+
+func BenchmarkRing_ShuffleShard_ShardSize_0(b *testing.B) {
+	const (
+		numInstances = 90
+		numZones     = 3
+		numTokens    = 512
+		shardSize    = 0
 		cacheEnabled = false
 	)
 


### PR DESCRIPTION
**What this PR does**:
PR #554 introduced a change to shuffle shard computation: when shard size <= 0 or size >= number of instances, returned shuffle shard can be different from shuffle shard before PR #554, if there are unbalanced zones in the ring.

For example, let's say there are three zones:
* zone-a, 3 instances
* zone-b, 2 instances
* zone-c, 1 instance

Before PR #554 shuffleShard with size = 0 or size = 6 would return entire ring.

After PR #554, shuffle shard with size = 0 or size = 6 returns ring with 5 instances, (2 from zone-a, 2 from zone-b, and 1 from zone-c).

This PR modifies that:
1. when shard size <= 0, shuffle shard now returns ring with all instances (that are not read-only)
2. when shard size == 6, shuffle shard now correctly returns only 2 instances from zone-a and zone-b, and 1 instance from zone-c.

Note that point 2 is still a change compared to before PR #554 was merged, **however previous version of the code was buggy**: if new instance is added in zone-c, and we request shard size 6 again, we will only get 6 instances back -- one instance from zone-a is now removed from the shard, and even though it has previously received data, it won't be queried anymore.

Since we now pass `math.MaxInt` as size to `shuffleShard` method, some changes were done to the method:
* map allocation hint is capped at "number of instances"

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
