### PR TITLE
Add PartitionRingWatcher delegate

### DIFF
--- a/ring/partition_ring_watcher.go
+++ b/ring/partition_ring_watcher.go
@@ -51,8 +51,11 @@ func NewPartitionRingWatcher(name, key string, kv kv.Client, logger log.Logger, 
 	return r
 }
 
-func (w *PartitionRingWatcher) WithDelegate(d PartitionRingWatcherDelegate) *PartitionRingWatcher {
-	w.delegate = d
+// WithDelegate adds the delegate to be called when the partition ring changes.
+//
+// Not concurrency safe.
+func (w *PartitionRingWatcher) WithDelegate(delegate PartitionRingWatcherDelegate) *PartitionRingWatcher {
+	w.delegate = delegate
 	return w
 }
 

--- a/ring/partition_ring_watcher_test.go
+++ b/ring/partition_ring_watcher_test.go
@@ -16,6 +16,15 @@ import (
 	"github.com/grafana/dskit/services"
 )
 
+type ringWatcherDelegateStub struct {
+	oldRing, newRing *PartitionRingDesc
+}
+
+func (r *ringWatcherDelegateStub) OnPartitionRingChanged(oldRing, newRing *PartitionRingDesc) {
+	r.oldRing = oldRing
+	r.newRing = newRing
+}
+
 func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	const ringKey = "ring"
 
@@ -26,7 +35,8 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	reg := prometheus.NewPedanticRegistry()
-	watcher := NewPartitionRingWatcher("test", ringKey, store, logger, reg)
+	delegate := &ringWatcherDelegateStub{}
+	watcher := NewPartitionRingWatcher("test", ringKey, store, logger, reg).WithDelegate(delegate)
 
 	// PartitionRing should never return nil, even if the watcher hasn't been started yet.
 	assert.NotNil(t, watcher.PartitionRing())
@@ -56,6 +66,7 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return watcher.PartitionRing().PartitionsCount() == 1
 	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, PartitionActive, delegate.newRing.GetPartitions()[1].State)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP partition_ring_partitions Number of partitions by state in the partitions ring.
@@ -75,6 +86,7 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return watcher.PartitionRing().PartitionsCount() == 2
 	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, PartitionInactive, delegate.newRing.GetPartitions()[2].State)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP partition_ring_partitions Number of partitions by state in the partitions ring.
@@ -94,6 +106,7 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return watcher.PartitionRing().PartitionsCount() == 3
 	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, PartitionPending, delegate.newRing.GetPartitions()[3].State)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP partition_ring_partitions Number of partitions by state in the partitions ring.
@@ -102,4 +115,18 @@ func TestPartitionRingWatcher_ShouldWatchUpdates(t *testing.T) {
 		partition_ring_partitions{name="test",state="Active"} 1
 		partition_ring_partitions{name="test",state="Inactive"} 1
 	`)))
+
+	// Change state of partition to Inactive
+	require.NoError(t, store.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := GetOrCreatePartitionRingDesc(in)
+		desc.UpdatePartitionState(1, PartitionInactive, time.Now())
+		return desc, true, nil
+	}))
+
+	require.Eventually(t, func() bool {
+		return watcher.PartitionRing().Partitions()[0].State == PartitionInactive
+	}, time.Second, 10*time.Millisecond)
+
+	// Ensure delegate is called
+	require.Equal(t, PartitionInactive, delegate.newRing.GetPartitions()[1].State)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds a PartitionRingWatcher delegate so users of that ring can observe state changes.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
