### PR TITLE
cache: Add `.Set` and `.Add` methods to cache clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,7 @@
 * [ENHANCEMENT] Runtimeconfig: support gzip-compressed files with `.gz` extension. #571
 * [ENHANCEMENT] grpcclient: Support custom gRPC compressors. #583
 * [ENHANCEMENT] Adapt `metrics.SendSumOfGaugesPerTenant` to use `metrics.MetricOption`. #584
+* [ENHANCEMENT] Cache: Add `.Add()` and `.Set()` methods to cache clients. #591
 * [CHANGE] Backoff: added `Backoff.ErrCause()` which is like `Backoff.Err()` but returns the context cause if backoff is terminated because the context has been canceled. #538
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -13,6 +13,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var (
+	ErrNotStored  = errors.New("item not stored")
+	ErrInvalidTTL = errors.New("invalid TTL")
+)
+
 // Cache is a high level interface to interact with a cache.
 type Cache interface {
 	// GetMulti fetches multiple keys at once from a cache. In case of error,
@@ -27,6 +32,14 @@ type Cache interface {
 	// SetMultiAsync enqueues operations to store a keys and values into a cache. In case
 	// any underlying async operations fail, the errors will be tracked/logged.
 	SetMultiAsync(data map[string][]byte, ttl time.Duration)
+
+	// Set stores a key and value into a cache.
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+
+	// Add stores a key and value into a cache only if it does not already exist. If the
+	// item was not stored because an entry already exists in the cache, ErrNotStored will
+	// be returned.
+	Add(ctx context.Context, key string, value []byte, ttl time.Duration) error
 
 	// Delete deletes a key from a cache. This is a synchronous operation. If an asynchronous
 	// set operation for key is still pending to be processed, it will wait for it to complete

--- a/cache/client.go
+++ b/cache/client.go
@@ -17,6 +17,7 @@ import (
 // Common functionality shared between the Memcached and Redis Cache implementations
 
 const (
+	opAdd            = "add"
 	opSet            = "set"
 	opGetMulti       = "getmulti"
 	opDelete         = "delete"
@@ -29,6 +30,8 @@ const (
 	reasonMaxItemSize     = "max-item-size"
 	reasonAsyncBufferFull = "async-buffer-full"
 	reasonMalformedKey    = "malformed-key"
+	reasonInvalidTTL      = "invalid-ttl"
+	reasonNotStored       = "not-stored"
 	reasonConnectTimeout  = "connect-timeout"
 	reasonTimeout         = "request-timeout"
 	reasonServerError     = "server-error"
@@ -85,10 +88,12 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Name: "operation_failures_total",
 		Help: "Total number of operations against cache that failed.",
 	}, []string{"operation", "reason"})
-	for _, op := range []string{opGetMulti, opSet, opDelete, opIncrement, opFlush, opTouch, opCompareAndSwap} {
+	for _, op := range []string{opGetMulti, opAdd, opSet, opDelete, opIncrement, opFlush, opTouch, opCompareAndSwap} {
 		cm.failures.WithLabelValues(op, reasonConnectTimeout)
 		cm.failures.WithLabelValues(op, reasonTimeout)
 		cm.failures.WithLabelValues(op, reasonMalformedKey)
+		cm.failures.WithLabelValues(op, reasonInvalidTTL)
+		cm.failures.WithLabelValues(op, reasonNotStored)
 		cm.failures.WithLabelValues(op, reasonServerError)
 		cm.failures.WithLabelValues(op, reasonNetworkError)
 		cm.failures.WithLabelValues(op, reasonOther)
@@ -99,6 +104,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Help: "Total number of operations against cache that have been skipped.",
 	}, []string{"operation", "reason"})
 	cm.skipped.WithLabelValues(opGetMulti, reasonMaxItemSize)
+	cm.skipped.WithLabelValues(opAdd, reasonMaxItemSize)
 	cm.skipped.WithLabelValues(opSet, reasonMaxItemSize)
 	cm.skipped.WithLabelValues(opSet, reasonAsyncBufferFull)
 
@@ -112,6 +118,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		NativeHistogramMinResetDuration: time.Hour,
 	}, []string{"operation"})
 	cm.duration.WithLabelValues(opGetMulti)
+	cm.duration.WithLabelValues(opAdd)
 	cm.duration.WithLabelValues(opSet)
 	cm.duration.WithLabelValues(opDelete)
 	cm.duration.WithLabelValues(opIncrement)
@@ -129,6 +136,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		[]string{"operation"},
 	)
 	cm.dataSize.WithLabelValues(opGetMulti)
+	cm.dataSize.WithLabelValues(opAdd)
 	cm.dataSize.WithLabelValues(opSet)
 	cm.dataSize.WithLabelValues(opCompareAndSwap)
 
