### PR TITLE
Tests: Listen on `localhost` instead of `0.0.0.0`

### DIFF
--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -44,7 +44,7 @@ func TestTCPTransport_WriteTo_ShouldNotLogAsWarningExpectedFailures(t *testing.T
 
 			cfg := TCPTransportConfig{}
 			flagext.DefaultValues(&cfg)
-			cfg.BindAddrs = []string{"127.0.0.1"}
+			cfg.BindAddrs = getLocalhostAddrs()
 			cfg.BindPort = 0
 			if testData.setup != nil {
 				testData.setup(t, &cfg)
@@ -88,6 +88,7 @@ func TestTCPTransportWriteToUnreachableAddr(t *testing.T) {
 
 	cfg := TCPTransportConfig{}
 	flagext.DefaultValues(&cfg)
+	cfg.BindAddrs = getLocalhostAddrs()
 	cfg.MaxConcurrentWrites = writeCt
 	cfg.PacketDialTimeout = 500 * time.Millisecond
 	transport, err := NewTCPTransport(cfg, logger, nil)
@@ -128,6 +129,7 @@ func TestTCPTransportWriterAcquireTimeout(t *testing.T) {
 
 	cfg := TCPTransportConfig{}
 	flagext.DefaultValues(&cfg)
+	cfg.BindAddrs = getLocalhostAddrs()
 	cfg.MaxConcurrentWrites = 1
 	cfg.AcquireWriterTimeout = 1 * time.Millisecond // very short timeout
 	transport, err := NewTCPTransport(cfg, logger, nil)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -132,6 +132,8 @@ func TestTCPv4Network(t *testing.T) {
 func TestDefaultAddresses(t *testing.T) {
 	var cfg Config
 	cfg.RegisterFlags(flag.NewFlagSet("", flag.ExitOnError))
+	cfg.GRPCListenAddress = "localhost"
+	cfg.HTTPListenAddress = "localhost"
 	cfg.HTTPListenPort = 9090
 	cfg.MetricsNamespace = "testing_addresses"
 
@@ -949,6 +951,8 @@ func TestGrpcOverProxyProtocol(t *testing.T) {
 	cfg.RegisterFlags(flag.NewFlagSet("", flag.ExitOnError))
 	cfg.ProxyProtocolEnabled = true
 	// Set this to 0 to have it choose a random port
+	cfg.HTTPListenAddress = "localhost"
+	cfg.GRPCListenAddress = "localhost"
 	cfg.HTTPListenPort = 0
 
 	fakeSourceIP := "1.2.3.4"


### PR DESCRIPTION
Closes https://github.com/grafana/dskit/issues/381

The MacOS network dialog is a bit annoying
