### PR TITLE
Add PartitionInstanceRing.GetReplicationSetForPartitionAndOperation()

### DIFF
--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -76,9 +76,9 @@ func (r *PartitionInstanceRing) GetReplicationSetsForOperation(op Operation) ([]
 // GetReplicationSetForPartitionAndOperation returns a ReplicationSet for the input partition. If the partition doesn't
 // exist or there are no healthy owners for the partition, an error is returned.
 func (r *PartitionInstanceRing) GetReplicationSetForPartitionAndOperation(partitionID int32, op Operation) (ReplicationSet, error) {
-	zonesBuffer := make([]string, 0, 3) // Pre-allocate buffer assuming 3 zones.
+	var stackZonesBuffer [3]string // Pre-allocate buffer assuming 3 zones.
 
-	return r.getReplicationSetForPartitionAndOperation(partitionID, op, time.Now(), zonesBuffer)
+	return r.getReplicationSetForPartitionAndOperation(partitionID, op, time.Now(), stackZonesBuffer[:])
 }
 
 func (r *PartitionInstanceRing) getReplicationSetForPartitionAndOperation(partitionID int32, op Operation, now time.Time, zonesBuffer []string) (ReplicationSet, error) {


### PR DESCRIPTION
**What this PR does**:

Add `PartitionInstanceRing.GetReplicationSetForPartitionAndOperation()`. This PR is against `usage-tracker` branch, which is a branch me and @colega  are using to build a prototype. This will **not** be merged to `main` for now.

Notes to reviewers:
- Review with "hide whitespace changes"

Ensuring no regression on the already-existing `GetReplicationSetsForOperation()`:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/ring
cpu: Apple M3 Pro
                                                        │ before.txt  │             after.txt              │
                                                        │   sec/op    │   sec/op     vs base               │
PartitionInstanceRing_GetReplicationSetsForOperation-11   21.81µ ± 0%   22.42µ ± 1%  +2.80% (p=0.000 n=10)

                                                        │  before.txt  │            after.txt             │
                                                        │     B/op     │     B/op      vs base            │
PartitionInstanceRing_GetReplicationSetsForOperation-11   39.12Ki ± 0%   39.12Ki ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                                                        │ before.txt │           after.txt            │
                                                        │ allocs/op  │ allocs/op   vs base            │
PartitionInstanceRing_GetReplicationSetsForOperation-11   101.0 ± 0%   101.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
