### PR TITLE
chore: Add option to hide tokens from ring statuspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495
+* [ENHANCEMENT] Add option to hide token information in ring status page #633
 * [ENHANCEMENT] Display token information in partition ring status page #631
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444
 * [ENHANCEMENT] Add configuration to customize backoff for the gRPC clients.

--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -53,6 +53,8 @@ type BasicLifecyclerConfig struct {
 	HeartbeatTimeout    time.Duration
 	TokensObservePeriod time.Duration
 	NumTokens           int
+	// HideTokens allows tokens to be hidden from e.g. the status page, for use in contexts which do not utilize tokens.
+	HideTokens bool
 
 	// If true lifecycler doesn't unregister instance from the ring when it's stopping. Default value is false,
 	// which means unregistering.
@@ -546,5 +548,5 @@ func (l *BasicLifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (l *BasicLifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(l, l.cfg.HeartbeatTimeout).handle(w, req)
+	newRingPageHandler(l, l.cfg.HeartbeatTimeout, l.cfg.HideTokens).handle(w, req)
 }

--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -53,8 +53,8 @@ type BasicLifecyclerConfig struct {
 	HeartbeatTimeout    time.Duration
 	TokensObservePeriod time.Duration
 	NumTokens           int
-	// HideTokens allows tokens to be hidden from e.g. the status page, for use in contexts which do not utilize tokens.
-	HideTokens bool
+	// HideTokensInStatusPage allows tokens to be hidden from management tools e.g. the status page, for use in contexts which do not utilize tokens.
+	HideTokensInStatusPage bool
 
 	// If true lifecycler doesn't unregister instance from the ring when it's stopping. Default value is false,
 	// which means unregistering.
@@ -548,5 +548,5 @@ func (l *BasicLifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (l *BasicLifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(l, l.cfg.HeartbeatTimeout, l.cfg.HideTokens).handle(w, req)
+	newRingPageHandler(l, l.cfg.HeartbeatTimeout, l.cfg.HideTokensInStatusPage).handle(w, req)
 }

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -55,8 +55,8 @@ type LifecyclerConfig struct {
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
-	// HideTokens allows tokens to be hidden from e.g. the status page, for use in contexts which do not utilize tokens.
-	HideTokens bool `yaml:"-"`
+	// HideTokensInStatusPage allows tokens to be hidden from management tools e.g. the status page, for use in contexts which do not utilize tokens.
+	HideTokensInStatusPage bool `yaml:"-"`
 
 	// If set, specifies the TokenGenerator implementation that will be used for generating tokens.
 	// Default value is nil, which means that RandomTokenGenerator is used.
@@ -1090,7 +1090,7 @@ func (i *Lifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (i *Lifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(i, i.cfg.HeartbeatTimeout, i.cfg.HideTokens).handle(w, req)
+	newRingPageHandler(i, i.cfg.HeartbeatTimeout, i.cfg.HideTokensInStatusPage).handle(w, req)
 }
 
 // unregister removes our entry from consul.

--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -55,6 +55,8 @@ type LifecyclerConfig struct {
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
+	// HideTokens allows tokens to be hidden from e.g. the status page, for use in contexts which do not utilize tokens.
+	HideTokens bool `yaml:"-"`
 
 	// If set, specifies the TokenGenerator implementation that will be used for generating tokens.
 	// Default value is nil, which means that RandomTokenGenerator is used.
@@ -1088,7 +1090,7 @@ func (i *Lifecycler) getRing(ctx context.Context) (*Desc, error) {
 }
 
 func (i *Lifecycler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(i, i.cfg.HeartbeatTimeout).handle(w, req)
+	newRingPageHandler(i, i.cfg.HeartbeatTimeout, i.cfg.HideTokens).handle(w, req)
 }
 
 // unregister removes our entry from consul.

--- a/ring/partition_ring_http_test.go
+++ b/ring/partition_ring_http_test.go
@@ -60,9 +60,8 @@ func TestPartitionRingPageHandler_ViewPage(t *testing.T) {
 		nil,
 	)
 
-	recorder := httptest.NewRecorder()
-
 	t.Run("displays expected partition info", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/partition-ring", nil))
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
@@ -97,6 +96,7 @@ func TestPartitionRingPageHandler_ViewPage(t *testing.T) {
 	})
 
 	t.Run("displays Show Tokens button by default", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/partition-ring", nil))
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
@@ -108,6 +108,7 @@ func TestPartitionRingPageHandler_ViewPage(t *testing.T) {
 	})
 
 	t.Run("displays tokens when Show Tokens is enabled", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/partition-ring?tokens=true", nil))
 
 		assert.Equal(t, http.StatusOK, recorder.Code)

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -150,9 +150,9 @@ type Config struct {
 	// Whether the shuffle-sharding subring cache is disabled. This option is set
 	// internally and never exposed to the user.
 	SubringCacheDisabled bool `yaml:"-"`
-	// HideTokens allows tokens to be hidden from e.g. the status page, for use in contexts which do not utilize tokens.
+	// HideTokensInStatusPage allows tokens to be hidden from management tools e.g. the status page, for use in contexts which do not utilize tokens.
 	// This option is set internally and never exposed to the user.
-	HideTokens bool `yaml:"-"`
+	HideTokensInStatusPage bool `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet with a specified prefix
@@ -1226,7 +1226,7 @@ func (r *Ring) getRing(_ context.Context) (*Desc, error) {
 }
 
 func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(r, r.cfg.HeartbeatTimeout, r.cfg.HideTokens).handle(w, req)
+	newRingPageHandler(r, r.cfg.HeartbeatTimeout, r.cfg.HideTokensInStatusPage).handle(w, req)
 }
 
 // InstancesCount returns the number of instances in the ring.

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -150,6 +150,9 @@ type Config struct {
 	// Whether the shuffle-sharding subring cache is disabled. This option is set
 	// internally and never exposed to the user.
 	SubringCacheDisabled bool `yaml:"-"`
+	// HideTokens allows tokens to be hidden from e.g. the status page, for use in contexts which do not utilize tokens.
+	// This option is set internally and never exposed to the user.
+	HideTokens bool `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet with a specified prefix
@@ -1223,7 +1226,7 @@ func (r *Ring) getRing(_ context.Context) (*Desc, error) {
 }
 
 func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	newRingPageHandler(r, r.cfg.HeartbeatTimeout).handle(w, req)
+	newRingPageHandler(r, r.cfg.HeartbeatTimeout, r.cfg.HideTokens).handle(w, req)
 }
 
 // InstancesCount returns the number of instances in the ring.

--- a/ring/ring_http.go
+++ b/ring/ring_http.go
@@ -30,9 +30,12 @@ var defaultPageTemplate = template.Must(template.New("webpage").Funcs(template.F
 }).Parse(defaultPageContent))
 
 type httpResponse struct {
-	Ingesters  []ingesterDesc `json:"shards"`
-	Now        time.Time      `json:"now"`
-	ShowTokens bool           `json:"-"`
+	Ingesters []ingesterDesc `json:"shards"`
+	Now       time.Time      `json:"now"`
+	// ShowTokens indicates whether the Show Tokens button is clicked.
+	ShowTokens bool `json:"-"`
+	// DisableTokens hides the concept of tokens entirely in the page, across all elements.
+	DisableTokens bool `json:"-"`
 }
 
 type ingesterDesc struct {
@@ -57,12 +60,14 @@ type ringAccess interface {
 type ringPageHandler struct {
 	r                ringAccess
 	heartbeatTimeout time.Duration
+	disableTokens    bool
 }
 
-func newRingPageHandler(r ringAccess, heartbeatTimeout time.Duration) *ringPageHandler {
+func newRingPageHandler(r ringAccess, heartbeatTimeout time.Duration, disableTokens bool) *ringPageHandler {
 	return &ringPageHandler{
 		r:                r,
 		heartbeatTimeout: heartbeatTimeout,
+		disableTokens:    disableTokens,
 	}
 }
 
@@ -132,9 +137,10 @@ func (h *ringPageHandler) handle(w http.ResponseWriter, req *http.Request) {
 	tokensParam := req.URL.Query().Get("tokens")
 
 	renderHTTPResponse(w, httpResponse{
-		Ingesters:  ingesters,
-		Now:        now,
-		ShowTokens: tokensParam == "true",
+		Ingesters:     ingesters,
+		Now:           now,
+		ShowTokens:    tokensParam == "true",
+		DisableTokens: h.disableTokens,
 	}, defaultPageTemplate, req)
 }
 

--- a/ring/ring_http_test.go
+++ b/ring/ring_http_test.go
@@ -1,0 +1,154 @@
+package ring
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRingPageHandler_handle(t *testing.T) {
+	now := time.Now()
+	ring := fakeRingAccess{
+		desc: &Desc{
+			Ingesters: map[string]InstanceDesc{
+				"1": {
+					Zone:      "zone-a",
+					State:     ACTIVE,
+					Addr:      "addr-a",
+					Timestamp: now.Unix(),
+					Tokens:    []uint32{1000000, 3000000, 6000000},
+				},
+				"2": {
+					Zone:      "zone-b",
+					State:     ACTIVE,
+					Addr:      "addr-b",
+					Timestamp: now.Unix(),
+					Tokens:    []uint32{2000000, 4000000, 5000000, 7000000},
+				},
+			},
+		},
+	}
+	handler := newRingPageHandler(&ring, 10*time.Second, false)
+
+	t.Run("displays instance info", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		handler.handle(recorder, httptest.NewRequest(http.MethodGet, "/ring", nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "text/html", recorder.Header().Get("Content-Type"))
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "1", "</td>",
+			"<td>", "zone-a", "</td>",
+			"<td>", "ACTIVE", "</td>",
+			"<td>", "addr-a", "</td>",
+		}, `\s*`))), recorder.Body.String())
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "3", "</td>",
+			"<td>", "100%", "</td>",
+		}, `\s*`))), recorder.Body.String())
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "2", "</td>",
+			"<td>", "zone-b", "</td>",
+			"<td>", "ACTIVE", "</td>",
+			"<td>", "addr-b", "</td>",
+		}, `\s*`))), recorder.Body.String())
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "4", "</td>",
+			"<td>", "100%", "</td>",
+		}, `\s*`))), recorder.Body.String())
+	})
+
+	t.Run("displays Show Tokens button by default", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		handler.handle(recorder, httptest.NewRequest(http.MethodGet, "/ring", nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "text/html", recorder.Header().Get("Content-Type"))
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			`<input type="button" value="Show Tokens" onclick="window.location.href = '\?tokens=true'"/>`,
+		}, `\s*`))), recorder.Body.String())
+	})
+
+	t.Run("displays tokens when Show Tokens is enabled", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		handler.handle(recorder, httptest.NewRequest(http.MethodGet, "/ring?tokens=true", nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "text/html", recorder.Header().Get("Content-Type"))
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			`<input type="button" value="Hide Tokens" onclick="window.location.href = '\?tokens=false' "/>`,
+		}, `\s*`))), recorder.Body.String())
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<h2>", "Instance: 1", "</h2>",
+			"<p>", "Tokens:<br/>", "1000000", "3000000", "6000000", "</p>",
+		}, `\s*`))), recorder.Body.String())
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<h2>", "Instance: 2", "</h2>",
+			"<p>", "Tokens:<br/>", "2000000", "4000000", "5000000", "7000000", "</p>",
+		}, `\s*`))), recorder.Body.String())
+	})
+
+	tokenDisabledHandler := newRingPageHandler(&ring, 10*time.Second, true)
+
+	t.Run("hides token columns when tokens are disabled", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		tokenDisabledHandler.handle(recorder, httptest.NewRequest(http.MethodGet, "/ring", nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "text/html", recorder.Header().Get("Content-Type"))
+
+		assert.NotRegexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<th>", "Tokens", "</th>",
+			"<th>", "Ownership", "</th>",
+		}, `\s*`))), recorder.Body.String())
+
+		assert.NotRegexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "3", "</td>",
+			"<td>", "100%", "</td>",
+		}, `\s*`))), recorder.Body.String())
+
+		assert.NotRegexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "4", "</td>",
+			"<td>", "100%", "</td>",
+		}, `\s*`))), recorder.Body.String())
+	})
+
+	t.Run("hides Show Tokens button when tokens are disabled", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		tokenDisabledHandler.handle(recorder, httptest.NewRequest(http.MethodGet, "/ring", nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "text/html", recorder.Header().Get("Content-Type"))
+
+		assert.NotRegexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			`input type="button" value="Show Tokens"`,
+		}, `\s*`))), recorder.Body.String())
+	})
+}
+
+type fakeRingAccess struct {
+	desc *Desc
+}
+
+func (f *fakeRingAccess) getRing(context.Context) (*Desc, error) {
+	return f.desc, nil
+}
+
+func (f *fakeRingAccess) casRing(ctx context.Context, fn func(in interface{}) (out interface{}, retry bool, err error)) error {
+	return nil
+}

