### PR TITLE
more useful body size buckets for response/request message bytes metrics

### DIFF
--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -225,28 +225,52 @@ func TestGrpcStatsStreaming(t *testing.T) {
 	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 			# HELP received_payload_bytes Size of received gRPC messages
 			# TYPE received_payload_bytes histogram
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1024"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2048"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4096"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8192"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="16384"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="32768"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="65536"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="131072"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="262144"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="524288"} 0
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+06"} 0
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.62144e+06"} 2
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.24288e+06"} 4
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+07"} 5
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.62144e+07"} 5
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.24288e+07"} 5
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+08"} 5
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.62144e+08"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.097152e+06"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4.194304e+06"} 3
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8.388608e+06"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.6777216e+07"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="3.3554432e+07"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="6.7108864e+07"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.34217728e+08"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.68435456e+08"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.36870912e+08"} 5
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="+Inf"} 5
 			received_payload_bytes_sum{method="gRPC",route="/middleware.EchoServer/Process"} 1.5728689e+07
 			received_payload_bytes_count{method="gRPC",route="/middleware.EchoServer/Process"} 5
 
 			# HELP sent_payload_bytes Size of sent gRPC
 			# TYPE sent_payload_bytes histogram
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1024"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2048"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4096"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8192"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="16384"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="32768"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="65536"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="131072"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="262144"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="524288"} 0
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+06"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.62144e+06"} 4
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.24288e+06"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+07"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.62144e+07"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.24288e+07"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+08"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.62144e+08"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.097152e+06"} 3
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4.194304e+06"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8.388608e+06"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.6777216e+07"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="3.3554432e+07"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="6.7108864e+07"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.34217728e+08"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.68435456e+08"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.36870912e+08"} 5
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="+Inf"} 5
 			sent_payload_bytes_sum{method="gRPC",route="/middleware.EchoServer/Process"} 7.864367e+06
 			sent_payload_bytes_count{method="gRPC",route="/middleware.EchoServer/Process"} 5

--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -83,28 +83,52 @@ func TestGrpcStats(t *testing.T) {
 	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 			# HELP received_payload_bytes Size of received gRPC messages
 			# TYPE received_payload_bytes histogram
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="1.048576e+06"} 1
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="2.62144e+06"} 1
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="5.24288e+06"} 1
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="1.048576e+07"} 2
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="2.62144e+07"} 2
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="5.24288e+07"} 2
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="1.048576e+08"} 2
-			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="2.62144e+08"} 2
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1024"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2048"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4096"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8192"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="16384"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="32768"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="65536"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="131072"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="262144"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="524288"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.048576e+06"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.097152e+06"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4.194304e+06"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8.388608e+06"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.6777216e+07"} 2
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="3.3554432e+07"} 2
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="6.7108864e+07"} 2
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.34217728e+08"} 2
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.68435456e+08"} 2
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="5.36870912e+08"} 2
 			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="+Inf"} 2
 			received_payload_bytes_sum{method="gRPC", route="/grpc.health.v1.Health/Check"} 8.388623e+06
 			received_payload_bytes_count{method="gRPC", route="/grpc.health.v1.Health/Check"} 2
 
 			# HELP sent_payload_bytes Size of sent gRPC
 			# TYPE sent_payload_bytes histogram
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="1.048576e+06"} 1
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="2.62144e+06"} 1
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="5.24288e+06"} 1
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="1.048576e+07"} 1
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="2.62144e+07"} 1
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="5.24288e+07"} 1
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="1.048576e+08"} 1
-			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="2.62144e+08"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1024"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2048"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4096"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8192"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="16384"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="32768"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="65536"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="131072"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="262144"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="524288"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.048576e+06"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.097152e+06"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4.194304e+06"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8.388608e+06"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.6777216e+07"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="3.3554432e+07"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="6.7108864e+07"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.34217728e+08"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.68435456e+08"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="5.36870912e+08"} 1
 			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="+Inf"} 1
 			sent_payload_bytes_sum{method="gRPC", route="/grpc.health.v1.Health/Check"} 7
 			sent_payload_bytes_count{method="gRPC", route="/grpc.health.v1.Health/Check"} 1

--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -20,10 +20,8 @@ import (
 	"github.com/grafana/dskit/instrument"
 )
 
-const mb = 1024 * 1024
-
 // BodySizeBuckets defines buckets for request/response body sizes.
