### PR TITLE
flagext: Add LimitsMap from Mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@
 * [ENHANCEMENT] Memberlist: Implemented the `Delete` operation in the memberlist backed KV store. How frequently deleted entries are cleaned up is specified by the `-memberlist.obsolete-entries-timeout` flag. #612
 * [ENHANCEMENT] KV: Add `MockCountingClient`, which wraps the `kv.client` and can be used in order to count calls at specific functions of the interface. #618
 * [ENHANCEMENT] Server: Add interceptor support to `GrpcInflightMethodLimiter`. #643
+* [ENHANCEMENT] flagext: Add `LimitsMap` as a new flag type. #651
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/flagext/map.go
+++ b/flagext/map.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package flagext
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LimitsMap is a flag.Value implementation that looks like a generic map, holding float64s, ints, or strings as values.
+type LimitsMap[T float64 | int | string] struct {
+	data      map[string]T
+	validator func(k string, v T) error
+}
+
+func NewLimitsMap[T float64 | int | string](validator func(k string, v T) error) LimitsMap[T] {
+	return NewLimitsMapWithData(make(map[string]T), validator)
+}
+
+func NewLimitsMapWithData[T float64 | int | string](data map[string]T, validator func(k string, v T) error) LimitsMap[T] {
+	return LimitsMap[T]{
+		data:      data,
+		validator: validator,
+	}
+}
+
+// IsInitialized returns true if the map is initialized.
+func (m LimitsMap[T]) IsInitialized() bool {
+	return m.data != nil
+}
+
+// String implements flag.Value
+func (m LimitsMap[T]) String() string {
+	out, err := json.Marshal(m.data)
+	if err != nil {
+		return fmt.Sprintf("failed to marshal: %v", err)
+	}
+	return string(out)
+}
+
+// Set implements flag.Value
+func (m LimitsMap[T]) Set(s string) error {
+	newMap := make(map[string]T)
+	if err := json.Unmarshal([]byte(s), &newMap); err != nil {
+		return err
+	}
+	return m.updateMap(newMap)
+}
+
+func (m LimitsMap[T]) Read() map[string]T {
+	return m.data
+}
+
+// Clone returns a copy of the LimitsMap.
+func (m LimitsMap[T]) Clone() LimitsMap[T] {
+	newMap := make(map[string]T, len(m.data))
+	for k, v := range m.data {
+		newMap[k] = v
+	}
+	return LimitsMap[T]{data: newMap, validator: m.validator}
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (m LimitsMap[T]) UnmarshalYAML(value *yaml.Node) error {
+	newMap := make(map[string]T)
+	if err := value.Decode(newMap); err != nil {
+		return err
+	}
+	return m.updateMap(newMap)
+}
+
+func (m LimitsMap[T]) updateMap(newMap map[string]T) error {
+	// Validate first, as we don't want to allow partial updates.
+	if m.validator != nil {
+		for k, v := range newMap {
+			if err := m.validator(k, v); err != nil {
+				return err
+			}
+		}
+	}
+
+	clear(m.data)
+	for k, v := range newMap {
+		m.data[k] = v
+	}
+
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (m LimitsMap[T]) MarshalYAML() (interface{}, error) {
+	return m.data, nil
+}
+
+// Equal compares two LimitsMap. This is needed to allow cmp.Equal to compare two LimitsMap.
+func (m LimitsMap[T]) Equal(other LimitsMap[T]) bool {
+	if len(m.data) != len(other.data) {
+		return false
+	}
+
+	for k, v := range m.data {
+		if other.data[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/flagext/map.go
+++ b/flagext/map.go
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-only
-
 package flagext
 
 import (

--- a/flagext/map_test.go
+++ b/flagext/map_test.go
@@ -281,74 +281,98 @@ func TestLimitsMap_MarshalYAML(t *testing.T) {
 }
 
 func TestLimitsMap_Equal(t *testing.T) {
-	t.Run("numeric", func(t *testing.T) {
+	t.Run("numeric, equal", func(t *testing.T) {
 		tc := map[string]struct {
-			map1     LimitsMap[float64]
-			map2     LimitsMap[float64]
-			expected bool
+			map1 LimitsMap[float64]
+			map2 LimitsMap[float64]
 		}{
 			"Equal maps with same key-value pairs": {
-				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
-				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
-				expected: true,
-			},
-			"Different maps with different lengths": {
-				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
-				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
-				expected: false,
-			},
-			"Different maps with same keys but different values": {
-				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
-				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.2}},
-				expected: false,
+				map1: LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+				map2: LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
 			},
 			"Equal empty maps": {
-				map1:     LimitsMap[float64]{data: map[string]float64{}},
-				map2:     LimitsMap[float64]{data: map[string]float64{}},
-				expected: true,
+				map1: LimitsMap[float64]{data: map[string]float64{}},
+				map2: LimitsMap[float64]{data: map[string]float64{}},
 			},
 		}
 
 		for name, tt := range tc {
 			t.Run(name, func(t *testing.T) {
-				require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[float64]{data: tt.map2.data}))
-				require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
+				require.Equal(t, tt.map1, tt.map2)
+				require.True(t, tt.map1.Equal(tt.map2))
+				require.True(t, cmp.Equal(tt.map1, tt.map2))
 			})
 		}
 	})
 
-	t.Run("string", func(t *testing.T) {
+	t.Run("numeric, not equal", func(t *testing.T) {
 		tc := map[string]struct {
-			map1     LimitsMap[string]
-			map2     LimitsMap[string]
-			expected bool
+			map1 LimitsMap[float64]
+			map2 LimitsMap[float64]
 		}{
-			"Equal maps with same key-value pairs": {
-				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
-				map2:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
-				expected: true,
-			},
 			"Different maps with different lengths": {
-				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc"}},
-				map2:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
-				expected: false,
+				map1: LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+				map2: LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
 			},
 			"Different maps with same keys but different values": {
-				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc"}},
-				map2:     LimitsMap[string]{data: map[string]string{"key1": "def"}},
-				expected: false,
-			},
-			"Equal empty maps": {
-				map1:     LimitsMap[string]{data: map[string]string{}},
-				map2:     LimitsMap[string]{data: map[string]string{}},
-				expected: true,
+				map1: LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+				map2: LimitsMap[float64]{data: map[string]float64{"key1": 1.2}},
 			},
 		}
 
 		for name, tt := range tc {
 			t.Run(name, func(t *testing.T) {
-				require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[string]{data: tt.map2.data}))
-				require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
+				require.NotEqual(t, tt.map1, tt.map2)
+				require.False(t, tt.map1.Equal(tt.map2))
+				require.False(t, cmp.Equal(tt.map1, tt.map2))
+			})
+		}
+	})
+
+	t.Run("string, equal", func(t *testing.T) {
+		tc := map[string]struct {
+			map1 LimitsMap[string]
+			map2 LimitsMap[string]
+		}{
+			"Equal maps with same key-value pairs": {
+				map1: LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+				map2: LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+			},
+			"Equal empty maps": {
+				map1: LimitsMap[string]{data: map[string]string{}},
+				map2: LimitsMap[string]{data: map[string]string{}},
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run(name, func(t *testing.T) {
+				require.Equal(t, tt.map1, tt.map2)
+				require.True(t, tt.map1.Equal(tt.map2))
+				require.True(t, cmp.Equal(tt.map1, tt.map2))
+			})
+		}
+	})
+
+	t.Run("string, not equal", func(t *testing.T) {
+		tc := map[string]struct {
+			map1 LimitsMap[string]
+			map2 LimitsMap[string]
+		}{
+			"Different maps with different lengths": {
+				map1: LimitsMap[string]{data: map[string]string{"key1": "abc"}},
+				map2: LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+			},
+			"Different maps with same keys but different values": {
+				map1: LimitsMap[string]{data: map[string]string{"key1": "abc"}},
+				map2: LimitsMap[string]{data: map[string]string{"key1": "def"}},
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run(name, func(t *testing.T) {
+				require.NotEqual(t, tt.map1, tt.map2)
+				require.False(t, tt.map1.Equal(tt.map2))
+				require.False(t, cmp.Equal(tt.map1, tt.map2))
 			})
 		}
 	})

--- a/flagext/map_test.go
+++ b/flagext/map_test.go
@@ -374,8 +374,7 @@ func TestLimitsMap_Clone(t *testing.T) {
 
 		// Modify the cloned LimitsMap and ensure the original map is not affected.
 		cloned.data["limit3"] = 3.0
-		_, exists := original.data["limit3"]
-		require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+		require.NotContains(t, original.data, "limit3", "expected original LimitsMap to be unaffected by changes to cloned")
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -396,8 +395,7 @@ func TestLimitsMap_Clone(t *testing.T) {
 
 		// Modify the cloned LimitsMap and ensure the original map is not affected.
 		cloned.data["limit3"] = "test"
-		_, exists := original.data["limit3"]
-		require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+		require.NotContains(t, original.data, "limit3", "expected original LimitsMap to be unaffected by changes to cloned")
 	})
 }
 

--- a/flagext/map_test.go
+++ b/flagext/map_test.go
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package flagext
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+var fakeFloat64Validator = func(_ string, v float64) error {
+	if v < 0 {
+		return errors.New("value cannot be negative")
+	}
+	return nil
+}
+
+var fakeIntValidator = func(_ string, v int) error {
+	if v < 0 {
+		return errors.New("value cannot be negative")
+	}
+	return nil
+}
+
+var fakeStringValidator = func(_ string, v string) error {
+	if len(v) == 0 {
+		return errors.New("value cannot be empty")
+	}
+	return nil
+}
+
+func TestNewLimitsMap(t *testing.T) {
+	t.Run("float64", func(t *testing.T) {
+		lm := NewLimitsMap(fakeFloat64Validator)
+		lm.data["key1"] = 10.6
+		require.Len(t, lm.Read(), 1)
+	})
+
+	t.Run("int", func(t *testing.T) {
+		lm := NewLimitsMap(fakeIntValidator)
+		lm.data["key1"] = 10
+		require.Len(t, lm.Read(), 1)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		lm := NewLimitsMap(fakeStringValidator)
+		lm.data["key1"] = "test"
+		require.Len(t, lm.Read(), 1)
+	})
+}
+
+func TestLimitsMap_IsNil(t *testing.T) {
+	tc := map[string]struct {
+		input    LimitsMap[float64]
+		expected bool
+	}{
+
+		"when the map is initialised": {
+			input:    LimitsMap[float64]{data: map[string]float64{"key1": 10}},
+			expected: true,
+		},
+		"when the map is not initialised": {
+			input:    LimitsMap[float64]{data: nil},
+			expected: false,
+		},
+	}
+
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.input.IsInitialized(), tt.expected)
+		})
+	}
+}
+
+func TestLimitsMap_SetAndString(t *testing.T) {
+	t.Run("numeric", func(t *testing.T) {
+		tc := map[string]struct {
+			input    string
+			expected map[string]float64
+			error    string
+		}{
+
+			"set without error": {
+				input:    `{"key1":10,"key2":20}`,
+				expected: map[string]float64{"key1": 10, "key2": 20},
+			},
+			"set with parsing error": {
+				input: `{"key1": 10, "key2": 20`,
+				error: "unexpected end of JSON input",
+			},
+			"set with validation error": {
+				input: `{"key1": -10, "key2": 20}`,
+				error: "value cannot be negative",
+			},
+			"set with incompatible value type": {
+				input: `{"key1": "abc", "key2": "def"}`,
+				error: "json: cannot unmarshal string into Go value of type float64",
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run("numeric/"+name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeFloat64Validator)
+				err := lm.Set(tt.input)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.Read())
+					require.Equal(t, tt.input, lm.String())
+				}
+			})
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		tc := map[string]struct {
+			input    string
+			expected map[string]string
+			error    string
+		}{
+
+			"set without error": {
+				input:    `{"key1":"abc","key2":"def"}`,
+				expected: map[string]string{"key1": "abc", "key2": "def"},
+			},
+			"set with parsing error": {
+				input: `{"key1": "abc", "key2": "def`,
+				error: "unexpected end of JSON input",
+			},
+			"set with validation error": {
+				input: `{"key1": "", "key2": "def"}`,
+				error: "value cannot be empty",
+			},
+			"set with incompatible value type": {
+				input: `{"key1": 10, "key2": 20}`,
+				error: "json: cannot unmarshal number into Go value of type string",
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run("string/"+name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeStringValidator)
+				err := lm.Set(tt.input)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.Read())
+					require.Equal(t, tt.input, lm.String())
+				}
+			})
+		}
+	})
+}
+
+func TestLimitsMap_UnmarshalYAML(t *testing.T) {
+	t.Run("numeric", func(t *testing.T) {
+		tc := []struct {
+			name     string
+			input    string
+			expected map[string]float64
+			error    string
+		}{
+			{
+				name: "unmarshal without error",
+				input: `
+key1: 10
+key2: 20
+`,
+				expected: map[string]float64{"key1": 10, "key2": 20},
+			},
+			{
+				name: "unmarshal with validation error",
+				input: `
+key1: -10
+key2: 20
+`,
+				error: "value cannot be negative",
+			},
+			{
+				name: "unmarshal with parsing error",
+				input: `
+key1: 10
+key2: 20
+	key3: 30
+`,
+				error: "yaml: line 3: found a tab character that violates indentation",
+			},
+		}
+
+		for _, tt := range tc {
+			t.Run(tt.name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeFloat64Validator)
+				err := yaml.Unmarshal([]byte(tt.input), &lm)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.data)
+				}
+			})
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		tc := []struct {
+			name     string
+			input    string
+			expected map[string]string
+			error    string
+		}{
+			{
+				name: "unmarshal without error",
+				input: `
+key1: abc
+key2: def
+`,
+				expected: map[string]string{"key1": "abc", "key2": "def"},
+			},
+			{
+				name: "unmarshal with validation error",
+				input: `
+key1: abc
+key2: ""
+`,
+				error: "value cannot be empty",
+			},
+			{
+				name: "unmarshal with parsing error",
+				input: `
+key1: abc
+key2: def
+	key3: ghi
+`,
+				error: "yaml: line 3: found a tab character that violates indentation",
+			},
+		}
+
+		for _, tt := range tc {
+			t.Run(tt.name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeStringValidator)
+				err := yaml.Unmarshal([]byte(tt.input), &lm)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.data)
+				}
+			})
+		}
+	})
+
+}
+
+func TestLimitsMap_MarshalYAML(t *testing.T) {
+	t.Run("numeric", func(t *testing.T) {
+		lm := NewLimitsMap(fakeFloat64Validator)
+		lm.data["key1"] = 10
+		lm.data["key2"] = 20
+
+		out, err := yaml.Marshal(&lm)
+		require.NoError(t, err)
+		require.Equal(t, "key1: 10\nkey2: 20\n", string(out))
+	})
+
+	t.Run("string", func(t *testing.T) {
+		lm := NewLimitsMap(fakeStringValidator)
+		lm.data["key1"] = "abc"
+		lm.data["key2"] = "def"
+
+		out, err := yaml.Marshal(&lm)
+		require.NoError(t, err)
+		require.Equal(t, "key1: abc\nkey2: def\n", string(out))
+	})
+}
+
+func TestLimitsMap_Equal(t *testing.T) {
+	t.Run("numeric", func(t *testing.T) {
+		tc := map[string]struct {
+			map1     LimitsMap[float64]
+			map2     LimitsMap[float64]
+			expected bool
+		}{
+			"Equal maps with same key-value pairs": {
+				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+				expected: true,
+			},
+			"Different maps with different lengths": {
+				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+				expected: false,
+			},
+			"Different maps with same keys but different values": {
+				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.2}},
+				expected: false,
+			},
+			"Equal empty maps": {
+				map1:     LimitsMap[float64]{data: map[string]float64{}},
+				map2:     LimitsMap[float64]{data: map[string]float64{}},
+				expected: true,
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run(name, func(t *testing.T) {
+				require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[float64]{data: tt.map2.data}))
+				require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
+			})
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		tc := map[string]struct {
+			map1     LimitsMap[string]
+			map2     LimitsMap[string]
+			expected bool
+		}{
+			"Equal maps with same key-value pairs": {
+				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+				map2:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+				expected: true,
+			},
+			"Different maps with different lengths": {
+				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc"}},
+				map2:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+				expected: false,
+			},
+			"Different maps with same keys but different values": {
+				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc"}},
+				map2:     LimitsMap[string]{data: map[string]string{"key1": "def"}},
+				expected: false,
+			},
+			"Equal empty maps": {
+				map1:     LimitsMap[string]{data: map[string]string{}},
+				map2:     LimitsMap[string]{data: map[string]string{}},
+				expected: true,
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run(name, func(t *testing.T) {
+				require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[string]{data: tt.map2.data}))
+				require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
+			})
+		}
+	})
+
+}
+
+func TestLimitsMap_Clone(t *testing.T) {
+	t.Run("numeric", func(t *testing.T) {
+		// Create an initial LimitsMap with some data.
+		original := NewLimitsMap[float64](nil)
+		original.data["limit1"] = 1.0
+		original.data["limit2"] = 2.0
+
+		// Clone the original LimitsMap.
+		cloned := original.Clone()
+
+		// Check that the cloned LimitsMap is equal to the original.
+		require.True(t, original.Equal(cloned), "expected cloned LimitsMap to be different from original")
+
+		// Modify the original LimitsMap and ensure the cloned map is not affected.
+		original.data["limit1"] = 10.0
+		require.False(t, cloned.data["limit1"] == 10.0, "expected cloned LimitsMap to be unaffected by changes to original")
+
+		// Modify the cloned LimitsMap and ensure the original map is not affected.
+		cloned.data["limit3"] = 3.0
+		_, exists := original.data["limit3"]
+		require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+	})
+
+	t.Run("string", func(t *testing.T) {
+		// Create an initial LimitsMap with some data.
+		original := NewLimitsMap[string](nil)
+		original.data["limit1"] = "abc"
+		original.data["limit2"] = "def"
+
+		// Clone the original LimitsMap.
+		cloned := original.Clone()
+
+		// Check that the cloned LimitsMap is equal to the original.
+		require.True(t, original.Equal(cloned), "expected cloned LimitsMap to be different from original")
+
+		// Modify the original LimitsMap and ensure the cloned map is not affected.
+		original.data["limit1"] = "zxcv"
+		require.False(t, cloned.data["limit1"] == "zxcv", "expected cloned LimitsMap to be unaffected by changes to original")
+
+		// Modify the cloned LimitsMap and ensure the original map is not affected.
+		cloned.data["limit3"] = "test"
+		_, exists := original.data["limit3"]
+		require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+	})
+}
+
+func TestLimitsMap_updateMap(t *testing.T) {
+	t.Run("does not apply partial updates", func(t *testing.T) {
+		initialData := map[string]float64{"a": 1.0, "b": 2.0}
+		updateData := map[string]float64{"a": 3.0, "b": -3.0, "c": 5.0}
+
+		limitsMap := LimitsMap[float64]{data: initialData, validator: fakeFloat64Validator}
+
+		err := limitsMap.updateMap(updateData)
+		require.Error(t, err)
+
+		// Verify that no partial updates were applied.
+		// Because maps in Go are accessed in random order, there's a chance that the validation will fail on the first invalid element of the map thus not asserting partial updates.
+		expectedData := map[string]float64{"a": 1.0, "b": 2.0}
+		require.Equal(t, expectedData, limitsMap.Read())
+	})
+
+	t.Run("updates totally replace all values", func(t *testing.T) {
+		initialData := map[string]float64{"a": 1.0, "b": 2.0}
+		updateData := map[string]float64{"b": 5.0, "c": 6.0}
+		limitsMap := LimitsMap[float64]{data: initialData, validator: fakeFloat64Validator}
+
+		err := limitsMap.updateMap(updateData)
+		require.NoError(t, err)
+
+		expectedData := updateData
+		require.Equal(t, expectedData, limitsMap.Read())
+	})
+}

--- a/flagext/map_test.go
+++ b/flagext/map_test.go
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-only
-
 package flagext
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gogo/status v1.1.0
 	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.4
+	github.com/google/go-cmp v0.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8

--- a/ring/example/local/go.mod
+++ b/ring/example/local/go.mod
@@ -68,6 +68,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 // indirect
 	google.golang.org/grpc v1.66.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe

--- a/ring/example/local/go.sum
+++ b/ring/example/local/go.sum
@@ -169,8 +169,11 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -248,6 +251,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
@@ -440,6 +445,8 @@ google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
**What this PR does**:

This PR moves the `LimitsMap` type used in a few Mimir configuration options to flagext.

It's a flag type that represents a map with string keys, similar to the other types in this package that represent lists of strings or similar, thus it seems to belong here. Specifically, I'm moving it now so that packages depending on this type don't have to depend on the whole `github.com/grafana/mimir/pkg/util/validation`.

The mimir implementation: https://github.com/grafana/mimir/blob/9d6eb2312b070892152aab1c36566407bcb411a3/pkg/util/validation/limits_map.go

It's copied verbatim along with its test file except for one line which is called out below.

**Which issue(s) this PR fixes**:

n/a

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
