### PR TITLE
Server: Add metric server_invalid_cluster_validation_label_requests_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495
 * [FEATURE] Add `middleware.ClusterUnaryClientInterceptor`, a `grpc.UnaryClientInterceptor` that propagates cluster validation labels to the outgoing gRPC metadata. #640 #648 #649 #655
 * [FEATURE] Add `middleware.ClusterUnaryServerInterceptor`, a `grpc.UnaryServerInterceptor` that checks if the incoming gRPC metadata contains a correct cluster validation label, and returns an error if it is not the case. #640 #648 #649 #655
-* [FEATURE] Server: Add support for adding `middleware.ClusterUnaryServerInterceptor` as `server.Server` unary interceptor via the following experimental configuration options: #650 #657
+* [FEATURE] Server: Add support for adding `middleware.ClusterUnaryServerInterceptor` as `server.Server` unary interceptor via the following experimental configuration options: #650 #657 #680
   * `-server.cluster-validation.label`
   * `-server.cluster-validation.grpc.soft-validation`
   * `-server.cluster-validation.grpc.enabled`

--- a/middleware/grpc_cluster.go
+++ b/middleware/grpc_cluster.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/grpcutil"
@@ -69,7 +70,7 @@ func handleClusterValidationError(err error, method string, invalidClusterValida
 // If an empty cluster label or nil logger are provided, ClusterUnaryServerInterceptor panics.
 // If the softValidation parameter is true, errors related to the cluster label validation are logged, but not returned.
 // Otherwise, an error is returned.
-func ClusterUnaryServerInterceptor(cluster string, softValidation bool, logger log.Logger) grpc.UnaryServerInterceptor {
+func ClusterUnaryServerInterceptor(cluster string, softValidation bool, invalidClusterValidations *prometheus.CounterVec, logger log.Logger) grpc.UnaryServerInterceptor {
 	validateClusterServerInterceptorInputParameters(cluster, logger)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		// We skip the gRPC health check.
@@ -77,7 +78,7 @@ func ClusterUnaryServerInterceptor(cluster string, softValidation bool, logger l
 			return handler(ctx, req)
 		}
 
-		if err := checkClusterFromIncomingContext(ctx, info.FullMethod, cluster, softValidation, logger); err != nil {
+		if err := checkClusterFromIncomingContext(ctx, info.FullMethod, cluster, softValidation, invalidClusterValidations, logger); err != nil {
 			stat := grpcutil.Status(codes.FailedPrecondition, err.Error(), &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL})
 			return nil, stat.Err()
 		}
@@ -94,16 +95,22 @@ func validateClusterServerInterceptorInputParameters(cluster string, logger log.
 	}
 }
 
-func checkClusterFromIncomingContext(ctx context.Context, method string, expectedCluster string, softValidationEnabled bool, logger log.Logger) error {
+func checkClusterFromIncomingContext(
+	ctx context.Context, method string, expectedCluster string, softValidationEnabled bool,
+	invalidClusterValidations *prometheus.CounterVec, logger log.Logger,
+) error {
 	reqCluster, err := clusterutil.GetClusterFromIncomingContext(ctx)
 	if err == nil {
 		if reqCluster == expectedCluster {
 			return nil
 		}
+
 		var wrongClusterErr error
 		if !softValidationEnabled {
 			wrongClusterErr = fmt.Errorf("rejected request with wrong cluster validation label %q - it should be %q", reqCluster, expectedCluster)
 		}
+
+		invalidClusterValidations.WithLabelValues("grpc", method, expectedCluster, reqCluster).Inc()
 		level.Warn(logger).Log("msg", "request with wrong cluster validation label", "method", method, "cluster_validation_label", expectedCluster, "request_cluster_validation_label", reqCluster, "soft_validation", softValidationEnabled)
 		return wrongClusterErr
 	}
@@ -113,13 +120,18 @@ func checkClusterFromIncomingContext(ctx context.Context, method string, expecte
 		if !softValidationEnabled {
 			emptyClusterErr = fmt.Errorf("rejected request with empty cluster validation label - it should be %q", expectedCluster)
 		}
+
+		invalidClusterValidations.WithLabelValues("grpc", method, expectedCluster, "").Inc()
 		level.Warn(logger).Log("msg", "request with no cluster validation label", "method", method, "cluster_validation_label", expectedCluster, "soft_validation", softValidationEnabled)
 		return emptyClusterErr
 	}
+
 	var rejectedRequestErr error
 	if !softValidationEnabled {
 		rejectedRequestErr = fmt.Errorf("rejected request: %w", err)
 	}
+
+	invalidClusterValidations.WithLabelValues("grpc", method, expectedCluster, "").Inc()
 	level.Warn(logger).Log("msg", "detected error during cluster validation label extraction", "method", method, "cluster_validation_label", expectedCluster, "soft_validation", softValidationEnabled, "err", err)
 	return rejectedRequestErr
 }

--- a/middleware/grpc_cluster_test.go
+++ b/middleware/grpc_cluster_test.go
@@ -68,10 +68,10 @@ func TestClusterUnaryClientInterceptor(t *testing.T) {
 		require.Len(t, clusterIDs, 1)
 		require.Equal(t, expectedCluster, clusterIDs[0])
 	}
-	invalidClusterValidationReporter := func(cluster string, logger log.Logger, invalidClusterValidations *prometheus.CounterVec) InvalidClusterValidationReporter {
+	invalidClusterValidationReporter := func(cluster string, logger log.Logger, invalidClusterRequests *prometheus.CounterVec) InvalidClusterValidationReporter {
 		return func(msg string, method string) {
 			level.Warn(logger).Log("msg", msg, "method", method, "cluster_validation_label", cluster)
-			invalidClusterValidations.WithLabelValues(method).Inc()
+			invalidClusterRequests.WithLabelValues(method).Inc()
 		}
 	}
 	for testName, testCase := range testCases {
@@ -197,7 +197,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 				logger := createLogger(t, buf)
 				reg := prometheus.NewPedanticRegistry()
 				interceptor := ClusterUnaryServerInterceptor(
-					testCase.serverCluster, softValidation, NewInvalidClusterValidations(reg), logger,
+					testCase.serverCluster, softValidation, NewInvalidClusterRequests(reg), logger,
 				)
 				handler := func(context.Context, interface{}) (interface{}, error) {
 					return nil, nil
@@ -255,8 +255,8 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
-			invalidClusterValidations := NewInvalidClusterValidations(reg)
-			interceptor := ClusterUnaryServerInterceptor(goodCluster, false, invalidClusterValidations, log.NewNopLogger())
+			invalidClusterRequests := NewInvalidClusterRequests(reg)
+			interceptor := ClusterUnaryServerInterceptor(goodCluster, false, invalidClusterRequests, log.NewNopLogger())
 			handler := func(context.Context, interface{}) (interface{}, error) {
 				return nil, nil
 			}

--- a/middleware/grpc_cluster_test.go
+++ b/middleware/grpc_cluster_test.go
@@ -113,9 +113,10 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 		serverCluster   string
 		verifyErr       func(err error, softValidation bool)
 		expectedLogs    string
+		expectedMetrics string
 		shouldPanic     bool
 	}{
-		"empty server cluster make ClusterUnaryServerInterceptor panic": {
+		"empty server cluster makes ClusterUnaryServerInterceptor panic": {
 			incomingContext: newIncomingContext(false, ""),
 			serverCluster:   "",
 			shouldPanic:     true,
@@ -128,6 +129,11 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			incomingContext: newIncomingContext(true, "wrong-cluster"),
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with wrong cluster validation label" method=/Test/Me cluster_validation_label=cluster request_cluster_validation_label=wrong-cluster soft_validation=%v`,
+			expectedMetrics: `
+                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_request_invalid_cluster_validation_labels_total counter
+                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster", method="/Test/Me",protocol="grpc",request_cluster_validation_label="wrong-cluster"} 1
+				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
 					require.Equal(t, grpcutil.Status(codes.FailedPrecondition, `rejected request with wrong cluster validation label "wrong-cluster" - it should be "cluster"`, &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL}).Err(), err)
@@ -138,6 +144,11 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			incomingContext: newIncomingContext(true, ""),
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
+			expectedMetrics: `
+                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_request_invalid_cluster_validation_labels_total counter
+                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
 					require.Equal(t, grpcutil.Status(codes.FailedPrecondition, `rejected request with empty cluster validation label - it should be "cluster"`, &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL}).Err(), err)
@@ -148,16 +159,26 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			incomingContext: newIncomingContext(false, ""),
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
+			expectedMetrics: `
+                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_request_invalid_cluster_validation_labels_total counter
+                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
 					require.Equal(t, grpcutil.Status(codes.FailedPrecondition, `rejected request with empty cluster validation label - it should be "cluster"`, &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL}).Err(), err)
 				}
 			},
 		},
-		"if the incoming context contains more than one cluster labels an error is returned if soft validation disabled": {
+		"if the incoming context contains more than one cluster label an error is returned if soft validation disabled": {
 			incomingContext: metadata.NewIncomingContext(context.Background(), map[string][]string{clusterutil.MetadataClusterValidationLabelKey: {"cluster", "another-cluster"}}),
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="detected error during cluster validation label extraction" method=/Test/Me cluster_validation_label=cluster soft_validation=%v err="gRPC metadata should contain exactly 1 value for key \"x-cluster\", but it contains [cluster another-cluster]"`,
+			expectedMetrics: `
+                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_request_invalid_cluster_validation_labels_total counter
+                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
 					require.Equal(t, grpcutil.Status(codes.FailedPrecondition, `rejected request: gRPC metadata should contain exactly 1 value for key "x-cluster", but it contains [cluster another-cluster]`, &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL}).Err(), err)
@@ -170,11 +191,14 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			t.Run(fmt.Sprintf("%s softValidation=%v", testName, softValidation), func(t *testing.T) {
 				defer func() {
 					r := recover()
-					require.Equal(t, testCase.shouldPanic, r != nil)
+					require.Equal(t, testCase.shouldPanic, r != nil, r)
 				}()
 				buf := bytes.NewBuffer(nil)
 				logger := createLogger(t, buf)
-				interceptor := ClusterUnaryServerInterceptor(testCase.serverCluster, softValidation, logger)
+				reg := prometheus.NewPedanticRegistry()
+				interceptor := ClusterUnaryServerInterceptor(
+					testCase.serverCluster, softValidation, NewInvalidClusterValidations(reg), logger,
+				)
 				handler := func(context.Context, interface{}) (interface{}, error) {
 					return nil, nil
 				}
@@ -189,6 +213,8 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 				} else {
 					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))))
 				}
+				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_request_invalid_cluster_validation_labels_total")
+				require.NoError(t, err)
 			})
 		}
 	}
@@ -201,6 +227,7 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 	testCases := map[string]struct {
 		serverInfo      *grpc.UnaryServerInfo
 		incomingContext context.Context
+		expectedMetrics string
 		expectedError   error
 	}{
 		"UnaryServerInfo with healthpb.HealthServer does no cluster check": {
@@ -216,13 +243,20 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 			serverInfo: &grpc.UnaryServerInfo{Server: nil, FullMethod: "/Test/Me"},
 			// We create a context with a bad cluster.
 			incomingContext: newIncomingContext(true, badCluster),
+			expectedMetrics: `
+                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_request_invalid_cluster_validation_labels_total counter
+                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="good-cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label="bad-cluster"} 1
+			`,
 			// Since UnaryServerInfo doesn't contain the grpc health server, the check is done, and we expect an error.
 			expectedError: grpcutil.Status(codes.FailedPrecondition, `rejected request with wrong cluster validation label "bad-cluster" - it should be "good-cluster"`, &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL}).Err(),
 		},
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			interceptor := ClusterUnaryServerInterceptor(goodCluster, false, log.NewNopLogger())
+			reg := prometheus.NewPedanticRegistry()
+			invalidClusterValidations := NewInvalidClusterValidations(reg)
+			interceptor := ClusterUnaryServerInterceptor(goodCluster, false, invalidClusterValidations, log.NewNopLogger())
 			handler := func(context.Context, interface{}) (interface{}, error) {
 				return nil, nil
 			}
@@ -233,6 +267,8 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 			} else {
 				require.Equal(t, testCase.expectedError, err)
 			}
+			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_request_invalid_cluster_validation_labels_total")
+			require.NoError(t, err)
 		})
 	}
 }

--- a/middleware/grpc_cluster_test.go
+++ b/middleware/grpc_cluster_test.go
@@ -130,9 +130,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with wrong cluster validation label" method=/Test/Me cluster_validation_label=cluster request_cluster_validation_label=wrong-cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster", method="/Test/Me",protocol="grpc",request_cluster_validation_label="wrong-cluster"} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster", method="/Test/Me",protocol="grpc",request_cluster_validation_label="wrong-cluster"} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -145,9 +145,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -160,9 +160,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -175,9 +175,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="detected error during cluster validation label extraction" method=/Test/Me cluster_validation_label=cluster soft_validation=%v err="gRPC metadata should contain exactly 1 value for key \"x-cluster\", but it contains [cluster another-cluster]"`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -213,7 +213,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 				} else {
 					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))))
 				}
-				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_request_invalid_cluster_validation_labels_total")
+				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
 				require.NoError(t, err)
 			})
 		}
