### PR TITLE
flagext: Go-cmp support for Secret

### DIFF
--- a/flagext/secret.go
+++ b/flagext/secret.go
@@ -38,6 +38,7 @@ func (v Secret) MarshalYAML() (interface{}, error) {
 	return "********", nil
 }
 
+// Equal implements go-cmp equality.
 func (v Secret) Equal(other Secret) bool {
 	return v.value == other.value
 }

--- a/flagext/secret.go
+++ b/flagext/secret.go
@@ -37,3 +37,7 @@ func (v Secret) MarshalYAML() (interface{}, error) {
 	}
 	return "********", nil
 }
+
+func (v Secret) Equal(other Secret) bool {
+	return v.value == other.value
+}

--- a/flagext/secret_test.go
+++ b/flagext/secret_test.go
@@ -3,6 +3,7 @@ package flagext
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -74,4 +75,59 @@ func TestSecretdYAML(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, testStruct, actualStruct)
 	}
+}
+
+func TestSecretEquals(t *testing.T) {
+	t.Run("equal", func(t *testing.T) {
+		tc := []struct {
+			name string
+			s1   Secret
+			s2   Secret
+		}{
+			{
+				name: "same value",
+				s1:   Secret{value: "somesecret"},
+				s2:   Secret{value: "somesecret"},
+			},
+			{
+				name: "empty value",
+				s1:   Secret{value: ""},
+				s2:   Secret{value: ""},
+			},
+		}
+
+		for _, tt := range tc {
+			require.True(t, tt.s1.Equal(tt.s2), cmp.Diff(tt.s1, tt.s2))
+			require.True(t, cmp.Equal(tt.s1, tt.s2), cmp.Diff(tt.s1, tt.s2))
+		}
+	})
+
+	t.Run("not equal", func(t *testing.T) {
+		tc := []struct {
+			name string
+			s1   Secret
+			s2   Secret
+		}{
+			{
+				name: "different value",
+				s1:   Secret{value: "somesecret"},
+				s2:   Secret{value: "anothersecret"},
+			},
+			{
+				name: "MarshalYAMLs to same value but different",
+				s1:   Secret{value: "secretone"},
+				s2:   Secret{value: "secrettwo"},
+			},
+			{
+				name: "one empty value",
+				s1:   Secret{value: "somesecret"},
+				s2:   Secret{value: ""},
+			},
+		}
+
+		for _, tt := range tc {
+			require.False(t, tt.s1.Equal(tt.s2), cmp.Diff(tt.s1, tt.s2))
+			require.False(t, cmp.Equal(tt.s1, tt.s2), cmp.Diff(tt.s1, tt.s2))
+		}
+	})
 }


### PR DESCRIPTION
**What this PR does**:

Go-cmp on any type containing a flagext.Secret panics due to the unexported field, without supplying specific options that may not be generally desirable.

Mimir expects its configuration objects to be comparable with go-cmp. The other flagext types generally implicitly support it, by using either exported inner fields or type aliases.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
