### PR TITLE
Make WatchPrefix buffer size configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 * [CHANGE] ring: Add `InstanceRingReader` interface to `ring` package. #597
 * [CHANGE] DNS: Introduce new `miekgdns2` resolver backend type with experimental DNS client. #660
 * [CHANGE] Server: The `PerTenantDurationInstrumentation` config option was renamed to `PerTenantInstrumentation` and now allows specifying whether a full histogram should be recorded or only a counter #642
-* [CHANGE] grpcclient: Signature of `grpcclient.Config.DialOption()` has changed. It now requires an additional parameter of type `middleware.InvalidClusterValidationReporter` used for reporting cluster validation issues back to the caller. #657 
+* [CHANGE] grpcclient: Signature of `grpcclient.Config.DialOption()` has changed. It now requires an additional parameter of type `middleware.InvalidClusterValidationReporter` used for reporting cluster validation issues back to the caller. #657
 * [FEATURE] Cache: Add support for configuring a Redis cache backend. #268 #271 #276
 * [FEATURE] Add support for waiting on the rate limiter using the new `WaitN` method. #279
 * [FEATURE] Add `log.BufferedLogger` type. #338
@@ -111,6 +111,7 @@
   * `-server.cluster-validation.grpc.enabled`
 * [FEATURE] grpcclient: Add experimental configuration option `-cluster-validation.label` to `grpcclient.Config` used for setting the cluster validation label of gRPC clients. #657
 * [FEATURE] Add `ring.GetWithOptions()` method to support additional features at a per-call level. #632
+* [FEATURE] Add `-memberlist.watch-prefix-buffer-size` that controls the size of the buffered channel used by WatchPrefix. #669
 * [ENHANCEMENT] Add feature flag to make Memcached soft-dependency on startup. If so, DNS failures on startup will be ignored on client creation. #647, #658
 * [ENHANCEMENT] Add option to hide token information in ring status page #633
 * [ENHANCEMENT] Display token information in partition ring status page #631

