### PR TITLE
spanlogger: fix multiple tenants tag with OTel

### DIFF
--- a/spanlogger/spanlogger.go
+++ b/spanlogger/spanlogger.go
@@ -90,7 +90,7 @@ func New(ctx context.Context, logger log.Logger, method string, resolver TenantR
 func NewOTel(ctx context.Context, logger log.Logger, tracer trace.Tracer, method string, resolver TenantResolver, kvps ...any) (*SpanLogger, context.Context) {
 	ctx, span := tracer.Start(ctx, method)
 	if ids, err := resolver.TenantIDs(ctx); err == nil && len(ids) > 0 {
-		span.SetAttributes(attribute.String(TenantIDsTagName, strings.Join(ids, ",")))
+		span.SetAttributes(attribute.StringSlice(TenantIDsTagName, ids))
 	}
 	sampled := span.SpanContext().IsSampled()
 


### PR DESCRIPTION
Opentracing was setting a slice of strings as tenant ID, we should do the same with OTel instead of building a string.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
