### PR TITLE
feat(grpc): Record max streams per connection

### DIFF
--- a/middleware/grpc_stats.go
+++ b/middleware/grpc_stats.go
@@ -163,6 +163,6 @@ func (st *StreamTracker) MaxStreams() int {
 	if st.tree.Len() == 0 {
 		return 0
 	}
-	entry := st.tree.Max().(streamEntry)
+	entry := st.tree.Min().(streamEntry)
 	return entry.streamCount
 }

--- a/middleware/grpc_stats.go
+++ b/middleware/grpc_stats.go
@@ -6,17 +6,22 @@ package middleware
 
 import (
 	"context"
+	"sync"
 
+	"github.com/google/btree"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/stats"
 )
 
 // NewStatsHandler creates handler that can be added to gRPC server options to track received and sent message sizes.
-func NewStatsHandler(receivedPayloadSize, sentPayloadSize *prometheus.HistogramVec, inflightRequests *prometheus.GaugeVec) stats.Handler {
+func NewStatsHandler(receivedPayloadSize, sentPayloadSize *prometheus.HistogramVec, inflightRequests *prometheus.GaugeVec, grpcConcurrentStreamsByConnMax *prometheus.GaugeVec) stats.Handler {
 	return &grpcStatsHandler{
 		receivedPayloadSize: receivedPayloadSize,
 		sentPayloadSize:     sentPayloadSize,
 		inflightRequests:    inflightRequests,
+
+		grpcConcurrentStreamsTracker:        NewStreamTracker(),
+		grpcConcurrentStreamsByConnMaxGauge: grpcConcurrentStreamsByConnMax,
 	}
 }
 
@@ -24,6 +29,9 @@ type grpcStatsHandler struct {
 	receivedPayloadSize *prometheus.HistogramVec
 	sentPayloadSize     *prometheus.HistogramVec
 	inflightRequests    *prometheus.GaugeVec
+
+	grpcConcurrentStreamsTracker        *StreamTracker
+	grpcConcurrentStreamsByConnMaxGauge *prometheus.GaugeVec
 }
 
 // Custom type to hide it from other packages.
@@ -32,6 +40,7 @@ type contextKey int
 const (
 	contextKeyMethodName contextKey = 1
 	contextKeyRouteName  contextKey = 2
+	contextKeyConnID     contextKey = 3
 )
 
 func (g *grpcStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
@@ -45,11 +54,21 @@ func (g *grpcStatsHandler) HandleRPC(ctx context.Context, rpcStats stats.RPCStat
 		return
 	}
 
+	connID, hasConnID := ctx.Value(contextKeyConnID).(string)
+
 	switch s := rpcStats.(type) {
 	case *stats.Begin:
 		g.inflightRequests.WithLabelValues(gRPC, fullMethodName).Inc()
+		if hasConnID {
+			g.grpcConcurrentStreamsTracker.OpenStream(connID)
+			g.grpcConcurrentStreamsByConnMaxGauge.WithLabelValues().Set(float64(g.grpcConcurrentStreamsTracker.MaxStreams()))
+		}
 	case *stats.End:
 		g.inflightRequests.WithLabelValues(gRPC, fullMethodName).Dec()
+		if hasConnID {
+			g.grpcConcurrentStreamsTracker.CloseStream(connID)
+			g.grpcConcurrentStreamsByConnMaxGauge.WithLabelValues().Set(float64(g.grpcConcurrentStreamsTracker.MaxStreams()))
+		}
 	case *stats.InHeader:
 		// Ignore incoming headers.
 	case *stats.InPayload:
@@ -65,10 +84,85 @@ func (g *grpcStatsHandler) HandleRPC(ctx context.Context, rpcStats stats.RPCStat
 	}
 }
 
-func (g *grpcStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
-	return ctx
+func (g *grpcStatsHandler) TagConn(ctx context.Context, conn *stats.ConnTagInfo) context.Context {
+	return context.WithValue(ctx, contextKeyConnID, conn.LocalAddr.String()+":"+conn.RemoteAddr.String())
 }
 
 func (g *grpcStatsHandler) HandleConn(_ context.Context, _ stats.ConnStats) {
 	// Not interested.
+}
+
+// streamEntry represents a connection and its stream count.
+type streamEntry struct {
+	streamCount int
+	connID      string
+}
+
+// Less defines the sort order: descending by streamCount, then ascending by connID.
+func (a streamEntry) Less(b btree.Item) bool {
+	bb := b.(streamEntry)
+	if a.streamCount != bb.streamCount {
+		return a.streamCount > bb.streamCount // descending order
+	}
+	return a.connID < bb.connID
+}
+
+// StreamTracker tracks the number of streams per connection and the max.
+type StreamTracker struct {
+	mu      sync.RWMutex
+	tree    *btree.BTree           // sorted set of stream counts
+	connMap map[string]streamEntry // connID -> entry
+}
+
+func NewStreamTracker() *StreamTracker {
+	return &StreamTracker{
+		tree:    btree.New(2), // degree 2 is fine for small datasets
+		connMap: make(map[string]streamEntry),
+	}
+}
+
+func (st *StreamTracker) OpenStream(connID string) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	entry, exists := st.connMap[connID]
+	if exists {
+		st.tree.Delete(entry)
+		entry.streamCount++
+	} else {
+		entry = streamEntry{streamCount: 1, connID: connID}
+	}
+	st.connMap[connID] = entry
+	st.tree.ReplaceOrInsert(entry)
+}
+
+func (st *StreamTracker) CloseStream(connID string) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	entry, exists := st.connMap[connID]
+	if !exists {
+		return // no-op
+	}
+
+	st.tree.Delete(entry)
+	entry.streamCount--
+	if entry.streamCount == 0 {
+		delete(st.connMap, connID)
+	} else {
+		st.connMap[connID] = entry
+		st.tree.ReplaceOrInsert(entry)
+	}
+}
+
+// MaxStreams returns the number of streams in the connection with the most streams.
+func (st *StreamTracker) MaxStreams() int {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+
+	if st.tree.Len() == 0 {
+		return 0
+	}
+	entry := st.tree.Max().(streamEntry)
+	return entry.streamCount
 }

--- a/middleware/grpc_stats.go
+++ b/middleware/grpc_stats.go
@@ -163,6 +163,6 @@ func (st *StreamTracker) MaxStreams() int {
 	if st.tree.Len() == 0 {
 		return 0
 	}
-	entry := st.tree.Min().(streamEntry)
+	entry := st.tree.Min().(streamEntry) // Min returns the first item in the tree which is the one with the most streams here (descending order)
 	return entry.streamCount
 }

--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -567,6 +567,13 @@ func BenchmarkStreamTracker(b *testing.B) {
 		}
 	})
 
