### PR TITLE
gRPC cluster validation: remove unnecessary metric labels

### DIFF
--- a/clusterutil/clusterutil.go
+++ b/clusterutil/clusterutil.go
@@ -10,9 +10,6 @@ import (
 const (
 	// MetadataClusterVerificationLabelKey is the key of the cluster verification label gRPC metadata.
 	MetadataClusterVerificationLabelKey = "x-cluster"
-
-	ReasonClient = "client_check_failed"
-	ReasonServer = "server_check_failed"
 )
 
 var (

--- a/middleware/grpc_cluster.go
+++ b/middleware/grpc_cluster.go
@@ -51,7 +51,7 @@ func handleClusterValidationError(err error, cluster string, method string, inva
 				if errDetails.GetCause() == grpcutil.WRONG_CLUSTER_VERIFICATION_LABEL {
 					msg := fmt.Sprintf("request rejected by the server: %s", stat.Message())
 					level.Warn(logger).Log("msg", msg, "method", method, "clusterVerificationLabel", cluster)
-					invalidCluster.WithLabelValues(method, clusterutil.ReasonServer).Inc()
+					invalidCluster.WithLabelValues(method).Inc()
 					return grpcutil.Status(codes.Internal, msg).Err()
 				}
 			}

--- a/middleware/grpc_cluster_test.go
+++ b/middleware/grpc_cluster_test.go
@@ -54,7 +54,7 @@ func TestClusterUnaryClientInterceptor(t *testing.T) {
 			expectedMetrics: `
 				# HELP test_request_invalid_cluster_verification_labels_total Number of requests with invalid cluster verification label.
 				# TYPE test_request_invalid_cluster_verification_labels_total counter
-				test_request_invalid_cluster_verification_labels_total{method="GET",reason="server_check_failed"} 1
+				test_request_invalid_cluster_verification_labels_total{method="GET"} 1
 			`,
 			expectedLogs: `level=warn msg="request rejected by the server: request intended for cluster \"cluster\" - this is cluster \"another-cluster\"" method=GET clusterVerificationLabel=cluster`,
 		},
@@ -255,7 +255,7 @@ func newRequestInvalidClusterVerficationLabelsTotalCounter(reg prometheus.Regist
 		Name:        "test_request_invalid_cluster_verification_labels_total",
 		Help:        "Number of requests with invalid cluster verification label.",
 		ConstLabels: nil,
-	}, []string{"method", "reason"})
+	}, []string{"method"})
 }
 
 func newIncomingContext(containsRequestCluster bool, requestCluster string) context.Context {


### PR DESCRIPTION
**What this PR does**:
In #648 we introduced `ClusterUnaryClientInterceptor`, a gRPC interceptor that enriches the outgoing context with a  cluster label, propagates further the request, and once a response is returned, if it corresponds to a cluster validation-related error, tracks it into a metrics given as input to the interceptor, and returns an error. This PR removes the `reason` label from the metrics, because it adds no additional value, since the only available reason was `server_check_failed`.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
