### PR TITLE
cache: Improve jump hash server selector performance

### DIFF
--- a/cache/memcached_server_selector_test.go
+++ b/cache/memcached_server_selector_test.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkMemcachedJumpHashSelector_PickServer(b *testing.B) {
+	servers := []string{
+		"localhost:11211",
+		"localhost:11212",
+		"localhost:11213",
+		"localhost:11214",
+		"localhost:11215",
+		"localhost:11216",
+		"localhost:11217",
+		"localhost:11218",
+		"localhost:11219",
+		"localhost:11220",
+		"localhost:11221",
+		"localhost:11222",
+		"localhost:11223",
+		"localhost:11224",
+		"localhost:11225",
+		"localhost:11226",
+		"localhost:11227",
+		"localhost:11228",
+		"localhost:11229",
+		"localhost:11230",
+	}
+
+	selector := &MemcachedJumpHashSelector{}
+	require.NoError(b, selector.SetServers(servers...))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := selector.PickServer("some-key")
+		if err != nil {
+			require.NoError(b, err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.6.0
 	github.com/gorilla/mux v1.8.0
-	github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56
+	github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
 	github.com/hashicorp/consul/api v1.15.3
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56 h1:X8IKQ0wu40wpvYcKfBcc5T4QnhdQjUhtUtB/1CY89lE=
-github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
+github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1 h1:vR5nELq+KtGO+IiGW+AclWeQ7uhLHCEz/zyQwbQVNnQ=
+github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=

--- a/ring/example/local/go.mod
+++ b/ring/example/local/go.mod
@@ -2,8 +2,6 @@ module github.com/grafana/dskit/ring/example/local
 
 go 1.21
 
-toolchain go1.22.4
-
 require (
 	github.com/go-kit/log v0.2.1
 	github.com/grafana/dskit v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
**What this PR does**:

Improve the performance of the jump hash Memcached ServerSelector implementation by _not_ delegating to the default implementation in `grafana/gomemcache`. This avoids the need to iterate through the entire list of servers to pick a single address.

I've tested the new implementation along side the original and the results (which server was picked for which key) were identical. Performance is about 3-4X better.

**Which issue(s) this PR fixes**:

See https://github.com/grafana/gomemcache/pull/22

**Checklist**
- [X] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
