### PR TITLE
fix: memberlist delete operation

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1052,7 +1052,6 @@ func (m *KV) Delete(key string) error {
 	if err != nil {
 		return err
 	}
-
 	if newver > 0 {
 		m.notifyWatchers(key)
 		m.broadcastNewValue(key, change, newver, c, false, deleted, updated)
@@ -1172,6 +1171,7 @@ func (m *KV) broadcastNewValue(key string, change Mergeable, version uint, codec
 		return
 	}
 	data, err := codec.Encode(change)
+
 	if err != nil {
 		level.Error(m.logger).Log("msg", "failed to encode change", "key", key, "version", version, "err", err)
 		m.numberOfBroadcastMessagesDropped.Inc()

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1047,7 +1047,6 @@ func (m *KV) Delete(key string) error {
 	if c == nil {
 		return fmt.Errorf("invalid codec: %s", val.CodecID)
 	}
-	level.Info(m.logger).Log("msg", "[memberlist_client]Delete", "key", key, "codec", val.CodecID, "Version", val.Version)
 	change, newver, deleted, updated, err := m.mergeValueForKey(key, val.value, false, 0, val.CodecID, true, time.Now())
 	if err != nil {
 		return err

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1047,13 +1047,14 @@ func (m *KV) Delete(key string) error {
 	if c == nil {
 		return fmt.Errorf("invalid codec: %s", val.CodecID)
 	}
+
 	change, newver, deleted, updated, err := m.mergeValueForKey(key, val.value, false, 0, val.CodecID, true, time.Now())
 	if err != nil {
 		return err
 	}
 
 	if newver > 0 {
-		//m.notifyWatchers(key)
+		m.notifyWatchers(key)
 		m.broadcastNewValue(key, change, newver, c, false, deleted, updated)
 	}
 
@@ -1104,6 +1105,7 @@ outer:
 		if change != nil {
 			m.casSuccesses.Inc()
 			m.notifyWatchers(key)
+
 			m.broadcastNewValue(key, change, newver, codec, true, deleted, updated)
 		}
 

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"github.com/grafana/dskit/test"
 	"math"
 	"math/rand"
 	"net"
@@ -17,6 +16,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/grafana/dskit/test"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -644,7 +645,7 @@ func TestDeleteMultipleClients(t *testing.T) {
 	}
 
 	cfg.GossipNodes = 1
-	cfg.GossipInterval = 100 * time.Millisecond
+	cfg.GossipInterval = 10 * time.Millisecond
 	cfg.PushPullInterval = deleteTime
 	cfg.ObsoleteEntriesTimeout = deleteTime
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

After the rollout of delete operation in memberlist we observed 2 things:
- Error `failed to decode value: snappy: corrupt input`. ([logs](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22ygx%22%3A%7B%22datasource%22%3A%22--+Mixed+--%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sum+by%28namespace%29%28count_over_time%28%7Bcluster%3D%5C%22dev-us-central-0%5C%22%2Cnamespace%3D%5C%22mimir-dev-11%5C%22%2Ccontainer%3D%5C%22distributor%5C%22%7D++%7C%3D+%60deleted+old+replica%60++%5B%24__auto%5D%29%29%22%2C%22range%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22OP27Xzxnk%22%7D%2C%22editorMode%22%3A%22code%22%2C%22queryType%22%3A%22range%22%2C%22direction%22%3A%22backward%22%2C%22hide%22%3Atrue%7D%2C%7B%22refId%22%3A%22B%22%2C%22expr%22%3A%22%7Bcluster%3D%5C%22dev-us-central-0%5C%22%2C+namespace%3D%5C%22mimir-dev-11%5C%22%2C+container%3D%5C%22distributor%5C%22%7D+%7C+logfmt+%7C+detected_level%3D%5C%22error%5C%22+%7C%3D+%5C%22failed+to+store+received+value%5C%22%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22OP27Xzxnk%22%7D%2C%22editorMode%22%3A%22code%22%2C%22direction%22%3A%22backward%22%2C%22hide%22%3Afalse%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221738594922337%22%2C%22to%22%3A%221738601933484%22%7D%2C%22panelsState%22%3A%7B%22logs%22%3A%7B%22visualisationType%22%3A%22logs%22%7D%7D%7D%7D&orgId=1))
- Delete was happening but the actual entry was not deleted completed. So the entry is deleted it and then comes back. 


In this PR we tackle these two issues by:
- returning an actual `change` when the only thing that gets updated is the Delete status, so we do not have to `handlePossibleNilEncode` which was returning an []byte{} that was causing the Decode issue.
- returning no change when the incoming entry has Delete true. Thist was an edge case in which the current HA tracker had deleted the entry and another one was coming with delete True. This can happen if we have regular push/pull interval.

Verified it locally. 


- [ ] Need to test it in a dev-cell. mimir-dev-11, would be the cell. https://github.com/grafana/deployment_tools/pull/220742/files


### Tests
- Introduces `checkMemberlistEntry`, that will constantly checks the memberlist entries up to specific amount of time before considers the test failure. It utilizes test.poll
- extend `TestDelete` to check if there are any encoding errors during the Delete flow. Covers `failed to decode value: snappy: corrupt input`

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
