### PR TITLE
Higher granularity in request / response size metrics

### DIFF
--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -83,52 +83,42 @@ func TestGrpcStats(t *testing.T) {
 	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 			# HELP received_payload_bytes Size of received gRPC messages
 			# TYPE received_payload_bytes histogram
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="16"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="64"} 1
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="256"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1024"} 1
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2048"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4096"} 1
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8192"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="16384"} 1
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="32768"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="65536"} 1
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="131072"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="262144"} 1
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="524288"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.048576e+06"} 1
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.097152e+06"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4.194304e+06"} 1
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8.388608e+06"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.6777216e+07"} 2
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="3.3554432e+07"} 2
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="6.7108864e+07"} 2
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.34217728e+08"} 2
 			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.68435456e+08"} 2
-			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="5.36870912e+08"} 2
+			received_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.073741824e+09"} 2
 			received_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="+Inf"} 2
 			received_payload_bytes_sum{method="gRPC", route="/grpc.health.v1.Health/Check"} 8.388623e+06
 			received_payload_bytes_count{method="gRPC", route="/grpc.health.v1.Health/Check"} 2
 
 			# HELP sent_payload_bytes Size of sent gRPC
 			# TYPE sent_payload_bytes histogram
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="16"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="64"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="256"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1024"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2048"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4096"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8192"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="16384"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="32768"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="65536"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="131072"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="262144"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="524288"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.048576e+06"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.097152e+06"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="4.194304e+06"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="8.388608e+06"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.6777216e+07"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="3.3554432e+07"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="6.7108864e+07"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.34217728e+08"} 1
 			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="2.68435456e+08"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="5.36870912e+08"} 1
+			sent_payload_bytes_bucket{method="gRPC",route="/grpc.health.v1.Health/Check",le="1.073741824e+09"} 1
 			sent_payload_bytes_bucket{method="gRPC", route="/grpc.health.v1.Health/Check",le="+Inf"} 1
 			sent_payload_bytes_sum{method="gRPC", route="/grpc.health.v1.Health/Check"} 7
 			sent_payload_bytes_count{method="gRPC", route="/grpc.health.v1.Health/Check"} 1
@@ -225,52 +215,42 @@ func TestGrpcStatsStreaming(t *testing.T) {
 	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 			# HELP received_payload_bytes Size of received gRPC messages
 			# TYPE received_payload_bytes histogram
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="16"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="64"} 0
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="256"} 0
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1024"} 0
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2048"} 0
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4096"} 0
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8192"} 0
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="16384"} 0
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="32768"} 0
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="65536"} 0
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="131072"} 0
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="262144"} 0
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="524288"} 0
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+06"} 0
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.097152e+06"} 1
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4.194304e+06"} 3
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8.388608e+06"} 5
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.6777216e+07"} 5
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="3.3554432e+07"} 5
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="6.7108864e+07"} 5
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.34217728e+08"} 5
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.68435456e+08"} 5
-			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.36870912e+08"} 5
+			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.073741824e+09"} 5
 			received_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="+Inf"} 5
 			received_payload_bytes_sum{method="gRPC",route="/middleware.EchoServer/Process"} 1.5728689e+07
 			received_payload_bytes_count{method="gRPC",route="/middleware.EchoServer/Process"} 5
 
 			# HELP sent_payload_bytes Size of sent gRPC
 			# TYPE sent_payload_bytes histogram
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="16"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="64"} 0
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="256"} 0
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1024"} 0
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2048"} 0
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4096"} 0
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8192"} 0
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="16384"} 0
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="32768"} 0
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="65536"} 0
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="131072"} 0
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="262144"} 0
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="524288"} 0
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.048576e+06"} 1
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.097152e+06"} 3
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="4.194304e+06"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="8.388608e+06"} 5
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.6777216e+07"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="3.3554432e+07"} 5
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="6.7108864e+07"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.34217728e+08"} 5
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="2.68435456e+08"} 5
-			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="5.36870912e+08"} 5
+			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="1.073741824e+09"} 5
 			sent_payload_bytes_bucket{method="gRPC",route="/middleware.EchoServer/Process",le="+Inf"} 5
 			sent_payload_bytes_sum{method="gRPC",route="/middleware.EchoServer/Process"} 7.864367e+06
 			sent_payload_bytes_count{method="gRPC",route="/middleware.EchoServer/Process"} 5

--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -21,7 +21,7 @@ import (
 )
 
 // BodySizeBuckets defines buckets for request/response body sizes.
