### PR TITLE
Update golangci-lint config format for deprecations

### DIFF
--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -1,5 +1,0 @@
-io/ioutil.WriteFile
-io/ioutil.ReadFile
-(github.com/go-kit/log.Logger).Log
-io.Copy
-(github.com/opentracing/opentracing-go.Tracer).Inject

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 output:
-  format: line-number
-
+  formats:
+    - format: line-number
 linters:
   enable:
     - goimports
@@ -8,18 +8,20 @@ linters:
     - misspell
     - revive
     - loggercheck
-
 linters-settings:
   errcheck:
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude: ./.errcheck-exclude
+    exclude-functions:
+      - io/ioutil.WriteFile
+      - io/ioutil.ReadFile
+      - (github.com/go-kit/log.Logger).Log
+      - io.Copy
+      - (github.com/opentracing/opentracing-go.Tracer).Inject
   goimports:
     local-prefixes: "github.com/grafana/dskit"
-
 run:
   timeout: 5m
-
   # List of build tags, all linters use it.
   build-tags:
     - netgo


### PR DESCRIPTION
**What this PR does**:

The file format for the golangci-lint configuration has changed.  Here we remove the deprecation warnings, which cause some editors to fail to render the lint warnings properly.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
