### PR TITLE
Memberlist: add -memberlist.abort-if-fast-join-fails support and retries on DNS resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,7 @@
 * [ENHANCEMENT] KV: Add `MockCountingClient`, which wraps the `kv.client` and can be used in order to count calls at specific functions of the interface. #618
 * [ENHANCEMENT] Server: Add interceptor support to `GrpcInflightMethodLimiter`. #643
 * [ENHANCEMENT] flagext: Add `LimitsMap` as a new flag type. #651
+* [ENHANCEMENT] Memberlist: Add `-memberlist.abort-if-fast-join-fails` support and retries on DNS resolution. #674
 * [BUGFIX] spanlogger: Support multiple tenant IDs. #59
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #85
 * [BUGFIX] Ring: `ring_member_ownership_percent` and `ring_tokens_owned` metrics are not updated on scale down. #109

--- a/kv/memberlist/kv_init_service_test.go
+++ b/kv/memberlist/kv_init_service_test.go
@@ -12,6 +12,6 @@ import (
 func TestStop(t *testing.T) {
 	var cfg KVConfig
 	flagext.DefaultValues(&cfg)
-	kvinit := NewKVInitService(&cfg, nil, &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	kvinit := NewKVInitService(&cfg, nil, &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, kvinit.stopping(nil))
 }

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -154,12 +154,13 @@ type KVConfig struct {
 	ClusterLabelVerificationDisabled bool   `yaml:"cluster_label_verification_disabled" category:"advanced"`
 
 	// List of members to join
-	JoinMembers      flagext.StringSlice `yaml:"join_members"`
-	MinJoinBackoff   time.Duration       `yaml:"min_join_backoff" category:"advanced"`
-	MaxJoinBackoff   time.Duration       `yaml:"max_join_backoff" category:"advanced"`
-	MaxJoinRetries   int                 `yaml:"max_join_retries" category:"advanced"`
-	AbortIfJoinFails bool                `yaml:"abort_if_cluster_join_fails"`
-	RejoinInterval   time.Duration       `yaml:"rejoin_interval" category:"advanced"`
+	JoinMembers          flagext.StringSlice `yaml:"join_members"`
+	MinJoinBackoff       time.Duration       `yaml:"min_join_backoff" category:"advanced"`
+	MaxJoinBackoff       time.Duration       `yaml:"max_join_backoff" category:"advanced"`
+	MaxJoinRetries       int                 `yaml:"max_join_retries" category:"advanced"`
+	AbortIfFastJoinFails bool                `yaml:"abort_if_cluster_fast_join_fails" category:"advanced"`
+	AbortIfJoinFails     bool                `yaml:"abort_if_cluster_join_fails"`
+	RejoinInterval       time.Duration       `yaml:"rejoin_interval" category:"advanced"`
 
 	// Remove LEFT ingesters from ring after this timeout.
 	LeftIngestersTimeout   time.Duration `yaml:"left_ingesters_timeout" category:"advanced"`
@@ -181,6 +182,10 @@ type KVConfig struct {
 
 	// Codecs to register. Codecs need to be registered before joining other members.
 	Codecs []codec.Codec `yaml:"-"`
+
+	// The backoff configuration used by retries when discovering memberlist members via DNS.
+	// This useful to override it in tests.
+	discoverMembersBackoff backoff.Config `yaml:"-"`
 }
 
 // RegisterFlagsWithPrefix registers flags.
@@ -196,7 +201,8 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.MinJoinBackoff, prefix+"memberlist.min-join-backoff", 1*time.Second, "Min backoff duration to join other cluster members.")
 	f.DurationVar(&cfg.MaxJoinBackoff, prefix+"memberlist.max-join-backoff", 1*time.Minute, "Max backoff duration to join other cluster members.")
 	f.IntVar(&cfg.MaxJoinRetries, prefix+"memberlist.max-join-retries", 10, "Max number of retries to join other cluster members.")
-	f.BoolVar(&cfg.AbortIfJoinFails, prefix+"memberlist.abort-if-join-fails", cfg.AbortIfJoinFails, "If this node fails to join memberlist cluster, abort.")
+	f.BoolVar(&cfg.AbortIfFastJoinFails, prefix+"memberlist.abort-if-fast-join-fails", false, "Abort if this node fails the fast memberlist cluster joining procedure at startup. When enabled, it's guaranteed that other services, depending on memberlist, have an updated view over the cluster state when they're started.")
+	f.BoolVar(&cfg.AbortIfJoinFails, prefix+"memberlist.abort-if-join-fails", cfg.AbortIfJoinFails, "Abort if this node fails to join memberlist cluster at startup. When enabled, it's not guaranteed that other services are started only after the cluster state has been successfully updated; use 'abort-if-fast-join-fails' instead.")
 	f.DurationVar(&cfg.RejoinInterval, prefix+"memberlist.rejoin-interval", 0, "If not 0, how often to rejoin the cluster. Occasional rejoin can help to fix the cluster split issue, and is harmless otherwise. For example when using only few components as a seed nodes (via -memberlist.join), then it's recommended to use rejoin. If -memberlist.join points to dynamic service that resolves to all gossiping nodes (eg. Kubernetes headless service), then rejoin is not needed.")
 	f.DurationVar(&cfg.LeftIngestersTimeout, prefix+"memberlist.left-ingesters-timeout", 5*time.Minute, "How long to keep LEFT ingesters in the ring.")
 	f.DurationVar(&cfg.ObsoleteEntriesTimeout, prefix+"memberlist.obsolete-entries-timeout", mlDefaults.PushPullInterval, "How long to keep obsolete entries in the KV store.")
@@ -217,6 +223,12 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.IntVar(&cfg.WatchPrefixBufferSize, prefix+"memberlist.watch-prefix-buffer-size", watchPrefixBufferSize, "Size of the buffered channel for the WatchPrefix function.")
 
 	cfg.TCPTransport.RegisterFlagsWithPrefix(f, prefix)
+
+	cfg.discoverMembersBackoff = backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 5 * time.Second,
+		MaxRetries: 10,
+	}
 }
 
 func (cfg *KVConfig) RegisterFlags(f *flag.FlagSet) {
@@ -502,7 +514,13 @@ func (m *KV) starting(ctx context.Context) error {
 
 	// Try to fast-join memberlist cluster in Starting state, so that we don't start with empty KV store.
 	if len(m.cfg.JoinMembers) > 0 {
-		m.fastJoinMembersOnStartup(ctx)
+		if err := m.fastJoinMembersOnStartup(ctx); err != nil {
+			level.Error(m.logger).Log("msg", "failed to fast-join the memberlist cluster at startup", "err", err)
+
+			if m.cfg.AbortIfFastJoinFails {
+				return fmt.Errorf("failed to fast-join the memberlist cluster at startup: %w", err)
+			}
+		}
 	}
 
 	return nil
@@ -586,10 +604,15 @@ func (m *KV) JoinMembers(members []string) (int, error) {
 }
 
 // fastJoinMembersOnStartup attempts to reach small subset of nodes (computed as RetransmitMult * log10(number of discovered members + 1)).
-func (m *KV) fastJoinMembersOnStartup(ctx context.Context) {
+func (m *KV) fastJoinMembersOnStartup(ctx context.Context) error {
 	startTime := time.Now()
 
-	nodes := m.discoverMembers(ctx, m.cfg.JoinMembers)
+	nodes, err := m.discoverMembersWithRetries(ctx, m.cfg.JoinMembers)
+	if err != nil && len(nodes) == 0 {
+		return err
+	}
+
+	// Shuffle the node addresses to randomize the ones picked for the fast join.
 	math_rand.Shuffle(len(nodes), func(i, j int) {
 		nodes[i], nodes[j] = nodes[j], nodes[i]
 	})
@@ -612,12 +635,13 @@ func (m *KV) fastJoinMembersOnStartup(ctx context.Context) {
 		nodes = nodes[1:]
 	}
 
-	l := level.Info(m.logger)
-	// Warn, if we didn't join any node.
 	if totalJoined == 0 {
-		l = level.Warn(m.logger)
+		level.Warn(m.logger).Log("memberlist fast-join failed because no node has been successfully reached", "elapsed_time", time.Since(startTime))
+		return fmt.Errorf("no memberlist node reached during fast-join procedure")
 	}
-	l.Log("msg", "memberlist fast-join finished", "joined_nodes", totalJoined, "elapsed_time", time.Since(startTime))
+
+	level.Info(m.logger).Log("msg", "memberlist fast-join finished", "joined_nodes", totalJoined, "elapsed_time", time.Since(startTime))
+	return nil
 }
 
 // The joinMembersOnStartup method resolves the addresses of the given join_members hosts and asks memberlist to join to them.
@@ -688,7 +712,10 @@ func (m *KV) joinMembersInBatches(ctx context.Context) (int, error) {
 		// Rediscover nodes and try to join a subset of them with each batch.
 		// When the list of nodes is large by the time we reach the end of the list some of the
 		// IPs can be unreachable.
-		newlyResolved := m.discoverMembers(ctx, m.cfg.JoinMembers)
+		//
+		// Ignores any DNS resolution error because it's not really actionable in this
+		// context.
+		newlyResolved, _ := m.discoverMembersWithRetries(ctx, m.cfg.JoinMembers)
 		if len(newlyResolved) > 0 {
 			// If the resolution fails we keep using the nodes list from the last resolution.
 			// If that failed too, then we fail the join attempt.
@@ -746,10 +773,11 @@ func (m *KV) joinMembersBatch(ctx context.Context, nodes []string) (successfully
 	return successfullyJoined, lastErr
 }
 
-// Provides a dns-based member disovery to join a memberlist cluster w/o knowning members' addresses upfront.
-func (m *KV) discoverMembers(ctx context.Context, members []string) []string {
+// Provides a dns-based member discovery to join a memberlist cluster w/o knowning members' addresses upfront.
+// May both return some addresses and an error in case of a partial resolution.
+func (m *KV) discoverMembers(ctx context.Context, members []string) ([]string, error) {
 	if len(members) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	var ms, resolve []string
@@ -765,12 +793,34 @@ func (m *KV) discoverMembers(ctx context.Context, members []string) []string {
 
 	err := m.provider.Resolve(ctx, resolve)
 	if err != nil {
-		level.Error(m.logger).Log("msg", "failed to resolve members", "addrs", strings.Join(resolve, ","), "err", err)
+		level.Warn(m.logger).Log("msg", "failed to resolve members", "addrs", strings.Join(resolve, ","), "err", err)
 	}
 
 	ms = append(ms, m.provider.Addresses()...)
 
-	return ms
+	return ms, err
+}
+
+// Like discoverMembers() but retries (up to 10 times) on error.
+func (m *KV) discoverMembersWithRetries(ctx context.Context, members []string) ([]string, error) {
+	boff := backoff.New(ctx, m.cfg.discoverMembersBackoff)
+
+	var (
+		lastErr   error
+		lastAddrs []string
+	)
+
+	for boff.Ongoing() {
+		lastAddrs, lastErr = m.discoverMembers(ctx, members)
+		if lastErr == nil {
+			return lastAddrs, nil
+		}
+
+		boff.Wait()
+	}
+
+	// We may have both some addresses and error, in case of a partial resolution.
+	return lastAddrs, lastErr
 }
 
 // While Stopping, we try to leave memberlist cluster and then shutdown memberlist client.

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -636,7 +636,7 @@ func (m *KV) fastJoinMembersOnStartup(ctx context.Context) error {
 	}
 
 	if totalJoined == 0 {
-		level.Warn(m.logger).Log("memberlist fast-join failed because no node has been successfully reached", "elapsed_time", time.Since(startTime))
+		level.Warn(m.logger).Log("msg", "memberlist fast-join failed because no node has been successfully reached", "elapsed_time", time.Since(startTime))
 		return fmt.Errorf("no memberlist node reached during fast-join procedure")
 	}
 

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -1843,7 +1843,7 @@ func newDNSProviderMock(onResolve func() ([]string, error)) *dnsProviderMock {
 	}
 }
 
-func (p *dnsProviderMock) Resolve(_ context.Context, addrs []string) error {
+func (p *dnsProviderMock) Resolve(_ context.Context, _ []string) error {
 	addrs, err := p.onResolve()
 
 	p.resolvedMx.Lock()
@@ -1853,7 +1853,7 @@ func (p *dnsProviderMock) Resolve(_ context.Context, addrs []string) error {
 	return err
 }
 
-func (p dnsProviderMock) Addresses() []string {
+func (p *dnsProviderMock) Addresses() []string {
 	p.resolvedMx.Lock()
 	defer p.resolvedMx.Unlock()
 

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -1155,6 +1155,7 @@ func TestMemberlist_discoverMembersWithRetries(t *testing.T) {
 	flagext.DefaultValues(&cfg)
 	cfg.discoverMembersBackoff.MinBackoff = time.Millisecond
 	cfg.discoverMembersBackoff.MaxBackoff = time.Millisecond
+	require.Greater(t, cfg.discoverMembersBackoff.MaxRetries, 0)
 
 	tests := map[string]struct {
 		numResolveFailures int
@@ -1170,7 +1171,7 @@ func TestMemberlist_discoverMembersWithRetries(t *testing.T) {
 			expectedAddrs:      addrsMocked,
 		},
 		"all resolutions fail": {
-			numResolveFailures: math.MaxInt,
+			numResolveFailures: cfg.discoverMembersBackoff.MaxRetries,
 			expectedErr:        errMocked,
 		},
 	}
@@ -1193,6 +1194,7 @@ func TestMemberlist_discoverMembersWithRetries(t *testing.T) {
 
 			if testData.expectedErr != nil {
 				require.EqualError(t, err, errMocked.Error())
+				require.Equal(t, cfg.discoverMembersBackoff.MaxRetries, currResolveFailures)
 			} else {
 				require.NoError(t, err)
 			}

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -273,7 +274,7 @@ func TestBasicGetAndCas(t *testing.T) {
 	}
 	cfg.Codecs = []codec.Codec{c}
 
-	mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv) //nolint:errcheck
 
@@ -336,7 +337,7 @@ func withFixtures(t *testing.T, testFN func(t *testing.T, kv *Client)) {
 	}
 	cfg.Codecs = []codec.Codec{c}
 
-	mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv) //nolint:errcheck
 
@@ -492,7 +493,7 @@ func TestMultipleCAS(t *testing.T) {
 	}
 	cfg.Codecs = []codec.Codec{c}
 
-	mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	mkv.maxCasRetries = 20
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv) //nolint:errcheck
@@ -605,7 +606,7 @@ func TestDelete(t *testing.T) {
 	cfg.ClusterLabelVerificationDisabled = true
 	cfg.Codecs = []codec.Codec{c}
 
-	mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, reg)
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, reg)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv) //nolint:errcheck
 
@@ -657,7 +658,7 @@ func TestDeleteMultipleClients(t *testing.T) {
 	cfg.PushPullInterval = deleteTime
 	cfg.ObsoleteEntriesTimeout = deleteTime
 
-	mkv1 := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv1 := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv1))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv1) //nolint:errcheck
 
@@ -673,7 +674,7 @@ func TestDeleteMultipleClients(t *testing.T) {
 	// We will read values from second KV, which will join the first one
 	cfg.JoinMembers = []string{net.JoinHostPort("127.0.0.1", strconv.Itoa(mkv1.GetListeningPort()))}
 
-	mkv2 := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv2 := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv2))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv2) //nolint:errcheck
 
@@ -814,7 +815,7 @@ func testMultipleClientsWithConfigGenerator(t *testing.T, members int, configGen
 		cfg := configGen(i)
 		cfg.Codecs = []codec.Codec{c}
 
-		mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
 
 		kv, err := NewClient(mkv, c)
@@ -1082,7 +1083,7 @@ func TestJoinMembersWithRetryBackoff(t *testing.T) {
 	}
 }
 
-func TestMemberlistFailsToJoin(t *testing.T) {
+func TestMemberlist_AbortIfJoinFailsAtStartup(t *testing.T) {
 	c := dataCodec{}
 
 	ports, err := getFreePorts(1)
@@ -1104,7 +1105,7 @@ func TestMemberlistFailsToJoin(t *testing.T) {
 
 	cfg.Codecs = []codec.Codec{c}
 
-	mkv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
 
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -1114,7 +1115,91 @@ func TestMemberlistFailsToJoin(t *testing.T) {
 	_ = mkv.AwaitTerminated(ctxTimeout)
 
 	// We verify service state here.
-	require.Equal(t, mkv.FailureCase(), errFailedToJoinCluster)
+	require.Equal(t, errFailedToJoinCluster, mkv.FailureCase())
+}
+
+func TestMemberlist_AbortIfFastJoinFailsAtStartup(t *testing.T) {
+	c := dataCodec{}
+
+	ports, err := getFreePorts(1)
+	require.NoError(t, err)
+
+	var cfg KVConfig
+	flagext.DefaultValues(&cfg)
+	cfg.MinJoinBackoff = 100 * time.Millisecond
+	cfg.MaxJoinBackoff = 100 * time.Millisecond
+	cfg.MaxJoinRetries = 2
+	cfg.AbortIfFastJoinFails = true
+	cfg.JoinMembers = []string{net.JoinHostPort(getLocalhostAddr(), strconv.Itoa(ports[0]))}
+	cfg.Codecs = []codec.Codec{c}
+
+	cfg.TCPTransport = TCPTransportConfig{
+		BindAddrs: getLocalhostAddrs(),
+		BindPort:  0,
+	}
+
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
+
+	// We expect the service to fail when starting.
+	err = services.StartAndAwaitRunning(context.Background(), mkv)
+	require.ErrorContains(t, err, "no memberlist node reached during fast-join procedure")
+}
+
+func TestMemberlist_discoverMembersWithRetries(t *testing.T) {
+	var (
+		cfg         KVConfig
+		errMocked   = errors.New("mocked error")
+		addrsMocked = []string{"1.1.1.1", "2.2.2.2"}
+	)
+
+	flagext.DefaultValues(&cfg)
+	cfg.discoverMembersBackoff.MinBackoff = time.Millisecond
+	cfg.discoverMembersBackoff.MaxBackoff = time.Millisecond
+
+	tests := map[string]struct {
+		numResolveFailures int
+		expectedErr        error
+		expectedAddrs      []string
+	}{
+		"first resolution succeed": {
+			numResolveFailures: 0,
+			expectedAddrs:      addrsMocked,
+		},
+		"first 3 resolutions fails": {
+			numResolveFailures: 3,
+			expectedAddrs:      addrsMocked,
+		},
+		"all resolutions fail": {
+			numResolveFailures: math.MaxInt,
+			expectedErr:        errMocked,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			currResolveFailures := 0
+
+			dns := newDNSProviderMock(func() ([]string, error) {
+				if currResolveFailures < testData.numResolveFailures {
+					currResolveFailures++
+					return nil, errMocked
+				}
+
+				return addrsMocked, nil
+			})
+
+			mkv := NewKV(cfg, log.NewNopLogger(), dns, prometheus.NewPedanticRegistry())
+			addrs, err := mkv.discoverMembersWithRetries(context.Background(), []string{"dns+memberlist.cluster"})
+
+			if testData.expectedErr != nil {
+				require.EqualError(t, err, errMocked.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, testData.expectedAddrs, addrs)
+		})
+	}
 }
 
 func getFreePorts(count int) ([]int, error) {
@@ -1277,7 +1362,7 @@ func TestMultipleCodecs(t *testing.T) {
 		distributedCounterCodec{},
 	}
 
-	mkv1 := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv1 := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv1))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv1) //nolint:errcheck
 
@@ -1320,7 +1405,7 @@ func TestMultipleCodecs(t *testing.T) {
 	require.NoError(t, err)
 
 	// We will read values from second KV, which will join the first one
-	mkv2 := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv2 := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv2))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv2) //nolint:errcheck
 
@@ -1372,11 +1457,11 @@ func TestRejoin(t *testing.T) {
 	cfg2.JoinMembers = []string{net.JoinHostPort("localhost", strconv.Itoa(ports[0]))}
 	cfg2.RejoinInterval = 1 * time.Second
 
-	mkv1 := NewKV(cfg1, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv1 := NewKV(cfg1, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv1))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv1) //nolint:errcheck
 
-	mkv2 := NewKV(cfg2, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv2 := NewKV(cfg2, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv2))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv2) //nolint:errcheck
 
@@ -1393,7 +1478,7 @@ func TestRejoin(t *testing.T) {
 	require.Eventually(t, expectMembers(1), 10*time.Second, 100*time.Millisecond, "expected 1 member in the cluster")
 
 	// Let's start first KV again. It is not configured to join the cluster, but KV2 is rejoining.
-	mkv1 = NewKV(cfg1, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv1 = NewKV(cfg1, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv1))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv1) //nolint:errcheck
 
@@ -1429,7 +1514,7 @@ func TestNotifyMsgResendsOnlyChanges(t *testing.T) {
 	cfg.RetransmitMult = 1
 	cfg.Codecs = append(cfg.Codecs, codec)
 
-	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
 	defer services.StopAndAwaitTerminated(context.Background(), kv) //nolint:errcheck
 
@@ -1499,7 +1584,7 @@ func TestSendingOldTombstoneShouldNotForwardMessage(t *testing.T) {
 	cfg.LeftIngestersTimeout = 5 * time.Minute
 	cfg.Codecs = append(cfg.Codecs, codec)
 
-	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
 	defer services.StopAndAwaitTerminated(context.Background(), kv) //nolint:errcheck
 
@@ -1594,7 +1679,7 @@ func TestFastJoin(t *testing.T) {
 		dataCodec{},
 	}
 
-	mkv1 := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv1 := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv1))
 	defer services.StopAndAwaitTerminated(context.Background(), mkv1) //nolint:errcheck
 
@@ -1610,7 +1695,7 @@ func TestFastJoin(t *testing.T) {
 	// We will read values from second KV, which will join the first one
 	cfg.JoinMembers = []string{net.JoinHostPort("127.0.0.1", strconv.Itoa(mkv1.GetListeningPort()))}
 
-	mkv2 := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	mkv2 := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 	go func() {
 		// Wait a bit, and then start mkv2.
 		time.Sleep(500 * time.Millisecond)
@@ -1640,7 +1725,7 @@ func TestDelegateMethodsDontCrashBeforeKVStarts(t *testing.T) {
 		BindAddrs: getLocalhostAddrs(),
 	}
 
-	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 
 	// Make sure we can call delegate methods on unstarted service, and they don't crash nor block.
 	kv.LocalState(true)
@@ -1684,7 +1769,7 @@ func TestMetricsRegistration(t *testing.T) {
 	cfg.Codecs = append(cfg.Codecs, c)
 
 	reg := prometheus.NewPedanticRegistry()
-	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, reg)
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, reg)
 	err := kv.CAS(context.Background(), "test", c, func(interface{}) (out interface{}, retry bool, err error) {
 		return &data{Members: map[string]member{
 			"member": {},
@@ -1746,15 +1831,45 @@ func (l testLogger) Log(_ ...interface{}) error {
 }
 
 type dnsProviderMock struct {
-	resolved []string
+	onResolve func() ([]string, error)
+
+	resolvedMx sync.Mutex
+	resolved   []string
+}
+
+func newDNSProviderMock(onResolve func() ([]string, error)) *dnsProviderMock {
+	return &dnsProviderMock{
+		onResolve: onResolve,
+	}
 }
 
 func (p *dnsProviderMock) Resolve(_ context.Context, addrs []string) error {
+	addrs, err := p.onResolve()
+
+	p.resolvedMx.Lock()
+	p.resolved = addrs
+	p.resolvedMx.Unlock()
+
+	return err
+}
+
+func (p dnsProviderMock) Addresses() []string {
+	p.resolvedMx.Lock()
+	defer p.resolvedMx.Unlock()
+
+	return slices.Clone(p.resolved)
+}
+
+type staticDNSProviderMock struct {
+	resolved []string
+}
+
+func (p *staticDNSProviderMock) Resolve(_ context.Context, addrs []string) error {
 	p.resolved = addrs
 	return nil
 }
 
-func (p dnsProviderMock) Addresses() []string {
+func (p staticDNSProviderMock) Addresses() []string {
 	return p.resolved
 }
 
@@ -1793,7 +1908,7 @@ func TestGetBroadcastsPrefersLocalUpdates(t *testing.T) {
 	cfg.Codecs = append(cfg.Codecs, codec)
 
 	reg := prometheus.NewRegistry()
-	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, reg)
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, reg)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
 	defer services.StopAndAwaitTerminated(context.Background(), kv) //nolint:errcheck
 
@@ -1851,7 +1966,7 @@ func TestRaceBetweenStoringNewValueForKeyAndUpdatingIt(t *testing.T) {
 		BindAddrs: getLocalhostAddrs(),
 	}
 
-	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
 	t.Cleanup(func() {
@@ -1930,7 +2045,7 @@ func TestNotificationDelay(t *testing.T) {
 	// We're going to trigger sends manually, so effectively disable the automatic send interval.
 	const hundredYears = 100 * 365 * 24 * time.Hour
 	cfg.NotifyInterval = hundredYears
-	kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 
 	watchChan := make(chan string, 16)
 
@@ -2046,16 +2161,16 @@ func TestWatchPrefix(t *testing.T) {
 		// Test custom buffer size
 		cfg := KVConfig{}
 		cfg.WatchPrefixBufferSize = 10
-		kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 		require.Equal(t, 10, kv.cfg.WatchPrefixBufferSize)
 
 		// Test invalid buffer size is rejected
-		kvInit := NewKVInitService(&KVConfig{WatchPrefixBufferSize: -3}, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		kvInit := NewKVInitService(&KVConfig{WatchPrefixBufferSize: -3}, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 		_, err := kvInit.GetMemberlistKV()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid WatchPrefixBufferSize")
 
-		kvInit = NewKVInitService(&KVConfig{WatchPrefixBufferSize: 0}, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		kvInit = NewKVInitService(&KVConfig{WatchPrefixBufferSize: 0}, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 		_, err = kvInit.GetMemberlistKV()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid WatchPrefixBufferSize")
@@ -2067,7 +2182,7 @@ func TestWatchPrefix(t *testing.T) {
 		cfg.WatchPrefixBufferSize = 2
 		// Disable notification batching to get immediate notifications
 		cfg.NotifyInterval = 0
-		kv := NewKV(cfg, log.NewNopLogger(), &dnsProviderMock{}, prometheus.NewPedanticRegistry())
+		kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
 		defer services.StopAndAwaitTerminated(context.Background(), kv) //nolint:errcheck
 


### PR DESCRIPTION
**What this PR does**:

In Mimir we have an issue (https://github.com/grafana/mimir/issues/10866) caused by memberlist cluster not being initialised when other services, depending memberlist, are started. As of today, there's no way to enforce that memberlist successfully runs a fast-join before switching to the Running state.

In this PR I propose to:

1. Add a new CLI flag, named `-memberlist.abort-if-fast-join-fails` (disabled by default), that allows to have memberlist service failing when the fast-join fails
2. Add retries to DNS resolution used by the cluster join procedure (both fast-join and full join), given this is the actual error we get, due to unreliable networking issues right after a new K8S node is created

How will be used in Mimir? My plan is to enable the new `-memberlist.abort-if-fast-join-fails` only for ingesters, because in our context it's critical to have an updated view of the memberlist cluster when the ingester service startup (otherwise it can't correctly compute local limits).

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
