### PR TITLE
Fix ring local example failing getting TCP config overridden

### DIFF
--- a/ring/example/local/local.go
+++ b/ring/example/local/local.go
@@ -162,10 +162,8 @@ func SimpleMemberlistKV(bindaddr string, bindport int, joinmembers []string) *me
 	config.Codecs = []codec.Codec{ring.GetCodec()}
 
 	// TCPTransport defines what addr and port this particular peer should listen on.
-	config.TCPTransport = memberlist.TCPTransportConfig{
-		BindPort:  bindport,
-		BindAddrs: []string{bindaddr},
-	}
+	config.TCPTransport.BindPort = bindport
+	config.TCPTransport.BindAddrs = []string{bindaddr}
 
 	// joinmembers are the addresses of peers who are already in the memberlist group.
 	// Usually provided if this peer is trying to join an existing cluster.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

- Fixes TCPTransportConfig getting overridden in the `ring/example/local` example code

**Which issue(s) this PR fixes**:

none

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

For context I was trying to use the ring example and was having issues with the following log messages:

```
Refuting a suspect message (from: 127.0.0.1-7a3fd3a1)
Suspect 127.0.0.1-7a3fd3a1 has failed, no acks received
```

Enabling debug logs showed some more juicy info:

```
level=debug component=memberlist component="memberlist TCPTransport" msg="WriteTo failed to acquire a writer. Dropping message" timeout=0s addr=127.0.0.1:7947
level=debug component=memberlist component="memberlist TCPTransport" msg="WriteTo failed to acquire a writer. Dropping message" timeout=0s addr=127.0.0.1:7947
level=debug component=memberlist component="memberlist TCPTransport" msg="WriteTo failed to acquire a writer. Dropping message" timeout=0s addr=127.0.0.1:7947
```

The weird thing is that this only occurred on Go 1.23.0+. The example still specifies 1.22.0 where the bug was not present. To reproduce just change the Go version:

```diff
diff --git a/ring/example/local/go.mod b/ring/example/local/go.mod
index b72cd79..2d62f84 100644
--- a/ring/example/local/go.mod
+++ b/ring/example/local/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/dskit/ring/example/local

-go 1.22.0
+go 1.23.0

 toolchain go1.24.2

```

The errornous example set the timeout to write a broadcast message to zero, which behaved differently between Go 1.22 and 1.23.

But now the example doesn't override the example anymore and works in both 1.22 and later.