@@ -244,9 +244,9 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 			// We create a context with a bad cluster.
 			incomingContext: newIncomingContext(true, badCluster),
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="good-cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label="bad-cluster"} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="good-cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label="bad-cluster"} 1
 			`,
 			// Since UnaryServerInfo doesn't contain the grpc health server, the check is done, and we expect an error.
 			expectedError: grpcutil.Status(codes.FailedPrecondition, `rejected request with wrong cluster validation label "bad-cluster" - it should be "good-cluster"`, &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL}).Err(),
@@ -267,7 +267,7 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 			} else {
 				require.Equal(t, testCase.expectedError, err)
 			}
-			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_request_invalid_cluster_validation_labels_total")
+			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
 			require.NoError(t, err)
 		})
 	}

--- a/middleware/http_cluster.go
+++ b/middleware/http_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/dskit/clusterutil"
 )
@@ -81,7 +82,9 @@ func validateClusterValidationRoundTripperInputParameters(cluster string, invali
 // The check is ignored if the request's path belongs to the list of excluded paths.
 // If the softValidation parameter is true, errors related to the cluster label validation are logged, but not returned.
 // Otherwise, an error is returned.
-func ClusterValidationMiddleware(cluster string, excludedPaths []string, softValidation bool, logger log.Logger) Interface {
+func ClusterValidationMiddleware(
+	cluster string, excludedPaths []string, softValidation bool, invalidClusterValidations *prometheus.CounterVec, logger log.Logger,
+) Interface {
 	validateClusterValidationMiddlewareInputParameters(cluster, logger)
 	var reB strings.Builder
 	// Allow for a potential path prefix being configured.
@@ -94,7 +97,7 @@ func ClusterValidationMiddleware(cluster string, excludedPaths []string, softVal
 
 	return Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if err := checkClusterFromRequest(r, cluster, softValidation, reExcludedPath, logger); err != nil {
+			if err := checkClusterFromRequest(r, cluster, softValidation, reExcludedPath, invalidClusterValidations, logger); err != nil {
 				clusterValidationErr := clusterValidationError{ClusterValidationErrorMessage: err.Error()}
 				clusterValidationErr.writeAsJSON(w)
 				return
@@ -113,34 +116,47 @@ func validateClusterValidationMiddlewareInputParameters(cluster string, logger l
 	}
 }
 
-func checkClusterFromRequest(r *http.Request, expectedCluster string, softValidationEnabled bool, reExcludedPath *regexp.Regexp, logger log.Logger) error {
+func checkClusterFromRequest(
+	r *http.Request, expectedCluster string, softValidationEnabled bool, reExcludedPath *regexp.Regexp,
+	invalidClusterValidations *prometheus.CounterVec, logger log.Logger,
+) error {
 	if reExcludedPath != nil && reExcludedPath.MatchString(r.URL.Path) {
 		return nil
 	}
+
 	reqCluster, err := clusterutil.GetClusterFromRequest(r)
 	if err == nil {
 		if reqCluster == expectedCluster {
 			return nil
 		}
+
 		var wrongClusterErr error
 		if !softValidationEnabled {
 			wrongClusterErr = fmt.Errorf("rejected request with wrong cluster validation label %q - it should be %q", reqCluster, expectedCluster)
 		}
+
+		invalidClusterValidations.WithLabelValues("http", r.URL.Path, expectedCluster, reqCluster).Inc()
 		level.Warn(logger).Log("msg", "request with wrong cluster validation label", "path", r.URL.Path, "cluster_validation_label", expectedCluster, "request_cluster_validation_label", reqCluster, "soft_validation", softValidationEnabled)
 		return wrongClusterErr
 	}
+
 	if errors.Is(err, clusterutil.ErrNoClusterValidationLabelInHeader) {
 		var emptyClusterErr error
 		if !softValidationEnabled {
 			emptyClusterErr = fmt.Errorf("rejected request with empty cluster validation label - it should be %q", expectedCluster)
 		}
+
+		invalidClusterValidations.WithLabelValues("http", r.URL.Path, expectedCluster, "").Inc()
 		level.Warn(logger).Log("msg", "request with no cluster validation label", "path", r.URL.Path, "cluster_validation_label", expectedCluster, "soft_validation", softValidationEnabled)
 		return emptyClusterErr
 	}
+
 	var rejectedRequestErr error
 	if !softValidationEnabled {
 		rejectedRequestErr = fmt.Errorf("rejected request: %w", err)
 	}
+
+	invalidClusterValidations.WithLabelValues("http", r.URL.Path, expectedCluster, "").Inc()
 	level.Warn(logger).Log("msg", "detected error during cluster validation label extraction", "path", r.URL.Path, "cluster_validation_label", expectedCluster, "soft_validation", softValidationEnabled, "err", err)
 	return rejectedRequestErr
 }

--- a/middleware/http_cluster_test.go
+++ b/middleware/http_cluster_test.go
@@ -165,9 +165,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="request with wrong cluster validation label" path=/Test/Me cluster_validation_label=cluster request_cluster_validation_label=wrong-cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="wrong-cluster"} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="wrong-cluster"} 1
 			`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request with wrong cluster validation label "wrong-cluster" - it should be "cluster"`,
@@ -179,9 +179,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="request with no cluster validation label" path=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
 			`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request with empty cluster validation label - it should be "cluster"`,
@@ -190,9 +190,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="request with no cluster validation label" path=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
 				`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request with empty cluster validation label - it should be "cluster"`,
@@ -204,9 +204,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="detected error during cluster validation label extraction" path=/Test/Me cluster_validation_label=cluster soft_validation=%v err="request header should contain exactly 1 value for key \"X-Cluster\", but it contains [cluster another-cluster]"`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
 			`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request: request header should contain exactly 1 value for key "X-Cluster", but it contains [cluster another-cluster]`,