--- a/kv/memberlist/kv_init_service.go
+++ b/kv/memberlist/kv_init_service.go
@@ -2,6 +2,7 @@ package memberlist
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 
@@ -46,6 +47,11 @@ func NewKVInitService(cfg *KVConfig, logger log.Logger, dnsProvider DNSProvider,
 
 // GetMemberlistKV will initialize Memberlist.KV on first call, and add it to service failure watcher.
 func (kvs *KVInitService) GetMemberlistKV() (*KV, error) {
+	// Validate WatchPrefixBufferSize before initialization
+	if kvs.cfg.WatchPrefixBufferSize <= 0 {
+		return nil, fmt.Errorf("invalid WatchPrefixBufferSize: must be greater than 0")
+	}
+
 	kvs.init.Do(func() {
 		kv := NewKV(*kvs.cfg, kvs.logger, kvs.dnsProvider, kvs.registerer)
 		kvs.watcher.WatchService(kv)

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -31,6 +31,7 @@ const (
 	maxCasRetries              = 10          // max retries in CAS operation
 	noChangeDetectedRetrySleep = time.Second // how long to sleep after no change was detected in CAS
 	notifyMsgQueueSize         = 1024        // size of buffered channels to handle memberlist messages
+	watchPrefixBufferSize      = 128         // size of buffered channel for the WatchPrefix function
 )
 
 // Client implements kv.Client interface, by using memberlist.KV
@@ -171,6 +172,9 @@ type KVConfig struct {
 	// How much space to use to keep received and sent messages in memory (for troubleshooting).
 	MessageHistoryBufferBytes int `yaml:"message_history_buffer_bytes" category:"advanced"`
 
+	// Size of the buffer for key watchers.
+	WatchPrefixBufferSize int `yaml:"watch_prefix_buffer_size" category:"advanced"`
+
 	TCPTransport TCPTransportConfig `yaml:",inline"`
 
 	MetricsNamespace string `yaml:"-"`
@@ -210,6 +214,7 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.StringVar(&cfg.ClusterLabel, prefix+"memberlist.cluster-label", mlDefaults.Label, "The cluster label is an optional string to include in outbound packets and gossip streams. Other members in the memberlist cluster will discard any message whose label doesn't match the configured one, unless the 'cluster-label-verification-disabled' configuration option is set to true.")
 	f.BoolVar(&cfg.ClusterLabelVerificationDisabled, prefix+"memberlist.cluster-label-verification-disabled", mlDefaults.SkipInboundLabelCheck, "When true, memberlist doesn't verify that inbound packets and gossip streams have the cluster label matching the configured one. This verification should be disabled while rolling out the change to the configured cluster label in a live memberlist cluster.")
 	f.DurationVar(&cfg.BroadcastTimeoutForLocalUpdatesOnShutdown, prefix+"memberlist.broadcast-timeout-for-local-updates-on-shutdown", 10*time.Second, "Timeout for broadcasting all remaining locally-generated updates to other nodes when shutting down. Only used if there are nodes left in the memberlist cluster, and only applies to locally-generated updates, not to broadcast messages that are result of incoming gossip updates. 0 = no timeout, wait until all locally-generated updates are sent.")
+	f.IntVar(&cfg.WatchPrefixBufferSize, prefix+"memberlist.watch-prefix-buffer-size", watchPrefixBufferSize, "Size of the buffered channel for the WatchPrefix function.")
 
 	cfg.TCPTransport.RegisterFlagsWithPrefix(f, prefix)
 }
@@ -298,6 +303,7 @@ type KV struct {
 	casFailures                         prometheus.Counter
 	casSuccesses                        prometheus.Counter
 	watchPrefixDroppedNotifications     *prometheus.CounterVec
+	numberOfKeyNotifications            prometheus.Gauge
 
 	storeValuesDesc        *prometheus.Desc
 	storeTombstones        *prometheus.GaugeVec
@@ -380,6 +386,10 @@ var (
 // and service enters Failed state.
 func NewKV(cfg KVConfig, logger log.Logger, dnsProvider DNSProvider, registerer prometheus.Registerer) *KV {
 	cfg.TCPTransport.MetricsNamespace = cfg.MetricsNamespace
+
+	if cfg.WatchPrefixBufferSize <= 0 {
+		cfg.WatchPrefixBufferSize = watchPrefixBufferSize
+	}
 
 	mlkv := &KV{
 		cfg:              cfg,
@@ -896,7 +906,7 @@ func (m *KV) WatchKey(ctx context.Context, key string, codec codec.Codec, f func
 // Watching ends when 'f' returns false, context is done, or this client is shut down.
 func (m *KV) WatchPrefix(ctx context.Context, prefix string, codec codec.Codec, f func(string, interface{}) bool) {
 	// we use bigger buffer here, since keys are interesting and we don't want to lose them.
-	w := make(chan string, 16)
+	w := make(chan string, m.cfg.WatchPrefixBufferSize)
 
 	// register watcher
 	m.watchersMu.Lock()
@@ -991,6 +1001,7 @@ func (m *KV) sendKeyNotifications() {
 			return nil
 		}
 		newMap := make(map[string]struct{})
+		m.numberOfKeyNotifications.Set(float64(len(m.keyNotifications)))
 		notifs := m.keyNotifications
 		m.keyNotifications = newMap
 		return notifs

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -387,10 +387,6 @@ var (
 func NewKV(cfg KVConfig, logger log.Logger, dnsProvider DNSProvider, registerer prometheus.Registerer) *KV {
 	cfg.TCPTransport.MetricsNamespace = cfg.MetricsNamespace
 
-	if cfg.WatchPrefixBufferSize <= 0 {
-		cfg.WatchPrefixBufferSize = watchPrefixBufferSize
-	}
-
 	mlkv := &KV{
 		cfg:              cfg,
 		logger:           logger,

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -2086,7 +2086,7 @@ func TestWatchPrefix(t *testing.T) {
 
 		// Start watching prefix
 		go func() {
-			kv.WatchPrefix(ctx, prefix, codec, func(key string, val interface{}) bool {
+			kv.WatchPrefix(ctx, prefix, codec, func(key string, _ any) bool {
 				mu.Lock()
 				notifications = append(notifications, key)
 				count := len(notifications)

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -2040,3 +2040,97 @@ func TestNotificationDelay(t *testing.T) {
 		}
 	}, 20*time.Second, 100*time.Millisecond)
 }
+
+func TestWatchPrefix(t *testing.T) {
+	t.Run("buffer size configuration", func(t *testing.T) {
+		// Test custom buffer size
+		cfg := KVConfig{}
+		cfg.WatchPrefixBufferSize = 10
+		kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		require.Equal(t, 10, kv.cfg.WatchPrefixBufferSize)
+
+		// Test invalid buffer size is rejected
+		kvInit := NewKVInitService(&KVConfig{WatchPrefixBufferSize: -3}, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		_, err := kvInit.GetMemberlistKV()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid WatchPrefixBufferSize")
+
+		kvInit = NewKVInitService(&KVConfig{WatchPrefixBufferSize: 0}, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		_, err = kvInit.GetMemberlistKV()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid WatchPrefixBufferSize")
+	})
+
+	t.Run("buffering behavior", func(t *testing.T) {
+		// Create KV with small buffer and fast notification interval
+		cfg := KVConfig{}
+		cfg.WatchPrefixBufferSize = 2
+		// Disable notification batching to get immediate notifications
+		cfg.NotifyInterval = 0
+		kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
+		defer services.StopAndAwaitTerminated(context.Background(), kv) //nolint:errcheck
+
+		// Setup test data
+		codec := dataCodec{}
+		prefix := "test_prefix_"
+		keys := []string{prefix + "1", prefix + "2", prefix + "3"}
+
+		// Create a channel to receive notifications
+		notifications := make([]string, 0)
+		mu := sync.Mutex{} // Protect notifications slice
+		done := make(chan struct{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Start watching prefix
+		go func() {
+			kv.WatchPrefix(ctx, prefix, codec, func(key string, val interface{}) bool {
+				mu.Lock()
+				notifications = append(notifications, key)
+				count := len(notifications)
+				mu.Unlock()
+
+				if count == len(keys) {
+					close(done)
+				}
+				return true // keep watching
+			})
+		}()
+
+		// Give the watcher time to register
+		time.Sleep(100 * time.Millisecond)
+
+		// Update keys
+		for _, key := range keys {
+			err := kv.CAS(context.Background(), key, codec, func(in interface{}) (out interface{}, retry bool, err error) {
+				d := getOrCreateData(in)
+				d.Members["test"] = member{Timestamp: time.Now().Unix(), State: JOINING}
+				return d, true, nil
+			})
+			require.NoError(t, err)
+		}
+
+		// Wait for all notifications or timeout
+		select {
+		case <-done:
+			mu.Lock()
+			defer mu.Unlock()
+			require.Len(t, notifications, len(keys))
+			// Verify all keys were notified about
+			for _, k := range keys {
+				found := false
+				for _, n := range notifications {
+					if n == k {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "key %s should have generated a notification", k)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for notifications")
+		}
+	})
+}

--- a/kv/memberlist/metrics.go
+++ b/kv/memberlist/metrics.go
@@ -189,6 +189,13 @@ func (m *KV) createAndRegisterMetrics() {
 		Help:      "Number of dropped notifications in WatchPrefix function",
 	}, []string{"prefix"})
 
+	m.numberOfKeyNotifications = promauto.With(m.registerer).NewGauge(prometheus.GaugeOpts{
+		Namespace: m.cfg.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "pending_key_notifications",
+		Help:      "Number of pending notifications in WatchPrefix function",
+	})
+
 	if m.registerer == nil {
 		return
 	}


### PR DESCRIPTION
This pull request introduces several changes to the `kv/memberlist/memberlist_client.go` file to improve the functionality and monitoring of the `WatchPrefix` function. The most important changes include adding a buffer size configuration for the `WatchPrefix` function, updating metrics, and ensuring proper default values for the buffer size.

### Configuration and Buffer Size:

* Added a new constant `watchPrefixBufferSize` to define the default buffer size for the `WatchPrefix` function.
* Introduced a new configuration field `WatchPrefixBufferSize` in the `KVConfig` struct to allow customization of the buffer size.
* Registered the new `WatchPrefixBufferSize` configuration field with flags to enable command-line configuration.
* Sets the default buffer size to 128. This is an increase from the previous static value of 16. By reviewing memberlist clusters of various sizes in production, 128 seems like a good default that should be sufficient for most environments without too much of an increase in memory.

### Metrics and Monitoring:

* Added a new gauge metric `numberOfKeyNotifications` to track the number of pending key notifications in the `WatchPrefix` function.
* Updated the `WatchPrefix` function to use the configured buffer size for its channel.
* Ensured the `WatchPrefixBufferSize` has a default value if not set in the configuration.
* Updated the `sendKeyNotifications` method to set the new `numberOfKeyNotifications` metric.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
