### PR TITLE
Allow gRPC cluster validation configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,8 +100,12 @@
 * [FEATURE] Add methods `Increment`, `FlushAll`, `CompareAndSwap`, `Touch` to `cache.MemcachedClient` #477
 * [FEATURE] Add `concurrency.ForEachJobMergeResults()` utility function. #486
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495
-* [FEATURE] Add `middleware.ClusterUnaryClientInterceptor`, a `grpc.UnaryClientInterceptor` that propagates a cluster info to the outgoing gRPC metadata. #640
-* [FEATURE] Add `middleware.ClusterUnaryServerInterceptor`, a `grpc.UnaryServerInterceptor` that checks if the incoming gRPC metadata contains a correct cluster info, and returns an error if it is not the case. #640
+* [FEATURE] Add `middleware.ClusterUnaryClientInterceptor`, a `grpc.UnaryClientInterceptor` that propagates a cluster info to the outgoing gRPC metadata. #640 #648 #649
+* [FEATURE] Add `middleware.ClusterUnaryServerInterceptor`, a `grpc.UnaryServerInterceptor` that checks if the incoming gRPC metadata contains a correct cluster info, and returns an error if it is not the case. #640 #648 #649
+* [FEATURE] Add support for adding `middleware.ClusterUnaryServerInterceptor` as `server.Server` unary interceptor via the following configuration options: #650 
+  * `-server.cluster-validation.label`
+  * `-server.cluster-validation.grpc.soft-validation`
+  * `-server.cluster-validation.grpc.enabled`
 * [FEATURE] Add `ring.GetWithOptions()` method to support additional features at a per-call level. #632
 * [ENHANCEMENT] Add option to hide token information in ring status page #633
 * [ENHANCEMENT] Display token information in partition ring status page #631

