### PR TITLE
Add lifecycler_read_only metric to observe read-only state of the lifecycler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,7 +220,7 @@
 * [ENHANCEMENT] memberlist: Added `-<prefix>memberlist.broadcast-timeout-for-local-updates-on-shutdown` option to set timeout for sending locally-generated updates on shutdown, instead of previously hardcoded 10s (which is still the default). #539
 * [ENHANCEMENT] tracing: add ExtractTraceSpanID function.
 * [EHNANCEMENT] crypto/tls: Support reloading client certificates #537 #552
-* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554 #556
+* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554 #556 #573
 * [ENHANCEMENT] Added new ring methods to expose number of writable instances with tokens per zone, and overall. #560 #562
 * [ENHANCEMENT] `services.FailureWatcher` can now be closed, which unregisters all service and manager listeners, and closes channel used to receive errors. #564
 * [ENHANCEMENT] Runtimeconfig: support gzip-compressed files with `.gz` extension. #571

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -415,6 +415,11 @@ func (i *Lifecycler) setReadOnlyState(readOnly bool, readOnlyLastUpdated time.Ti
 	defer i.stateMtx.Unlock()
 	i.readOnly = readOnly
 	i.readOnlyLastUpdated = readOnlyLastUpdated
+	if readOnly {
+		i.lifecyclerMetrics.readonly.Set(1)
+	} else {
+		i.lifecyclerMetrics.readonly.Set(0)
+	}
 }
 
 // ClaimTokensFor takes all the tokens for the supplied ingester and assigns them to this ingester.
@@ -678,8 +683,8 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			now := time.Now()
 			// The instance doesn't exist in the ring, so it's safe to set the registered timestamp as of now.
 			i.setRegisteredAt(now)
-			// Clear read-only state, and set last update time to "now".
-			i.setReadOnlyState(false, now)
+			// Clear read-only state, and set last update time to "zero".
+			i.setReadOnlyState(false, time.Time{})
 
 			// We use the tokens from the file only if it does not exist in the ring yet.
 			if len(tokensFromFile) > 0 {

--- a/ring/lifecycler_metrics.go
+++ b/ring/lifecycler_metrics.go
@@ -8,6 +8,7 @@ import (
 type LifecyclerMetrics struct {
 	consulHeartbeats prometheus.Counter
 	shutdownDuration *prometheus.HistogramVec
+	readonly         prometheus.Gauge
 }
 
 func NewLifecyclerMetrics(ringName string, reg prometheus.Registerer) *LifecyclerMetrics {
@@ -23,6 +24,11 @@ func NewLifecyclerMetrics(ringName string, reg prometheus.Registerer) *Lifecycle
 			Buckets:     prometheus.ExponentialBuckets(10, 2, 8), // Biggest bucket is 10*2^(9-1) = 2560, or 42 mins.
 			ConstLabels: prometheus.Labels{"name": ringName},
 		}, []string{"op", "status"}),
+		readonly: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name:        "lifecycler_read_only",
+			Help:        "Set to 1 if this lifecycler's instance entry is in read-only state.",
+			ConstLabels: prometheus.Labels{"name": ringName},
+		}),
 	}
 
 }


### PR DESCRIPTION
**What this PR does**:

This PR adds `lifecycler_read_only` metric to observe read-only state of the Lifecycler.

This PR also changes `ReadOnlyUpdatedTimestamp` from current time to zero when initializing ring entry by lifecycler in case that lifecycler's entry doesn't exist in the ring yet. This is cosmetic change for testing and making Ring HTML page simpler by not including too many timestamps.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
