### PR TITLE
Faster tests using the mocked consul in-memory backend

### DIFF
--- a/kv/consul/mock.go
+++ b/kv/consul/mock.go
@@ -15,6 +15,9 @@ import (
 	"github.com/grafana/dskit/kv/codec"
 )
 
+// The max wait time allowed for mockKV operations, in order to have faster tests.
+const maxWaitTime = 100 * time.Millisecond
+
 type mockKV struct {
 	mtx     sync.Mutex
 	cond    *sync.Cond
@@ -87,7 +90,7 @@ func (m *mockKV) loop() {
 		select {
 		case <-m.close:
 			return
-		case <-time.After(time.Second):
+		case <-time.After(maxWaitTime):
 			m.mtx.Lock()
 			m.cond.Broadcast()
 			m.mtx.Unlock()
@@ -258,7 +261,6 @@ func (m *mockKV) ResetIndexForKey(key string) {
 // mockedMaxWaitTime returns the minimum duration between the input duration
 // and the max wait time allowed in this mock, in order to have faster tests.
 func mockedMaxWaitTime(queryWaitTime time.Duration) time.Duration {
-	const maxWaitTime = time.Second
 	if queryWaitTime > maxWaitTime {
 		return maxWaitTime
 	}


### PR DESCRIPTION
**What this PR does**:

I was investigating some slow unit tests in Mimir and I noticed they're slow because of the slow long polling done by `WatchKey()` on the mocked consul in-memory backend. In https://github.com/cortexproject/cortex/pull/2078 I introduced `mockedMaxWaitTime()` to have faster tests. In this PR I propose to further reduce the max wait interval to 100ms. To get faster tests we also have to increase the `m.cond.Broadcast()` frequency too (done in this PR too).

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
