### PR TITLE
Alerting: adapt sum of gauges to use options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@
 * [ENHANCEMENT] `services.FailureWatcher` can now be closed, which unregisters all service and manager listeners, and closes channel used to receive errors. #564
 * [ENHANCEMENT] Runtimeconfig: support gzip-compressed files with `.gz` extension. #571
 * [ENHANCEMENT] grpcclient: Support custom gRPC compressors. #583
+* [ENHANCEMENT] Adapt `metrics.SendSumOfGaugesPerTenant` to use `metrics.MetricOption`. #584
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -219,20 +219,16 @@ func (d MetricFamiliesPerTenant) SendSumOfGaugesWithLabels(out chan<- prometheus
 
 // SendSumOfGaugesPerTenant provides metrics on a per-tenant basis.
 // This function assumes that `tenant` is the first label on the provided metric Desc.
-func (d MetricFamiliesPerTenant) SendSumOfGaugesPerTenant(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string) {
-	d.SendSumOfGaugesPerTenantWithLabels(out, desc, gauge)
-}
+func (d MetricFamiliesPerTenant) SendSumOfGaugesPerTenant(out chan<- prometheus.Metric, desc *prometheus.Desc, metric string, options ...MetricOption) {
+	opts := applyMetricOptions(options...)
 
-// SendSumOfGaugesPerTenantWithLabels provides metrics with the provided label names on a per-tenant basis. This function assumes that `tenant` is the
-// first label on the provided metric Desc
-func (d MetricFamiliesPerTenant) SendSumOfGaugesPerTenantWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, metric string, labelNames ...string) {
 	for _, tenantEntry := range d {
 		if tenantEntry.tenant == "" {
 			continue
 		}
 
 		result := singleValueWithLabelsMap{}
-		tenantEntry.metrics.sumOfSingleValuesWithLabels(metric, labelNames, gaugeValue, result.aggregateFn, false)
+		tenantEntry.metrics.sumOfSingleValuesWithLabels(metric, opts.labelNames, gaugeValue, result.aggregateFn, opts.skipZeroValueMetrics)
 		result.prependTenantLabelValue(tenantEntry.tenant)
 		result.WriteToMetricChannel(out, desc, prometheus.GaugeValue)
 	}

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -237,7 +237,7 @@ func (d MetricFamiliesPerTenant) SendSumOfGaugesPerTenant(out chan<- prometheus.
 // SendSumOfGaugesPerTenantWithLabels provides metrics with the provided label names on a per-tenant basis. This function assumes that `tenant` is the
 // first label on the provided metric Desc
 //
-// Deprecated: use SendSumOfGaugesPerTenant instead.
+// Deprecated: use SendSumOfGaugesPerTenant with WithLabels option instead.
 func (d MetricFamiliesPerTenant) SendSumOfGaugesPerTenantWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, metric string, labelNames ...string) {
 	d.SendSumOfGaugesPerTenant(out, desc, metric, WithLabels(labelNames...))
 }

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -234,6 +234,14 @@ func (d MetricFamiliesPerTenant) SendSumOfGaugesPerTenant(out chan<- prometheus.
 	}
 }
 
+// SendSumOfGaugesPerTenantWithLabels provides metrics with the provided label names on a per-tenant basis. This function assumes that `tenant` is the
+// first label on the provided metric Desc
+//
+// Deprecated: use SendSumOfGaugesPerTenant instead.
+func (d MetricFamiliesPerTenant) SendSumOfGaugesPerTenantWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, metric string, labelNames ...string) {
+	d.SendSumOfGaugesPerTenant(out, desc, metric, WithLabels(labelNames...))
+}
+
 func (d MetricFamiliesPerTenant) sumOfSingleValuesWithLabels(metric string, fn func(*dto.Metric) float64, labelNames []string, skipZeroValue bool) singleValueWithLabelsMap {
 	result := singleValueWithLabelsMap{}
 	for _, tenantEntry := range d {

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -184,9 +184,9 @@ func BenchmarkGetMetricsWithLabelNames(b *testing.B) {
 	}
 }
 
-// TestSendSumOfGaugesPerTenantWithLabels tests to ensure multiple metrics for the same tenant with a matching label are
+// TestSendSumOfGaugesPerTenant_WithLabels tests to ensure multiple metrics for the same tenant with a matching label are
 // summed correctly.
-func TestSendSumOfGaugesPerTenantWithLabels(t *testing.T) {
+func TestSendSumOfGaugesPerTenant_WithLabels(t *testing.T) {
 	user1Reg := prometheus.NewRegistry()
 	user2Reg := prometheus.NewRegistry()
 	user1Metric := promauto.With(user1Reg).NewGaugeVec(prometheus.GaugeOpts{Name: "test_metric"}, []string{"label_one", "label_two"})
@@ -204,7 +204,7 @@ func TestSendSumOfGaugesPerTenantWithLabels(t *testing.T) {
 	{
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendSumOfGaugesPerTenantWithLabels(out, desc, "test_metric", "label_one")
+			mf.SendSumOfGaugesPerTenant(out, desc, "test_metric", WithLabels("label_one"))
 		})
 		expected := []*dto.Metric{
 			{Label: makeLabels("label_one", "a", "user", "user-1"), Gauge: &dto.Gauge{Value: proto.Float64(180)}},
@@ -216,7 +216,7 @@ func TestSendSumOfGaugesPerTenantWithLabels(t *testing.T) {
 	{
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_two"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendSumOfGaugesPerTenantWithLabels(out, desc, "test_metric", "label_two")
+			mf.SendSumOfGaugesPerTenant(out, desc, "test_metric", WithLabels("label_two"))
 		})
 		expected := []*dto.Metric{
 			{Label: makeLabels("label_two", "b", "user", "user-1"), Gauge: &dto.Gauge{Value: proto.Float64(100)}},
@@ -230,7 +230,7 @@ func TestSendSumOfGaugesPerTenantWithLabels(t *testing.T) {
 	{
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one", "label_two"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendSumOfGaugesPerTenantWithLabels(out, desc, "test_metric", "label_one", "label_two")
+			mf.SendSumOfGaugesPerTenant(out, desc, "test_metric", WithLabels("label_one", "label_two"))
 		})
 		expected := []*dto.Metric{
 			{Label: makeLabels("label_one", "a", "label_two", "b", "user", "user-1"), Gauge: &dto.Gauge{Value: proto.Float64(100)}},

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -184,9 +184,9 @@ func BenchmarkGetMetricsWithLabelNames(b *testing.B) {
 	}
 }
 
-// TestSendSumOfGaugesPerTenant_WithLabels tests to ensure multiple metrics for the same tenant with a matching label are
+// TestSendSumOfGaugesPerTenantWithLabels tests to ensure multiple metrics for the same tenant with a matching label are
 // summed correctly.
-func TestSendSumOfGaugesPerTenant_WithLabels(t *testing.T) {
+func TestSendSumOfGaugesPerTenantWithLabels(t *testing.T) {
 	user1Reg := prometheus.NewRegistry()
 	user2Reg := prometheus.NewRegistry()
 	user1Metric := promauto.With(user1Reg).NewGaugeVec(prometheus.GaugeOpts{Name: "test_metric"}, []string{"label_one", "label_two"})
@@ -204,7 +204,7 @@ func TestSendSumOfGaugesPerTenant_WithLabels(t *testing.T) {
 	{
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendSumOfGaugesPerTenant(out, desc, "test_metric", WithLabels("label_one"))
+			mf.SendSumOfGaugesPerTenantWithLabels(out, desc, "test_metric", "label_one")
 		})
 		expected := []*dto.Metric{
 			{Label: makeLabels("label_one", "a", "user", "user-1"), Gauge: &dto.Gauge{Value: proto.Float64(180)}},
@@ -216,7 +216,7 @@ func TestSendSumOfGaugesPerTenant_WithLabels(t *testing.T) {
 	{
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_two"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendSumOfGaugesPerTenant(out, desc, "test_metric", WithLabels("label_two"))
+			mf.SendSumOfGaugesPerTenantWithLabels(out, desc, "test_metric", "label_two")
 		})
 		expected := []*dto.Metric{
 			{Label: makeLabels("label_two", "b", "user", "user-1"), Gauge: &dto.Gauge{Value: proto.Float64(100)}},
@@ -230,7 +230,7 @@ func TestSendSumOfGaugesPerTenant_WithLabels(t *testing.T) {
 	{
 		desc := prometheus.NewDesc("test_metric", "", []string{"user", "label_one", "label_two"}, nil)
 		actual := collectMetrics(t, func(out chan prometheus.Metric) {
-			mf.SendSumOfGaugesPerTenant(out, desc, "test_metric", WithLabels("label_one", "label_two"))
+			mf.SendSumOfGaugesPerTenantWithLabels(out, desc, "test_metric", "label_one", "label_two")
 		})
 		expected := []*dto.Metric{
 			{Label: makeLabels("label_one", "a", "label_two", "b", "user", "user-1"), Gauge: &dto.Gauge{Value: proto.Float64(100)}},


### PR DESCRIPTION
To be able to filter 0 value gauges per tenant, we need to adapt the helper as it was done already before for other metrics.

Trying to follow the name convention, but not sure if we should introduce a new function instead. Despite being simple to adapt, it would require changes