--- a/clusterutil/cluster_validation_config.go
+++ b/clusterutil/cluster_validation_config.go
@@ -16,7 +16,7 @@ type ClusterValidationProtocolConfig struct {
 }
 
 func (cfg *ClusterValidationConfig) Validate() error {
-	return cfg.GRPC.Validate("gRPC", cfg.Label)
+	return cfg.GRPC.Validate("grpc", cfg.Label)
 }
 
 func (cfg *ClusterValidationConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -25,20 +25,16 @@ func (cfg *ClusterValidationConfig) RegisterFlagsWithPrefix(prefix string, f *fl
 	cfg.GRPC.RegisterFlagsWithPrefix(clusterValidationPrefix+".grpc", f)
 }
 
-func (cfg *ClusterValidationConfig) GRPCValidationEnabled() bool {
-	return cfg.GRPC.Enabled || cfg.GRPC.SoftValidation
-}
-
 func (cfg *ClusterValidationProtocolConfig) Validate(prefix string, label string) error {
 	if label == "" {
 		if cfg.Enabled || cfg.SoftValidation {
-			return fmt.Errorf("%s: no validation can be enabled if cluster validation label is not configured", prefix)
+			return fmt.Errorf("%s: validation cannot be enabled if cluster validation label is not configured", prefix)
 		}
 		return nil
 	}
 
-	if cfg.Enabled && cfg.SoftValidation {
-		return fmt.Errorf("%s: hard validation and soft validation cannot be enabled at the same time", prefix)
+	if !cfg.Enabled && cfg.SoftValidation {
+		return fmt.Errorf("%s: soft validation can be enabled only if cluster validation is enabled", prefix)
 	}
 	return nil
 }
@@ -46,6 +42,6 @@ func (cfg *ClusterValidationProtocolConfig) Validate(prefix string, label string
 func (cfg *ClusterValidationProtocolConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	softValidationFlag := prefix + ".soft-validation"
 	enabledFlag := prefix + ".enabled"
-	f.BoolVar(&cfg.SoftValidation, softValidationFlag, false, fmt.Sprintf("When enabled, soft cluster label validation will be executed. Cannot be enabled together with %s", enabledFlag))
-	f.BoolVar(&cfg.Enabled, enabledFlag, false, fmt.Sprintf("When enabled, cluster label validation will be executed. Cannot be enabled together with %s", softValidationFlag))
+	f.BoolVar(&cfg.SoftValidation, softValidationFlag, false, fmt.Sprintf("When enabled, soft cluster label validation will be executed. Can be enabled only together with %s", enabledFlag))
+	f.BoolVar(&cfg.Enabled, enabledFlag, false, "When enabled, cluster label validation will be executed.")
 }

--- a/clusterutil/cluster_validation_config.go
+++ b/clusterutil/cluster_validation_config.go
@@ -1,0 +1,51 @@
+package clusterutil
+
+import (
+	"flag"
+	"fmt"
+)
+
+type ClusterValidationConfig struct {
+	Label string
+	GRPC  ClusterValidationProtocolConfig
+}
+
+type ClusterValidationProtocolConfig struct {
+	Enabled        bool
+	SoftValidation bool
+}
+
+func (cfg *ClusterValidationConfig) Validate() error {
+	return cfg.GRPC.Validate("gRPC", cfg.Label)
+}
+
+func (cfg *ClusterValidationConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	clusterValidationPrefix := prefix + ".cluster-validation"
+	f.StringVar(&cfg.Label, clusterValidationPrefix+".label", "", "Optionally define server's cluster validation label.")
+	cfg.GRPC.RegisterFlagsWithPrefix(clusterValidationPrefix, f)
+}
+
+func (cfg *ClusterValidationConfig) GRPCValidationEnabled() bool {
+	return cfg.GRPC.Enabled || cfg.GRPC.SoftValidation
+}
+
+func (cfg *ClusterValidationProtocolConfig) Validate(prefix string, label string) error {
+	if label == "" {
+		if cfg.Enabled || cfg.SoftValidation {
+			return fmt.Errorf("%s: no validation can be enabled if cluster validation label is not configured", prefix)
+		}
+		return nil
+	}
+
+	if cfg.Enabled && cfg.SoftValidation {
+		return fmt.Errorf("%s: hard validation and soft validation cannot be enabled at the same time", prefix)
+	}
+	return nil
+}
+
+func (cfg *ClusterValidationProtocolConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	softValidationFlag := prefix + ".soft-validation"
+	enabledFlag := prefix + ".enabled"
+	f.BoolVar(&cfg.SoftValidation, softValidationFlag, false, fmt.Sprintf("When enabled, soft cluster label validation will be executed. Cannot be enabled together with %s", enabledFlag))
+	f.BoolVar(&cfg.Enabled, softValidationFlag, false, fmt.Sprintf("When enabled, cluster label validation will be executed. Cannot be enabled together with %s", softValidationFlag))
+}

--- a/clusterutil/cluster_validation_config.go
+++ b/clusterutil/cluster_validation_config.go
@@ -22,7 +22,7 @@ func (cfg *ClusterValidationConfig) Validate() error {
 func (cfg *ClusterValidationConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	clusterValidationPrefix := prefix + ".cluster-validation"
 	f.StringVar(&cfg.Label, clusterValidationPrefix+".label", "", "Optionally define server's cluster validation label.")
-	cfg.GRPC.RegisterFlagsWithPrefix(clusterValidationPrefix, f)
+	cfg.GRPC.RegisterFlagsWithPrefix(clusterValidationPrefix+".grpc", f)
 }
 
 func (cfg *ClusterValidationConfig) GRPCValidationEnabled() bool {
@@ -47,5 +47,5 @@ func (cfg *ClusterValidationProtocolConfig) RegisterFlagsWithPrefix(prefix strin
 	softValidationFlag := prefix + ".soft-validation"
 	enabledFlag := prefix + ".enabled"
 	f.BoolVar(&cfg.SoftValidation, softValidationFlag, false, fmt.Sprintf("When enabled, soft cluster label validation will be executed. Cannot be enabled together with %s", enabledFlag))
-	f.BoolVar(&cfg.Enabled, softValidationFlag, false, fmt.Sprintf("When enabled, cluster label validation will be executed. Cannot be enabled together with %s", softValidationFlag))
+	f.BoolVar(&cfg.Enabled, enabledFlag, false, fmt.Sprintf("When enabled, cluster label validation will be executed. Cannot be enabled together with %s", softValidationFlag))
 }

--- a/clusterutil/cluster_validation_config_test.go
+++ b/clusterutil/cluster_validation_config_test.go
@@ -16,37 +16,37 @@ func TestClusterValidationProtocolConfigValidate(t *testing.T) {
 	}{
 		"soft validation cannot be done if cluster validation label is not set": {
 			softValidation: true,
-			expectedErr:    fmt.Errorf("testProtocol: no validation can be enabled if cluster validation label is not configured"),
+			expectedErr:    fmt.Errorf("testProtocol: validation cannot be enabled if cluster validation label is not configured"),
 		},
-		"hard validation cannot be done if cluster validation label is not set": {
+		"cluster validation cannot be done if cluster validation label is not set": {
 			enabled:     true,
-			expectedErr: fmt.Errorf("testProtocol: no validation can be enabled if cluster validation label is not configured"),
+			expectedErr: fmt.Errorf("testProtocol: validation cannot be enabled if cluster validation label is not configured"),
 		},
-		"soft and hard validation can be disabled if cluster validation label is not set": {
+		"cluster validation and soft validation can be disabled if cluster validation label is not set": {
 			label:          "",
 			enabled:        false,
 			softValidation: false,
 		},
-		"soft and hard validation can be disabled if cluster validation label is set": {
+		"cluster validation and soft validation can be disabled if cluster validation label is set": {
 			label:          "my-cluster",
 			enabled:        false,
 			softValidation: false,
 		},
-		"only soft validation can be enabled if cluster validation label is set": {
+		"soft validation cannot be enabled if cluster validation is disabled": {
 			label:          "my-cluster",
 			enabled:        false,
 			softValidation: true,
+			expectedErr:    fmt.Errorf("testProtocol: soft validation can be enabled only if cluster validation is enabled"),
 		},
-		"only hard validation can be enabled if cluster validation label is set": {
+		"soft validation can be disabled if cluster validation is enabled": {
 			label:          "my-cluster",
 			enabled:        true,
 			softValidation: false,
 		},
-		"soft and hard validation cannot be enabled at the same time": {
+		"cluster validation and soft validation can be enabled at the same time": {
 			label:          "my-cluster",
 			enabled:        true,
 			softValidation: true,
-			expectedErr:    fmt.Errorf("testProtocol: hard validation and soft validation cannot be enabled at the same time"),
 		},
 	}
 	for testName, testCase := range testCases {

--- a/clusterutil/cluster_validation_config_test.go
+++ b/clusterutil/cluster_validation_config_test.go
@@ -1,0 +1,62 @@
+package clusterutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterValidationProtocolConfigValidate(t *testing.T) {
+	testCases := map[string]struct {
+		label          string
+		enabled        bool
+		softValidation bool
+		expectedErr    error
+	}{
+		"soft validation cannot be done if cluster validation label is not set": {
+			softValidation: true,
+			expectedErr:    fmt.Errorf("testProtocol: no validation can be enabled if cluster validation label is not configured"),
+		},
+		"hard validation cannot be done if cluster validation label is not set": {
+			enabled:     true,
+			expectedErr: fmt.Errorf("testProtocol: no validation can be enabled if cluster validation label is not configured"),
+		},
+		"soft and hard validation can be disabled if cluster validation label is not set": {
+			label:          "",
+			enabled:        false,
+			softValidation: false,
+		},
+		"soft and hard validation can be disabled if cluster validation label is set": {
+			label:          "my-cluster",
+			enabled:        false,
+			softValidation: false,
+		},
+		"only soft validation can be enabled if cluster validation label is set": {
+			label:          "my-cluster",
+			enabled:        false,
+			softValidation: true,
+		},
+		"only hard validation can be enabled if cluster validation label is set": {
+			label:          "my-cluster",
+			enabled:        true,
+			softValidation: false,
+		},
+		"soft and hard validation cannot be enabled at the same time": {
+			label:          "my-cluster",
+			enabled:        true,
+			softValidation: true,
+			expectedErr:    fmt.Errorf("testProtocol: hard validation and soft validation cannot be enabled at the same time"),
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			testProtocolCfg := ClusterValidationProtocolConfig{
+				Enabled:        testCase.enabled,
+				SoftValidation: testCase.softValidation,
+			}
+			err := testProtocolCfg.Validate("testProtocol", testCase.label)
+			require.Equal(t, testCase.expectedErr, err)
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -408,7 +408,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		middleware.UnaryServerInstrumentInterceptor(metrics.RequestDuration, grpcInstrumentationOptions...),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
-	if cfg.ClusterValidation.GRPCValidationEnabled() {
+	if cfg.ClusterValidation.GRPC.Enabled {
 		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation, logger))
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,6 @@ import (
 	gokit_log "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
-	"github.com/grafana/dskit/clusterutil"
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof" // anonymous import to get godelatprof handlers registered
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
@@ -34,6 +33,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 
+	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/httpgrpc"
 	httpgrpc_server "github.com/grafana/dskit/httpgrpc/server"
 	"github.com/grafana/dskit/log"

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,7 @@ import (
 	gokit_log "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/clusterutil"
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof" // anonymous import to get godelatprof handlers registered
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
@@ -155,6 +156,8 @@ type Config struct {
 	GrpcMethodLimiter GrpcInflightMethodLimiter `yaml:"-"`
 
 	Throughput Throughput `yaml:"-"`
+
+	ClusterValidation clusterutil.ClusterValidationConfig `yaml:"cluster_validation"`
 }
 
 type Throughput struct {
@@ -218,6 +221,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ProxyProtocolEnabled, "server.proxy-protocol-enabled", false, "Enables PROXY protocol.")
 	f.DurationVar(&cfg.Throughput.LatencyCutoff, "server.throughput.latency-cutoff", 0, "Requests taking over the cutoff are be observed to measure throughput. Server-Timing header is used with specified unit as the indicator, for example 'Server-Timing: unit;val=8.2'. If set to 0, the throughput is not calculated.")
 	f.StringVar(&cfg.Throughput.Unit, "server.throughput.unit", "samples_processed", "Unit of the server throughput metric, for example 'processed_bytes' or 'samples_processed'. Observed values are gathered from the 'Server-Timing' header with the 'val' key. If set, it is appended to the request_server_throughput metric name.")
+	cfg.ClusterValidation.RegisterFlagsWithPrefix("server", f)
+}
+
+func (cfg *Config) Validate() error {
+	return cfg.ClusterValidation.Validate()
 }
 
 func (cfg *Config) registererOrDefault() prometheus.Registerer {
@@ -400,6 +408,9 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		middleware.UnaryServerInstrumentInterceptor(metrics.RequestDuration, grpcInstrumentationOptions...),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
+	if cfg.ClusterValidation.GRPCValidationEnabled() {
+		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation, logger))
+	}
 
 	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
 		serverLog.StreamServerInterceptor,


### PR DESCRIPTION
**What this PR does**:
In #648 we introduced `ClusterClientUnaryInterceptor` and `ClusterServerUnaryInterceptor`, gRPC client and server interceptors that allow request cluster validation in gRPC calls.
This PR introduces configuration options for enabling cluster validation.
The following configuration options are introduced:
- `-server.cluster-validation.label`: specifies the cluster validation label of the server, that is used for request validation.
- `-server.cluster-validation.grpc.enabled`: when enabled, allows the server to execute `ClusterServerUnaryInterceptor`'s cluster validation.
-`-server.cluster-validation.grpc.soft-validation`: when enabled, allows the server to execute `ClusterServerUnaryInterceptor`'s soft validation, i.e., the server tries to go ahead with the request execution, even if the request's cluster validation label doesn't match with `-server.cluster-validation.label`. It can be enabled only if `-server.cluster-validation.grpc.enabled` is enabled too.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
