### PR TITLE
Build with Go v1.24 / upgrade golangci-lint to v1.64.8

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.24.x'
       - name: Go mod check
         run: make mod-check
       - name: Lint
@@ -46,7 +46,7 @@ jobs:
       matrix:
         # We want to make sure dskit can support multiple golang versions
         # by ensuring the test would pass using all these supported versions.
-        go-version: ['1.21.x', '1.22.x', '1.23.x']
+        go-version: ['1.22.x', '1.23.x', '1.24.x']
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,10 @@ linters-settings:
       - (github.com/opentracing/opentracing-go.Tracer).Inject
   goimports:
     local-prefixes: "github.com/grafana/dskit"
+  revive:
+    rules:
+      - name: redefines-builtin-id
+        disabled: true
 run:
   timeout: 5m
   # List of build tags, all linters use it.

--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,10 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 	GOPATH=$(CURDIR)/.tools go install github.com/client9/misspell/cmd/misspell@v0.3.4
 
 .tools/bin/faillint: .tools
-	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.13.0
+	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.15.0
 
 .tools/bin/golangci-lint: .tools
-	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 
 .tools/bin/protoc: .tools
 ifeq ("$(wildcard .tools/protoc/bin/protoc)","")

--- a/crypto/tls/test/tls_integration_test.go
+++ b/crypto/tls/test/tls_integration_test.go
@@ -145,14 +145,14 @@ func newIntegrationClientServer(
 				if err == nil {
 					return false
 				}
-				return strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "broken pipe")
+				return strings.Contains(err.Error(), "connection reset by peer") ||
+					strings.Contains(err.Error(), "broken pipe") ||
+					strings.Contains(err.Error(), "client conn could not be established")
 			}
-			for i := 0; i < 3 && isRST(err) && tc.httpExpectError != nil; i++ {
+			for i := 0; i < 5 && isRST(err) && tc.httpExpectError != nil; i++ {
+				t.Logf("Sleeping before retry #%d, due to RST error: %s", i+1, err)
 				time.Sleep(100 * time.Millisecond)
 				resp, err = client.Do(req)
-				if err == nil {
-					defer resp.Body.Close()
-				}
 			}
 			if err == nil {
 				defer resp.Body.Close()

--- a/kv/memberlist/mergeable.go
+++ b/kv/memberlist/mergeable.go
@@ -33,7 +33,7 @@ type Mergeable interface {
 	// LocalCAS flag is used when doing Merge as part of local CAS operation on KV store. It can be used to detect
 	// missing entries, and generate tombstones. (This breaks commutativity and associativity [!] so it can *only* be
 	// used when doing CAS operation)
-	Merge(other Mergeable, localCAS bool) (change Mergeable, error error)
+	Merge(other Mergeable, localCAS bool) (change Mergeable, err error)
 
 	// MergeContent describes the content of this mergeable value. Used by memberlist client to decide if
 	// one change-value can invalidate some other value, that was received previously.


### PR DESCRIPTION
**What this PR does**:

Build with Go v1.24 in CI. This also requires upgrading golangci-lint to v1.64.8 and faillint to v1.15.0.

Dependency updates are blocked until we upgrade the Go version compatibility.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
