### PR TITLE
Fix race in memberlist client when KV store keeps the value returned from CAS function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,3 +266,4 @@
 * [BUGFIX] Cache: initialise the `operation_failures_total{reason="connect-timeout"}` metric to 0 for each cache operation type on startup. #545
 * [BUGFIX] spanlogger: include correct caller information in log messages logged through a `SpanLogger`. #547
 * [BUGFIX] Ring: shuffle shard without lookback no longer returns entire ring when shard size >= number of instances. Instead proper subring is computed, with correct number of instances in each zone. Returning entire ring was a bug, and such ring can contain instances that were not supposed to be used, if zones are not balanced. #554 #556
+* [BUGFIX] Memberlist: clone value returned by function used in CAS operation before storing the value into KV store. #586

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1018,14 +1018,16 @@ func (m *KV) trySingleCas(key string, codec codec.Codec, f func(in interface{}) 
 	}
 
 	// Don't even try
-	r, ok := out.(Mergeable)
-	if !ok || r == nil {
+	incomingValue, ok := out.(Mergeable)
+	if !ok || incomingValue == nil {
 		return nil, 0, retry, fmt.Errorf("invalid type: %T, expected Mergeable", out)
 	}
 
 	// To support detection of removed items from value, we will only allow CAS operation to
 	// succeed if version hasn't changed, i.e. state hasn't changed since running 'f'.
-	change, newver, err := m.mergeValueForKey(key, r, ver, codec)
+	// Supplied function may have kept a reference to the returned "incoming value".
+	// If KV store will keep this value as well, it needs to make a clone.
+	change, newver, err := m.mergeValueForKey(key, incomingValue, true, ver, codec)
 	if err == errVersionMismatch {
 		return nil, 0, retry, err
 	}
@@ -1379,14 +1381,15 @@ func (m *KV) mergeBytesValueForKey(key string, incomingData []byte, codec codec.
 		return nil, 0, fmt.Errorf("expected Mergeable, got: %T", decodedValue)
 	}
 
-	return m.mergeValueForKey(key, incomingValue, 0, codec)
+	// No need to clone this "incomingValue", since we have just decoded it from bytes, and won't be using it.
+	return m.mergeValueForKey(key, incomingValue, false, 0, codec)
 }
 
 // Merges incoming value with value we have in our store. Returns "a change" that can be sent to other
 // cluster members to update their state, and new version of the value.
 // If CAS version is specified, then merging will fail if state has changed already, and errVersionMismatch is reported.
 // If no modification occurred, new version is 0.
