### PR TITLE
chore: Display token information in partition ring status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495
+* [ENHANCEMENT] Display token information in partition ring status page #631
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.
 * [ENHANCEMENT] Use `SecretReader` interface to fetch secrets when configuring TLS. #274

--- a/ring/partition_ring_http.go
+++ b/ring/partition_ring_http.go
@@ -68,6 +68,8 @@ func (h *PartitionRingPageHandler) handleGetRequest(w http.ResponseWriter, req *
 			State:          partition.State,
 			StateTimestamp: partition.GetStateTime(),
 			OwnerIDs:       owners,
+			Tokens:         partition.Tokens,
+			NumTokens:      len(partition.Tokens),
 		}
 	}
 
@@ -83,6 +85,8 @@ func (h *PartitionRingPageHandler) handleGetRequest(w http.ResponseWriter, req *
 				State:          PartitionUnknown,
 				StateTimestamp: time.Time{},
 				OwnerIDs:       []string{ownerID},
+				Tokens:         partition.Tokens,
+				NumTokens:      len(partition.Tokens),
 			}
 
 			partitionsByID[owner.OwnedPartition] = partition
@@ -105,6 +109,8 @@ func (h *PartitionRingPageHandler) handleGetRequest(w http.ResponseWriter, req *
 		return partitions[i].ID < partitions[j].ID
 	})
 
+	tokensParam := req.URL.Query().Get("tokens")
+
 	renderHTTPResponse(w, partitionRingPageData{
 		Partitions: partitions,
 		PartitionStateChanges: map[PartitionState]PartitionState{
@@ -112,6 +118,7 @@ func (h *PartitionRingPageHandler) handleGetRequest(w http.ResponseWriter, req *
 			PartitionActive:   PartitionInactive,
 			PartitionInactive: PartitionActive,
 		},
+		ShowTokens: tokensParam == "true",
 	}, partitionRingPageTemplate, req)
 }
 
@@ -146,6 +153,7 @@ type partitionRingPageData struct {
 
 	// PartitionStateChanges maps the allowed state changes through the UI.
 	PartitionStateChanges map[PartitionState]PartitionState `json:"-"`
+	ShowTokens            bool                              `json:"-"`
 }
 
 type partitionPageData struct {
@@ -154,4 +162,6 @@ type partitionPageData struct {
 	State          PartitionState `json:"state"`
 	StateTimestamp time.Time      `json:"state_timestamp"`
 	OwnerIDs       []string       `json:"owner_ids"`
+	Tokens         []uint32       `json:"tokens"`
+	NumTokens      int            `json:"-"`
 }

--- a/ring/partition_ring_http_test.go
+++ b/ring/partition_ring_http_test.go
@@ -118,17 +118,17 @@ func TestPartitionRingPageHandler_ViewPage(t *testing.T) {
 		}, `\s*`))), recorder.Body.String())
 
 		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
-			"<h2>", "Instance: 1", "</h2>",
+			"<h2>", "Partition: 1", "</h2>",
 			"<p>", "Tokens:<br/>", "1000000", "3000000", "6000000", "</p>",
 		}, `\s*`))), recorder.Body.String())
 
 		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
-			"<h2>", "Instance: 2", "</h2>",
+			"<h2>", "Partition: 2", "</h2>",
 			"<p>", "Tokens:<br/>", "2000000", "4000000", "5000000", "7000000", "</p>",
 		}, `\s*`))), recorder.Body.String())
 
 		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
-			"<h2>", "Instance: 3", "</h2>",
+			"<h2>", "Partition: 3", "</h2>",
 			"<p>", "Tokens:<br/>", "</p>",
 		}, `\s*`))), recorder.Body.String())
 	})

--- a/ring/partition_ring_model.go
+++ b/ring/partition_ring_model.go
@@ -94,6 +94,34 @@ func (m *PartitionRingDesc) partitionByToken() map[Token]int32 {
 	return out
 }
 
