### PR TITLE
Replace `exp/slices` with `slices` from standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Changelog
 
-* [CHANGE] Replace `exp/slices` package with `slices` from standard library. #626
 * [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries. #619
 * [CHANGE] Log middleware updated to honor `logRequestHeaders` in all logging scenarios. #615
 * [CHANGE] Roll back the gRPC dependency to v1.65.0 to allow downstream projects to avoid a performance regression and maybe a bug in v1.66.0. #581

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Replace `exp/slices` package with `slices` from standard library. #626
 * [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries. #619
 * [CHANGE] Log middleware updated to honor `logRequestHeaders` in all logging scenarios. #615
 * [CHANGE] Roll back the gRPC dependency to v1.65.0 to allow downstream projects to avoid a performance regression and maybe a bug in v1.66.0. #581

--- a/loser/loser.go
+++ b/loser/loser.go
@@ -2,9 +2,9 @@
 
 package loser
 
-import "golang.org/x/exp/constraints"
+import "cmp"
 
-func New[E constraints.Ordered](lists [][]E, maxVal E) *Tree[E] {
+func New[E cmp.Ordered](lists [][]E, maxVal E) *Tree[E] {
 	nLists := len(lists)
 	t := Tree[E]{
 		maxVal: maxVal,
@@ -23,12 +23,12 @@ func New[E constraints.Ordered](lists [][]E, maxVal E) *Tree[E] {
 // A loser tree is a binary tree laid out such that nodes N and N+1 have parent N/2.
 // We store M leaf nodes in positions M...2M-1, and M-1 internal nodes in positions 1..M-1.
 // Node 0 is a special node, containing the winner of the contest.
-type Tree[E constraints.Ordered] struct {
+type Tree[E cmp.Ordered] struct {
 	maxVal E
 	nodes  []node[E]
 }
 
-type node[E constraints.Ordered] struct {
+type node[E cmp.Ordered] struct {
 	index int // This is the loser for all nodes except the 0th, where it is the winner.
 	value E   // Value copied from the loser node, or winner for node 0.
 	items []E // Only populated for leaf nodes.

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -1,19 +1,19 @@
 package loser_test
 
 import (
+	"cmp"
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
 
 	"github.com/grafana/dskit/loser"
 )
 
-func checkTreeEqual[E constraints.Ordered](t *testing.T, tree *loser.Tree[E], expected []E, msg ...interface{}) {
+func checkTreeEqual[E cmp.Ordered](t *testing.T, tree *loser.Tree[E], expected []E, msg ...interface{}) {
 	t.Helper()
 	actual := []E{}
 

--- a/ring/example/local/go.mod
+++ b/ring/example/local/go.mod
@@ -57,7 +57,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -2,9 +2,8 @@ package ring
 
 import (
 	"fmt"
+	"slices"
 	"time"
-
-	"golang.org/x/exp/slices"
 )
 
 type PartitionRingReader interface {

--- a/ring/partition_instance_ring_test.go
+++ b/ring/partition_instance_ring_test.go
@@ -2,12 +2,12 @@ package ring
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestPartitionInstanceRing_GetReplicationSetsForOperation(t *testing.T) {

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"strconv"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	shardUtil "github.com/grafana/dskit/ring/shard"
 )

--- a/ring/partition_ring_http.go
+++ b/ring/partition_ring_http.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
-
-	"golang.org/x/exp/slices"
 )
 
 //go:embed partition_ring_status.gohtml

--- a/ring/partition_ring_model.go
+++ b/ring/partition_ring_model.go
@@ -2,12 +2,12 @@ package ring
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"golang.org/x/exp/slices"
 
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 func TestPartitionRing_ActivePartitionForKey(t *testing.T) {

--- a/ring/spread_minimizing_token_generator.go
+++ b/ring/spread_minimizing_token_generator.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
-
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/ring/token_range.go
+++ b/ring/token_range.go
@@ -2,9 +2,9 @@ package ring
 
 import (
 	"math"
+	"slices"
 
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slices" // using exp/slices until moving to go 1.21.
 )
 
 // TokenRanges describes token ranges owned by an instance.

--- a/ring/util.go
+++ b/ring/util.go
@@ -3,11 +3,11 @@ package ring
 import (
 	"context"
 	"math"
+	"slices"
 	"sort"
 	"time"
 
 	"github.com/go-kit/log"
-	"golang.org/x/exp/slices"
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/netutil"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

https://github.com/grafana/dskit/blob/e27df29220ea69cf7335f653da18b8ea51ab27e4/ring/token_range.go#L7

We upgraded the minimum Go version to 1.21 in PR https://github.com/grafana/dskit/pull/540.

The experimental functions in `golang.org/x/exp/slices` are now included in the standard library since Go 1.21.

Reference: https://go.dev/doc/go1.21#slices

**Which issue(s) this PR fixes**:

**Checklist**
- [N/A] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
