### PR TITLE
spanlogger: fix double logging of caller information

### DIFF
--- a/spanlogger/spanlogger_test.go
+++ b/spanlogger/spanlogger_test.go
@@ -326,6 +326,7 @@ func TestSpanLogger_CallerInfo(t *testing.T) {
 
 				logged := logs.String()
 				require.Contains(t, logged, "caller="+toCallerInfo(thisFile, lineNumberTwoLinesBeforeFirstLogCall+2))
+				require.Equalf(t, 1, strings.Count(logged, "caller="), "expected to only have one caller field, but got: %v", logged)
 
 				logs.Reset()
 				_, _, lineNumberTwoLinesBeforeSecondLogCall, ok := runtime.Caller(0)
@@ -334,6 +335,7 @@ func TestSpanLogger_CallerInfo(t *testing.T) {
 
 				logged = logs.String()
 				require.Contains(t, logged, "caller="+toCallerInfo(thisFile, lineNumberTwoLinesBeforeSecondLogCall+2))
+				require.Equalf(t, 1, strings.Count(logged, "caller="), "expected to only have one caller field, but got: %v", logged)
 
 				requireSpanHasTwoLogLinesWithoutCaller(t, span)
 			})
@@ -346,6 +348,7 @@ func TestSpanLogger_CallerInfo(t *testing.T) {
 
 				logged := logs.String()
 				require.Contains(t, logged, "caller="+toCallerInfo(thisFile, lineNumberTwoLinesBeforeLogCall+2))
+				require.Equalf(t, 1, strings.Count(logged, "caller="), "expected to only have one caller field, but got: %v", logged)
 
 				logs.Reset()
 				_, _, lineNumberTwoLinesBeforeSecondLogCall, ok := runtime.Caller(0)
@@ -354,6 +357,7 @@ func TestSpanLogger_CallerInfo(t *testing.T) {
 
 				logged = logs.String()
 				require.Contains(t, logged, "caller="+toCallerInfo(thisFile, lineNumberTwoLinesBeforeSecondLogCall+2))
+				require.Equalf(t, 1, strings.Count(logged, "caller="), "expected to only have one caller field, but got: %v", logged)
 
 				requireSpanHasTwoLogLinesWithoutCaller(t, span)
 			})


### PR DESCRIPTION
**What this PR does**:

This PR fixes an issue with the changes introduced in https://github.com/grafana/dskit/pull/547.

That PR added logging correct caller information for code that used `SpanLogger`, however, it would log both the correct caller as well as `caller=spanlogger.go:xxx`.

I incorrectly believed that `github.com/go-kit/log` would use the last value if multiple `caller` keys were logged for the same message. It turns out that is incorrect: if multiple duplicate keys are logged for the same message, both are included in the output.

The fix for this is to introduce a `SpanLoggerAwareCaller` that returns the correct caller information, ignoring any `SpanLogger` methods. It should be used in place of `github.com/go-kit/log`'s `Caller` when creating the logger at application startup.

There is a small performance penalty (~1% additional latency for logging) when logging with `SpanLoggerAwareCaller` instead of `Caller`:

```
               │ SpanLoggerAwareCaller/with_go-kit's_Caller-10 │ SpanLoggerAwareCaller/with_dskit's_SpanLoggerAwareCaller-10 │
               │                    sec/op                     │                sec/op                  vs base              │
comparison.txt                                     935.2n ± 2%                             947.9n ± 6%  +1.36% (p=0.013 n=6)

               │ SpanLoggerAwareCaller/with_go-kit's_Caller-10 │ SpanLoggerAwareCaller/with_dskit's_SpanLoggerAwareCaller-10 │
               │                     B/op                      │                 B/op                   vs base              │
comparison.txt                                      734.0 ± 0%                              736.0 ± 6%  +0.27% (p=0.002 n=6)

               │ SpanLoggerAwareCaller/with_go-kit's_Caller-10 │ SpanLoggerAwareCaller/with_dskit's_SpanLoggerAwareCaller-10 │
               │                   allocs/op                   │                allocs/op                  vs base           │
comparison.txt                                      9.000 ± 0%                                 9.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal
```

