### PR TITLE
test: Use interface for passing instance ring to partition instance ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [CHANGE] memberlist: Metric `memberlist_client_messages_in_broadcast_queue` is now split into `queue="local"` and `queue="gossip"` values. #539
 * [CHANGE] memberlist: Failure to fast-join a cluster via contacting a node is now logged at `info` instead of `debug`. #585
 * [CHANGE] `Service.AddListener` and `Manager.AddListener` now return function for stopping the listener. #564
+* [CHANGE] Add `InstanceRingReader` interface to `ring` package.
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -13,15 +13,25 @@ type PartitionRingReader interface {
 	PartitionRing() *PartitionRing
 }
 
+type InstanceRingReader interface {
+	// GetInstance return the InstanceDesc for the given instanceID or an error
+	// if the instance doesn't exist in the ring. The returned InstanceDesc is NOT a
+	// deep copy, so the caller should never modify it.
+	GetInstance(string) (InstanceDesc, error)
+
+	// InstancesCount returns the number of instances in the ring.
+	InstancesCount() int
+}
+
 // PartitionInstanceRing holds a partitions ring and a instances ring, and provide functions
 // to look up the intersection of the two (e.g. healthy instances by partition).
 type PartitionInstanceRing struct {
 	partitionsRingReader PartitionRingReader
-	instancesRing        *Ring
+	instancesRing        InstanceRingReader
 	heartbeatTimeout     time.Duration
 }
 
-func NewPartitionInstanceRing(partitionsRingWatcher PartitionRingReader, instancesRing *Ring, heartbeatTimeout time.Duration) *PartitionInstanceRing {
+func NewPartitionInstanceRing(partitionsRingWatcher PartitionRingReader, instancesRing InstanceRingReader, heartbeatTimeout time.Duration) *PartitionInstanceRing {
 	return &PartitionInstanceRing{
 		partitionsRingReader: partitionsRingWatcher,
 		instancesRing:        instancesRing,
@@ -33,7 +43,7 @@ func (r *PartitionInstanceRing) PartitionRing() *PartitionRing {
 	return r.partitionsRingReader.PartitionRing()
 }
 
-func (r *PartitionInstanceRing) InstanceRing() *Ring {
+func (r *PartitionInstanceRing) InstanceRing() InstanceRingReader {
 	return r.instancesRing
 }
 


### PR DESCRIPTION
**What this PR does**:

Define a InstanceRingReader interface for creating a new PartitionInstanceRing.
* This is to enable mocking the Partition Instance Ring during tests external to this package.
* Specifically, Loki already uses an ingester ring mock to test certain functionality, such as looking up ingesters for querying, without defining a full, in-memory ring. I would like to extend this test to use a partition instance ring without rewriting the whole test suite, but this isn't possible right now.
* I cannot use approaches such as `&Ring{ringDesc: &Desc{}}` outside of the `ring` package because `ringDesc` is private, and the existing `ReadRing` interface does not provide the `GetInstance(string)` method.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
