### PR TITLE
dns: New resolver backend "miekgdns2" with reliability improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * [CHANGE] memberlist: Failure to fast-join a cluster via contacting a node is now logged at `info` instead of `debug`. #585
 * [CHANGE] `Service.AddListener` and `Manager.AddListener` now return function for stopping the listener. #564
 * [CHANGE] ring: Add `InstanceRingReader` interface to `ring` package. #597
+* [CHANGE] DNS: Introduce new `miekgdns2` resolver backend type with experimental DNS client. #660
 * [CHANGE] Server: The `PerTenantDurationInstrumentation` config option was renamed to `PerTenantInstrumentation` and now allows specifying whether a full histogram should be recorded or only a counter #642
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279

--- a/dns/miekgdns2/resolver.go
+++ b/dns/miekgdns2/resolver.go
@@ -1,0 +1,356 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/discovery/dns/miekgdns/resolver.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package miekgdns2
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+
+	"github.com/grafana/dskit/multierror"
+)
+
+const (
+	DefaultResolvConfPath  = "/etc/resolv.conf"
+	defaultMaxConnsPerHost = 2
+)
+
+type Client interface {
+	Exchange(ctx context.Context, msg *dns.Msg, server string) (*dns.Msg, time.Duration, error)
+	Clean(known []string)
+}
+
+// Resolver is a DNS service discovery backend that retries on errors, only uses TCP,
+// and pools connections to nameservers to increase reliability.
+//
+// This backend:
+// * Does _not_ use search domains, all names are assumed to be fully qualified
+// * Only uses TCP connections to the nameservers
+// * Keeps several connections to each nameserver open
+// * Reads resolv.conf on every query
+// * Closes connections to unknown nameservers on every query
+type Resolver struct {
+	confPath string
+	client   Client
+}
+
+// NewResolver creates a new Resolver that uses the provided resolv.conf configuration
+// to perform DNS queries.
+func NewResolver(resolvConf string) *Resolver {
+	return NewResolverWithClient(resolvConf, NewPoolingClient(defaultMaxConnsPerHost))
+}
+
+// NewResolverWithClient creates a new Resolver that uses the provided resolv.conf configuration
+// and Client implementation to perform DNS queries.
+func NewResolverWithClient(resolvConf string, client Client) *Resolver {
+	return &Resolver{
+		confPath: resolvConf,
+		client:   client,
+	}
+}
+
+func (r *Resolver) IsNotFound(error) bool {
+	// We don't return an error when there are no hosts found so this is
+	// always false. Instead, we return the empty DNS response with the
+	// appropriate return code set.
+	return false
+}
+
+func (r *Resolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	servers, conf, err := r.loadConfiguration()
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Close connections to nameservers no longer configured in resolv.conf
+	r.client.Clean(servers)
+	return r.lookupSRV(ctx, servers, conf, service, proto, name)
+}
+
+func (r *Resolver) lookupSRV(ctx context.Context, servers []string, conf *dns.ClientConfig, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	var target string
+	if service == "" && proto == "" {
+		target = name
+	} else {
+		target = "_" + service + "._" + proto + "." + name
+	}
+
+	response, err := r.query(ctx, servers, conf.Attempts, target, dns.Type(dns.TypeSRV))
+	if err != nil {
+		return "", nil, err
+	}
+
+	for _, record := range response.Answer {
+		switch addr := record.(type) {
+		case *dns.SRV:
+			addrs = append(addrs, &net.SRV{
+				Weight:   addr.Weight,
+				Target:   addr.Target,
+				Priority: addr.Priority,
+				Port:     addr.Port,
+			})
+		default:
+			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+		}
+	}
+
+	return "", addrs, err
+}
+
+func (r *Resolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	servers, conf, err := r.loadConfiguration()
+	if err != nil {
+		return nil, err
+	}
+
+	// Close connections to nameservers no longer configured in resolv.conf
+	r.client.Clean(servers)
+	return r.lookupIPAddr(ctx, servers, conf, host, 1, 8)
+}
+
+func (r *Resolver) lookupIPAddr(ctx context.Context, servers []string, conf *dns.ClientConfig, host string, currIteration, maxIterations int) ([]net.IPAddr, error) {
+	// We want to protect from infinite loops when resolving DNS records recursively.
+	if currIteration > maxIterations {
+		return nil, fmt.Errorf("maximum number of recursive iterations reached (%d)", maxIterations)
+	}
+
+	response, err := r.query(ctx, servers, conf.Attempts, host, dns.Type(dns.TypeAAAA))
+	if err != nil || len(response.Answer) == 0 {
+		// Ugly fallback to A lookup.
+		response, err = r.query(ctx, servers, conf.Attempts, host, dns.Type(dns.TypeA))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var resp []net.IPAddr
+	for _, record := range response.Answer {
+		switch addr := record.(type) {
+		case *dns.A:
+			resp = append(resp, net.IPAddr{IP: addr.A})
+		case *dns.AAAA:
+			resp = append(resp, net.IPAddr{IP: addr.AAAA})
+		case *dns.CNAME:
+			// Recursively resolve it.
+			addrs, err := r.lookupIPAddr(ctx, servers, conf, addr.Target, currIteration+1, maxIterations)
+			if err != nil {
+				return nil, fmt.Errorf("%w: recursively resolve %s", err, addr.Target)
+			}
+			resp = append(resp, addrs...)
+		default:
+			return nil, fmt.Errorf("invalid A, AAAA or CNAME response record %s", record)
+		}
+	}
+	return resp, nil
+}
+
+func (r *Resolver) query(ctx context.Context, servers []string, attempts int, name string, qType dns.Type) (*dns.Msg, error) {
+	// We don't support search domains, all names are assumed to be fully qualified already.
+	msg := new(dns.Msg).SetQuestion(dns.Fqdn(name), uint16(qType))
+
+	merr := multierror.New()
+	// `man 5 resolv.conf` says that we should try each server, continuing to the next if
+	// there is a timeout. We should repeat this process up to "attempt" times trying to get
+	// a viable response.
+	//
+	// > (The algorithm used is to try a name server, and if the query times out, try the next,
+	// > until out of name servers, then repeat trying all the name servers until a maximum number
+	// > of retries are made.)
+	for i := 0; i < attempts; i++ {
+		for _, server := range servers {
+			response, _, err := r.client.Exchange(ctx, msg, server)
+			if err != nil {
+				merr.Add(fmt.Errorf("resolution against server %s for %s: %w", server, name, err))
+				continue
+			}
+
+			if response.Truncated {
+				merr.Add(fmt.Errorf("resolution against server %s for %s: response truncated", server, name))
+				continue
+			}
+
+			if response.Rcode == dns.RcodeSuccess || response.Rcode == dns.RcodeNameError {
+				return response, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("could not resolve %s: no servers returned a viable answer. Errs %s", name, merr.Err())
+}
+
+// loadConfiguration parses and returns a resolv.conf configuration and builds a list of
+// nameservers of the form "ip:port" for convenience. Returns an error if the file cannot
+// be loaded or is not syntactically valid.
+func (r *Resolver) loadConfiguration() ([]string, *dns.ClientConfig, error) {
+	conf, err := dns.ClientConfigFromFile(r.confPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not load resolv.conf: %w", err)
+	}
+
+	servers := make([]string, len(conf.Servers))
+	for i, nameserver := range conf.Servers {
+		servers[i] = net.JoinHostPort(nameserver, conf.Port)
+	}
+
+	return servers, conf, nil
+}
+
+// PoolingClient is a DNS client that pools TCP connections to each nameserver.
+type PoolingClient struct {
+	network string
+	maxOpen int
+
+	mtx   sync.Mutex
+	pools map[string]*Pool
+}
+
+// NewPoolingClient creates a new PoolingClient instance that keeps up to maxOpen connections to each nameserver.
+func NewPoolingClient(maxOpen int) *PoolingClient {
+	return &PoolingClient{
+		network: "tcp",
+		maxOpen: maxOpen,
+		pools:   make(map[string]*Pool),
+	}
+}
+
+// Exchange sends the DNS msg to the nameserver using a pooled connection. The nameserver must be
+// of the form "ip:port".
+func (c *PoolingClient) Exchange(ctx context.Context, msg *dns.Msg, server string) (*dns.Msg, time.Duration, error) {
+	pool := c.getPool(server)
+	conn, err := pool.Get(ctx, c.network, server)
+	if err != nil {
+		return nil, 0, fmt.Errorf("unable to create connection to %s via %s: %w", server, c.network, err)
+	}
+
+	connOk := true
+	defer func() {
+		if connOk {
+			_ = pool.Put(conn)
+		} else {
+			pool.Discard(conn)
+		}
+	}()
+
+	client := &dns.Client{Net: c.network}
+	response, rtt, err := client.ExchangeWithConnContext(ctx, msg, conn)
+	if err != nil {
+		connOk = false
+	}
+
+	return response, rtt, err
+}
+
+// Clean closes connections to any nameservers that are _not_ part of list of known
+// nameservers. The nameservers must be of the form "ip:port", the same format as the
+// Exchange method.
+func (c *PoolingClient) Clean(known []string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	for server, pool := range c.pools {
+		if slices.Contains(known, server) {
+			continue
+		}
+
+		pool.Close()
+		delete(c.pools, server)
+	}
+}
+
+func (c *PoolingClient) getPool(server string) *Pool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	p, ok := c.pools[server]
+	if !ok {
+		p = NewPool(c.maxOpen)
+		c.pools[server] = p
+	}
+
+	return p
+}
+
+// Pool is a pool of DNS connections for a single DNS server.
+type Pool struct {
+	mtx    sync.RWMutex
+	conns  chan *dns.Conn
+	closed bool
+}
+
+// NewPool creates a new DNS connection Pool, keeping up to maxConns open.
+func NewPool(maxConns int) *Pool {
+	return &Pool{
+		conns: make(chan *dns.Conn, maxConns),
+	}
+}
+
+// Get gets an existing connection from the pool or creates a new one if there are no
+// pooled connections available. If the pool has been closed, an error is returned.
+func (p *Pool) Get(ctx context.Context, network string, server string) (*dns.Conn, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.closed {
+		return nil, fmt.Errorf("connection pool for %s %s is closed", network, server)
+	}
+
+	select {
+	case conn := <-p.conns:
+		return conn, nil
+	default:
+		return p.newConn(ctx, network, server)
+	}
+}
+
+// Put returns a healthy connection to the pool, potentially closing it if the pool is
+// already at capacity. If the pool has been closed, the connection will be closed immediately.
+func (p *Pool) Put(conn *dns.Conn) error {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.closed {
+		return conn.Close()
+	}
+
+	select {
+	case p.conns <- conn:
+		return nil
+	default:
+		return conn.Close()
+	}
+}
+
+// Discard closes and does not return the given broken connection to the pool.
+func (p *Pool) Discard(conn *dns.Conn) {
+	_ = conn.Close()
+}
+
+// Close shuts down this pool, closing all existing connections and preventing new connections
+// from being created. Any attempts to get a connection from this pool after it is closed will
+// result in an error.
+func (p *Pool) Close() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	p.closed = true
+	for {
+		select {
+		case c := <-p.conns:
+			_ = c.Close()
+		default:
+			return
+		}
+	}
+}
+
+func (p *Pool) newConn(ctx context.Context, network string, server string) (*dns.Conn, error) {
+	client := &dns.Client{Net: network}
+	return client.DialContext(ctx, server)
+}

--- a/dns/miekgdns2/resolver.go
+++ b/dns/miekgdns2/resolver.go
@@ -237,17 +237,21 @@ func (r *Resolver) loadConfig() error {
 		return fmt.Errorf("could not load %s: %w", r.confPath, err)
 	}
 
+	// Note that we're building the list of known servers for the r.client.Clean method
+	// below from the newly read configuration before updating r.conf so that we know
+	// that the configuration can't be modified by another thread.
 	servers := make([]string, len(conf.Servers))
 	for i, ip := range conf.Servers {
 		servers[i] = net.JoinHostPort(ip, conf.Port)
 	}
 
-	// Close connections to any servers that are no longer in resolv.conf.
-	r.client.Clean(servers)
-
 	r.mtx.Lock()
 	r.conf = conf
 	r.mtx.Unlock()
+
+	// Close connections to any servers that are no longer in resolv.conf.
+	r.client.Clean(servers)
+
 	return nil
 }
 

--- a/dns/miekgdns2/resolver_test.go
+++ b/dns/miekgdns2/resolver_test.go
@@ -61,6 +61,18 @@ func TestResolver_ConfigParsing(t *testing.T) {
 		require.Equal(t, []string{"127.0.0.53"}, conf.Servers)
 		require.Equal(t, 3, conf.Attempts)
 	})
