### PR TITLE
Update GrpcInflightMethodLimiter to support interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@
 * [ENHANCEMENT] Memberlist: Notifications can now be processed once per interval specified by `-memberlist.notify-interval` to reduce notify storms in large clusters. #592
 * [ENHANCEMENT] Memberlist: Implemented the `Delete` operation in the memberlist backed KV store. How frequently deleted entries are cleaned up is specified by the `-memberlist.obsolete-entries-timeout` flag. #612
 * [ENHANCEMENT] KV: Add `MockCountingClient`, which wraps the `kv.client` and can be used in order to count calls at specific functions of the interface. #618
+* [ENHANCEMENT] Server: Add interceptor support to `GrpcInflightMethodLimiter`. #643
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/server/limits.go
+++ b/server/limits.go
@@ -20,8 +20,9 @@ type GrpcInflightMethodLimiter interface {
 	// otherwise gRPC-server implementation-specific error will be returned to the client (codes.PermissionDenied in grpc@v1.55.0).
 	RPCCallStarting(ctx context.Context, methodName string, md metadata.MD) (context.Context, error)
 
-	// RPCCallProcessing is called by a server interceptor, allowing request pre-processing or blocking to be performed.
-	// handler should propagate the req.
+	// RPCCallProcessing is called by a server interceptor, allowing request pre-processing or request blocking to be
+	// performed. The returned function will be applied after the request is handled, providing any error that occurred while
+	// handling the request.
 	RPCCallProcessing(ctx context.Context, methodName string) (func(error), error)
 
 	// RPCCallFinished is called when an RPC call is finished being handled.

--- a/server/limits.go
+++ b/server/limits.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/tap"
@@ -19,6 +20,11 @@ type GrpcInflightMethodLimiter interface {
 	// otherwise gRPC-server implementation-specific error will be returned to the client (codes.PermissionDenied in grpc@v1.55.0).
 	RPCCallStarting(ctx context.Context, methodName string, md metadata.MD) (context.Context, error)
 
+	// RPCCallProcessing is called by a server interceptor, allowing request pre-processing or blocking to be performed.
+	// handler should propagate the req.
+	RPCCallProcessing(ctx context.Context, methodName string) (func(error), error)
+
+	// RPCCallFinished is called when an RPC call is finished being handled.
 	RPCCallFinished(ctx context.Context)
 }
 
@@ -45,6 +51,31 @@ func (g *grpcInflightLimitCheck) TapHandle(ctx context.Context, info *tap.Info) 
 	}
 
 	return g.methodLimiter.RPCCallStarting(ctx, info.FullMethodName, info.Header)
+}
+
+func (g *grpcInflightLimitCheck) UnaryServerInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	finish, err := g.methodLimiter.RPCCallProcessing(ctx, info.FullMethod)
+	if err != nil {
+		return nil, err
+	}
+	result, err := handler(ctx, req)
+	if finish != nil {
+		finish(err)
+	}
+	return result, err
+
+}
+
+func (g *grpcInflightLimitCheck) StreamServerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	finish, err := g.methodLimiter.RPCCallProcessing(ss.Context(), info.FullMethod)
+	if err != nil {
+		return err
+	}
+	err = handler(srv, ss)
+	if finish != nil {
+		finish(err)
+	}
+	return err
 }
 
 func (g *grpcInflightLimitCheck) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {

--- a/server/limits_test.go
+++ b/server/limits_test.go
@@ -322,6 +322,10 @@ func (m *methodLimiter) RPCCallStarting(ctx context.Context, methodName string, 
 	return context.WithValue(ctx, ctxMethodName, methodName), nil
 }
 
+func (m *methodLimiter) RPCCallProcessing(_ context.Context, _ string) (func(error), error) {
+	return nil, nil
+}
+
 func (m *methodLimiter) RPCCallFinished(ctx context.Context) {
 	m.allInflight.Dec()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds server interceptor support to the `GrpcInflightMethodLimiter` via a `RPCCallProcessing` callback. This is in addition to the existing tap handle support via `RPCCallStarting`.

Interceptors are needed for inflight limiting where we want request blocking to be able to happen, since tap handles are not meant to have any blocking occur. In particular, adaptive limiters will use tap handles for most rejection, but interceptors for any blocking of requests that might be needed since they'll generally keep concurrency limits low.

This will require downstream users of `GrpcInflightMethodLimiter` to implement `RPCCallProcessing`, which can be a noop if it's not used:

```go
func (m *methodLimiter) RPCCallProcessing(_ context.Context, _ string) (func(error), error) {
	return nil, nil
}
```

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
