### PR TITLE
middleware: Allow namespace for server_invalid_cluster_validation_label_requests_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@
 * [FEATURE] Add `ring.DoMultiUntilQuorumWithoutSuccessfulContextCancellation()`. #495
 * [FEATURE] Add `middleware.ClusterUnaryClientInterceptor`, a `grpc.UnaryClientInterceptor` that propagates cluster validation labels to the outgoing gRPC metadata. #640 #648 #649 #655
 * [FEATURE] Add `middleware.ClusterUnaryServerInterceptor`, a `grpc.UnaryServerInterceptor` that checks if the incoming gRPC metadata contains a correct cluster validation label, and returns an error if it is not the case. #640 #648 #649 #655
-* [FEATURE] Server: Add support for adding `middleware.ClusterUnaryServerInterceptor` as `server.Server` unary interceptor via the following experimental configuration options: #650 #657 #680
+* [FEATURE] Server: Add support for adding `middleware.ClusterUnaryServerInterceptor` as `server.Server` unary interceptor via the following experimental configuration options: #650 #657 #680 #682
   * `-server.cluster-validation.label`
   * `-server.cluster-validation.grpc.soft-validation`
   * `-server.cluster-validation.grpc.enabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@
   * `-server.cluster-validation.grpc.soft-validation`
   * `-server.cluster-validation.grpc.enabled`
 * [FEATURE] Add `middleware.ClusterValidationRoundTripper`, an `http.RoundTripper` that enriches HTTP request headers with the cluster validation labels. #671
-* [FEATURE] Add `middleware.ClusterValidationMiddleware`, an implementation of `middleware.Interface` that checks if HTTP requests contain a correct cluster validation label, and returns an error if it is not the case. #671
+* [FEATURE] Add `middleware.ClusterValidationMiddleware`, an implementation of `middleware.Interface` that checks if HTTP requests contain a correct cluster validation label, and returns an error if it is not the case. #671 #682
 * [FEATURE] Server: Add support for adding `middleware.ClusterValidationMiddleware` as `server.Server` HTTP middleware via the following experimental configuration options: #671
   * `-server.cluster-validation.label`
   * `-server.cluster-validation.http.soft-validation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@
   * `-server.cluster-validation.grpc.soft-validation`
   * `-server.cluster-validation.grpc.enabled`
 * [FEATURE] Add `middleware.ClusterValidationRoundTripper`, an `http.RoundTripper` that enriches HTTP request headers with the cluster validation labels. #671
-* [FEATURE] Add `middleware.ClusterValidationMiddleware`, an implementation of `middleware.Interface` that checks if HTTP requests contain a correct cluster validation label, and returns an error if it is not the case. #671 #682
+* [FEATURE] Add `middleware.ClusterValidationMiddleware`, an implementation of `middleware.Interface` that checks if HTTP requests contain a correct cluster validation label, and returns an error if it is not the case. #671 #680 #682
 * [FEATURE] Server: Add support for adding `middleware.ClusterValidationMiddleware` as `server.Server` HTTP middleware via the following experimental configuration options: #671
   * `-server.cluster-validation.label`
   * `-server.cluster-validation.http.soft-validation`

--- a/middleware/grpc_cluster_test.go
+++ b/middleware/grpc_cluster_test.go
@@ -130,9 +130,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with wrong cluster validation label" method=/Test/Me cluster_validation_label=cluster request_cluster_validation_label=wrong-cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster", method="/Test/Me",protocol="grpc",request_cluster_validation_label="wrong-cluster"} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster", method="/Test/Me",protocol="grpc",request_cluster_validation_label="wrong-cluster"} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -145,9 +145,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -160,9 +160,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -175,9 +175,9 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 			serverCluster:   "cluster",
 			expectedLogs:    `level=warn msg="detected error during cluster validation label extraction" method=/Test/Me cluster_validation_label=cluster soft_validation=%v err="gRPC metadata should contain exactly 1 value for key \"x-cluster\", but it contains [cluster another-cluster]"`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label=""} 1
 				`,
 			verifyErr: func(err error, softValidation bool) {
 				if !softValidation {
@@ -197,7 +197,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 				logger := createLogger(t, buf)
 				reg := prometheus.NewPedanticRegistry()
 				interceptor := ClusterUnaryServerInterceptor(
-					testCase.serverCluster, softValidation, NewInvalidClusterRequests(reg), logger,
+					testCase.serverCluster, softValidation, NewInvalidClusterRequests(reg, "test"), logger,
 				)
 				handler := func(context.Context, interface{}) (interface{}, error) {
 					return nil, nil
@@ -213,7 +213,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 				} else {
 					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))))
 				}
-				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
+				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "test_server_invalid_cluster_validation_label_requests_total")
 				require.NoError(t, err)
 			})
 		}
@@ -244,9 +244,9 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 			// We create a context with a bad cluster.
 			incomingContext: newIncomingContext(true, badCluster),
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="good-cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label="bad-cluster"} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="good-cluster",method="/Test/Me",protocol="grpc",request_cluster_validation_label="bad-cluster"} 1
 			`,
 			// Since UnaryServerInfo doesn't contain the grpc health server, the check is done, and we expect an error.
 			expectedError: grpcutil.Status(codes.FailedPrecondition, `rejected request with wrong cluster validation label "bad-cluster" - it should be "good-cluster"`, &grpcutil.ErrorDetails{Cause: grpcutil.WRONG_CLUSTER_VALIDATION_LABEL}).Err(),