@@ -172,28 +180,44 @@ func (c *baseClient) setAsync(key string, value []byte, ttl time.Duration, f fun
 	}
 
 	err := c.asyncQueue.submit(func() {
-		start := time.Now()
-		c.metrics.operations.WithLabelValues(opSet).Inc()
-
-		err := f(key, value, ttl)
-		if err != nil {
-			level.Debug(c.logger).Log(
-				"msg", "failed to store item to cache",
-				"key", key,
-				"sizeBytes", len(value),
-				"err", err,
-			)
-			c.trackError(opSet, err)
-		}
-
-		c.metrics.dataSize.WithLabelValues(opSet).Observe(float64(len(value)))
-		c.metrics.duration.WithLabelValues(opSet).Observe(time.Since(start).Seconds())
+		// Because this operation is executed in a separate goroutine: We run the operation without
+		// a context (it is expected to keep running no matter what happens) and we don't return the
+		// error (it will be tracked via metrics instead of being returned to the caller).
+		_ = c.storeOperation(context.Background(), key, value, ttl, opSet, func(_ context.Context, key string, value []byte, ttl time.Duration) error {
+			return f(key, value, ttl)
+		})
 	})
 
 	if err != nil {
 		c.metrics.skipped.WithLabelValues(opSet, reasonAsyncBufferFull).Inc()
 		level.Debug(c.logger).Log("msg", "failed to store item to cache because the async buffer is full", "err", err, "size", c.asyncBuffSize)
 	}
+}
+
+func (c *baseClient) storeOperation(ctx context.Context, key string, value []byte, ttl time.Duration, operation string, f func(ctx context.Context, key string, value []byte, ttl time.Duration) error) error {
+	if c.maxItemSize > 0 && uint64(len(value)) > c.maxItemSize {
+		c.metrics.skipped.WithLabelValues(operation, reasonMaxItemSize).Inc()
+		return nil
+	}
+
+	start := time.Now()
+	c.metrics.operations.WithLabelValues(operation).Inc()
+
+	err := f(ctx, key, value, ttl)
+	if err != nil {
+		level.Debug(c.logger).Log(
+			"msg", "failed to store item to cache",
+			"operation", operation,
+			"key", key,
+			"sizeBytes", len(value),
+			"err", err,
+		)
+		c.trackError(operation, err)
+	}
+
+	c.metrics.dataSize.WithLabelValues(operation).Observe(float64(len(value)))
+	c.metrics.duration.WithLabelValues(operation).Observe(time.Since(start).Seconds())
+	return err
 }
 
 // wait submits an async task and blocks until it completes. This can be used during
@@ -255,6 +279,10 @@ func (c *baseClient) trackError(op string, err error) {
 		} else {
 			c.metrics.failures.WithLabelValues(op, reasonNetworkError).Inc()
 		}
+	case errors.Is(err, ErrNotStored):
+		c.metrics.failures.WithLabelValues(op, reasonNotStored).Inc()
+	case errors.Is(err, ErrInvalidTTL):
+		c.metrics.failures.WithLabelValues(op, reasonInvalidTTL).Inc()
 	case errors.Is(err, memcache.ErrMalformedKey):
 		c.metrics.failures.WithLabelValues(op, reasonMalformedKey).Inc()
 	case errors.Is(err, memcache.ErrServerError):

--- a/cache/client.go
+++ b/cache/client.go
@@ -77,6 +77,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Help: "Total number of operations against cache.",
 	}, []string{"operation"})
 	cm.operations.WithLabelValues(opGetMulti)
+	cm.operations.WithLabelValues(opAdd)
 	cm.operations.WithLabelValues(opSet)
 	cm.operations.WithLabelValues(opDelete)
 	cm.operations.WithLabelValues(opIncrement)

--- a/cache/compression.go
+++ b/cache/compression.go
@@ -85,6 +85,14 @@ func (s *SnappyCache) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	s.next.SetMultiAsync(encoded, ttl)
 }
 
