### PR TITLE
Usage tracker: support ownership of multiple partitions, read-only in basic lifecycler and write replica selection

### DIFF
--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -546,7 +546,7 @@ func (l *BasicLifecycler) changeReadOnlyState(ctx context.Context, readOnly bool
 			i.ReadOnlyUpdatedTimestamp = time.Now().Unix()
 		} else {
 			i.ReadOnly = false
-			i.ReadOnlyUpdatedTimestamp = 0
+			i.ReadOnlyUpdatedTimestamp = time.Now().Unix()
 		}
 		return true
 	})

--- a/ring/partition_instance_ring.go
+++ b/ring/partition_instance_ring.go
@@ -2,7 +2,9 @@ package ring
 
 import (
 	"fmt"
+	"math"
 	"slices"
+	"strconv"
 	"time"
 )
 
@@ -88,14 +90,15 @@ func (r *PartitionInstanceRing) GetReplicationSetsForOperation(op Operation) ([]
 
 // GetReplicationSetForPartitionAndOperation returns a ReplicationSet for the input partition. If the partition doesn't
 // exist or there are no healthy owners for the partition, an error is returned.
-// // pickHighestOwnerFromEachZone instructs to pick the highest instance from each zone when building the replication set.
-func (r *PartitionInstanceRing) GetReplicationSetForPartitionAndOperation(partitionID int32, op Operation, pickHighestOwnerFromEachZone bool) (ReplicationSet, error) {
+// pickHighestPreferrablyNonReadOnlyOwnerFromEachZone instructs to pick the highest instance from each zone when building the replication set,
+// non-read-only instances are preferred over read-only instances (this is more important than picking the highest instance).
+func (r *PartitionInstanceRing) GetReplicationSetForPartitionAndOperation(partitionID int32, op Operation, pickHighestPreferrablyNonReadOnlyOwnerFromEachZone bool) (ReplicationSet, error) {
 	var stackZonesBuffer [3]string // Pre-allocate buffer assuming 3 zones.
 
-	return r.getReplicationSetForPartitionAndOperation(partitionID, op, pickHighestOwnerFromEachZone, time.Now(), stackZonesBuffer[:])
+	return r.getReplicationSetForPartitionAndOperation(partitionID, op, pickHighestPreferrablyNonReadOnlyOwnerFromEachZone, time.Now(), stackZonesBuffer[:])
 }
 
-func (r *PartitionInstanceRing) getReplicationSetForPartitionAndOperation(partitionID int32, op Operation, pickHighestOwnerFromEachZone bool, now time.Time, zonesBuffer []string) (ReplicationSet, error) {
+func (r *PartitionInstanceRing) getReplicationSetForPartitionAndOperation(partitionID int32, op Operation, pickHighestPreferrablyNonReadOnlyOwnerFromEachZone bool, now time.Time, zonesBuffer []string) (ReplicationSet, error) {
 	const maxExpectedPartitionOwners = 16
 	var ownerIDs []string
 	var stackOwnerIDs [maxExpectedPartitionOwners]string
@@ -133,19 +136,8 @@ func (r *PartitionInstanceRing) getReplicationSetForPartitionAndOperation(partit
 	zonesBuffer = uniqueZonesFromInstances(instances, zonesBuffer[:0])
 	uniqueZones := len(zonesBuffer)
 
-	if pickHighestOwnerFromEachZone {
-		var stackAllInstances [maxExpectedPartitionOwners]InstanceDesc
-		allInstances := append(stackAllInstances[:0], instances...)
-		instances = instances[:0] // Reset, this is what we're going to return.
-		for _, zone := range zonesBuffer {
-			highest := -1
-			for i, instance := range allInstances {
-				if instance.Zone == zone && (highest == -1 || ownerIDs[i] > ownerIDs[highest]) {
-					highest = i
-				}
-			}
-			instances = append(instances, allInstances[highest])
-		}
+	if pickHighestPreferrablyNonReadOnlyOwnerFromEachZone {
+		instances = highestPreferrablyNonReadOnlyFromEachZone(instances, ownerIDs, zonesBuffer)
 	}
 
 	return ReplicationSet{
@@ -160,6 +152,73 @@ func (r *PartitionInstanceRing) getReplicationSetForPartitionAndOperation(partit
 		// we can do here is to just request a successful response from at least 1 zone.
 		MaxUnavailableZones: uniqueZones - 1,
 	}, nil
+}
+
+// this method expects instanceIDs to be in the same order as instances.
+// instanceIDs should hold the parsed multi-partition owner IDs.
+func highestPreferrablyNonReadOnlyFromEachZone(instances []InstanceDesc, instanceIDs []string, instanceZones []string) []InstanceDesc {
+	var stackAllInstances [16]InstanceDesc
+	allInstances := append(stackAllInstances[:0], instances...)
+	instances = instances[:0] // Reset, this is what we're going to return.
+	for _, zone := range instanceZones {
+		highest := -1
+		for i, instance := range allInstances {
+			if instance.Zone != zone {
+				// Not our zone.
+				continue
+			}
+
+			// Always pick the first one.
+			if highest == -1 {
+				highest = i
+				continue
+			}
+
+			// If highest is read-only, and this one is not, pick it without checking the order.
+			if allInstances[highest].ReadOnly && !instance.ReadOnly {
+				highest = i
+				continue
+			}
+
+			// If this one is read only, and highest is not, skip it.
+			if instance.ReadOnly && !allInstances[highest].ReadOnly {
+				continue
+			}
+
+			// If this one has a lower index than the one we have, skip it.
+			if indexFromInstanceSuffix(instanceIDs[i]) < indexFromInstanceSuffix(instanceIDs[highest]) {
+				continue
+			}
+
+			// This one is better than the one we have.
+			highest = i
+		}
+
+		// We know there's always a highest instance for a zone, because zones were calculated from instances.
+		instances = append(instances, allInstances[highest])
+	}
+	return instances
+}
+
+// indexFromInstanceSuffix returns the index from the instance suffix. The suffix is expected to be a number.
+func indexFromInstanceSuffix(instance string) int {
+	digitsSuffixLen := 0
+	for digitsSuffixLen < len(instance) {
+		i := len(instance) - digitsSuffixLen - 1
+		if instance[i] >= '0' && instance[i] <= '9' {
+			digitsSuffixLen++
+		} else {
+			break
+		}
+	}
+	if digitsSuffixLen == 0 {
+		return math.MaxInt64
+	}
+	index, err := strconv.Atoi(instance[len(instance)-digitsSuffixLen:])
+	if err != nil {
+		return math.MaxInt64 // Shouldn't happen, we already made sure that the suffix is a number.
+	}
+	return index
 }
 
 // ShuffleShard wraps PartitionRing.ShuffleShard().

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	shardUtil "github.com/grafana/dskit/ring/shard"
@@ -352,6 +353,31 @@ func (r *PartitionRing) PartitionOwnerIDsCopy(partitionID int32) []string {
 	}
 
 	return slices.Clone(ids)
+}
+
+// MultiPartitionOwnerIDs returns the ownerIDs of the given partitionID removing the suffix added to support ownership of multiple partitions.
+// The slice returned will try to use the provided buf, and it can be modified (it will modify the buf if it was used).
+func (r *PartitionRing) MultiPartitionOwnerIDs(partitionID int32, buf []string) []string {
+	ids := r.ownersByPartition[partitionID]
+	if len(ids) == 0 {
+		return nil
+	}
+
+	if cap(buf) < len(ids) {
+		buf = make([]string, len(ids))
+	} else {
+		buf = buf[:len(ids)]
+	}
+
+	for i, ownerID := range ids {
+		if p := strings.IndexByte(ownerID, '/'); p != -1 {
+			buf[i] = ownerID[:p]
+		} else {
+			// This isn't expected here: all owner IDs should have a suffix when multiple partitions can be owned.
+			buf[i] = ownerID
+		}
+	}
+	return buf
 }
 
 func (r *PartitionRing) String() string {


### PR DESCRIPTION
This merges into `usage-tracker` hackathon branch.

There are three main features implemented here:

### Support multiple partition ownership in PartitionInstanceRing. 

Since PartitionInstanceRing doesn't allow owning multiple partitions by a single instance out of the box, we workaround that by adding a well known suffix to the instance IDs owning the partitions, this suffix is built by adding a slash `/` and the partition that is being owned. I.e. `foo-zone-a-1/0` is `foo-zone-a-1` owning the partition `0`, while `foo-zone-a-1/2` is the same instance owning partition 2. This is being taken into account when calculating the replication set.

### Support selecting highest replica from each zone

By specifying a flag we can select only the highest replica from each zone: this is useful when a partition is being transferred to a different instance when scaling out. There's also a flag introduced to attempt select an non-readonly instance: this allows distributors to transfer the writes to the lower replica when scaling down the instance number and highest replicas become read-only.

### Add read-only state to BasicLifecycler

This is just a port of same functionality from Lifecycler, as we need it for Usage-Tracker.