### PR TITLE
Revert "feat: extend kv.client storeconfig to support memberlist flags"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,6 @@
 * [CHANGE] memberlist: Failure to fast-join a cluster via contacting a node is now logged at `info` instead of `debug`. #585
 * [CHANGE] `Service.AddListener` and `Manager.AddListener` now return function for stopping the listener. #564
 * [CHANGE] ring: Add `InstanceRingReader` interface to `ring` package. #597
-* [CHANGE] KV: Add `MemberlistKVConfig` at kv `StoreConfig`. Extended `RegisterFlagsWithPrefix` to populate `MemberlistKVConfig` flags with specific prefix. #621
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/kv/client.go
+++ b/kv/client.go
@@ -42,10 +42,9 @@ var (
 // Consul, Etcd, Memberlist or MultiClient. It was extracted from Config to keep
 // single-client config separate from final client-config (with all the wrappers)
 type StoreConfig struct {
-	Consul             consul.Config       `yaml:"consul"`
-	Etcd               etcd.Config         `yaml:"etcd"`
-	MemberlistKVConfig memberlist.KVConfig `yaml:"memberlist"`
-	Multi              MultiConfig         `yaml:"multi"`
+	Consul consul.Config `yaml:"consul"`
+	Etcd   etcd.Config   `yaml:"etcd"`
+	Multi  MultiConfig   `yaml:"multi"`
 
 	// Function that returns memberlist.KV store to use. By using a function, we can delay
 	// initialization of memberlist.KV until it is actually required.
@@ -75,7 +74,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(flagsPrefix, defaultPrefix string, f 
 	cfg.Consul.RegisterFlags(f, flagsPrefix)
 	cfg.Etcd.RegisterFlagsWithPrefix(f, flagsPrefix)
 	cfg.Multi.RegisterFlagsWithPrefix(f, flagsPrefix)
-	cfg.MemberlistKVConfig.RegisterFlagsWithPrefix(f, flagsPrefix)
 
 	if flagsPrefix == "" {
 		flagsPrefix = "ring."

--- a/kv/client_test.go
+++ b/kv/client_test.go
@@ -23,10 +23,6 @@ consul:
   host: "consul:8500"
   consistentreads: true
 prefix: "test/"
-memberlist:
-  node_name: "testNode"	
-  randomize_node_name: false
-  stream_timeout: 3s
 multi:
   primary: consul
   secondary: etcd
@@ -39,9 +35,6 @@ multi:
 	require.Equal(t, "consul", cfg.Store)
 	require.Equal(t, "test/", cfg.Prefix)
 	require.Equal(t, "consul:8500", cfg.Consul.Host)
-	require.Equal(t, "testNode", cfg.MemberlistKVConfig.NodeName)
-	require.Equal(t, false, cfg.MemberlistKVConfig.RandomizeNodeName)
-	require.Equal(t, 3*time.Second, cfg.MemberlistKVConfig.StreamTimeout)
 	require.Equal(t, "consul", cfg.Multi.Primary)
 	require.Equal(t, "etcd", cfg.Multi.Secondary)
 }


### PR DESCRIPTION
Reverts grafana/dskit#621

The purpose of this PR was to enable configuring Memberlist on a per-component basis, specifically for the HA-tracker. However, we observed the following issue:

The change inadvertently exposed the MemberlistConfig for each component, which is not desirable.
We are reverting this change to reconsider the approach.

Potential Solutions:

- Leverage the global Memberlist configuration (thanks to @dimitarvdimitrov  for the suggestion).
- Limit the exposure of MemberlistKVConfig to the HA-tracker specifically.

need to think pros, cons
