### PR TITLE
cache: Remove optional Memcached client read/write buffer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,6 @@
 * [ENHANCEMENT] Ring: clarify the message logged by `DoUntilQuorum` when the first failure in a zone occurs. #402
 * [ENHANCEMENT] Ring: include instance ID in log messages emitted by `DoUntilQuorum`. #402
 * [ENHANCEMENT] Ring: add support for aborting early if a terminal error is returned by a request initiated by `DoUntilQuorum`. #404 #413
-* [ENHANCEMENT] Memcached: allow to configure write and read buffer size (in bytes). #414
 * [ENHANCEMENT] Server: Add `-server.http-read-header-timeout` option to specify timeout for reading HTTP request header. It defaults to 0, in which case reading of headers can take up to `-server.http-read-timeout`, leaving no time for reading body, if there's any. #423
 * [ENHANCEMENT] Make httpgrpc.Server produce non-loggable errors when a header with key `httpgrpc.DoNotLogErrorHeaderKey` and any value is present in the HTTP response. #421
 * [ENHANCEMENT] Server: Add `-server.report-grpc-codes-in-instrumentation-label-enabled` CLI flag to specify whether gRPC status codes should be used in `status_code` label of request duration metric. It defaults to false, meaning that gRPC status codes are represented with `error` value. #424 #425

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -34,8 +34,6 @@ const (
 var (
 	ErrNoMemcachedAddresses                    = errors.New("no memcached addresses provided")
 	ErrMemcachedMaxAsyncConcurrencyNotPositive = errors.New("max async concurrency must be positive")
-	ErrInvalidWriteBufferSizeBytes             = errors.New("invalid write buffer size specified (must be greater than 0)")
-	ErrInvalidReadBufferSizeBytes              = errors.New("invalid read buffer size specified (must be greater than 0)")
 
 	dnsProviders = []string{dns.GolangResolverType.String(), dns.MiekgdnsResolverType.String(), dns.MiekgdnsResolverType2.String()}
 
@@ -87,14 +85,6 @@ type MemcachedClientConfig struct {
 	// ConnectTimeout specifies the connection timeout.
 	ConnectTimeout time.Duration `yaml:"connect_timeout"`
 
-	// WriteBufferSizeBytes specifies the size of the write buffer (in bytes). The buffer
-	// is allocated for each connection.
-	WriteBufferSizeBytes int `yaml:"write_buffer_size_bytes" category:"experimental"`
-
-	// ReadBufferSizeBytes specifies the size of the read buffer (in bytes). The buffer
-	// is allocated for each connection.
-	ReadBufferSizeBytes int `yaml:"read_buffer_size_bytes" category:"experimental"`
-
 	// MinIdleConnectionsHeadroomPercentage specifies the minimum number of idle connections
 	// to keep open as a percentage of the number of recently used idle connections.
 	// If negative, idle connections are kept open indefinitely.
@@ -142,8 +132,6 @@ func (c *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.F
 	f.Var(&c.AddressesProvider, prefix+"addresses-provider", fmt.Sprintf("DNS provider used for resolving memcached addresses. Available providers %s", strings.Join(dnsProviders, ", ")))
 	f.DurationVar(&c.Timeout, prefix+"timeout", 200*time.Millisecond, "The socket read/write timeout.")
 	f.DurationVar(&c.ConnectTimeout, prefix+"connect-timeout", 200*time.Millisecond, "The connection timeout.")
-	f.IntVar(&c.WriteBufferSizeBytes, prefix+"write-buffer-size-bytes", 4096, "The size of the write buffer (in bytes). The buffer is allocated for each connection to memcached.")
-	f.IntVar(&c.ReadBufferSizeBytes, prefix+"read-buffer-size-bytes", 4096, "The size of the read buffer (in bytes). The buffer is allocated for each connection to memcached.")
 	f.Float64Var(&c.MinIdleConnectionsHeadroomPercentage, prefix+"min-idle-connections-headroom-percentage", -1, "The minimum number of idle connections to keep open as a percentage (0-100) of the number of recently used idle connections. If negative, idle connections are kept open indefinitely.")
 	f.IntVar(&c.MaxIdleConnections, prefix+"max-idle-connections", 100, "The maximum number of idle connections that will be maintained per address.")
 	f.IntVar(&c.MaxAsyncConcurrency, prefix+"max-async-concurrency", 50, "The maximum number of concurrent asynchronous operations can occur.")
@@ -159,12 +147,6 @@ func (c *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.F
 func (c *MemcachedClientConfig) Validate() error {
 	if len(c.Addresses) == 0 {
 		return ErrNoMemcachedAddresses
-	}
-	if c.WriteBufferSizeBytes <= 0 {
-		return ErrInvalidWriteBufferSizeBytes
-	}
-	if c.ReadBufferSizeBytes <= 0 {
-		return ErrInvalidReadBufferSizeBytes
 	}
 
 	// Set async only available when MaxAsyncConcurrency > 0.
@@ -226,8 +208,6 @@ func NewMemcachedClientWithConfig(logger log.Logger, name string, config Memcach
 	client := memcache.NewFromSelector(selector)
 	client.Timeout = config.Timeout
 	client.ConnectTimeout = config.ConnectTimeout
-	client.WriteBufferSizeBytes = config.WriteBufferSizeBytes
-	client.ReadBufferSizeBytes = config.ReadBufferSizeBytes
 	client.MinIdleConnsHeadroomPercentage = config.MinIdleConnectionsHeadroomPercentage
 	client.MaxIdleConns = config.MaxIdleConnections
 
@@ -297,9 +277,7 @@ func newMemcachedClient(
 		Name: clientInfoMetricName,
 		Help: "A metric with a constant '1' value labeled by configuration options from which memcached client was configured.",
 		ConstLabels: prometheus.Labels{
-			"timeout":                                  config.Timeout.String(),
-			"write_buffer_size_bytes":                  strconv.Itoa(config.WriteBufferSizeBytes),
-			"read_buffer_size_bytes":                   strconv.Itoa(config.ReadBufferSizeBytes),
+			"timeout": config.Timeout.String(),
 			"min_idle_connections_headroom_percentage": fmt.Sprintf("%f.2", config.MinIdleConnectionsHeadroomPercentage),
 			"max_idle_connections":                     strconv.Itoa(config.MaxIdleConnections),
 			"max_async_concurrency":                    strconv.Itoa(config.MaxAsyncConcurrency),

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -18,49 +18,6 @@ import (
 	"github.com/grafana/dskit/flagext"
 )
 
-func TestMemcachedClientConfig_Validate(t *testing.T) {
-	tests := map[string]struct {
-		setup       func(config *MemcachedClientConfig)
-		expectedErr error
-	}{
-		"should pass on positive write buffer size": {
-			setup: func(config *MemcachedClientConfig) {
-				config.WriteBufferSizeBytes = 12345
-			},
-			expectedErr: nil,
-		},
-		"should pass on positive read buffer size": {
-			setup: func(config *MemcachedClientConfig) {
-				config.ReadBufferSizeBytes = 12345
-			},
-			expectedErr: nil,
-		},
-		"should return error on negative write buffer size": {
-			setup: func(config *MemcachedClientConfig) {
-				config.WriteBufferSizeBytes = -1
-			},
-			expectedErr: ErrInvalidWriteBufferSizeBytes,
-		},
-		"should return error on negative read buffer size": {
-			setup: func(config *MemcachedClientConfig) {
-				config.ReadBufferSizeBytes = -1
-			},
-			expectedErr: ErrInvalidReadBufferSizeBytes,
-		},
-	}
-
-	for testName, testData := range tests {
-		t.Run(testName, func(t *testing.T) {
-			cfg := MemcachedClientConfig{}
-			memcachedClientConfigDefaultValues(&cfg)
-			cfg.Addresses = flagext.StringSliceCSV{"localhost:11211"}
-
-			testData.setup(&cfg)
-			require.Equal(t, testData.expectedErr, cfg.Validate())
-		})
-	}
-}
-
 func TestMemcachedClient_SetAsync(t *testing.T) {
 	t.Run("with non-zero TTL", func(t *testing.T) {
 		client, _, err := setupDefaultMemcachedClient()

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.6.0
 	github.com/gorilla/mux v1.8.0
-	github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1
+	github.com/grafana/gomemcache v0.0.0-20250318131618-74242eea118d
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
 	github.com/hashicorp/consul/api v1.15.3
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1 h1:vR5nELq+KtGO+IiGW+AclWeQ7uhLHCEz/zyQwbQVNnQ=
-github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
+github.com/grafana/gomemcache v0.0.0-20250318131618-74242eea118d h1:oXRJlb9UjVsl6LhqBdbyAQ9YFhExwsj4bjh5vwMNRZY=
+github.com/grafana/gomemcache v0.0.0-20250318131618-74242eea118d/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=


### PR DESCRIPTION
**What this PR does**:

Remove experimental options to set read and write buffer sizes for each Memcached connection. This didn't have much impact and so is being removed.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
