### PR TITLE
Chore: log last heartbeat timestamp along with "instance found in the ring"

### DIFF
--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -294,7 +294,7 @@ func (l *BasicLifecycler) registerInstance(ctx context.Context) error {
 		var exists bool
 		instanceDesc, exists = ringDesc.Ingesters[l.cfg.ID]
 		if exists {
-			level.Info(l.logger).Log("msg", "instance found in the ring", "instance", l.cfg.ID, "ring", l.ringName, "state", instanceDesc.GetState(), "tokens", len(instanceDesc.GetTokens()), "registered_at", instanceDesc.GetRegisteredAt().String())
+			level.Info(l.logger).Log("msg", "instance found in the ring", "instance", l.cfg.ID, "ring", l.ringName, "state", instanceDesc.GetState(), "tokens", len(instanceDesc.GetTokens()), "registered_at", instanceDesc.GetRegisteredAt().String(), "last_heartbeat_at", instanceDesc.GetLastHeartbeatAt().String())
 		} else {
 			level.Info(l.logger).Log("msg", "instance not found in the ring", "instance", l.cfg.ID, "ring", l.ringName)
 		}

--- a/ring/model.go
+++ b/ring/model.go
@@ -146,6 +146,16 @@ func (i *InstanceDesc) GetRegisteredAt() time.Time {
 	return time.Unix(i.RegisteredTimestamp, 0)
 }
 
+// GetLastHeartbeatAt returns the timestamp of the last heartbeat sent by the instance
+// or a zero value if unknown.
+func (i *InstanceDesc) GetLastHeartbeatAt() time.Time {
+	if i == nil || i.Timestamp == 0 {
+		return time.Time{}
+	}
+
+	return time.Unix(i.Timestamp, 0)
+}
+
 // GetReadOnlyState returns the read-only state and timestamp of last read-only state update.
 func (i *InstanceDesc) GetReadOnlyState() (bool, time.Time) {
 	if i == nil {

--- a/ring/model_test.go
+++ b/ring/model_test.go
@@ -93,6 +93,36 @@ func TestInstanceDesc_GetRegisteredAt(t *testing.T) {
 	}
 }
 
+func TestInstanceDesc_GetLastHeartbeatAt(t *testing.T) {
+	tests := map[string]struct {
+		desc     *InstanceDesc
+		expected time.Time
+	}{
+		"should return zero value on nil desc": {
+			desc:     nil,
+			expected: time.Time{},
+		},
+		"should return zero value if timestamp = 0": {
+			desc: &InstanceDesc{
+				Timestamp: 0,
+			},
+			expected: time.Time{},
+		},
+		"should return timestamp parsed from desc": {
+			desc: &InstanceDesc{
+				Timestamp: time.Unix(10000000, 0).Unix(),
+			},
+			expected: time.Unix(10000000, 0),
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.True(t, testData.desc.GetLastHeartbeatAt().Equal(testData.expected))
+		})
+	}
+}
+
 func normalizedSource() *Desc {
 	r := NewDesc()
 	r.Ingesters["first"] = InstanceDesc{


### PR DESCRIPTION
**What this PR does**:

Few weeks ago I was investigating an issue and I needed to know how long an instance didn't heartbeat the ring during a rolling update (the instance didn't leave the ring at shutdown). This is an information that's missing. In this PR I propose to log it.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