+
+	t.Run("unknown settings ignored", func(t *testing.T) {
+		cfgPath := writeResovConf(t, tmpDir, "nameserver 127.0.0.53\noptions attempts:3\nfoo bar\noptions whatever:4\noptions single-request\n")
+		client := newMockClient()
+
+		resolver := NewResolverWithClient(cfgPath, logger, period, client)
+		t.Cleanup(resolver.Stop)
+
+		conf := resolver.getConfig()
+		require.Equal(t, []string{"127.0.0.53"}, conf.Servers)
+		require.Equal(t, 3, conf.Attempts)
+	})
 }
 
 func TestResolver_LookupSRV(t *testing.T) {

--- a/dns/miekgdns2/resolver_test.go
+++ b/dns/miekgdns2/resolver_test.go
@@ -1,0 +1,323 @@
+package miekgdns2
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+var resolvConfContents = `
+nameserver 127.0.0.1
+nameserver 127.0.0.2
+option attempts:2
+option timeout:1
+`
+
+func TestResolver_LookupSRV(t *testing.T) {
+	t.Run("bad resolv.conf", func(t *testing.T) {
+		cfgPath := path.Join(t.TempDir(), "resolv.conf")
+		client := newMockClient()
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		_, _, err := resolver.LookupSRV(context.Background(), "cache", "tcp", "example.com")
+
+		require.Error(t, err)
+	})
+
+	t.Run("multiple timeouts", func(t *testing.T) {
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		client.err["127.0.0.1:53"] = errors.New("timeout 1 in test")
+		client.err["127.0.0.2:53"] = errors.New("timeout 2 in test")
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		_, _, err := resolver.LookupSRV(context.Background(), "cache", "tcp", "example.com")
+
+		require.Error(t, err)
+	})
+
+	t.Run("one timeout and one success", func(t *testing.T) {
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		client.err["127.0.0.1:53"] = errors.New("timeout 1 in test")
+		client.res["127.0.0.2:53"] = []*dns.Msg{newSrvDNSResponse("_cache._tcp.example.com.", "cache01.example.com.")}
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		_, res, err := resolver.LookupSRV(context.Background(), "cache", "tcp", "example.com")
+
+		require.Equal(t, []*net.SRV{
+			{
+				Target:   "cache01.example.com.",
+				Port:     11211,
+				Priority: 10,
+				Weight:   100,
+			},
+		}, res)
+		require.NoError(t, err)
+	})
+
+	t.Run("name error", func(t *testing.T) {
+		response := new(dns.Msg).SetQuestion("_cache._tcp.example.com.", dns.TypeSRV)
+		response.Rcode = dns.RcodeNameError
+		response.Response = true
+
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		client.err["127.0.0.1:53"] = errors.New("timeout 1 in test")
+		client.res["127.0.0.2:53"] = []*dns.Msg{response}
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		_, res, err := resolver.LookupSRV(context.Background(), "cache", "tcp", "example.com")
+
+		require.Empty(t, res)
+		require.NoError(t, err)
+	})
+
+	t.Run("truncated", func(t *testing.T) {
+		response := newSrvDNSResponse("_cache._tcp.example.com.", "cache01.example.com.")
+		response.Truncated = true
+
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		// Include two responses, one for each attempt made since truncation triggers retries
+		client.res["127.0.0.1:53"] = []*dns.Msg{response, response}
+		client.err["127.0.0.2:53"] = errors.New("timeout 2 in test")
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		_, res, err := resolver.LookupSRV(context.Background(), "cache", "tcp", "example.com")
+
+		require.Nil(t, res)
+		require.Error(t, err)
+	})
+}
+
+func TestResolver_LookupIP(t *testing.T) {
+	t.Run("bad resolv.conf", func(t *testing.T) {
+		cfgPath := path.Join(t.TempDir(), "resolv.conf")
+		client := newMockClient()
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		_, err := resolver.LookupIPAddr(context.Background(), "cache01.example.com.")
+
+		require.Error(t, err)
+	})
+
+	t.Run("multiple timeouts", func(t *testing.T) {
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		client.err["127.0.0.1:53"] = errors.New("timeout 1 in test")
+		client.err["127.0.0.2:53"] = errors.New("timeout 2 in test")
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		_, err := resolver.LookupIPAddr(context.Background(), "cache01.example.com.")
+
+		require.Error(t, err)
+	})
+
+	t.Run("one timeout and one success", func(t *testing.T) {
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		client.err["127.0.0.1:53"] = errors.New("timeout 1 in test")
+		client.res["127.0.0.2:53"] = []*dns.Msg{newIPDNSResponse("cache01.example.com.", net.IPv4(10, 0, 0, 1))}
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		res, err := resolver.LookupIPAddr(context.Background(), "cache01.example.com")
+
+		require.Equal(t, []net.IPAddr{{IP: net.IPv4(10, 0, 0, 1)}}, res)
+		require.NoError(t, err)
+	})
+
+	t.Run("name error", func(t *testing.T) {
+		response1 := new(dns.Msg).SetQuestion("cache01.example.com.", dns.TypeAAAA)
+		response1.Rcode = dns.RcodeNameError
+		response1.Response = true
+
+		response2 := new(dns.Msg).SetQuestion("cache01.example.com.", dns.TypeA)
+		response2.Rcode = dns.RcodeNameError
+		response2.Response = true
+
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		client.err["127.0.0.1:53"] = errors.New("timeout 1 in test")
+		// Include two responses since a failed AAAA lookup will result in an A fallback
+		client.res["127.0.0.2:53"] = []*dns.Msg{response1, response2}
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		res, err := resolver.LookupIPAddr(context.Background(), "cache01.example.com")
+
+		require.Empty(t, res)
+		require.NoError(t, err)
+	})
+
+	t.Run("one level of CNAME", func(t *testing.T) {
+		cfgPath := writeResovConf(t, resolvConfContents)
+		client := newMockClient()
+		client.err["127.0.0.1:53"] = errors.New("timeout 1 in test")
+		client.res["127.0.0.2:53"] = []*dns.Msg{
+			newCnameDNSResponse("cache01.example.com.", "cache01.east.example.com."),
+			newIPDNSResponse("cache01.east.example.com.", net.IPv4(10, 0, 0, 1)),
+		}
+
+		resolver := NewResolverWithClient(cfgPath, client)
+		res, err := resolver.LookupIPAddr(context.Background(), "cache01.example.com")
+
+		require.Equal(t, []net.IPAddr{{IP: net.IPv4(10, 0, 0, 1)}}, res)
+		require.NoError(t, err)
+	})
+}
+
+func TestPoolingClient(t *testing.T) {
+	// NOTE: This test talks to the local DNS server over the network
+
+	conf := getClientConfig(t)
+	server := net.JoinHostPort(conf.Servers[0], conf.Port)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	msg := new(dns.Msg).SetQuestion(dns.Fqdn("localhost"), dns.TypeA)
+	client := NewPoolingClient(defaultMaxConnsPerHost)
+
+	t.Run("exchange", func(t *testing.T) {
+		resp, _, err := client.Exchange(ctx, msg, server)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Answer)
+		require.Len(t, client.pools, 1)
+	})
+
+	t.Run("clean", func(t *testing.T) {
+		client.Clean([]string{})
+		require.Empty(t, client.pools)
+	})
+}
+
+func TestPool(t *testing.T) {
+	// NOTE: This test talks to the local DNS server over the network
+
+	conf := getClientConfig(t)
+	server := net.JoinHostPort(conf.Servers[0], conf.Port)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	pool := NewPool(defaultMaxConnsPerHost)
+	var conn *dns.Conn
+	var err error
+
+	t.Run("get connection", func(t *testing.T) {
+		conn, err = pool.Get(ctx, "tcp", server)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+	})
+
+	t.Run("put connection", func(t *testing.T) {
+		require.NoError(t, pool.Put(conn))
+	})
+
+	t.Run("close", func(t *testing.T) {
+		pool.Close()
+		_, err = pool.Get(ctx, "tcp", server)
+		require.Error(t, err)
+	})
+}
+
+type mockClient struct {
+	err     map[string]error
+	res     map[string][]*dns.Msg
+	cleaned atomic.Uint64
+}
+
+func newMockClient() *mockClient {
+	return &mockClient{
+		err: make(map[string]error),
+		res: make(map[string][]*dns.Msg),
+	}
+}
+
+func (m *mockClient) Exchange(_ context.Context, _ *dns.Msg, server string) (*dns.Msg, time.Duration, error) {
+	if err, ok := m.err[server]; ok {
+		return nil, 0, err
+	}
+
+	// Shift the first element off the front of the slice
+	response := m.res[server][0]
+	m.res[server] = m.res[server][1:]
+
+	return response, 0, nil
+}
+
+func (m *mockClient) Clean([]string) {
+	m.cleaned.Add(1)
+}
+
+func writeResovConf(t *testing.T, contents string) string {
+	p := path.Join(t.TempDir(), "resolv.conf")
+	require.NoError(t, os.WriteFile(p, []byte(contents), 0777))
+	return p
+}
+
+func getClientConfig(t *testing.T) *dns.ClientConfig {
+	conf, err := dns.ClientConfigFromFile(DefaultResolvConfPath)
+	require.NoError(t, err)
+	return conf
+}
+
+func newSrvDNSResponse(host string, target string) *dns.Msg {
+	request := new(dns.Msg).SetQuestion(host, dns.TypeSRV)
+	response := new(dns.Msg).SetReply(request)
+	response.Answer = append(response.Answer, &dns.SRV{
+		Hdr: dns.RR_Header{
+			Name:     host,
+			Rrtype:   dns.TypeSRV,
+			Class:    dns.ClassINET,
+			Ttl:      30,
+			Rdlength: 0, // our client ignores the header
+		},
+		Priority: 10,
+		Weight:   100,
+		Port:     11211,
+		Target:   target,
+	})
+
+	return response
+}
+
+func newIPDNSResponse(host string, addr net.IP) *dns.Msg {
+	request := new(dns.Msg).SetQuestion(host, dns.TypeA)
+	response := new(dns.Msg).SetReply(request)
+	response.Answer = append(response.Answer, &dns.A{
+		Hdr: dns.RR_Header{
+			Name:     host,
+			Rrtype:   dns.TypeA,
+			Class:    dns.ClassINET,
+			Ttl:      30,
+			Rdlength: 4,
+		},
+		A: addr,
+	})
+
+	return response
+}
+
+func newCnameDNSResponse(host string, target string) *dns.Msg {
+	request := new(dns.Msg).SetQuestion(host, dns.TypeCNAME)
+	response := new(dns.Msg).SetReply(request)
+	response.Answer = append(response.Answer, &dns.CNAME{
+		Hdr: dns.RR_Header{
+			Name:     host,
+			Rrtype:   dns.TypeCNAME,
+			Class:    dns.ClassINET,
+			Ttl:      30,
+			Rdlength: 4,
+		},
+		Target: target,
+	})
+
+	return response
+}

