### PR TITLE
Support gzipped runtime configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,7 +222,8 @@
 * [EHNANCEMENT] crypto/tls: Support reloading client certificates #537 #552
 * [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554 #556
 * [ENHANCEMENT] Added new ring methods to expose number of writable instances with tokens per zone, and overall. #560 #562
-* [ENHANCEMENT] `services.FailureWatcher` can now be closed, which unregisters all service and manager listeners, and closes channel used to receive errors. #564 
+* [ENHANCEMENT] `services.FailureWatcher` can now be closed, which unregisters all service and manager listeners, and closes channel used to receive errors. #564
+* [ENHANCEMENT] Runtimeconfig: support gzip-compressed files with `.gz` extension. #571
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -239,7 +239,7 @@ func TestManagerGzip(t *testing.T) {
 		require.NoError(t, err)
 		err = services.StartAndAwaitRunning(context.Background(), manager)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "file looks gzipped but gzip is disabled")
+		require.Contains(t, err.Error(), "file looks gzipped but doesn't have a .gz extension")
 	})
 }
 


### PR DESCRIPTION
Some runtime configs can be too large to fit in one kubernetes configmap. However, Kubernetes configmaps accept binary data, so we can gzip the yaml, which offers up to 10x compression.

This would decompress using gzip runtime config files that have the `.gz` suffix.