### PR TITLE
Change how read-only fields disaply in ring HTML page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 * [CHANGE] Cache: Remove superfluous `cache.RemoteCacheClient` interface and unify all caches using the `cache.Cache` interface. #520
 * [CHANGE] Updated the minimum required Go version to 1.21. #540
 * [CHANGE] memberlist: Metric `memberlist_client_messages_in_broadcast_queue` is now split into `queue="local"` and `queue="gossip"` values. #539
-* [CHANGE] memberlist: Failure to fast-join a cluster via contacting a node is now logged at `info` instead of `debug`. #585 
+* [CHANGE] memberlist: Failure to fast-join a cluster via contacting a node is now logged at `info` instead of `debug`. #585
 * [CHANGE] `Service.AddListener` and `Manager.AddListener` now return function for stopping the listener. #564
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
@@ -224,7 +224,7 @@
 * [ENHANCEMENT] memberlist: Added `-<prefix>memberlist.broadcast-timeout-for-local-updates-on-shutdown` option to set timeout for sending locally-generated updates on shutdown, instead of previously hardcoded 10s (which is still the default). #539
 * [ENHANCEMENT] tracing: add ExtractTraceSpanID function.
 * [EHNANCEMENT] crypto/tls: Support reloading client certificates #537 #552
-* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554 #556 #573 #578
+* [ENHANCEMENT] Add read only support for ingesters in the ring and lifecycler. #553 #554 #556 #573 #578 #587
 * [ENHANCEMENT] Added new ring methods to expose number of writable instances with tokens per zone, and overall. #560 #562
 * [ENHANCEMENT] `services.FailureWatcher` can now be closed, which unregisters all service and manager listeners, and closes channel used to receive errors. #564
 * [ENHANCEMENT] Runtimeconfig: support gzip-compressed files with `.gz` extension. #571

--- a/ring/ring_status.gohtml
+++ b/ring/ring_status.gohtml
@@ -38,8 +38,13 @@
             <td>{{ .State }}</td>
             <td>{{ .Address }}</td>
             <td>{{ .RegisteredTimestamp | timeOrEmptyString }}</td>
+            {{ if .ReadOnly }}
             <td>{{ .ReadOnly }}</td>
+            <td>{{ .ReadOnlyUpdatedTimestamp | durationSince }} ago ({{ .ReadOnlyUpdatedTimestamp.Format "15:04:05.999" }})</td>
+            {{ else }}
+            <td></td>
             <td>{{ .ReadOnlyUpdatedTimestamp | timeOrEmptyString }}</td>
+            {{ end }}
             <td>{{ .HeartbeatTimestamp | durationSince }} ago ({{ .HeartbeatTimestamp.Format "15:04:05.999" }})</td>
             <td>{{ .NumTokens }}</td>
             <td>{{ .Ownership | humanFloat }}%</td>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

When dealing with a ring status page with hundreds of instances, it can be difficult to tell which ones are currently read-only. This PR makes two changes:
- for instances that are not read-only, leave the `Read-Only` field in the status page empty, rather than showing `false`
- for instances that are read-only, also show the duration that they have been read-only in the `Read-Only Updated` field

Before:
<img width="382" alt="Screenshot 2024-09-25 at 2 44 52 AM" src="https://github.com/user-attachments/assets/607a43d0-5150-474b-8f07-18e7b125ef9d">

After:
<img width="392" alt="Screenshot 2024-09-25 at 2 56 16 AM" src="https://github.com/user-attachments/assets/fb198a6d-800d-4360-8420-7c7d23e0e78e">


**Which issue(s) this PR fixes**:

Fixes #N/A

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