+func (s *SnappyCache) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return s.next.Set(ctx, key, snappy.Encode(nil, value), ttl)
+}
+
+func (s *SnappyCache) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return s.next.Add(ctx, key, snappy.Encode(nil, value), ttl)
+}
+
 // GetMulti implements Cache.
 func (s *SnappyCache) GetMulti(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
 	found := s.next.GetMulti(ctx, keys, opts...)

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -114,4 +114,16 @@ func TestLRUCache_SetAdd(t *testing.T) {
 		# TYPE cache_memory_items_count gauge
 		cache_memory_items_count{name="test"} 3
 	`), "cache_memory_items_count"))
+
+	result := lru.GetMulti(ctx, []string{"key_1", "key_2", "key_3"})
+	require.Equal(t, map[string][]byte{
+		"key_1": []byte("value_1"),
+		"key_2": []byte("value_2"),
+		"key_3": []byte("value_3"),
+	}, result)
+
+	// Ensure we cache back entries from the underlying cache.
+	item, ok := lru.lru.Get("key_1")
+	require.True(t, ok, "expected to fetch %s from inner LRU cache, got %+v", "key_1", item)
+	require.Equal(t, []byte("value_1"), item.Data)
 }

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -374,7 +374,11 @@ func (c *MemcachedClient) setSingleItem(key string, value []byte, ttl time.Durat
 	})
 }
 
-// TODO: Docs
+// toSeconds converts a time.Duration to seconds as an int32 and returns a boolean
+// indicating if the value is valid to be used as a TTL. Durations might not be valid
+// to be used for a TTL if they are non-zero but less than a second long (Memcached
+// uses seconds for TTL units but "0" to mean infinite TTL) or if they are longer than
+// 30 days (Memcached treats TTLs more than 30 days as UNIX timestamps).
 func toSeconds(d time.Duration) (int32, bool) {
 	if d > maxTTL {
 		return 0, false

--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -226,7 +226,7 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 	return c, nil
 }
 
-// SetMultiAsync implements RemoteCacheClient.
+// SetMultiAsync implements Cache.
 func (c *RedisClient) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	c.setMultiAsync(data, ttl, func(key string, value []byte, ttl time.Duration) error {
 		_, err := c.client.Set(context.Background(), key, value, ttl).Result()
@@ -234,7 +234,7 @@ func (c *RedisClient) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	})
 }
 
-// SetAsync implements RemoteCacheClient.
+// SetAsync implements Cache.
 func (c *RedisClient) SetAsync(key string, value []byte, ttl time.Duration) {
 	c.setAsync(key, value, ttl, func(key string, buf []byte, ttl time.Duration) error {
 		_, err := c.client.Set(context.Background(), key, buf, ttl).Result()
@@ -242,7 +242,30 @@ func (c *RedisClient) SetAsync(key string, value []byte, ttl time.Duration) {
 	})
 }
 
-// GetMulti implements RemoteCacheClient.
+// Set implements Cache.
+func (c *RedisClient) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.storeOperation(ctx, key, value, ttl, opSet, func(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+		_, err := c.client.Set(ctx, key, value, ttl).Result()
+		return err
+	})
+}
+
+// Add implements Cache.
+func (c *RedisClient) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.storeOperation(ctx, key, value, ttl, opAdd, func(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+		stored, err := c.client.SetNX(ctx, key, value, ttl).Result()
+		if err != nil {
+			return err
+		}
+		if !stored {
+			return fmt.Errorf("%w: for Set NX operation on %s", ErrNotStored, key)
+		}
+
+		return nil
+	})
+}
+
+// GetMulti implements Cache.
 func (c *RedisClient) GetMulti(ctx context.Context, keys []string, _ ...Option) map[string][]byte {
 	if len(keys) == 0 {
 		return nil

--- a/cache/redis_client_test.go
+++ b/cache/redis_client_test.go
@@ -156,7 +156,7 @@ func TestRedisClient(t *testing.T) {
 	}
 }
 
-func TestRedisClientDelete(t *testing.T) {
+func TestRedisClient_Delete(t *testing.T) {
 	s, err := miniredis.Run()
 	require.NoError(t, err)
 	defer s.Close()

--- a/cache/tracing.go
+++ b/cache/tracing.go
@@ -31,6 +31,14 @@ func (t *SpanlessTracingCache) SetMultiAsync(data map[string][]byte, ttl time.Du
 	t.next.SetMultiAsync(data, ttl)
 }
 
+func (t *SpanlessTracingCache) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return t.next.Set(ctx, key, value, ttl)
+}
+
+func (t *SpanlessTracingCache) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return t.next.Add(ctx, key, value, ttl)
+}
+
 func (t *SpanlessTracingCache) GetMulti(ctx context.Context, keys []string, opts ...Option) (result map[string][]byte) {
 	var (
 		bytes  int

--- a/cache/versioned.go
+++ b/cache/versioned.go
@@ -36,6 +36,14 @@ func (c *Versioned) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	c.cache.SetMultiAsync(versioned, ttl)
 }
 
+func (c *Versioned) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.cache.Set(ctx, c.addVersion(key), value, ttl)
+}
+
+func (c *Versioned) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.cache.Add(ctx, c.addVersion(key), value, ttl)
+}
+
 func (c *Versioned) GetMulti(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
 	versionedKeys := make([]string, len(keys))
 	for i, k := range keys {


### PR DESCRIPTION
**What this PR does**:

This change adds a synchronous version of `.Set` to Memcached and Redis clients as well as the various `Cache` wrapper implementations. This allows callers to set a key and be sure it exists in the cache. This change also adds an `.Add` method which conditionally adds an item to the cache only if it does not already exist.

**Which issue(s) this PR fixes**:


This change is a prerequisite for grafana/mimir#9386

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
