### PR TITLE
Really fix flaky `TestMultipleClients` tests

### DIFF
--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gogo/status"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,6 +104,7 @@ func newIntegrationClientServer(
 
 	serv, err := server.New(cfg)
 	require.NoError(t, err)
+	defer serv.Shutdown()
 
 	serv.HTTP.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "OK")
@@ -115,36 +117,26 @@ func newIntegrationClientServer(
 		require.NoError(t, err)
 	}()
 
-	// Wait until the server is up and running
-	assert.Eventually(t, func() bool {
-		conn, err := net.DialTimeout("tcp", httpAddr.String(), 1*time.Second)
-		if err != nil {
-			t.Logf("error dialing http: %v", err)
-			return false
-		}
-		defer conn.Close()
-		grpcConn, err := net.DialTimeout("tcp", grpcAddr.String(), 1*time.Second)
-		if err != nil {
-			t.Logf("error dialing grpc: %v", err)
-			return false
-		}
-		defer grpcConn.Close()
-		return true
-	}, 2500*time.Millisecond, 1*time.Second, "server is not up")
-
 	httpURL := fmt.Sprintf("https://localhost:%d/hello", httpAddr.Port)
 	grpcHost := net.JoinHostPort("localhost", strconv.Itoa(grpcAddr.Port))
 
 	for _, tc := range tcs {
-		tlsClientConfig, err := tc.tlsConfig.GetTLSConfig()
-		require.NoError(t, err)
-
 		// HTTP
 		t.Run("HTTP/"+tc.name, func(t *testing.T) {
-			transport := &http.Transport{TLSClientConfig: tlsClientConfig, MaxIdleConnsPerHost: 100} // DefaultMaxIdleConnsPerHost is 2
+			tlsClientConfig, err := tc.tlsConfig.GetTLSConfig()
+			require.NoError(t, err)
+
+			transport := cleanhttp.DefaultTransport()
+			transport.TLSClientConfig = tlsClientConfig
 			client := &http.Client{Transport: transport}
 
-			resp, err := client.Get(httpURL)
+			cancellableCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(cancellableCtx, http.MethodGet, httpURL, nil)
+			require.NoError(t, err)
+
+			resp, err := client.Do(req)
 			if err == nil {
 				defer resp.Body.Close()
 			}
@@ -178,12 +170,15 @@ func newIntegrationClientServer(
 			require.NoError(t, err, tc.name)
 			defer conn.Close()
 
+			cancellableCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			client := grpc_health_v1.NewHealthClient(conn)
 
 			// TODO: Investigate why the client doesn't really receive the
 			// error about the bad certificate from the server side and just
 			// see connection closed instead
-			resp, err := client.Check(context.TODO(), &grpc_health_v1.HealthCheckRequest{})
+			resp, err := client.Check(cancellableCtx, &grpc_health_v1.HealthCheckRequest{})
 			if tc.grpcExpectError != nil {
 				tc.grpcExpectError(t, err)
 				return
@@ -193,10 +188,7 @@ func newIntegrationClientServer(
 				assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
 			}
 		})
-
 	}
-
-	serv.Shutdown()
 }
 
 func TestServerWithoutTlsEnabled(t *testing.T) {

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -175,9 +175,8 @@ func newIntegrationClientServer(
 			dialOptions = append([]grpc.DialOption{grpc.WithDefaultCallOptions(clientConfig.CallOptions()...)}, dialOptions...)
 
 			conn, err := grpc.NewClient(grpcHost, dialOptions...)
-			assert.NoError(t, err, tc.name)
 			require.NoError(t, err, tc.name)
-			require.NoError(t, err, tc.name)
+			defer conn.Close()
 
 			client := grpc_health_v1.NewHealthClient(conn)
 

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -141,7 +141,7 @@ func newIntegrationClientServer(
 
 		// HTTP
 		t.Run("HTTP/"+tc.name, func(t *testing.T) {
-			transport := &http.Transport{TLSClientConfig: tlsClientConfig}
+			transport := &http.Transport{TLSClientConfig: tlsClientConfig, MaxIdleConnsPerHost: 100} // DefaultMaxIdleConnsPerHost is 2
 			client := &http.Client{Transport: transport}
 
 			resp, err := client.Get(httpURL)


### PR DESCRIPTION
https://github.com/grafana/dskit/pull/599 went in a wrong direction, so I revert it here: it makes all `TestMultipleClients` tests flaky since not all members are necessarily joined after the updates

Instead, to fix the `TestMultipleClientsWithMixedLabelsAndExpectFailure` test, I add a couple more labeled members, that way, even if we reach 3 updates (which happened some times, hence the flakes), we'll never get to 5 with a single member

Also, try to fix the `TestTLSServerWithLocalhostCertWithClientCertificateEnforcementUsingClientCA1` test by re-doing requests that have been reset by the server, but only if we were expecting an error. Note that this is not newly flaky, this comment has been there since the beginning: https://github.com/grafana/dskit/blob/2e104a8053fa31d76ba7f568fdc7ef20e38a5bf7/crypto/tls/test/tls_integration_test.go#L381-L383

Flaky tests run: https://github.com/grafana/dskit/actions/runs/11257895128 🟢 