### PR TITLE
Fix computation of ShuffleShardExpectedInstancesPerZone for math.MaxInt.

### DIFF
--- a/ring/shard/shard.go
+++ b/ring/shard/shard.go
@@ -30,6 +30,9 @@ func ShuffleShardSeed(identifier, zone string) int64 {
 // zone when zone-aware replication is enabled. The algorithm expects the shard size to be divisible
 // by the number of zones, in order to have nodes balanced across zones. If it's not, we do round up.
 func ShuffleShardExpectedInstancesPerZone(shardSize, numZones int) int {
+	if shardSize == math.MaxInt {
+		return math.MaxInt
+	}
 	return int(math.Ceil(float64(shardSize) / float64(numZones)))
 }
 

--- a/ring/shard/shard_test.go
+++ b/ring/shard/shard_test.go
@@ -1,6 +1,7 @@
 package shard
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,11 @@ func TestShuffleShardExpectedInstancesPerZone(t *testing.T) {
 			shardSize: 6,
 			numZones:  3,
 			expected:  2,
+		},
+		{
+			shardSize: math.MaxInt,
+			numZones:  3,
+			expected:  math.MaxInt,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does**:

Fix computation of `ShuffleShardExpectedInstancesPerZone` for `size=math.MaxInt`, used by PR #566.

Without this change, we were getting `ShuffleShardExpectedInstancesPerZone(math.MaxInt, 1) => -9223372036854775808` on amd64.

**Checklist**
- [na] Tests updated
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
