### PR TITLE
Make Memcached soft-dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Changelog
 
-* [CHANGE] Make Memcached soft-dependency on startup. Memcached addresses will be resolved periodically. #647
 * [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries. #619
 * [CHANGE] Log middleware updated to honor `logRequestHeaders` in all logging scenarios. #615
 * [CHANGE] Roll back the gRPC dependency to v1.65.0 to allow downstream projects to avoid a performance regression and maybe a bug in v1.66.0. #581
@@ -104,6 +103,7 @@
 * [FEATURE] Add `middleware.ClusterUnaryClientInterceptor`, a `grpc.UnaryClientInterceptor` that propagates a cluster info to the outgoing gRPC metadata. #640
 * [FEATURE] Add `middleware.ClusterUnaryServerInterceptor`, a `grpc.UnaryServerInterceptor` that checks if the incoming gRPC metadata contains a correct cluster info, and returns an error if it is not the case. #640
 * [FEATURE] Add `ring.GetWithOptions()` method to support additional features at a per-call level. #632
+* [ENHANCEMENT] Add feature flag to make Memcached soft-dependency on startup. If so, `Initialize()` will have to be called after client creation. #647
 * [ENHANCEMENT] Add option to hide token information in ring status page #633
 * [ENHANCEMENT] Display token information in partition ring status page #631
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Make Memcached soft-dependency on startup. Memcached addresses will be resolved periodically. #647
 * [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries. #619
 * [CHANGE] Log middleware updated to honor `logRequestHeaders` in all logging scenarios. #615
 * [CHANGE] Roll back the gRPC dependency to v1.65.0 to allow downstream projects to avoid a performance regression and maybe a bug in v1.66.0. #581

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -311,6 +311,7 @@ func newMemcachedClient(
 }
 
 // Initialize will start the background DNS resolution periodically and do an initial DNS resolution.
+// The background resolution goroutine is started even if the initial resolution fails.
 func (c *MemcachedClient) Initialize() error {
 	// Start the background DNS resolution
 	go c.resolveAddrsLoop()

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -127,7 +127,7 @@ type MemcachedClientConfig struct {
 
 	// DNSInitializationEnabled enables initial DNS lookup and background resolution on client creation.
 	// When false, Initialize() must be called manually.
-	DNSInitializationEnabled bool `yaml:"dns_initialization_enabled" category:"advanced"`
+	DNSInitializationEnabled bool `yaml:"dns_initialization_enabled" category:"experimental"`
 }
 
 func (c *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -336,8 +335,6 @@ func BenchmarkMemcachedClient_sortKeysByServer(b *testing.B) {
 }
 
 func TestMemcachedClient_NoServerDependency(t *testing.T) {
-	var buf bytes.Buffer
-	logger := log.NewLogfmtLogger(&buf)
 
 	cfg := MemcachedClientConfig{
 		Addresses:           []string{},
@@ -347,7 +344,7 @@ func TestMemcachedClient_NoServerDependency(t *testing.T) {
 	}
 
 	client, err := newMemcachedClient(
-		logger,
+		log.NewNopLogger(),
 		memcache.New(cfg.Addresses...),
 		&memcache.ServerList{},
 		cfg,
@@ -356,9 +353,7 @@ func TestMemcachedClient_NoServerDependency(t *testing.T) {
 	)
 
 	require.NotNil(t, client)
-	require.NoError(t, err)
-
-	require.Contains(t, buf.String(), "no memcached server addresses were resolved")
+	require.Contains(t, err.Error(), "no memcached server addresses were resolved")
 
 	res := client.GetMulti(context.Background(), []string{"some-key"})
 	require.Empty(t, res)

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -353,7 +353,7 @@ func TestMemcachedClient_ServerDependency(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &MemcachedClientConfig{}
 			memcachedClientConfigDefaultValues(cfg)
-			cfg.Addresses = flagext.StringSliceCSV{"dns+test:11211"}
+			cfg.Addresses = flagext.StringSliceCSV{"dns+invalid.:11211"}
 			cfg.DNSInitializationEnabled = tc.dnsInitializationEnabled
 
 			client, err := NewMemcachedClientWithConfig(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: This PR makes Memcached a soft-dependency on startup.

**Which issue(s) this PR fixes**: If Memcached is not available on cache initialization, `MemcachedClient` would return `nil` with `error` which would not permit for a recovery if Memcached gets available.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
