### PR TITLE
add a span tag for content type if the header is set

### DIFF
--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -38,6 +38,11 @@ func (t Tracer) Wrap(next http.Handler) http.Handler {
 				sp.SetTag("http.user_agent", userAgent)
 			}
 
+			// add the content type, useful when query requests are sent as POST
+			if ct := r.Header.Get("Content-Type"); ct != "" {
+				sp.SetTag("http.content_type", ct)
+			}
+
 			// add a tag with the client's sourceIPs to the span, if a
 			// SourceIPExtractor is given.
 			if t.SourceIPs != nil {


### PR DESCRIPTION
Sometimes queries are sent to our databases as post requests, which may have the query encoded into the request body. To parse it out properly via `r.ParseForm`, the http method must be POST and the content type must be `application/x-www-form-urlencoded`. It would be useful when looking at traces for requests which have not been able to log their query properly to see a span tag with the content type, to know if these POST queries were sent with the correct content type, or if we're unable to log the query for some other reason.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
