### PR TITLE
feat(server): Add option to count per-tenant requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * [CHANGE] memberlist: Failure to fast-join a cluster via contacting a node is now logged at `info` instead of `debug`. #585
 * [CHANGE] `Service.AddListener` and `Manager.AddListener` now return function for stopping the listener. #564
 * [CHANGE] ring: Add `InstanceRingReader` interface to `ring` package. #597
+* [CHANGE] Server: The `PerTenantDurationInstrumentation` config option was renamed to `PerTenantInstrumentation` and now allows specifying whether a full histogram should be recorded or only a counter #642
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -20,6 +20,7 @@ type Metrics struct {
 	TCPConnectionsLimit      *prometheus.GaugeVec
 	RequestDuration          *prometheus.HistogramVec
 	PerTenantRequestDuration *prometheus.HistogramVec
+	PerTenantRequestTotal    *prometheus.CounterVec
 	ReceivedMessageSize      *prometheus.HistogramVec
 	SentMessageSize          *prometheus.HistogramVec
 	InflightRequests         *prometheus.GaugeVec
@@ -57,6 +58,11 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"method", "route", "status_code", "ws", "tenant"}),
+		PerTenantRequestTotal: reg.NewCounterVec(prometheus.CounterOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "per_tenant_request_total",
+			Help:      "Total count of requests for a particular tenant.",
 		}, []string{"method", "route", "status_code", "ws", "tenant"}),
 		ReceivedMessageSize: reg.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,

--- a/server/server.go
+++ b/server/server.go
@@ -100,7 +100,7 @@ type Config struct {
 	ExcludeRequestInLog                      bool `yaml:"-"`
 	DisableRequestSuccessLog                 bool `yaml:"-"`
 
-	PerTenantDurationInstrumentation middleware.PerTenantCallback `yaml:"-"`
+	PerTenantInstrumentation middleware.PerTenantCallback `yaml:"-"`
 
 	ServerGracefulShutdownTimeout time.Duration `yaml:"graceful_shutdown_timeout"`
 	HTTPServerReadTimeout         time.Duration `yaml:"http_server_read_timeout"`
@@ -385,11 +385,12 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	if cfg.ReportGRPCCodesInInstrumentationLabel {
 		grpcInstrumentationOptions = append(grpcInstrumentationOptions, middleware.ReportGRPCStatusOption)
 	}
-	if cfg.PerTenantDurationInstrumentation != nil {
+	if cfg.PerTenantInstrumentation != nil {
 		grpcInstrumentationOptions = append(grpcInstrumentationOptions,
 			middleware.WithPerTenantInstrumentation(
+				metrics.PerTenantRequestTotal,
 				metrics.PerTenantRequestDuration,
-				cfg.PerTenantDurationInstrumentation,
+				cfg.PerTenantInstrumentation,
 			))
 	}
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
@@ -532,7 +533,8 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 		middleware.Instrument{
 			Duration:          metrics.RequestDuration,
 			PerTenantDuration: metrics.PerTenantRequestDuration,
-			PerTenantCallback: cfg.PerTenantDurationInstrumentation,
+			PerTenantTotal:    metrics.PerTenantRequestTotal,
+			PerTenantCallback: cfg.PerTenantInstrumentation,
 			RequestBodySize:   metrics.ReceivedMessageSize,
 			ResponseBodySize:  metrics.SentMessageSize,
 			InflightRequests:  metrics.InflightRequests,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -317,7 +317,7 @@ func TestHTTPInstrumentationMetrics(t *testing.T) {
 	prometheus.DefaultGatherer = reg
 
 	var cfg Config
-	cfg.PerTenantInstrumentation = func(ctx context.Context) *middleware.PerTenantConfig {
+	cfg.PerTenantInstrumentation = func(_ context.Context) *middleware.PerTenantConfig {
 		return &middleware.PerTenantConfig{
 			TenantID:     "test",
 			TotalCounter: true,


### PR DESCRIPTION
In https://github.com/grafana/dskit/pull/490, the option was added to record durations in an histogram but this adds too many metrics to enable it for a large number of tenants

This PR extends the feature to have a counter instead. We can have a counter for most tenants, and an histogram for select tenants

From my code search, the only place where this option is used is in our own private repo (backend-enterprise)

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