@@ -250,7 +250,7 @@ func TestClusterValidationMiddleware(t *testing.T) {
 				if testCase.expectedLogs != "" {
 					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))))
 				}
-				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_request_invalid_cluster_validation_labels_total")
+				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
 				require.NoError(t, err)
 			})
 		}
@@ -294,9 +294,9 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 			expectedStatusCode:   http.StatusOK,
 			expectedErrorMessage: "",
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
 			`,
 		},
 		"when soft validation is disabled and request path is not excluded an error is returned": {
@@ -306,9 +306,9 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 			expectedStatusCode:   http.StatusNetworkAuthenticationRequired,
 			expectedErrorMessage: `rejected request with wrong cluster validation label "client-cluster" - it should be "server-cluster"`,
 			expectedMetrics: `
-                                # HELP server_request_invalid_cluster_validation_labels_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_request_invalid_cluster_validation_labels_total counter
-                                server_request_invalid_cluster_validation_labels_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
+                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE server_invalid_cluster_validation_label_requests_total counter
+                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
 			`,
 		},
 	}
@@ -334,7 +334,7 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, testCase.expectedErrorMessage, clusterValidationErr.ClusterValidationErrorMessage)
 			}
-			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_request_invalid_cluster_validation_labels_total")
+			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
 			require.NoError(t, err)
 		})
 	}

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -5,7 +5,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// NewInvalidClusterValidations registers and returns a new counter metric server_request_invalid_cluster_validation_labels_total.
+// NewInvalidClusterValidations registers and returns a new counter metric server_invalid_cluster_validation_label_requests_total.
 func NewInvalidClusterValidations(reg prometheus.Registerer) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "server_invalid_cluster_validation_label_requests_total",

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -8,7 +8,7 @@ import (
 // NewInvalidClusterValidations registers and returns a new counter metric server_request_invalid_cluster_validation_labels_total.
 func NewInvalidClusterValidations(reg prometheus.Registerer) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "server_request_invalid_cluster_validation_labels_total",
+		Name: "server_invalid_cluster_validation_label_requests_total",
 		Help: "Number of requests received by server with invalid cluster validation label.",
 	}, []string{"protocol", "method", "cluster_validation_label", "request_cluster_validation_label"})
 }

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -5,8 +5,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// NewInvalidClusterValidations registers and returns a new counter metric server_invalid_cluster_validation_label_requests_total.
-func NewInvalidClusterValidations(reg prometheus.Registerer) *prometheus.CounterVec {
+// NewInvalidClusterRequests registers and returns a new counter metric server_invalid_cluster_validation_label_requests_total.
+func NewInvalidClusterRequests(reg prometheus.Registerer) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "server_invalid_cluster_validation_label_requests_total",
 		Help: "Number of requests received by server with invalid cluster validation label.",

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// NewInvalidClusterValidations registers and returns a new counter metric server_request_invalid_cluster_validation_labels_total.
+func NewInvalidClusterValidations(reg prometheus.Registerer) *prometheus.CounterVec {
+	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "server_request_invalid_cluster_validation_labels_total",
+		Help: "Number of requests received by server with invalid cluster validation label.",
+	}, []string{"protocol", "method", "cluster_validation_label", "request_cluster_validation_label"})
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -16,32 +16,34 @@ import (
 )
 
 type Metrics struct {
-	TCPConnections           *prometheus.GaugeVec
-	TCPConnectionsLimit      *prometheus.GaugeVec
-	RequestDuration          *prometheus.HistogramVec
-	PerTenantRequestDuration *prometheus.HistogramVec
-	PerTenantRequestTotal    *prometheus.CounterVec
-	ReceivedMessageSize      *prometheus.HistogramVec
-	SentMessageSize          *prometheus.HistogramVec
-	InflightRequests         *prometheus.GaugeVec
-	RequestThroughput        *prometheus.HistogramVec
+	TCPConnections            *prometheus.GaugeVec
+	TCPConnectionsLimit       *prometheus.GaugeVec
+	RequestDuration           *prometheus.HistogramVec
+	PerTenantRequestDuration  *prometheus.HistogramVec
+	PerTenantRequestTotal     *prometheus.CounterVec
+	ReceivedMessageSize       *prometheus.HistogramVec
+	SentMessageSize           *prometheus.HistogramVec
+	InflightRequests          *prometheus.GaugeVec
+	RequestThroughput         *prometheus.HistogramVec
+	InvalidClusterValidations *prometheus.CounterVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
-	reg := promauto.With(cfg.registererOrDefault())
+	reg := cfg.registererOrDefault()
+	factory := promauto.With(reg)
 
 	return &Metrics{
-		TCPConnections: reg.NewGaugeVec(prometheus.GaugeOpts{
+		TCPConnections: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "tcp_connections",
 			Help:      "Current number of accepted TCP connections.",
 		}, []string{"protocol"}),
-		TCPConnectionsLimit: reg.NewGaugeVec(prometheus.GaugeOpts{
+		TCPConnectionsLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "tcp_connections_limit",
 			Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
 		}, []string{"protocol"}),
-		RequestDuration: reg.NewHistogramVec(prometheus.HistogramOpts{
+		RequestDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "request_duration_seconds",
 			Help:                            "Time (in seconds) spent serving HTTP requests.",
@@ -50,7 +52,7 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route", "status_code", "ws"}),
-		PerTenantRequestDuration: reg.NewHistogramVec(prometheus.HistogramOpts{
+		PerTenantRequestDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "per_tenant_request_duration_seconds",
 			Help:                            "Time (in seconds) spent serving HTTP requests for a particular tenant.",
@@ -59,29 +61,29 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route", "status_code", "ws", "tenant"}),
-		PerTenantRequestTotal: reg.NewCounterVec(prometheus.CounterOpts{
+		PerTenantRequestTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "per_tenant_request_total",
 			Help:      "Total count of requests for a particular tenant.",
 		}, []string{"method", "route", "status_code", "ws", "tenant"}),
-		ReceivedMessageSize: reg.NewHistogramVec(prometheus.HistogramOpts{
+		ReceivedMessageSize: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "request_message_bytes",
 			Help:      "Size (in bytes) of messages received in the request.",
 			Buckets:   middleware.BodySizeBuckets,
 		}, []string{"method", "route"}),
-		SentMessageSize: reg.NewHistogramVec(prometheus.HistogramOpts{
+		SentMessageSize: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "response_message_bytes",
 			Help:      "Size (in bytes) of messages sent in response.",
 			Buckets:   middleware.BodySizeBuckets,
 		}, []string{"method", "route"}),
-		InflightRequests: reg.NewGaugeVec(prometheus.GaugeOpts{
+		InflightRequests: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "inflight_requests",
 			Help:      "Current number of inflight requests.",
 		}, []string{"method", "route"}),
-		RequestThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
+		RequestThroughput: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "request_throughput_" + cfg.Throughput.Unit,
 			Help:                            "Server throughput of running requests.",
@@ -91,5 +93,6 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route"}),
+		InvalidClusterValidations: middleware.NewInvalidClusterValidations(reg),
 	}
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -16,16 +16,16 @@ import (
 )
 
 type Metrics struct {
-	TCPConnections            *prometheus.GaugeVec
-	TCPConnectionsLimit       *prometheus.GaugeVec
-	RequestDuration           *prometheus.HistogramVec
-	PerTenantRequestDuration  *prometheus.HistogramVec
-	PerTenantRequestTotal     *prometheus.CounterVec
-	ReceivedMessageSize       *prometheus.HistogramVec
-	SentMessageSize           *prometheus.HistogramVec
-	InflightRequests          *prometheus.GaugeVec
-	RequestThroughput         *prometheus.HistogramVec
-	InvalidClusterValidations *prometheus.CounterVec
+	TCPConnections           *prometheus.GaugeVec
+	TCPConnectionsLimit      *prometheus.GaugeVec
+	RequestDuration          *prometheus.HistogramVec
+	PerTenantRequestDuration *prometheus.HistogramVec
+	PerTenantRequestTotal    *prometheus.CounterVec
+	ReceivedMessageSize      *prometheus.HistogramVec
+	SentMessageSize          *prometheus.HistogramVec
+	InflightRequests         *prometheus.GaugeVec
+	RequestThroughput        *prometheus.HistogramVec
+	InvalidClusterRequests   *prometheus.CounterVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
@@ -93,6 +93,6 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route"}),
-		InvalidClusterValidations: middleware.NewInvalidClusterValidations(reg),
+		InvalidClusterRequests: middleware.NewInvalidClusterRequests(reg),
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -411,7 +411,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	if cfg.ClusterValidation.GRPC.Enabled {
 		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(
 			cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation,
-			metrics.InvalidClusterValidations, logger,
+			metrics.InvalidClusterRequests, logger,
 		))
 	}
 
@@ -576,7 +576,7 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(
 			cfg.ClusterValidation.Label, cfg.ClusterValidation.HTTP.ExcludedPaths,
 			cfg.ClusterValidation.HTTP.SoftValidation,
-			metrics.InvalidClusterValidations, logger,
+			metrics.InvalidClusterRequests, logger,
 		))
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -409,7 +409,10 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 	if cfg.ClusterValidation.GRPC.Enabled {
-		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation, logger))
+		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(
+			cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation,
+			metrics.InvalidClusterValidations, logger,
+		))
 	}
 
 	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
@@ -570,7 +573,11 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 		httpMiddleware = append(defaultHTTPMiddleware, cfg.HTTPMiddleware...)
 	}
 	if cfg.ClusterValidation.HTTP.Enabled {
-		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(cfg.ClusterValidation.Label, cfg.ClusterValidation.HTTP.ExcludedPaths, cfg.ClusterValidation.HTTP.SoftValidation, logger))
+		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(
+			cfg.ClusterValidation.Label, cfg.ClusterValidation.HTTP.ExcludedPaths,
+			cfg.ClusterValidation.HTTP.SoftValidation,
+			metrics.InvalidClusterValidations, logger,
+		))
 	}
 
 	return httpMiddleware, nil

--- a/server/server_tracing_test.go
+++ b/server/server_tracing_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go"
 	"golang.org/x/exp/maps"
@@ -201,18 +202,19 @@ func TestHTTPGRPCTracing(t *testing.T) {
 			t.Cleanup(func() { _ = closer.Close() })
 			opentracing.SetGlobalTracer(tracer)
 
-			var cfg Config
-			cfg.HTTPListenAddress = httpAddress
-			cfg.HTTPListenPort = httpPort
-			cfg.GRPCListenAddress = httpAddress
-			cfg.GRPCListenPort = 1234
-			cfg.GRPCServerMaxRecvMsgSize = 4 * 1024 * 1024
-			cfg.GRPCServerMaxSendMsgSize = 4 * 1024 * 1024
-			cfg.MetricsNamespace = "testing_httpgrpc_tracing_" + middleware.MakeLabelValue(testName)
 			var lvl log.Level
 			require.NoError(t, lvl.Set("info"))
-			cfg.LogLevel = lvl
-
+			cfg := Config{
+				HTTPListenAddress:        httpAddress,
+				HTTPListenPort:           httpPort,
+				GRPCListenAddress:        httpAddress,
+				GRPCListenPort:           1234,
+				GRPCServerMaxRecvMsgSize: 4 * 1024 * 1024,
+				GRPCServerMaxSendMsgSize: 4 * 1024 * 1024,
+				MetricsNamespace:         "testing_httpgrpc_tracing_" + middleware.MakeLabelValue(testName),
+				LogLevel:                 lvl,
+				Registerer:               prometheus.NewPedanticRegistry(),
+			}
 			server, err := New(cfg)
 			require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does**:

Add server metric `server_invalid_cluster_validation_label_requests_total`, that is incremented whenever the gRPC or HTTP server receives a request with an invalid cluster validation label. The metric is incremented even when validation is in soft mode.

Please note that I also had to fix some tests, so they won't register the new metric multiple times (causes a panic).

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
