### PR TITLE
Feature: Add new metric `request_throughput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-* [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries.
+* [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries. #619
 * [CHANGE] Log middleware updated to honor `logRequestHeaders` in all logging scenarios. #615
 * [CHANGE] Roll back the gRPC dependency to v1.65.0 to allow downstream projects to avoid a performance regression and maybe a bug in v1.66.0. #581
 * [CHANGE] Update the gRPC dependency to v1.66.0 and deprecate the `grpc_server_recv_buffer_pools_enabled` option that is no longer supported by it. #580

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries.
 * [CHANGE] Log middleware updated to honor `logRequestHeaders` in all logging scenarios. #615
 * [CHANGE] Roll back the gRPC dependency to v1.65.0 to allow downstream projects to avoid a performance regression and maybe a bug in v1.66.0. #581
 * [CHANGE] Update the gRPC dependency to v1.66.0 and deprecate the `grpc_server_recv_buffer_pools_enabled` option that is no longer supported by it. #580

--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -126,7 +126,7 @@ func extractValueFromMultiValueHeader(h, name string, key string) (float64, erro
 		return 0, fmt.Errorf("not a multi-value header")
 	}
 	for _, part := range parts {
-		if part, found := strings.CutPrefix(part, name); found == true {
+		if part, found := strings.CutPrefix(part, name); found {
 			for _, spart := range strings.Split(part, ";") {
 				if !strings.HasPrefix(spart, key) {
 					continue

--- a/middleware/instrument_test.go
+++ b/middleware/instrument_test.go
@@ -1,0 +1,148 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/instrument"
+)
+
+func TestThroughputMetricHistogram(t *testing.T) {
+	tests := []struct {
+		name     string
+		sleep    bool
+		header   string
+		observed bool
+	}{
+		{"WithSleep", true, "unit=0, other_unit=2", true},
+		{"WithoutSleep", false, "unit=0, other_unit=2", false},
+		{"WithoutSleep", true, "", false},
+		{"WithoutSleep", false, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			reg := prometheus.NewPedanticRegistry()
+			i := NewInstrument(reg)
+
+			wrap := i.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.sleep {
+					time.Sleep(i.RequestCutoff)
+				}
+				w.Header().Set("Server-Timing", tt.header)
+			}))
+
+			req := httptest.NewRequest("GET", "/", nil)
+			res := httptest.NewRecorder()
+
+			wrap.ServeHTTP(res, req)
+
+			output := ``
+			if tt.observed {
+				output = `
+				# HELP request_throughput_unit Server throughput running requests.
+				# TYPE request_throughput_unit histogram
+				request_throughput_unit_bucket{cutoff_ms="100",method="GET",route="other",le="1"} 1
+				request_throughput_unit_bucket{cutoff_ms="100",method="GET",route="other",le="5"} 1
+				request_throughput_unit_bucket{cutoff_ms="100",method="GET",route="other",le="10"} 1
+				request_throughput_unit_bucket{cutoff_ms="100",method="GET",route="other",le="+Inf"} 1
+				request_throughput_unit_sum{cutoff_ms="100",method="GET",route="other"} 0
+				request_throughput_unit_count{cutoff_ms="100",method="GET",route="other"} 1
+			`
+			}
+
+			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(output), "slow_request_throughput_"+i.ThroughputUnit))
+		})
+	}
+}
+
+func NewInstrument(registry *prometheus.Registry) Instrument {
+	reg := promauto.With(registry)
+
+	const metricsNativeHistogramFactor = 1.1
+	const throughputUnit = "unit"
+	const SlowRequestCutoff = 100 * time.Millisecond
+
+	return Instrument{
+		Duration: reg.NewHistogramVec(prometheus.HistogramOpts{
+			Name:                            "request_duration_seconds",
+			Help:                            "Time (in seconds) spent serving HTTP requests.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     metricsNativeHistogramFactor,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"method", "route", "status_code", "ws"}),
+		PerTenantDuration: reg.NewHistogramVec(prometheus.HistogramOpts{
+			Name:                            "per_tenant_request_duration_seconds",
+			Help:                            "Time (in seconds) spent serving HTTP requests for a particular tenant.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     metricsNativeHistogramFactor,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"method", "route", "status_code", "ws", "tenant"}),
+		RequestBodySize: reg.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "request_message_bytes",
+			Help:    "Size (in bytes) of messages received in the request.",
+			Buckets: BodySizeBuckets,
+		}, []string{"method", "route"}),
+		ResponseBodySize: reg.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "response_message_bytes",
+			Help:    "Size (in bytes) of messages sent in response.",
+			Buckets: BodySizeBuckets,
+		}, []string{"method", "route"}),
+		InflightRequests: reg.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "inflight_requests",
+			Help: "Current number of inflight requests.",
+		}, []string{"method", "route"}),
+		RequestCutoff:  SlowRequestCutoff,
+		ThroughputUnit: throughputUnit,
+		RequestThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
+			Name:                            "request_throughput_" + throughputUnit,
+			Help:                            "Server throughput running requests.",
+			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(SlowRequestCutoff.Milliseconds(), 10)},
+			Buckets:                         []float64{1, 5, 10},
+			NativeHistogramBucketFactor:     metricsNativeHistogramFactor,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"method", "route"}),
+	}
+}
+
+func TestExtractValueFromMultiValueHeader(t *testing.T) {
+	tests := []struct {
+		header   string
+		key      string
+		expected int64
+		err      bool
+	}{
+		{"key0=0, key1=1", "key0", 0, false},
+		{"key0=0, key1=1", "key1", 1, false},
+		{"key0=0, key1=1", "key2", 0, true},
+		{"key0=1.0, key1=1", "key0", 1, false},
+		{"foo", "foo", 0, true},
+		{"foo=bar", "foo", 0, true},
+		{"", "foo", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			value, err := extractValueFromMultiValueHeader(tt.header, tt.key)
+			if (err != nil) != tt.err {
+				t.Errorf("expected error: %v, got: %v", tt.err, err)
+			}
+			if value != tt.expected {
+				t.Errorf("expected value: %d, got: %d", tt.expected, value)
+			}
+		})
+	}
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -79,7 +79,7 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "request_throughput_" + cfg.Throughput.Unit,
 			Help:                            "Server throughput of running requests.",
-			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(cfg.Throughput.RequestCutoff.Milliseconds(), 10)},
+			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(cfg.Throughput.LatencyCutoff.Milliseconds(), 10)},
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
 			NativeHistogramMaxBucketNumber:  100,

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -77,8 +77,8 @@ func NewServerMetrics(cfg Config) *Metrics {
 		}, []string{"method", "route"}),
 		RequestThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
-			Name:                            "slow_request_throughput_" + cfg.Throughput.Unit,
-			Help:                            "Server throughput of long running requests.",
+			Name:                            "request_throughput_" + cfg.Throughput.Unit,
+			Help:                            "Server throughput of running requests.",
 			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(cfg.Throughput.RequestCutoff.Milliseconds(), 10)},
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -16,14 +16,14 @@ import (
 )
 
 type Metrics struct {
-	TCPConnections              *prometheus.GaugeVec
-	TCPConnectionsLimit         *prometheus.GaugeVec
-	RequestDuration             *prometheus.HistogramVec
-	PerTenantRequestDuration    *prometheus.HistogramVec
-	ReceivedMessageSize         *prometheus.HistogramVec
-	SentMessageSize             *prometheus.HistogramVec
-	InflightRequests            *prometheus.GaugeVec
-	SlowRequestServerThroughput *prometheus.HistogramVec
+	TCPConnections           *prometheus.GaugeVec
+	TCPConnectionsLimit      *prometheus.GaugeVec
+	RequestDuration          *prometheus.HistogramVec
+	PerTenantRequestDuration *prometheus.HistogramVec
+	ReceivedMessageSize      *prometheus.HistogramVec
+	SentMessageSize          *prometheus.HistogramVec
+	InflightRequests         *prometheus.GaugeVec
+	SlowRequestThroughput    *prometheus.HistogramVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
@@ -75,11 +75,12 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Name:      "inflight_requests",
 			Help:      "Current number of inflight requests.",
 		}, []string{"method", "route"}),
-		SlowRequestServerThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
+		SlowRequestThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
-			Name:                            "slow_request_server_throughput_" + cfg.ThroughputConfig.Unit,
+			Name:                            "slow_request_throughput_" + cfg.Throughput.Unit,
 			Help:                            "Server throughput of long running requests.",
-			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(cfg.ThroughputConfig.SlowRequestCutoff.Milliseconds(), 10)},
+			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(cfg.Throughput.SlowRequestCutoff.Milliseconds(), 10)},
+			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -23,7 +23,7 @@ type Metrics struct {
 	ReceivedMessageSize      *prometheus.HistogramVec
 	SentMessageSize          *prometheus.HistogramVec
 	InflightRequests         *prometheus.GaugeVec
-	SlowRequestThroughput    *prometheus.HistogramVec
+	RequestThroughput        *prometheus.HistogramVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
@@ -75,11 +75,11 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Name:      "inflight_requests",
 			Help:      "Current number of inflight requests.",
 		}, []string{"method", "route"}),
-		SlowRequestThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
+		RequestThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "slow_request_throughput_" + cfg.Throughput.Unit,
 			Help:                            "Server throughput of long running requests.",
-			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(cfg.Throughput.SlowRequestCutoff.Milliseconds(), 10)},
+			ConstLabels:                     prometheus.Labels{"cutoff_ms": strconv.FormatInt(cfg.Throughput.RequestCutoff.Milliseconds(), 10)},
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
 			NativeHistogramMaxBucketNumber:  100,

--- a/server/server.go
+++ b/server/server.go
@@ -154,10 +154,10 @@ type Config struct {
 	// This limiter is called for every started and finished gRPC request.
 	GrpcMethodLimiter GrpcInflightMethodLimiter `yaml:"-"`
 
-	ThroughputConfig ThroughputConfig `yaml:"throughput_config"`
+	Throughput Throughput `yaml:"throughput"`
 }
 
-type ThroughputConfig struct {
+type Throughput struct {
 	SlowRequestCutoff time.Duration `yaml:"slow_request_cutoff"`
 	Unit              string        `yaml:"unit"`
 }
@@ -216,8 +216,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.LogRequestExcludeHeadersList, "server.log-request-headers-exclude-list", "", "Comma separated list of headers to exclude from loggin. Only used if server.log-request-headers is true.")
 	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log-request-at-info-level-enabled", false, "Optionally log requests at info level instead of debug level. Applies to request headers as well if server.log-request-headers is enabled.")
 	f.BoolVar(&cfg.ProxyProtocolEnabled, "server.proxy-protocol-enabled", false, "Enables PROXY protocol.")
-	f.DurationVar(&cfg.ThroughputConfig.SlowRequestCutoff, "server.throughput-config.slow-request-cutoff", 0, "Duration after which a request is considered slow. For requests taking longer than this duration to finish, the throughput will be calculated. If set to 0, the throughput will not be calculated.")
-	f.StringVar(&cfg.ThroughputConfig.Unit, "server.throughput-config.unit", "total_samples", "Unit of the server throughput metric, for example 'processed_bytes' or 'total_samples'. If set, it is appended to the server_throughput metric name.")
+	f.DurationVar(&cfg.Throughput.SlowRequestCutoff, "server.throughput.slow-request-cutoff", 0, "Duration after which a request is considered slow. For requests taking longer than this duration to finish, the throughput will be calculated. If set to 0, the throughput will not be calculated.")
+	f.StringVar(&cfg.Throughput.Unit, "server.throughput.unit", "total_samples", "Unit of the server throughput metric, for example 'processed_bytes' or 'total_samples'. If set, it is appended to the slow_request_server_throughput metric name.")
 }
 
 func (cfg *Config) registererOrDefault() prometheus.Registerer {
@@ -530,15 +530,15 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 		},
 		defaultLogMiddleware,
 		middleware.Instrument{
-			Duration:                    metrics.RequestDuration,
-			PerTenantDuration:           metrics.PerTenantRequestDuration,
-			PerTenantCallback:           cfg.PerTenantDurationInstrumentation,
-			RequestBodySize:             metrics.ReceivedMessageSize,
-			ResponseBodySize:            metrics.SentMessageSize,
-			InflightRequests:            metrics.InflightRequests,
-			SlowRequestCutoff:           cfg.ThroughputConfig.SlowRequestCutoff,
-			ServerThroughputUnit:        cfg.ThroughputConfig.Unit,
-			SlowRequestServerThroughput: metrics.SlowRequestServerThroughput,
+			Duration:              metrics.RequestDuration,
+			PerTenantDuration:     metrics.PerTenantRequestDuration,
+			PerTenantCallback:     cfg.PerTenantDurationInstrumentation,
+			RequestBodySize:       metrics.ReceivedMessageSize,
+			ResponseBodySize:      metrics.SentMessageSize,
+			InflightRequests:      metrics.InflightRequests,
+			SlowRequestCutoff:     cfg.Throughput.SlowRequestCutoff,
+			ThroughputUnit:        cfg.Throughput.Unit,
+			SlowRequestThroughput: metrics.SlowRequestThroughput,
 		},
 	}
 	var httpMiddleware []middleware.Interface

--- a/server/server.go
+++ b/server/server.go
@@ -154,12 +154,12 @@ type Config struct {
 	// This limiter is called for every started and finished gRPC request.
 	GrpcMethodLimiter GrpcInflightMethodLimiter `yaml:"-"`
 
-	Throughput Throughput `yaml:"throughput"`
+	Throughput Throughput `yaml:"-"`
 }
 
 type Throughput struct {
-	RequestCutoff time.Duration `yaml:"request_cutoff"`
-	Unit          string        `yaml:"unit"`
+	RequestCutoff time.Duration `yaml:"throughput_request_cutoff"`
+	Unit          string        `yaml:"throughput_unit"`
 }
 
 var infinty = time.Duration(math.MaxInt64)
@@ -216,7 +216,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.LogRequestExcludeHeadersList, "server.log-request-headers-exclude-list", "", "Comma separated list of headers to exclude from loggin. Only used if server.log-request-headers is true.")
 	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log-request-at-info-level-enabled", false, "Optionally log requests at info level instead of debug level. Applies to request headers as well if server.log-request-headers is enabled.")
 	f.BoolVar(&cfg.ProxyProtocolEnabled, "server.proxy-protocol-enabled", false, "Enables PROXY protocol.")
-	f.DurationVar(&cfg.Throughput.RequestCutoff, "server.throughput.request-cutoff", 0, "Duration after which a request will be observed. For requests taking longer than this duration to finish, the throughput will be calculated. If set to 0, the throughput will not be calculated.")
+	f.DurationVar(&cfg.Throughput.RequestCutoff, "server.throughput.request-cutoff", 0, "Requests taking over cutoff will be observed to measure Throughput. Server-Timing header will be used with specified unit as the indicator, for example 'Server-Timing: unit;val=8.2'. If set to 0, the throughput will not be calculated.")
 	f.StringVar(&cfg.Throughput.Unit, "server.throughput.unit", "total_samples", "Unit of the server throughput metric, for example 'processed_bytes' or 'total_samples'. Observed values will be gathered from Server-Timing header with defined key. If set, it is appended to the request_server_throughput metric name.")
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ type Config struct {
 }
 
 type Throughput struct {
-	RequestCutoff time.Duration `yaml:"throughput_request_cutoff"`
+	LatencyCutoff time.Duration `yaml:"throughput_latency_cutoff"`
 	Unit          string        `yaml:"throughput_unit"`
 }
 
@@ -216,7 +216,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.LogRequestExcludeHeadersList, "server.log-request-headers-exclude-list", "", "Comma separated list of headers to exclude from loggin. Only used if server.log-request-headers is true.")
 	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log-request-at-info-level-enabled", false, "Optionally log requests at info level instead of debug level. Applies to request headers as well if server.log-request-headers is enabled.")
 	f.BoolVar(&cfg.ProxyProtocolEnabled, "server.proxy-protocol-enabled", false, "Enables PROXY protocol.")
-f.DurationVar(&cfg.Throughput.RequestCutoff, "server.throughput.request-cutoff", 0, "Requests taking over the cutoff are be observed to measure throughput. Server-Timing header is used with specified unit as the indicator, for example 'Server-Timing: unit;val=8.2'. If set to 0, the throughput is not calculated.")
+	f.DurationVar(&cfg.Throughput.LatencyCutoff, "server.throughput.latency-cutoff", 0, "Requests taking over the cutoff are be observed to measure throughput. Server-Timing header is used with specified unit as the indicator, for example 'Server-Timing: unit;val=8.2'. If set to 0, the throughput is not calculated.")
 	f.StringVar(&cfg.Throughput.Unit, "server.throughput.unit", "total_samples", "Unit of the server throughput metric, for example 'processed_bytes' or 'total_samples'. Observed values are gathered from the 'Server-Timing' header with the 'val' key. If set, it is appended to the request_server_throughput metric name.")
 }
 
@@ -536,7 +536,7 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 			RequestBodySize:   metrics.ReceivedMessageSize,
 			ResponseBodySize:  metrics.SentMessageSize,
 			InflightRequests:  metrics.InflightRequests,
-			RequestCutoff:     cfg.Throughput.RequestCutoff,
+			LatencyCutoff:     cfg.Throughput.LatencyCutoff,
 			ThroughputUnit:    cfg.Throughput.Unit,
 			RequestThroughput: metrics.RequestThroughput,
 		},

--- a/server/server.go
+++ b/server/server.go
@@ -216,8 +216,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.LogRequestExcludeHeadersList, "server.log-request-headers-exclude-list", "", "Comma separated list of headers to exclude from loggin. Only used if server.log-request-headers is true.")
 	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log-request-at-info-level-enabled", false, "Optionally log requests at info level instead of debug level. Applies to request headers as well if server.log-request-headers is enabled.")
 	f.BoolVar(&cfg.ProxyProtocolEnabled, "server.proxy-protocol-enabled", false, "Enables PROXY protocol.")
-	f.DurationVar(&cfg.Throughput.RequestCutoff, "server.throughput.request-cutoff", 0, "Requests taking over cutoff will be observed to measure Throughput. Server-Timing header will be used with specified unit as the indicator, for example 'Server-Timing: unit;val=8.2'. If set to 0, the throughput will not be calculated.")
-	f.StringVar(&cfg.Throughput.Unit, "server.throughput.unit", "total_samples", "Unit of the server throughput metric, for example 'processed_bytes' or 'total_samples'. Observed values will be gathered from Server-Timing header with defined key. If set, it is appended to the request_server_throughput metric name.")
+f.DurationVar(&cfg.Throughput.RequestCutoff, "server.throughput.request-cutoff", 0, "Requests taking over the cutoff are be observed to measure throughput. Server-Timing header is used with specified unit as the indicator, for example 'Server-Timing: unit;val=8.2'. If set to 0, the throughput is not calculated.")
+	f.StringVar(&cfg.Throughput.Unit, "server.throughput.unit", "total_samples", "Unit of the server throughput metric, for example 'processed_bytes' or 'total_samples'. Observed values are gathered from the 'Server-Timing' header with the 'val' key. If set, it is appended to the request_server_throughput metric name.")
 }
 
 func (cfg *Config) registererOrDefault() prometheus.Registerer {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds two configuration parameters `server.throughput.request-cutoff` and `server.throughput.unit`, exposes a new metric `request_server_throughput` and calculates throughput in `units/s` for the metric using information from header `Server-Timing`.

If `server.throughput.request-cutoff` is `0` no throughput will be calculated.

Implemented code is really similar to [this branch](https://github.com/grafana/dskit/tree/krajo/throughputmetric) by @krajorama. But adds some flexibility to measure throughput based on different signals. It will default to `total_samples` as _processed samples are easier to explain to users_. Discussed with @dimitarvdimitrov.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
