### PR TITLE
find-flaky-tests.yml: Remove `issue_comment` trigger

### DIFF
--- a/.github/workflows/find-flaky-tests.yml
+++ b/.github/workflows/find-flaky-tests.yml
@@ -1,13 +1,9 @@
 name: Find flaky tests
 on:
-  issue_comment:
-    types: [created]
   workflow_dispatch:
 
 jobs:
   find-flaky-tests:
-    # Only run this workflow when the comment contains '/find-flaky-tests' or it's manually triggered
-    if: contains(github.event.comment.body, '/find-flaky-tests') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It doesn't work well, it actually pulls the main branch. `workflow_dispatch` does though, so we can use that