### PR TITLE
memberlist: WatchPrefix, handle gracefully nil generated value

### DIFF
--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -2365,3 +2365,77 @@ func TestMemberlist_WatchKey_ShouldStartNotifyingChangesBeforeFullJoinIsComplete
 		})
 	}
 }
+
+// Every duration interval (100ms), cleanupObsoleteEntries() is called to remove obsolete entries from the KV store
+// After 5*duration interval (500ms), notifications are sent to the appropriate keys. Since the entry is already deleted,
+// it should generate a nil notification that will never be processed.
+func TestWatchPrefixHandlesGracefullyNotificationForAlreadyDeletedEntry(t *testing.T) {
+	c := dataCodec{}
+
+	duration := 100 * time.Millisecond
+
+	var cfg KVConfig
+	flagext.DefaultValues(&cfg)
+	cfg.TCPTransport = TCPTransportConfig{
+		BindAddrs: getLocalhostAddrs(),
+		BindPort:  0, // randomize ports
+	}
+	cfg.ClusterLabelVerificationDisabled = true
+	cfg.Codecs = []codec.Codec{c}
+
+	cfg.ObsoleteEntriesTimeout = duration
+	cfg.NotifyInterval = 5 * duration // 5 * ObsoleteEntriesTimeout to ensure the entry is deleted before sending the notification
+
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
+	defer services.StopAndAwaitTerminated(context.Background(), mkv) //nolint:errcheck
+
+	kv, err := NewClient(mkv, c)
+	require.NoError(t, err)
+
+	const key = "test"
+
+	val := get(t, kv, key)
+	if val != nil {
+		t.Error("Expected nil, got:", val)
+	}
+
+	// Create a channel to receive nil notifications
+	nilNotifications := make([]string, 0)
+	mu := sync.Mutex{} // Protect nil notification's slice
+	done := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		kv.WatchPrefix(ctx, "test", func(s string, i interface{}) bool {
+			if i == nil {
+				mu.Lock()
+				nilNotifications = append(nilNotifications, s)
+				mu.Unlock()
+			}
+			close(done)
+			return true
+		})
+	}()
+
+	// Create entry with key:  test
+	err = cas(kv, key, updateFn("test"))
+	require.NoError(t, err)
+
+	// Delete entry with key: test
+	err = kv.Delete(context.Background(), key)
+
+	if err != nil {
+		t.Fatalf("Failed to delete key %s: %v", key, err)
+	}
+	select {
+	case <-done:
+		mu.Lock()
+		defer mu.Unlock()
+		t.Fatalf("Received unexpected nil notification for key %s", key)
+	case <-time.After(1 * time.Second):
+		require.Len(t, nilNotifications, 0) // didn't receive any nil notification
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

In this PR, we modify memberlist.WatchPrefix to ignore nil values, which can occur when an entry has already been deleted from the Memberlist KV store.


### Test

In the test scenario, we reproduced the issue by increasing the NotifyInterval, so that the notification is sent after the cleanupObsoleteTimeout has been triggered.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
