### PR TITLE
Readd 5xx response logging when LogRequestHeaders is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* [CHANGE] Readd 5xx response logging when `logRequestHeaders` is false. #693
 * [CHANGE] Update the minimum required Go version to 1.22. #665
 * [CHANGE] Remove function aws.ConfigFromURL. #667
 * [CHANGE] Add new metric `slow_request_server_throughput` to track the throughput of slow queries. #619

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -139,7 +139,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 			if l.LogRequestHeaders && headers != nil {
 				level.Warn(requestLog).Log("msg", dskit_log.LazySprintf("%s %s (%d) %s Response: %q ws: %v; %s", r.Method, uri, statusCode, time.Since(begin), buf.Bytes(), IsWSHandshakeRequest(r), headers))
 			} else {
-				level.Warn(requestLog).Log("msg", dskit_log.LazySprintf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin)))
+				level.Warn(requestLog).Log("msg", dskit_log.LazySprintf("%s %s (%d) %s Response: %q", r.Method, uri, statusCode, time.Since(begin), buf.Bytes()))
 			}
 		}
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

A change made in https://github.com/grafana/dskit/pull/615 was to skip logging 5xx responses when LogRequestHeaders was set to false. This was unintentional - the intent of that PR was to make sure LogRequestHeaders = false meant headers weren't logged.

I don't think LogRequestHeaders should affect whether error responses are logged, so I propose to readd the 5xx response logging when LogRequestHeaders is false

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
