### PR TITLE
dns: Change test assertion that fails on MacOS

### DIFF
--- a/dns/miekgdns2/resolver_test.go
+++ b/dns/miekgdns2/resolver_test.go
@@ -274,7 +274,7 @@ func TestPoolingClient(t *testing.T) {
 	t.Run("exchange", func(t *testing.T) {
 		resp, _, err := client.Exchange(ctx, msg, server)
 		require.NoError(t, err)
-		require.NotEmpty(t, resp.Answer)
+		require.Equal(t, dns.RcodeSuccess, resp.Rcode)
 		require.Len(t, client.pools, 1)
 	})
 


### PR DESCRIPTION
**What this PR does**:

Don't assert that an actual query done in tests returns results. Instead, just assert than there's no error doing the query.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [X] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
