### PR TITLE
Upgrade to golangci-lint v1.60.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.13.0
 
 .tools/bin/golangci-lint: .tools
-	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 
 .tools/bin/protoc: .tools
 ifeq ("$(wildcard .tools/protoc/bin/protoc)","")

--- a/grpcutil/status_test.go
+++ b/grpcutil/status_test.go
@@ -2,6 +2,7 @@ package grpcutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,10 +27,10 @@ func TestErrorToStatus(t *testing.T) {
 			err: nil,
 		},
 		"a random error cannot be cast to status.Status": {
-			err: fmt.Errorf(msgErr),
+			err: errors.New(msgErr),
 		},
 		"a wrapped error of a random error cannot be cast to status.Status": {
-			err: fmt.Errorf("wrapped: %w", fmt.Errorf(msgErr)),
+			err: fmt.Errorf("wrapped: %w", errors.New(msgErr)),
 		},
 		"a gRPC error built by gogo/status can be cast to status.Status": {
 			err:            status.Error(codes.Internal, msgErr),
@@ -74,11 +75,11 @@ func TestErrorToStatusCode(t *testing.T) {
 			expectedStatusCode: codes.OK,
 		},
 		"a non-gRPC error returns codes.Unknown": {
-			err:                fmt.Errorf(msgErr),
+			err:                errors.New(msgErr),
 			expectedStatusCode: codes.Unknown,
 		},
 		"a wrapped non-gRPC error returns codes.Unknown": {
-			err:                fmt.Errorf("wrapped: %w", fmt.Errorf(msgErr)),
+			err:                fmt.Errorf("wrapped: %w", errors.New(msgErr)),
 			expectedStatusCode: codes.Unknown,
 		},
 		"a gRPC error built by gogo/status returns its code": {
@@ -132,11 +133,11 @@ func TestIsCanceled(t *testing.T) {
 			expectedOutcome: true,
 		},
 		"a random error returns false": {
-			err:             fmt.Errorf(msgErr),
+			err:             errors.New(msgErr),
 			expectedOutcome: false,
 		},
 		"a wrapped random error returns false": {
-			err:             fmt.Errorf("wrapped: %w", fmt.Errorf(msgErr)),
+			err:             fmt.Errorf("wrapped: %w", errors.New(msgErr)),
 			expectedOutcome: false,
 		},
 		"a gRPC error with code different from codes.Canceled returns false": {

--- a/httpgrpc/httpgrpc.go
+++ b/httpgrpc/httpgrpc.go
@@ -106,14 +106,21 @@ func FromHeader(hs http.Header) []*Header {
 	return result
 }
 
-// Errorf returns a HTTP gRPC error than is correctly forwarded over
+// Error returns a HTTP gRPC error that is correctly forwarded over
+// gRPC, and can eventually be converted back to a HTTP response with
+// HTTPResponseFromError.
+func Error(code int, msg string) error {
+	return ErrorFromHTTPResponse(&HTTPResponse{
+		Code: int32(code),
+		Body: []byte(msg),
+	})
+}
+
+// Errorf returns a HTTP gRPC error that is correctly forwarded over
 // gRPC, and can eventually be converted back to a HTTP response with
 // HTTPResponseFromError.
 func Errorf(code int, tmpl string, args ...interface{}) error {
-	return ErrorFromHTTPResponse(&HTTPResponse{
-		Code: int32(code),
-		Body: []byte(fmt.Sprintf(tmpl, args...)),
-	})
+	return Error(code, fmt.Sprintf(tmpl, args...))
 }
 
 // ErrorFromHTTPResponse converts an HTTP response into a grpc error, and uses HTTP response body as an error message.

--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -2,6 +2,7 @@ package httpgrpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -52,7 +53,7 @@ func TestErrorf(t *testing.T) {
 		Code: int32(code),
 		Body: []byte(errMsg),
 	}
-	err := Errorf(code, errMsg)
+	err := Error(code, errMsg)
 	stat, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, code, int(stat.Code()))
@@ -90,7 +91,7 @@ func TestHTTPResponseFromError(t *testing.T) {
 			err: nil,
 		},
 		"a random error cannot be parsed to an HTTPResponse": {
-			err: fmt.Errorf(msgErr),
+			err: errors.New(msgErr),
 		},
 		"a gRPC error built by gogo/status cannot be parsed to an HTTPResponse": {
 			err: status.Error(codes.Internal, msgErr),
@@ -99,11 +100,11 @@ func TestHTTPResponseFromError(t *testing.T) {
 			err: grpcstatus.Error(codes.Internal, msgErr),
 		},
 		"a gRPC error built by httpgrpc can be parsed to an HTTPResponse": {
-			err:                  Errorf(400, msgErr),
+			err:                  Error(400, msgErr),
 			expectedHTTPResponse: &HTTPResponse{Code: 400, Body: []byte(msgErr)},
 		},
 		"a wrapped gRPC error built by httpgrpc can be parsed to an HTTPResponse": {
-			err:                  fmt.Errorf("wrapped: %w", Errorf(400, msgErr)),
+			err:                  fmt.Errorf("wrapped: %w", Error(400, msgErr)),
 			expectedHTTPResponse: &HTTPResponse{Code: 400, Body: []byte(msgErr)},
 		},
 	}

--- a/middleware/grpc_instrumentation_test.go
+++ b/middleware/grpc_instrumentation_test.go
@@ -219,11 +219,11 @@ func TestInstrumentationLabel_ErrorToStatusCode(t *testing.T) {
 			expectedGRPCStatueCodes: codes.FailedPrecondition,
 		},
 		"a gRPC error with status codes.Canceled returns codes.Canceled": {
-			err:                     status.Errorf(codes.Canceled, context.Canceled.Error()),
+			err:                     status.Error(codes.Canceled, context.Canceled.Error()),
 			expectedGRPCStatueCodes: codes.Canceled,
 		},
 		"a wrapped gRPC error with status codes.Canceled returns codes.Canceled": {
-			err:                     fmt.Errorf("wrapped: %w", status.Errorf(codes.Canceled, context.Canceled.Error())),
+			err:                     fmt.Errorf("wrapped: %w", status.Error(codes.Canceled, context.Canceled.Error())),
 			expectedGRPCStatueCodes: codes.Canceled,
 		},
 		"context.Canceled returns codes.Canceled": {
@@ -239,7 +239,7 @@ func TestInstrumentationLabel_ErrorToStatusCode(t *testing.T) {
 			expectedGRPCStatueCodes: codes.Unknown,
 		},
 		"a non-gRPC error returns codes.Unknown": {
-			err:                     fmt.Errorf(errMsg),
+			err:                     errors.New(errMsg),
 			expectedGRPCStatueCodes: codes.Unknown,
 		},
 	}

--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -316,7 +316,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 			ext.Error.Set(cfg.Logger.Span, true)
 		}
 
-		contextTracker.cancelAllContexts(cancellation.NewErrorf(cause))
+		contextTracker.cancelAllContexts(cancellation.NewError(errors.New(cause)))
 		cleanupResultsAlreadyReceived()
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -48,7 +47,7 @@ func (f FakeServer) FailWithError(_ context.Context, _ *protobuf.Empty) (*protob
 }
 
 func (f FakeServer) FailWithHTTPError(_ context.Context, req *FailWithHTTPErrorRequest) (*protobuf.Empty, error) {
-	return nil, httpgrpc.Errorf(int(req.Code), strconv.Itoa(int(req.Code)))
+	return nil, httpgrpc.Errorf(int(req.Code), "%d", req.Code)
 }
 
 func (f FakeServer) Succeed(_ context.Context, _ *protobuf.Empty) (*protobuf.Empty, error) {


### PR DESCRIPTION
**What this PR does**:
Upgrade to golangci-lint v1.60.1, in which `staticcheck` forbids calling `printf` style functions without a formatting string/arguments.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