+	// Benchmark getting the max streams with a ton of streams
+	b.Run("MaxStreams", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tracker.MaxStreams()
+		}
+	})
+
 	// Shuffle the streams to close
 	rand.Shuffle(len(streamsToClose), func(i, j int) {
 		streamsToClose[i], streamsToClose[j] = streamsToClose[j], streamsToClose[i]

--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -387,7 +387,9 @@ func launchConnWithStreams(t *testing.T, ctx context.Context, listener net.Liste
 			for {
 				select {
 				case <-ctx.Done():
-					streams[streamIndex].CloseSend()
+					if err := streams[streamIndex].CloseSend(); err != nil {
+						t.Log("Error closing stream", err)
+					}
 					return
 				default:
 					msg := &middleware_test.Msg{

--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -7,8 +7,9 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	mathRand "math/rand"
 	"net"
 	"sync"
 	"testing"
@@ -553,7 +554,7 @@ func BenchmarkStreamTracker(b *testing.B) {
 
 	// Bootstrap a bit of streams to make sure we have a bit of load
 	for i := 0; i < numConns*1000; i++ {
-		connID := fmt.Sprintf("conn%d", rand.Intn(numConns))
+		connID := fmt.Sprintf("conn%d", mathRand.Intn(numConns))
 		tracker.OpenStream(connID)
 		streamsToClose = append(streamsToClose, connID)
 	}
@@ -561,7 +562,7 @@ func BenchmarkStreamTracker(b *testing.B) {
 	// Benchmark opening streams
 	b.Run("OpenStream", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			connID := fmt.Sprintf("conn%d", rand.Intn(numConns))
+			connID := fmt.Sprintf("conn%d", mathRand.Intn(numConns))
 			tracker.OpenStream(connID)
 			streamsToClose = append(streamsToClose, connID)
 		}
@@ -575,7 +576,7 @@ func BenchmarkStreamTracker(b *testing.B) {
 	})
 
 	// Shuffle the streams to close
-	rand.Shuffle(len(streamsToClose), func(i, j int) {
+	mathRand.Shuffle(len(streamsToClose), func(i, j int) {
 		streamsToClose[i], streamsToClose[j] = streamsToClose[j], streamsToClose[i]
 	})
 

--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -8,7 +8,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"fmt"
 	"net"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -520,11 +522,7 @@ func BenchmarkStreamTracker_OpenStream(b *testing.B) {
 		tracker.OpenStream("conn3")
 		tracker.OpenStream("conn4")
 		tracker.OpenStream("conn5")
-		tracker.OpenStream("conn6")
-		tracker.OpenStream("conn7")
-		tracker.OpenStream("conn8")
-		tracker.OpenStream("conn9")
-		tracker.OpenStream("conn10")
+		tracker.OpenStream("newconn" + strconv.Itoa(i))
 	}
 }
 
@@ -543,11 +541,14 @@ func BenchmarkStreamTracker_CloseStream(b *testing.B) {
 func bootstrapStreamTracker(b *testing.B) *StreamTracker {
 	b.Helper()
 
-	conns := []string{"conn1", "conn2", "conn3", "conn4", "conn5"}
+	conns := make([]string, 1000)
+	for ix := range conns {
+		conns[ix] = fmt.Sprintf("conn%d", ix)
+	}
 
 	tracker := NewStreamTracker()
 	for ix, conn := range conns {
-		streams := (ix + 1) * 100
+		streams := (ix + 1) * 1
 		for i := 0; i < streams; i++ {
 			tracker.OpenStream(conn)
 		}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -16,16 +16,18 @@ import (
 )
 
 type Metrics struct {
-	TCPConnections           *prometheus.GaugeVec
-	TCPConnectionsLimit      *prometheus.GaugeVec
-	RequestDuration          *prometheus.HistogramVec
-	PerTenantRequestDuration *prometheus.HistogramVec
-	PerTenantRequestTotal    *prometheus.CounterVec
-	ReceivedMessageSize      *prometheus.HistogramVec
-	SentMessageSize          *prometheus.HistogramVec
-	InflightRequests         *prometheus.GaugeVec
-	RequestThroughput        *prometheus.HistogramVec
-	InvalidClusterRequests   *prometheus.CounterVec
+	TCPConnections                 *prometheus.GaugeVec
+	TCPConnectionsLimit            *prometheus.GaugeVec
+	GRPCConcurrentStreamsByConnMax *prometheus.GaugeVec
+	GRPCConcurrentStreamsLimit     *prometheus.GaugeVec
+	RequestDuration                *prometheus.HistogramVec
+	PerTenantRequestDuration       *prometheus.HistogramVec
+	PerTenantRequestTotal          *prometheus.CounterVec
+	ReceivedMessageSize            *prometheus.HistogramVec
+	SentMessageSize                *prometheus.HistogramVec
+	InflightRequests               *prometheus.GaugeVec
+	RequestThroughput              *prometheus.HistogramVec
+	InvalidClusterRequests         *prometheus.CounterVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
@@ -43,6 +45,16 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Name:      "tcp_connections_limit",
 			Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
 		}, []string{"protocol"}),
+		GRPCConcurrentStreamsByConnMax: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "grpc_concurrent_streams_by_connection_max",
+			Help:      "The current number of concurrent streams in the connection with the most.",
+		}, []string{}),
+		GRPCConcurrentStreamsLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "grpc_concurrent_streams_limit",
+			Help:      "The max number of concurrent streams that can be accepted (0 means no limit).",
+		}, []string{}),
 		RequestDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "request_duration_seconds",

--- a/server/server.go
+++ b/server/server.go
@@ -460,6 +460,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		grpcStreamMiddleware = append(grpcStreamMiddleware, grpcServerLimit.StreamServerInterceptor)
 	}
 
+	metrics.GRPCConcurrentStreamsLimit.WithLabelValues().Set(float64(cfg.GRPCServerMaxConcurrentStreams))
 	grpcOptions := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(grpcMiddleware...),
 		grpc.ChainStreamInterceptor(grpcStreamMiddleware...),
@@ -485,6 +486,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 				metrics.ReceivedMessageSize,
 				metrics.SentMessageSize,
 				metrics.InflightRequests,
+				metrics.GRPCConcurrentStreamsByConnMax,
 			)),
 		)
 	}


### PR DESCRIPTION
This will be used to alert if we're approaching the `-server.grpc-max-concurrent-streams` limit 

It uses a b-tree to keep track of the highest number of streams per connection