### PR TITLE
SpanLogger: don't embed Span

### DIFF
--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -10,7 +10,6 @@ import (
 
 	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/spanlogger"
@@ -313,7 +312,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 
 	terminate := func(err error, cause string) ([]T, error) {
 		if cfg.Logger != nil && !errors.Is(err, context.Canceled) { // Cancellation is not an error.
-			ext.Error.Set(cfg.Logger.Span, true)
+			cfg.Logger.SetError()
 		}
 
 		contextTracker.cancelAllContexts(cancellation.NewError(errors.New(cause)))

--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -7,6 +7,7 @@ package spanlogger
 import (
 	"context"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,11 +43,11 @@ var (
 
 // SpanLogger unifies tracing and logging, to reduce repetition.
 type SpanLogger struct {
-	ctx        context.Context            // context passed in, with logger
-	resolver   TenantResolver             // passed in
-	baseLogger log.Logger                 // passed in
-	logger     atomic.Pointer[log.Logger] // initialized on first use
-	opentracing.Span
+	ctx          context.Context            // context passed in, with logger
+	resolver     TenantResolver             // passed in
+	baseLogger   log.Logger                 // passed in
+	logger       atomic.Pointer[log.Logger] // initialized on first use
+	span         opentracing.Span
 	sampled      bool
 	debugEnabled bool
 }
@@ -63,7 +64,7 @@ func New(ctx context.Context, logger log.Logger, method string, resolver TenantR
 		ctx:          ctx,
 		resolver:     resolver,
 		baseLogger:   log.With(logger, "method", method),
-		Span:         span,
+		span:         span,
 		sampled:      sampled,
 		debugEnabled: debugEnabled(logger),
 	}
@@ -95,7 +96,7 @@ func FromContext(ctx context.Context, fallback log.Logger, resolver TenantResolv
 		ctx:          ctx,
 		baseLogger:   logger,
 		resolver:     resolver,
-		Span:         sp,
+		span:         sp,
 		sampled:      sampled,
 		debugEnabled: debugEnabled(logger),
 	}
@@ -146,7 +147,7 @@ func (s *SpanLogger) Error(err error) error {
 	if err == nil || !s.sampled {
 		return err
 	}
-	ext.Error.Set(s.Span, true)
+	s.SetError()
 	s.LogFields(otlog.Error(err))
 	return err
 }
@@ -188,6 +189,41 @@ func (s *SpanLogger) SetSpanAndLogTag(key string, value interface{}) {
 	logger := s.getLogger()
 	wrappedLogger := log.With(logger, key, value)
 	s.logger.Store(&wrappedLogger)
+}
+
+// SetError will set the error flag on the span.
+func (s *SpanLogger) SetError() {
+	ext.Error.Set(s.span, true)
+}
+
+// SetTag will set a tag/attribute on the span.
+func (s *SpanLogger) SetTag(key string, value interface{}) {
+	s.span.SetTag(key, value)
+}
+
+// Finish will finish the span.
+func (s *SpanLogger) Finish() {
+	s.span.Finish()
+}
+
+// LogFields will log the provided fields in the span, this is more performant that LogKV when using opentracing library.
+func (s *SpanLogger) LogFields(kvps ...otlog.Field) {
+	if !s.sampled {
+		return
+	}
+
+	// Clone kvps to prevent it from escaping to heap even when it's not sampled.
+	s.span.LogFields(slices.Clone(kvps)...)
+}
+
+// LogKV will log the provided key/value pairs in the span, this is less performant than LogFields when using opentracing library.
+func (s *SpanLogger) LogKV(kvps ...interface{}) {
+	if !s.sampled {
+		return
+	}
+
+	// Clone kvps to prevent it from escaping to heap even when it's not sampled.
+	s.span.LogKV(slices.Clone(kvps)...)
 }
 
 // Caller is like github.com/go-kit/log's Caller, but ensures that the caller information is

--- a/spanlogger/spanlogger_test.go
+++ b/spanlogger/spanlogger_test.go
@@ -30,7 +30,7 @@ func TestSpanLogger_Log(t *testing.T) {
 	span, ctx := New(context.Background(), logger, "test", resolver, "bar")
 	_ = span.Log("foo")
 	newSpan := FromContext(ctx, logger, resolver)
-	require.Equal(t, span.Span, newSpan.Span)
+	require.Equal(t, span.span, newSpan.span)
 	_ = newSpan.Log("bar")
 	noSpan := FromContext(context.Background(), logger, resolver)
 	_ = noSpan.Log("foo")
@@ -95,7 +95,7 @@ func TestSpanLogger_SetSpanAndLogTag(t *testing.T) {
 	spanLogger.SetSpanAndLogTag("more context", "abc")
 	require.NoError(t, spanLogger.Log("msg", "this is the third message"))
 
-	span := spanLogger.Span.(*mocktracer.MockSpan)
+	span := spanLogger.span.(*mocktracer.MockSpan)
 	expectedTags := map[string]interface{}{
 		"id":           "123",
 		"more context": "abc",
@@ -128,7 +128,7 @@ func createSpan(ctx context.Context) *mocktracer.MockSpan {
 	opentracing.SetGlobalTracer(mockTracer)
 
 	logger, _ := New(ctx, log.NewNopLogger(), "name", fakeResolver{})
-	return logger.Span.(*mocktracer.MockSpan)
+	return logger.span.(*mocktracer.MockSpan)
 }
 
 type funcLogger func(keyvals ...interface{}) error


### PR DESCRIPTION
**What this PR does**:

Instead of embedding the span and letting everyone access it, expose methods explicitly.

This would allow us to replace the implementation with OTEL without having to modify all usages of the Spanlogger.

Users of this library will have to replace the `ext.Error.Set(spanlog, true)` by `spanlog.SetError`.

**Which issue(s) this PR fixes**:

Ref: https://github.com/grafana/mimir-squad/issues/1511#event-16121302090

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