--- a/ring/ring_http_test.go
+++ b/ring/ring_http_test.go
@@ -149,6 +149,6 @@ func (f *fakeRingAccess) getRing(context.Context) (*Desc, error) {
 	return f.desc, nil
 }
 
-func (f *fakeRingAccess) casRing(ctx context.Context, fn func(in interface{}) (out interface{}, retry bool, err error)) error {
+func (f *fakeRingAccess) casRing(_ context.Context, _ func(in interface{}) (out interface{}, retry bool, err error)) error {
 	return nil
 }

--- a/ring/ring_status.gohtml
+++ b/ring/ring_status.gohtml
@@ -21,8 +21,10 @@
             <th>Read-Only</th>
             <th>Read-Only Updated</th>
             <th>Last Heartbeat</th>
+            {{ if not .DisableTokens }}
             <th>Tokens</th>
             <th>Ownership</th>
+            {{ end }}
             <th>Actions</th>
         </tr>
         </thead>
@@ -46,8 +48,10 @@
             <td>{{ .ReadOnlyUpdatedTimestamp | timeOrEmptyString }}</td>
             {{ end }}
             <td>{{ .HeartbeatTimestamp | durationSince }} ago ({{ .HeartbeatTimestamp.Format "15:04:05.999" }})</td>
+            {{ if not $.DisableTokens }}
             <td>{{ .NumTokens }}</td>
             <td>{{ .Ownership | humanFloat }}%</td>
+            {{ end }}
             <td>
                 <button name="forget" value="{{ .ID }}" type="submit">Forget</button>
             </td>
@@ -56,21 +60,24 @@
         </tbody>
     </table>
     <br>
-    {{ if .ShowTokens }}
-        <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' "/>
-    {{ else }}
-        <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'"/>
-    {{ end }}
 
-    {{ if .ShowTokens }}
-        {{ range $i, $ing := .Ingesters }}
-            <h2>Instance: {{ .ID }}</h2>
-            <p>
-                Tokens:<br/>
-                {{ range $token := .Tokens }}
-                    {{ $token }}
-                {{ end }}
-            </p>
+    {{ if not .DisableTokens}}
+        {{ if .ShowTokens }}
+            <input type="button" value="Hide Tokens" onclick="window.location.href = '?tokens=false' "/>
+        {{ else }}
+            <input type="button" value="Show Tokens" onclick="window.location.href = '?tokens=true'"/>
+        {{ end }}
+
+        {{ if .ShowTokens }}
+            {{ range $i, $ing := .Ingesters }}
+                <h2>Instance: {{ .ID }}</h2>
+                <p>
+                    Tokens:<br/>
+                    {{ range $token := .Tokens }}
+                        {{ $token }}
+                    {{ end }}
+                </p>
+            {{ end }}
         {{ end }}
     {{ end }}
 </form>


### PR DESCRIPTION
**What this PR does**:

This PR is the inverse of https://github.com/grafana/dskit/pull/631.
There are contexts in which the instance ring is used, but tokens are ignored. Such contexts can now configure `HideTokens` on the ring or lifecycler in order to hide the concept of tokens completely from the ring status page.

Here is what the page looks like with the toggle left at default (no visible changes):
![2025-01-03-154402_2545x814_scrot](https://github.com/user-attachments/assets/7389c08d-acc2-4a28-ac86-13c713f46c53)

Hiding the tokens changes the page to look like:
![2025-01-03-155551_2546x721_scrot](https://github.com/user-attachments/assets/dec410dc-106b-4a5e-9953-30dba21b730e)

Similarly, no "Show Tokens" button at the bottom:
![2025-01-03-155604_507x180_scrot](https://github.com/user-attachments/assets/e3be3246-83b0-4bf0-a723-5c589bb8b652)

**Which issue(s) this PR fixes**:

Contrib https://github.com/grafana/mimir-squad/issues/2350

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