@@ -255,7 +255,7 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
-			invalidClusterRequests := NewInvalidClusterRequests(reg)
+			invalidClusterRequests := NewInvalidClusterRequests(reg, "test")
 			interceptor := ClusterUnaryServerInterceptor(goodCluster, false, invalidClusterRequests, log.NewNopLogger())
 			handler := func(context.Context, interface{}) (interface{}, error) {
 				return nil, nil
@@ -267,7 +267,7 @@ func TestClusterUnaryServerInterceptorWithHealthServer(t *testing.T) {
 			} else {
 				require.Equal(t, testCase.expectedError, err)
 			}
-			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
+			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "test_server_invalid_cluster_validation_label_requests_total")
 			require.NoError(t, err)
 		})
 	}

--- a/middleware/http_cluster_test.go
+++ b/middleware/http_cluster_test.go
@@ -165,9 +165,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="request with wrong cluster validation label" path=/Test/Me cluster_validation_label=cluster request_cluster_validation_label=wrong-cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="wrong-cluster"} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="wrong-cluster"} 1
 			`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request with wrong cluster validation label "wrong-cluster" - it should be "cluster"`,
@@ -179,9 +179,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="request with no cluster validation label" path=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
 			`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request with empty cluster validation label - it should be "cluster"`,
@@ -190,9 +190,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="request with no cluster validation label" path=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
 				`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request with empty cluster validation label - it should be "cluster"`,
@@ -204,9 +204,9 @@ func TestClusterValidationMiddleware(t *testing.T) {
 			serverCluster: "cluster",
 			expectedLogs:  `level=warn msg="detected error during cluster validation label extraction" path=/Test/Me cluster_validation_label=cluster soft_validation=%v err="request header should contain exactly 1 value for key \"X-Cluster\", but it contains [cluster another-cluster]"`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="cluster",method="/Test/Me",protocol="http",request_cluster_validation_label=""} 1
 			`,
 			expectedStatusCode: http.StatusNetworkAuthenticationRequired,
 			expectedErrorMsg:   `rejected request: request header should contain exactly 1 value for key "X-Cluster", but it contains [cluster another-cluster]`,
@@ -222,7 +222,7 @@ func TestClusterValidationMiddleware(t *testing.T) {
 				buf := bytes.NewBuffer(nil)
 				logger := createLogger(t, buf)
 				reg := prometheus.NewPedanticRegistry()
-				invalidClusterRequests := NewInvalidClusterRequests(reg)
+				invalidClusterRequests := NewInvalidClusterRequests(reg, "test")
 				m := ClusterValidationMiddleware(testCase.serverCluster, nil, softValidation, invalidClusterRequests, logger)
 				handler := Merge(m).Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusOK)
@@ -250,7 +250,7 @@ func TestClusterValidationMiddleware(t *testing.T) {
 				if testCase.expectedLogs != "" {
 					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))))
 				}
-				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
+				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "test_server_invalid_cluster_validation_label_requests_total")
 				require.NoError(t, err)
 			})
 		}
@@ -294,9 +294,9 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 			expectedStatusCode:   http.StatusOK,
 			expectedErrorMessage: "",
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
 			`,
 		},
 		"when soft validation is disabled and request path is not excluded an error is returned": {
@@ -306,16 +306,16 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 			expectedStatusCode:   http.StatusNetworkAuthenticationRequired,
 			expectedErrorMessage: `rejected request with wrong cluster validation label "client-cluster" - it should be "server-cluster"`,
 			expectedMetrics: `
-                                # HELP server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
-                                # TYPE server_invalid_cluster_validation_label_requests_total counter
-                                server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="/Test/Me",protocol="http",request_cluster_validation_label="client-cluster"} 1
 			`,
 		},
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
-			invalidClusterRequests := NewInvalidClusterRequests(reg)
+			invalidClusterRequests := NewInvalidClusterRequests(reg, "test")
 			m := ClusterValidationMiddleware("server-cluster", testCase.excludedPaths, testCase.softValidation, invalidClusterRequests, log.NewNopLogger())
 			handler := Merge(m).Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -334,7 +334,7 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, testCase.expectedErrorMessage, clusterValidationErr.ClusterValidationErrorMessage)
 			}
-			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "server_invalid_cluster_validation_label_requests_total")
+			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "test_server_invalid_cluster_validation_label_requests_total")
 			require.NoError(t, err)
 		})
 	}

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -5,10 +5,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// NewInvalidClusterRequests registers and returns a new counter metric server_invalid_cluster_validation_label_requests_total.
-func NewInvalidClusterRequests(reg prometheus.Registerer) *prometheus.CounterVec {
+// NewInvalidClusterRequests registers and returns a new counter metric server_invalid_cluster_validation_label_requests_total, with namespace.
+func NewInvalidClusterRequests(reg prometheus.Registerer, namespace string) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "server_invalid_cluster_validation_label_requests_total",
-		Help: "Number of requests received by server with invalid cluster validation label.",
+		Name:      "server_invalid_cluster_validation_label_requests_total",
+		Namespace: namespace,
+		Help:      "Number of requests received by server with invalid cluster validation label.",
 	}, []string{"protocol", "method", "cluster_validation_label", "request_cluster_validation_label"})
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -93,6 +93,6 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route"}),
-		InvalidClusterRequests: middleware.NewInvalidClusterRequests(reg),
+		InvalidClusterRequests: middleware.NewInvalidClusterRequests(reg, cfg.MetricsNamespace),
 	}
 }


### PR DESCRIPTION
**What this PR does**:

Support namespace for metric `server_invalid_cluster_validation_label_requests_total`, in the `middleware` package. This should have been done in #680, but I missed it.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