-func (m *KV) mergeValueForKey(key string, incomingValue Mergeable, casVersion uint, codec codec.Codec) (Mergeable, uint, error) {
+func (m *KV) mergeValueForKey(key string, incomingValue Mergeable, incomingValueRequiresClone bool, casVersion uint, codec codec.Codec) (Mergeable, uint, error) {
 	m.storeMu.Lock()
 	defer m.storeMu.Unlock()
 
@@ -1398,7 +1401,7 @@ func (m *KV) mergeValueForKey(key string, incomingValue Mergeable, casVersion ui
 	if casVersion > 0 && curr.Version != casVersion {
 		return nil, 0, errVersionMismatch
 	}
-	result, change, err := computeNewValue(incomingValue, curr.value, casVersion > 0)
+	result, change, err := computeNewValue(incomingValue, incomingValueRequiresClone, curr.value, casVersion > 0)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1441,8 +1444,16 @@ func (m *KV) mergeValueForKey(key string, incomingValue Mergeable, casVersion ui
 }
 
 // returns [result, change, error]
-func computeNewValue(incoming Mergeable, oldVal Mergeable, cas bool) (Mergeable, Mergeable, error) {
+func computeNewValue(incoming Mergeable, incomingValueRequiresClone bool, oldVal Mergeable, cas bool) (Mergeable, Mergeable, error) {
 	if oldVal == nil {
+		// It's OK to return the same value twice (once as result, once as change), because "change" will be cloned
+		// in mergeValueForKey if needed.
+
+		if incomingValueRequiresClone {
+			clone := incoming.Clone()
+			return clone, clone, nil
+		}
+
 		return incoming, incoming, nil
 	}
 

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -1745,7 +1745,7 @@ func TestRaceBetweenStoringNewValueForKeyAndUpdatingIt(t *testing.T) {
 			d.Members[fmt.Sprintf("member_%d", i)] = member{Timestamp: time.Now().Unix(), State: i % 3}
 		}
 
-		err := kv.CAS(context.Background(), key, codec, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := kv.CAS(context.Background(), key, codec, func(_ interface{}) (out interface{}, retry bool, err error) {
 			return d, true, nil
 		})
 		require.NoError(t, err)

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -3,6 +3,7 @@ package memberlist
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -1567,12 +1568,18 @@ func decodeDataFromMarshalledKeyValuePair(t *testing.T, marshalledKVP []byte, ke
 	return d
 }
 
-func marshalKeyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}) []byte {
+func keyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}) *KeyValuePair {
 	data, err := codec.Encode(value)
 	require.NoError(t, err)
 
-	kvp := KeyValuePair{Key: key, Codec: codec.CodecID(), Value: data}
-	data, err = kvp.Marshal()
+	return &KeyValuePair{Key: key, Codec: codec.CodecID(), Value: data}
+
+}
+
+func marshalKeyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}) []byte {
+	kvp := keyValuePair(t, key, codec, value)
+
+	data, err := kvp.Marshal()
 	require.NoError(t, err)
 	return data
 }
@@ -1709,4 +1716,84 @@ func getKey(t *testing.T, msg []byte) string {
 	err := kvPair.Unmarshal(msg)
 	require.NoError(t, err)
 	return kvPair.Key
+}
+
+func TestRaceBetweenStoringNewValueForKeyAndUpdatingIt(t *testing.T) {
+	codec := dataCodec{}
+
+	cfg := KVConfig{}
+	cfg.Codecs = append(cfg.Codecs, codec)
+	cfg.TCPTransport = TCPTransportConfig{
+		BindAddrs: getLocalhostAddrs(),
+	}
+
+	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
+	defer services.StopAndAwaitTerminated(context.Background(), kv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	vals := make(chan int64, 10000)
+
+	go func() {
+		d := &data{Members: map[string]member{}}
+		for i := 0; i < 100; i++ {
+			d.Members[fmt.Sprintf("member_%d", i)] = member{Timestamp: time.Now().Unix(), State: i % 3}
+		}
+
+		kv.CAS(context.Background(), key, codec, func(in interface{}) (out interface{}, retry bool, err error) {
+			return d, true, nil
+		})
+
+		// keep iterating over d.Members. If other goroutine modifies same ring descriptor, we will see a race error.
+		for ctx.Err() == nil {
+			sum := int64(0)
+			for n, m := range d.Members {
+				sum += int64(len(n))
+				sum += m.Timestamp
+				sum += int64(len(m.Tokens))
+			}
+			vals <- sum
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// Wait until CAS and iteration finishes before pushing remote state.
+	<-vals
+
+	s := 0
+	for ctx.Err() == nil {
+		s++
+		d := &data{Members: map[string]member{}}
+		for i := 0; i < 100; i++ {
+			d.Members[fmt.Sprintf("member_%d", i)] = member{Timestamp: time.Now().Unix(), State: (i + s) % 3}
+		}
+
+		kv.MergeRemoteState(marshalState(t, keyValuePair(t, key, codec, d)), false)
+		time.Sleep(10 * time.Millisecond)
+
+	drain:
+		select {
+		case <-vals:
+			goto drain
+		default:
+			// stop draining.
+		}
+	}
+}
+
+func marshalState(t *testing.T, kvps ...*KeyValuePair) []byte {
+	buf := bytes.Buffer{}
+
+	for _, kvp := range kvps {
+		d, err := kvp.Marshal()
+		require.NoError(t, err)
+		err = binary.Write(&buf, binary.BigEndian, uint32(len(d)))
+		require.NoError(t, err)
+		buf.Write(d)
+	}
+
+	return buf.Bytes()
 }


### PR DESCRIPTION
**What this PR does**:

This PR fixes a race, which was observed in Mimir CI: https://github.com/grafana/mimir/actions/runs/10773357362/job/29874922698?pr=9241

Here's the race report:

```
2024-09-09T13:23:25.6897216Z 13:16:46 mimir-1: ==================
2024-09-09T13:23:25.6897580Z 13:16:46 mimir-1: WARNING: DATA RACE

2024-09-09T13:23:25.6898051Z 13:16:46 mimir-1: Write at 0x00c003023200 by goroutine 2979:
2024-09-09T13:23:25.6898546Z 13:16:46 mimir-1: runtime.mapassign_faststr()
2024-09-09T13:23:25.6899089Z 13:16:46 mimir-1: /usr/local/go/src/runtime/map_faststr.go:223 +0x0
2024-09-09T13:23:25.6899742Z 13:16:46 mimir-1: github.com/grafana/dskit/ring.(*Desc).mergeWithTime()
2024-09-09T13:23:25.6900668Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/ring/model.go:246 +0xdda
2024-09-09T13:23:25.6901382Z 13:16:46 mimir-1: github.com/grafana/dskit/ring.(*Desc).Merge()
2024-09-09T13:23:25.6902103Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/ring/model.go:213 +0x5c
2024-09-09T13:23:25.6902859Z 13:16:46 mimir-1: github.com/grafana/dskit/kv/memberlist.computeNewValue()
2024-09-09T13:23:25.6903777Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1450 +0x58
2024-09-09T13:23:25.6904690Z 13:16:46 mimir-1: github.com/grafana/dskit/kv/memberlist.(*KV).mergeValueForKey()
2024-09-09T13:23:25.6905656Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1401 +0x2d3
2024-09-09T13:23:25.6906601Z 13:16:46 mimir-1: github.com/grafana/dskit/kv/memberlist.(*KV).mergeBytesValueForKey()
2024-09-09T13:23:25.6907577Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1382 +0x1ad
2024-09-09T13:23:25.6908482Z 13:16:46 mimir-1: github.com/grafana/dskit/kv/memberlist.(*KV).MergeRemoteState()
2024-09-09T13:23:25.6909395Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go:1343 +0x484
2024-09-09T13:23:25.6910315Z 13:16:46 mimir-1: github.com/hashicorp/memberlist.(*Memberlist).mergeRemoteState()
2024-09-09T13:23:25.6911129Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/hashicorp/memberlist/net.go:1261 +0x25b
2024-09-09T13:23:25.6911912Z 13:16:46 mimir-1: github.com/hashicorp/memberlist.(*Memberlist).handleConn()
2024-09-09T13:23:25.6912700Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/hashicorp/memberlist/net.go:309 +0x1159
2024-09-09T13:23:25.6913532Z 13:16:46 mimir-1: github.com/hashicorp/memberlist.(*Memberlist).streamListen.gowrap1()
2024-09-09T13:23:25.6914509Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/hashicorp/memberlist/net.go:224 +0x4f

2024-09-09T13:23:25.6915239Z 13:16:46 mimir-1: Previous read at 0x00c003023200 by goroutine 3035:
2024-09-09T13:23:25.6915748Z 13:16:46 mimir-1: runtime.mapiterinit()
2024-09-09T13:23:25.6916237Z 13:16:46 mimir-1: /usr/local/go/src/runtime/map.go:877 +0x0
2024-09-09T13:23:25.6916880Z 13:16:46 mimir-1: github.com/grafana/dskit/ring.(*Lifecycler).updateCounters()
2024-09-09T13:23:25.6917698Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/ring/lifecycler.go:992 +0x1a6
2024-09-09T13:23:25.6918471Z 13:16:46 mimir-1: github.com/grafana/dskit/ring.(*Lifecycler).initRing()
2024-09-09T13:23:25.6919303Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/ring/lifecycler.go:779 +0x7fc
2024-09-09T13:23:25.6920141Z 13:16:46 mimir-1: github.com/grafana/dskit/ring.(*Lifecycler).loop()
2024-09-09T13:23:25.6920915Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/ring/lifecycler.go:526 +0x68
2024-09-09T13:23:25.6921685Z 13:16:46 mimir-1: github.com/grafana/dskit/ring.(*Lifecycler).loop-fm()
2024-09-09T13:23:25.6922215Z 13:16:46 mimir-1: <autogenerated>:1 +0x47
2024-09-09T13:23:25.6922764Z 13:16:46 mimir-1: github.com/grafana/dskit/services.(*BasicService).main()
2024-09-09T13:23:25.6923600Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/services/basic_service.go:193 +0x3b7
2024-09-09T13:23:25.6924523Z 13:16:46 mimir-1: github.com/grafana/dskit/services.(*BasicService).StartAsync.func1.gowrap1()
2024-09-09T13:23:25.6925452Z 13:16:46 mimir-1: /__w/mimir/mimir/vendor/github.com/grafana/dskit/services/basic_service.go:122 +0x33
```

Problem is that when lifecycler starts and there’s no entry in the ring, it creates one and memberlist KV doesn’t put a clone to the store, but original value. Lifecycler then iterates over it, while memberlist KV can update it.

This PR implements solution for this race -- adds cloning of values returned by function used by CAS operation, in cases when value is actually stored in the KV store.

Fortunately this is pretty rare occurence... typically KV store already contains previous version of the value and instead of storing new value, KV store "merges" incoming value with previous value.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
