### PR TITLE
test(kv): create mock client for counting func calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,7 @@
 * [ENHANCEMENT] Cache: Add `.Advance()` methods to mock cache clients for easier testing of TTLs. #601
 * [ENHANCEMENT] Memberlist: Add concurrency to the transport's WriteTo method. #525
 * [ENHANCEMENT] Memberlist: Notifications can now be processed once per interval specified by `-memberlist.notify-interval` to reduce notify storms in large clusters. #592
+* [ENHANCEMENT] KV: Add `MockCountingClient`, which wraps the `kv.client` and can be used in order to count calls at specific functions of the interface. #618
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -2,9 +2,11 @@ package kv
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"go.uber.org/atomic"
 )
 
 // The mockClient does not anything.
@@ -36,4 +38,79 @@ func (m mockClient) WatchKey(_ context.Context, _ string, _ func(interface{}) bo
 }
 
 func (m mockClient) WatchPrefix(_ context.Context, _ string, _ func(string, interface{}) bool) {
+}
+
+// MockCountingClient is a wrapper around the Client interface that counts the number of times its functions are called.
+// This is used for testing only.
+type MockCountingClient struct {
+	client Client
+
+	mtx   sync.Mutex
+	calls map[string]*atomic.Int32
+}
+
+func NewMockCountingClient(client Client) *MockCountingClient {
+	return &MockCountingClient{
+		client: client,
+		calls:  make(map[string]*atomic.Int32),
+	}
+}
+
+func (mc *MockCountingClient) List(ctx context.Context, prefix string) ([]string, error) {
+	mc.incCall("List")
+
+	return mc.client.List(ctx, prefix)
+}
+func (mc *MockCountingClient) Get(ctx context.Context, key string) (interface{}, error) {
+	mc.incCall("Get")
+
+	return mc.client.Get(ctx, key)
+}
+
+func (mc *MockCountingClient) Delete(ctx context.Context, key string) error {
+	mc.incCall("Delete")
+
+	return mc.client.Delete(ctx, key)
+}
+
+func (mc *MockCountingClient) CAS(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
+	mc.incCall("CAS")
+
+	return mc.client.CAS(ctx, key, f)
+}
+
+func (mc *MockCountingClient) WatchKey(ctx context.Context, key string, f func(interface{}) bool) {
+	mc.incCall("WatchKey")
+
+	mc.client.WatchKey(ctx, key, f)
+}
+
+func (mc *MockCountingClient) WatchPrefix(ctx context.Context, key string, f func(string, interface{}) bool) {
+	mc.incCall("WatchPrefix")
+
+	mc.client.WatchPrefix(ctx, key, f)
+}
+
+func (mc *MockCountingClient) GetCalls(name string) int {
+	mc.mtx.Lock()
+	defer mc.mtx.Unlock()
+	count, exists := mc.calls[name]
+
+	if !exists {
+		return 0
+	}
+
+	return int(count.Load())
+}
+
+func (mc *MockCountingClient) incCall(name string) {
+	mc.mtx.Lock()
+	defer mc.mtx.Unlock()
+
+	if _, exists := mc.calls[name]; !exists {
+		mc.calls[name] = atomic.NewInt32(0)
+	}
+
+	value := mc.calls[name]
+	value.Add(1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR creates a `MockCountingClient`, which wraps the `kv.client` and can be use in order to count calls at specific functions of the interface.

This will be used [here](https://github.com/grafana/mimir/pull/9905) for testing purposes

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
