### PR TITLE
chore: Bump minimum go version to 1.22

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         # We want to make sure dskit can support multiple golang versions
         # by ensuring the test would pass using all these supported versions.
-        go-version: ['1.21.x', '1.22.x', '1.23.x']
+        go-version: ['1.22.x', '1.23.x', '1.24.x']
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [CHANGE] `Service.AddListener` and `Manager.AddListener` now return function for stopping the listener. #564
 * [CHANGE] ring: Add `InstanceRingReader` interface to `ring` package. #597
 * [CHANGE] Server: The `PerTenantDurationInstrumentation` config option was renamed to `PerTenantInstrumentation` and now allows specifying whether a full histogram should be recorded or only a counter #642
+* [CHANGE] Updated the minimum required Go version to 1.22. #653
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338

--- a/crypto/tls/test/tls_integration_go_1_20_test.go
+++ b/crypto/tls/test/tls_integration_go_1_20_test.go
@@ -1,6 +1,0 @@
-//go:build !go1.21
-
-package test
-
-// The error message changed in Go 1.21.
-const badCertificateErrorMessage = "remote error: tls: bad certificate"

--- a/crypto/tls/test/tls_integration_go_1_21_test.go
+++ b/crypto/tls/test/tls_integration_go_1_21_test.go
@@ -1,6 +1,0 @@
-//go:build go1.21
-
-package test
-
-// The error message changed in Go 1.21.
-const badCertificateErrorMessage = "remote error: tls: certificate required"

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -34,7 +34,10 @@ import (
 	"github.com/grafana/dskit/crypto/tls"
 )
 
-const mismatchCAAndCerts = "remote error: tls: unknown certificate authority"
+const (
+	badCertificateErrorMessage = "remote error: tls: certificate required"
+	mismatchCAAndCerts         = "remote error: tls: unknown certificate authority"
+)
 
 type tcIntegrationClientServer struct {
 	name            string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/dskit
 
-go 1.21
+go 1.22
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137

--- a/ring/example/local/go.mod
+++ b/ring/example/local/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/dskit/ring/example/local
 
-go 1.21
+go 1.22
 
 toolchain go1.22.4
 


### PR DESCRIPTION
**What this PR does**:

Test with 1.22, 1.23, 1.24

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