+// CountTokens returns the summed token distance of all tokens in each partition.
+func (m *PartitionRingDesc) countTokens() map[int32]int64 {
+	owned := make(map[int32]int64, len(m.Partitions))
+	sortedTokens := m.tokens()
+	tokensToPartitions := m.partitionByToken()
+
+	for i, token := range sortedTokens {
+		partition := tokensToPartitions[Token(token)]
+
+		var prevToken uint32
+		if i == 0 {
+			prevToken = sortedTokens[len(sortedTokens)-1]
+		} else {
+			prevToken = sortedTokens[i-1]
+		}
+		diff := tokenDistance(prevToken, token)
+		owned[partition] = owned[partition] + diff
+	}
+
+	// Partitions with 0 tokens should still exist in the result.
+	for id := range m.Partitions {
+		if _, ok := owned[id]; !ok {
+			owned[id] = 0
+		}
+	}
+	return owned
+}
+
 // ownersByPartition returns a map where the key is the partition ID and the value is a list of owner IDs.
 func (m *PartitionRingDesc) ownersByPartition() map[int32][]string {
 	out := make(map[int32][]string, len(m.Partitions))

--- a/ring/partition_ring_status.gohtml
+++ b/ring/partition_ring_status.gohtml
@@ -72,7 +72,7 @@
 
     {{ if .ShowTokens }}
         {{ range $i, $partition := .Partitions }}
-            <h2>Instance: {{ .ID }}</h2>
+            <h2>Partition: {{ .ID }}</h2>
             <p>
                 Tokens:<br/>
                 {{ range $token := .Tokens }}

--- a/ring/partition_ring_status.gohtml
+++ b/ring/partition_ring_status.gohtml
@@ -45,6 +45,7 @@
                     {{ end }}
                 </td>
                 <td>{{ .NumTokens }}</td>
+                <td>{{ .Ownership | humanFloat }}%</td>
                 <td>
                     <!-- Allow to force a state change -->
                     {{ if and (not .Corrupted) (ne (index $stateChanges .State) 0) }}
@@ -64,7 +65,7 @@
     </table>
     <br>
     {{ if .ShowTokens }}
-        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' "/>
+        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false'"/>
     {{ else }}
         <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'"/>
     {{ end }}

--- a/ring/partition_ring_status.gohtml
+++ b/ring/partition_ring_status.gohtml
@@ -15,6 +15,8 @@
                 <th>State</th>
                 <th>State updated at</th>
                 <th>Owners</th>
+                <th>Tokens</th>
+                <th>Ownership</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -42,6 +44,7 @@
                         {{$ownerID}} <br />
                     {{ end }}
                 </td>
+                <td>{{ .NumTokens }}</td>
                 <td>
                     <!-- Allow to force a state change -->
                     {{ if and (not .Corrupted) (ne (index $stateChanges .State) 0) }}
@@ -59,5 +62,23 @@
         {{ end }}
         </tbody>
     </table>
+    <br>
+    {{ if .ShowTokens }}
+        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' "/>
+    {{ else }}
+        <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'"/>
+    {{ end }}
+
+    {{ if .ShowTokens }}
+        {{ range $i, $partition := .Partitions }}
+            <h2>Instance: {{ .ID }}</h2>
+            <p>
+                Tokens:<br/>
+                {{ range $token := .Tokens }}
+                    {{ $token }}
+                {{ end }}
+            </p>
+        {{ end }}
+    {{ end }}
 </body>
 </html>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The partition ring has a concept of tokens, but its tokens aren't visible in the partition ring status UI.

This PR ports the token-related affordances (count, ownership%, view all) from the ingester ring status page to the partition ring status page.

Screenshot of new columns:
![2025-01-02-165849_2553x822_scrot](https://github.com/user-attachments/assets/63dcd0c6-65eb-4f03-ade2-df7d96785f66)

When "Show Tokens" at the bottom is clicked:
![2025-01-02-165908_2553x819_scrot](https://github.com/user-attachments/assets/2b66b1bf-8c0d-4705-8802-587aaf4b0003)

**Which issue(s) this PR fixes**:

Contrib https://github.com/grafana/mimir-squad/issues/2350

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