--- a/dns/miekgdns2/resolver_test.go
+++ b/dns/miekgdns2/resolver_test.go
@@ -78,7 +78,7 @@ func TestResolver_LookupSRV(t *testing.T) {
 		t.Cleanup(resolver.Stop)
 		_, _, err := resolver.LookupSRV(context.Background(), "cache", "tcp", "example.com")
 
-		require.Error(t, err)
+		require.ErrorContains(t, err, "timeout")
 	})
 
 	t.Run("one timeout and one success", func(t *testing.T) {

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -65,6 +65,7 @@ func (t ResolverType) toResolver(logger log.Logger) ipLookupResolver {
 	case MiekgdnsResolverType:
 		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath}
 	case MiekgdnsResolverType2:
+		level.Info(logger).Log("msg", "using experimental DNS resolver type", "type", t)
 		r = miekgdns2.NewResolver(miekgdns2.DefaultResolvConfPath, logger)
 	default:
 		level.Warn(logger).Log("msg", "no such resolver type, defaulting to golang", "type", t)

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -64,7 +64,7 @@ func (t ResolverType) toResolver(logger log.Logger) ipLookupResolver {
 	case MiekgdnsResolverType:
 		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath}
 	case MiekgdnsResolverType2:
-		r = miekgdns2.NewResolver(miekgdns2.DefaultResolvConfPath)
+		r = miekgdns2.NewResolver(miekgdns2.DefaultResolvConfPath, logger)
 	default:
 		level.Warn(logger).Log("msg", "no such resolver type, defaulting to golang", "type", t)
 		r = &godns.Resolver{Resolver: net.DefaultResolver}

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -47,9 +47,10 @@ func (t ResolverType) String() string {
 	return string(t)
 }
 
-func (t ResolverType) Set(v string) error {
+func (t *ResolverType) Set(v string) error {
 	switch ResolverType(v) {
 	case GolangResolverType, MiekgdnsResolverType, MiekgdnsResolverType2:
+		*t = ResolverType(v)
 		return nil
 	default:
 		return fmt.Errorf("unsupported resolver type %s", v)

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -6,6 +6,7 @@ package dns
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/grafana/dskit/dns/godns"
 	"github.com/grafana/dskit/dns/miekgdns"
+	"github.com/grafana/dskit/dns/miekgdns2"
 	"github.com/grafana/dskit/multierror"
 )
 
@@ -36,17 +38,33 @@ type Provider struct {
 type ResolverType string
 
 const (
-	GolangResolverType   ResolverType = "golang"
-	MiekgdnsResolverType ResolverType = "miekgdns"
+	GolangResolverType    ResolverType = "golang"
+	MiekgdnsResolverType  ResolverType = "miekgdns"
+	MiekgdnsResolverType2 ResolverType = "miekgdns2"
 )
 
-func (t ResolverType) ToResolver(logger log.Logger) ipLookupResolver {
+func (t ResolverType) String() string {
+	return string(t)
+}
+
+func (t ResolverType) Set(v string) error {
+	switch ResolverType(v) {
+	case GolangResolverType, MiekgdnsResolverType, MiekgdnsResolverType2:
+		return nil
+	default:
+		return fmt.Errorf("unsupported resolver type %s", v)
+	}
+}
+
+func (t ResolverType) toResolver(logger log.Logger) ipLookupResolver {
 	var r ipLookupResolver
 	switch t {
 	case GolangResolverType:
 		r = &godns.Resolver{Resolver: net.DefaultResolver}
 	case MiekgdnsResolverType:
 		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath}
+	case MiekgdnsResolverType2:
+		r = miekgdns2.NewResolver(miekgdns2.DefaultResolvConfPath)
 	default:
 		level.Warn(logger).Log("msg", "no such resolver type, defaulting to golang", "type", t)
 		r = &godns.Resolver{Resolver: net.DefaultResolver}
@@ -58,7 +76,7 @@ func (t ResolverType) ToResolver(logger log.Logger) ipLookupResolver {
 // If empty resolver type is net.DefaultResolver.
 func NewProvider(logger log.Logger, reg prometheus.Registerer, resolverType ResolverType) *Provider {
 	p := &Provider{
-		resolver: NewResolver(resolverType.ToResolver(logger), logger),
+		resolver: NewResolver(resolverType.toResolver(logger), logger),
 		resolved: make(map[string][]string),
 		logger:   logger,
 		resolverAddrsDesc: prometheus.NewDesc(

--- a/dns/provider_test.go
+++ b/dns/provider_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProvider(t *testing.T) {
@@ -145,4 +146,21 @@ func TestIsDynamicNode(t *testing.T) {
 		isDynamic := IsDynamicNode(tcase.node)
 		assert.Equal(t, tcase.isDynamic, isDynamic, "mismatch between results")
 	}
+}
+
+func TestResolverType(t *testing.T) {
+	t.Run("set valid types", func(t *testing.T) {
+		for _, val := range []string{"golang", "miekgdns", "miekgdns2"} {
+			var rt ResolverType
+			require.NoError(t, rt.Set(val))
+			require.Equal(t, val, rt.String())
+		}
+	})
+
+	t.Run("set invalid types", func(t *testing.T) {
+		for _, val := range []string{"dns+golang", "invalid", "miekgdns27"} {
+			var rt ResolverType
+			require.Error(t, rt.Set(val))
+		}
+	})
 }


### PR DESCRIPTION
**What this PR does**:

Create a new version of the `dns/miekgdns` package with changes to improve the reliability of queries since they are typically used for service discovery.

The notable changes:
* Search domains are not supported. We don't use them, when they are used they put more load on DNS servers, and they make the behavior of resolution harder to understand.
* Always use TCP for queries, don't start with UDP. We're using DNS for service discovery and the result size is usually large enough that TCP must be used anyway. Instead of starting with UDP and needing to wait N seconds to know if the packet was dropped - just start with TCP. [TCP support for DNS is required as of RFC 7766](https://datatracker.ietf.org/doc/html/rfc7766.txt).
* Pool connections to DNS servers. Instead of creating new UDP and TCP sockets for every query, we keep TCP connections to DNS servers open and reuse them if possible.
* Use the "attempts" option from /etc/resolv.conf. Instead of failing the query immediately due to network issues, we retry based on the "attempts" setting which is 2 by default.

This change also makes the resolver backend used by the Memcached client configurable so that we can test the new backend before making it the default implementation.

**Which issue(s) this PR fixes**:

N/A

**Notes for reviewers**:

* `Resolver` is the majority of this change. `miekgdns2.Resolver` serves the same purpose as `miekgdns.Resolver` - doing A, AAAA, and SRV DNS requests to discover a list of servers.
* `PoolingClient` is a thin wrapper over the `dns.Client` type that supports keeping connections to each nameserver open. It maintains a `Pool` instance for each nameserver.
* `Pool` is a pool of connections to a single server that stores them in a channel, [roughly based on the `filePool` type](https://github.com/grafana/mimir/blob/5126fa342b148c70fcb7385e993f561515a67bbb/pkg/storage/indexheader/encoding/factory.go#L168-L182) in Mimir.
 

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