This cost is only paid when a log line is actually logged, and not if the log line is filtered out (eg. if the log line is at debug level but the application is configured to emit info level and above, using `SpanLoggerAwareCaller` makes no difference).

This change also improves the performance of `SpanLogger` in general, as we no longer need to allocate a new `spanLoggerAwareCaller` for each instance. And the behaviour above when the log line is filtered also applies, which can be seen in the `info_and_above_allowed/level.Debug` benchmark below:

```
                                                               │ original.txt │             after.txt              │
                                                               │    sec/op    │   sec/op     vs base               │
SpanLoggerWithRealLogger/info_and_above_allowed/Log-10            1.941µ ± 1%   1.782µ ± 2%   -8.19% (p=0.002 n=6)
SpanLoggerWithRealLogger/info_and_above_allowed/level.Debug-10    570.3n ± 4%   161.0n ± 1%  -71.77% (p=0.002 n=6)
SpanLoggerWithRealLogger/info_and_above_allowed/DebugLog-10       2.865n ± 1%   2.904n ± 1%   +1.38% (p=0.006 n=6)
SpanLoggerWithRealLogger/all_levels_allowed/Log-10                1.941µ ± 2%   1.780µ ± 1%   -8.29% (p=0.002 n=6)
SpanLoggerWithRealLogger/all_levels_allowed/level.Debug-10        1.941µ ± 1%   2.439µ ± 3%  +25.66% (p=0.002 n=6)
SpanLoggerWithRealLogger/all_levels_allowed/DebugLog-10           2.231µ ± 1%   2.050µ ± 1%   -8.11% (p=0.002 n=6)
geomean                                                           546.5n        441.6n       -19.20%

                                                               │  original.txt   │               after.txt                │
                                                               │      B/op       │     B/op       vs base                 │
SpanLoggerWithRealLogger/info_and_above_allowed/Log-10            1072.0 ± 21%       960.0 ± 34%  -10.45% (p=0.013 n=6)
SpanLoggerWithRealLogger/info_and_above_allowed/level.Debug-10     720.0 ±  0%       400.0 ±  0%  -44.44% (p=0.002 n=6)
SpanLoggerWithRealLogger/info_and_above_allowed/DebugLog-10        0.000 ±  0%       0.000 ±  0%        ~ (p=1.000 n=6) ¹
SpanLoggerWithRealLogger/all_levels_allowed/Log-10                1072.0 ± 21%       960.0 ±  0%  -10.45% (p=0.002 n=6)
SpanLoggerWithRealLogger/all_levels_allowed/level.Debug-10       1.305Ki ±  0%     1.445Ki ±  0%  +10.78% (p=0.002 n=6)
SpanLoggerWithRealLogger/all_levels_allowed/DebugLog-10          1.312Ki ±  0%     1.141Ki ±  0%  -13.10% (p=0.002 n=6)
geomean                                                                        ²                  -13.16%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                               │ original.txt  │              after.txt              │
                                                               │   allocs/op   │ allocs/op   vs base                 │
SpanLoggerWithRealLogger/info_and_above_allowed/Log-10            15.00 ± 0%     12.00 ± 0%  -20.00% (p=0.002 n=6)
SpanLoggerWithRealLogger/info_and_above_allowed/level.Debug-10   10.000 ± 0%     5.000 ± 0%  -50.00% (p=0.002 n=6)
SpanLoggerWithRealLogger/info_and_above_allowed/DebugLog-10       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
SpanLoggerWithRealLogger/all_levels_allowed/Log-10                15.00 ± 0%     12.00 ± 0%  -20.00% (p=0.002 n=6)
SpanLoggerWithRealLogger/all_levels_allowed/level.Debug-10        18.00 ± 0%     17.00 ± 0%   -5.56% (p=0.002 n=6)
SpanLoggerWithRealLogger/all_levels_allowed/DebugLog-10           17.00 ± 0%     14.00 ± 0%  -17.65% (p=0.002 n=6)
geomean                                                                      ²               -20.69%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```


**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