-var BodySizeBuckets = prometheus.ExponentialBuckets(1024, 2, 20)
+var BodySizeBuckets = prometheus.ExponentialBuckets(2, 2, 30)
 
 // RouteMatcher matches routes
 type RouteMatcher interface {

--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -21,7 +21,7 @@ import (
 )
 
 // BodySizeBuckets defines buckets for request/response body sizes.
-var BodySizeBuckets = prometheus.ExponentialBuckets(2, 2, 30)
+var BodySizeBuckets = prometheus.ExponentialBuckets(4, 4, 15)
 
 // RouteMatcher matches routes
 type RouteMatcher interface {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -386,147 +386,118 @@ func TestHTTPInstrumentationMetrics(t *testing.T) {
 
 		# HELP request_message_bytes Size (in bytes) of messages received in the request.
 		# TYPE request_message_bytes histogram
+		request_message_bytes_bucket{method="GET",route="error500",le="4"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="16"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="64"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="256"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="1024"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="2048"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="4096"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="8192"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="16384"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="32768"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="65536"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="131072"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="262144"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="524288"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="1.048576e+06"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="2.097152e+06"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="4.194304e+06"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="8.388608e+06"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="1.6777216e+07"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="3.3554432e+07"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="6.7108864e+07"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="1.34217728e+08"} 1
 		request_message_bytes_bucket{method="GET",route="error500",le="2.68435456e+08"} 1
-		request_message_bytes_bucket{method="GET",route="error500",le="5.36870912e+08"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="1.073741824e+09"} 1
+		request_message_bytes_bucket{method="GET",route="error500",le="+Inf"} 1
 		request_message_bytes_sum{method="GET",route="error500"} 0
 		request_message_bytes_count{method="GET",route="error500"} 1
 
+		request_message_bytes_bucket{method="POST",route="sleep10",le="4"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="16"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="64"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="256"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="1024"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="2048"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="4096"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="8192"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="16384"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="32768"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="65536"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="131072"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="262144"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="524288"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+06"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="2.097152e+06"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="4.194304e+06"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="8.388608e+06"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="1.6777216e+07"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="3.3554432e+07"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="6.7108864e+07"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="1.34217728e+08"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="2.68435456e+08"} 1
-		request_message_bytes_bucket{method="POST",route="sleep10",le="5.36870912e+08"} 1
+		request_message_bytes_bucket{method="POST",route="sleep10",le="1.073741824e+09"} 1
 		request_message_bytes_bucket{method="POST",route="sleep10",le="+Inf"} 1
 		request_message_bytes_sum{method="POST",route="sleep10"} 4
 		request_message_bytes_count{method="POST",route="sleep10"} 1
-
+		
+		request_message_bytes_bucket{method="GET",route="succeed",le="4"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="16"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="64"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="256"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="1024"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="2048"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="4096"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="8192"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="16384"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="32768"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="65536"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="131072"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="262144"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="524288"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+06"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="2.097152e+06"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="4.194304e+06"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="8.388608e+06"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="1.6777216e+07"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="3.3554432e+07"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="6.7108864e+07"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="1.34217728e+08"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="2.68435456e+08"} 1
-		request_message_bytes_bucket{method="GET",route="succeed",le="5.36870912e+08"} 1
+		request_message_bytes_bucket{method="GET",route="succeed",le="1.073741824e+09"} 1
 		request_message_bytes_bucket{method="GET",route="succeed",le="+Inf"} 1
 		request_message_bytes_sum{method="GET",route="succeed"} 0
 		request_message_bytes_count{method="GET",route="succeed"} 1
 
 		# HELP response_message_bytes Size (in bytes) of messages sent in response.
 		# TYPE response_message_bytes histogram
+		response_message_bytes_bucket{method="GET",route="error500",le="4"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="16"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="64"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="256"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="1024"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="2048"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="4096"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="8192"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="16384"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="32768"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="65536"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="131072"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="262144"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="524288"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="1.048576e+06"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="2.097152e+06"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="4.194304e+06"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="8.388608e+06"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="1.6777216e+07"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="3.3554432e+07"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="6.7108864e+07"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="1.34217728e+08"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="2.68435456e+08"} 1
-		response_message_bytes_bucket{method="GET",route="error500",le="5.36870912e+08"} 1
+		response_message_bytes_bucket{method="GET",route="error500",le="1.073741824e+09"} 1
 		response_message_bytes_bucket{method="GET",route="error500",le="+Inf"} 1
 		response_message_bytes_sum{method="GET",route="error500"} 0
 		response_message_bytes_count{method="GET",route="error500"} 1
 
+		response_message_bytes_bucket{method="POST",route="sleep10",le="4"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="16"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="64"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="256"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="1024"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="2048"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="4096"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="8192"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="16384"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="32768"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="65536"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="131072"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="262144"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="524288"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="1.048576e+06"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="2.097152e+06"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="4.194304e+06"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="8.388608e+06"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="1.6777216e+07"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="3.3554432e+07"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="6.7108864e+07"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="1.34217728e+08"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="2.68435456e+08"} 1
-		response_message_bytes_bucket{method="POST",route="sleep10",le="5.36870912e+08"} 1
+		response_message_bytes_bucket{method="POST",route="sleep10",le="1.073741824e+09"} 1
 		response_message_bytes_bucket{method="POST",route="sleep10",le="+Inf"} 1
 		response_message_bytes_sum{method="POST",route="sleep10"} 0
 		response_message_bytes_count{method="POST",route="sleep10"} 1
 
+		response_message_bytes_bucket{method="GET",route="succeed",le="4"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="16"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="64"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="256"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="1024"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="2048"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="4096"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="8192"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="16384"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="32768"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="65536"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="131072"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="262144"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="524288"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="1.048576e+06"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="2.097152e+06"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="4.194304e+06"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="8.388608e+06"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="1.6777216e+07"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="3.3554432e+07"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="6.7108864e+07"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="1.34217728e+08"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="2.68435456e+08"} 1
-		response_message_bytes_bucket{method="GET",route="succeed",le="5.36870912e+08"} 1
+		response_message_bytes_bucket{method="GET",route="succeed",le="1.073741824e+09"} 1
 		response_message_bytes_bucket{method="GET",route="succeed",le="+Inf"} 1
 		response_message_bytes_sum{method="GET",route="succeed"} 2
 		response_message_bytes_count{method="GET",route="succeed"} 1


### PR DESCRIPTION
This extends the bucket ranges of the two metrics `request_message_bytes` and `response_message_bytes` such that they can also capture smaller requests than 1KB.