### PR TITLE
Memcached: Change `dns_initialization_enabled` for `dns_ignore_startup_failures`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@
   * `-server.cluster-validation.grpc.soft-validation`
   * `-server.cluster-validation.grpc.enabled`
 * [FEATURE] Add `ring.GetWithOptions()` method to support additional features at a per-call level. #632
-* [ENHANCEMENT] Add feature flag to make Memcached soft-dependency on startup. If so, `Initialize()` will have to be called after client creation. #647
+* [ENHANCEMENT] Add feature flag to make Memcached soft-dependency on startup. If so, DNS failures on startup will be ignored on client creation. #647, #658
 * [ENHANCEMENT] Add option to hide token information in ring status page #633
 * [ENHANCEMENT] Display token information in partition ring status page #631
 * [ENHANCEMENT] Add ability to log all source hosts from http header instead of only the first one. #444


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR is a followup of #647, it tries to simplify usability of the client by using the config flag to ignore DNS startup failures or not.

- Cache is an interface, so whenever we create the cache,  I would argue that we need to return something directly usable.
- Using a config variable to give the user the freedom to call a method right after creating the client seemed a little bit redundant, using the config variable to decide preferred behavior of error handling looks cleaner to me.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