-var BodySizeBuckets = []float64{1 * mb, 2.5 * mb, 5 * mb, 10 * mb, 25 * mb, 50 * mb, 100 * mb, 250 * mb}
+var BodySizeBuckets = prometheus.LinearBuckets(1024, 2, 20)
 
 // RouteMatcher matches routes
 type RouteMatcher interface {

--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -21,7 +21,7 @@ import (
 )
 
 // BodySizeBuckets defines buckets for request/response body sizes.
-var BodySizeBuckets = prometheus.LinearBuckets(1024, 2, 20)
+var BodySizeBuckets = prometheus.ExponentialBuckets(1024, 2, 20)
 
 // RouteMatcher matches routes
 type RouteMatcher interface {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -386,76 +386,147 @@ func TestHTTPInstrumentationMetrics(t *testing.T) {
 
 		# HELP request_message_bytes Size (in bytes) of messages received in the request.
 		# TYPE request_message_bytes histogram
+		request_message_bytes_bucket{method="GET",route="error500",le="1024"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="2048"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="4096"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="8192"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="16384"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="32768"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="65536"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="131072"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="262144"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="524288"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="1.048576e+06"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="2.62144e+06"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="5.24288e+06"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="1.048576e+07"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="2.62144e+07"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="5.24288e+07"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="1.048576e+08"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="2.62144e+08"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="+Inf"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="2.097152e+06"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="4.194304e+06"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="8.388608e+06"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="1.6777216e+07"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="3.3554432e+07"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="6.7108864e+07"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="1.34217728e+08"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="2.68435456e+08"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="5.36870912e+08"} 1
 		request_message_bytes_sum{method="GET",route="error500"} 0
 		request_message_bytes_count{method="GET",route="error500"} 1
 
+		request_message_bytes_bucket{method="POST",route="sleep10",le="1024"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="2048"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="4096"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="8192"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="16384"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="32768"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="65536"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="131072"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="262144"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="524288"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+06"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="2.62144e+06"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="5.24288e+06"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+07"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="2.62144e+07"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="5.24288e+07"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+08"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="2.62144e+08"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="2.097152e+06"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="4.194304e+06"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="8.388608e+06"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="1.6777216e+07"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="3.3554432e+07"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="6.7108864e+07"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="1.34217728e+08"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="2.68435456e+08"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="5.36870912e+08"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="+Inf"} 1
 		request_message_bytes_sum{method="POST",route="sleep10"} 4
 		request_message_bytes_count{method="POST",route="sleep10"} 1
 
+		request_message_bytes_bucket{method="GET",route="succeed",le="1024"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="2048"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="4096"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="8192"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="16384"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="32768"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="65536"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="131072"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="262144"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="524288"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+06"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="2.62144e+06"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="5.24288e+06"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+07"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="2.62144e+07"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="5.24288e+07"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+08"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="2.62144e+08"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="2.097152e+06"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="4.194304e+06"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="8.388608e+06"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="1.6777216e+07"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="3.3554432e+07"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="6.7108864e+07"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="1.34217728e+08"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="2.68435456e+08"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="5.36870912e+08"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="+Inf"} 1
 		request_message_bytes_sum{method="GET",route="succeed"} 0
 		request_message_bytes_count{method="GET",route="succeed"} 1
 
 		# HELP response_message_bytes Size (in bytes) of messages sent in response.
 		# TYPE response_message_bytes histogram
+		response_message_bytes_bucket{method="GET",route="error500",le="1024"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="2048"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="4096"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="8192"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="16384"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="32768"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="65536"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="131072"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="262144"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="524288"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="1.048576e+06"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="2.62144e+06"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="5.24288e+06"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="1.048576e+07"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="2.62144e+07"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="5.24288e+07"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="1.048576e+08"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="2.62144e+08"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="2.097152e+06"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="4.194304e+06"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="8.388608e+06"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="1.6777216e+07"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="3.3554432e+07"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="6.7108864e+07"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="1.34217728e+08"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="2.68435456e+08"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="5.36870912e+08"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="+Inf"} 1
 		response_message_bytes_sum{method="GET",route="error500"} 0
 		response_message_bytes_count{method="GET",route="error500"} 1
 
+		response_message_bytes_bucket{method="POST",route="sleep10",le="1024"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="2048"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="4096"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="8192"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="16384"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="32768"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="65536"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="131072"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="262144"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="524288"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+06"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="2.62144e+06"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="5.24288e+06"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+07"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="2.62144e+07"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="5.24288e+07"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+08"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="2.62144e+08"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="2.097152e+06"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="4.194304e+06"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="8.388608e+06"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="1.6777216e+07"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="3.3554432e+07"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="6.7108864e+07"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="1.34217728e+08"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="2.68435456e+08"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="5.36870912e+08"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="+Inf"} 1
 		response_message_bytes_sum{method="POST",route="sleep10"} 0
 		response_message_bytes_count{method="POST",route="sleep10"} 1
 
+		response_message_bytes_bucket{method="GET",route="succeed",le="1024"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="2048"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="4096"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="8192"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="16384"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="32768"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="65536"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="131072"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="262144"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="524288"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+06"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="2.62144e+06"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="5.24288e+06"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+07"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="2.62144e+07"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="5.24288e+07"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+08"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="2.62144e+08"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="2.097152e+06"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="4.194304e+06"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="8.388608e+06"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="1.6777216e+07"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="3.3554432e+07"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="6.7108864e+07"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="1.34217728e+08"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="2.68435456e+08"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="5.36870912e+08"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="+Inf"} 1
 		response_message_bytes_sum{method="GET",route="succeed"} 2
 		response_message_bytes_count{method="GET",route="succeed"} 1


### PR DESCRIPTION
The current body size buckets are not very useful because they start at 1MB, but many of our service's responses are <1MB in size. The buckets are used in the metrics `response_message_bytes` and `request_message_bytes`. For example this histogram which shows the sizes of Mimir ingester responses is not very useful because all buckets have the same values: [explore](https://admin-ops-eu-south-0.grafana-ops.net/grafana/explore?schemaVersion=1&panes=%7B%22zm3%22:%7B%22datasource%22:%22mimir-ops-03%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%20by%20%28le%29%20%28cortex_response_message_bytes_bucket%7Bjob%3D%5C%22mimir-ops-03%2Fingester-zone-a%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22mimir-ops-03%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%221737117135377%22,%22to%22:%221737120603694%22%7D%7D%7D&orgId=1)