### PR TITLE
middleware: log trace_id from cluster validation failures

### DIFF
--- a/middleware/grpc_cluster.go
+++ b/middleware/grpc_cluster.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/peer"
 
 	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/grpcutil"
@@ -113,6 +114,9 @@ func checkClusterFromIncomingContext(
 	)
 	if traceID, ok := tracing.ExtractSampledTraceID(ctx); ok {
 		logger = log.With(logger, "trace_id", traceID)
+	}
+	if p, ok := peer.FromContext(ctx); ok {
+		logger = log.With(logger, "peer_address", p.Addr.String())
 	}
 
 	if err == nil {

--- a/middleware/grpc_cluster.go
+++ b/middleware/grpc_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/tracing"
+	"github.com/grafana/dskit/user"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -112,11 +113,14 @@ func checkClusterFromIncomingContext(
 		"cluster_validation_label", expectedCluster,
 		"soft_validation", softValidationEnabled,
 	)
-	if traceID, ok := tracing.ExtractSampledTraceID(ctx); ok {
-		logger = log.With(logger, "trace_id", traceID)
+	if tenantID, err := user.ExtractOrgID(ctx); err == nil {
+		logger = log.With(logger, "tenant", tenantID)
 	}
 	if p, ok := peer.FromContext(ctx); ok {
-		logger = log.With(logger, "peer_address", p.Addr.String())
+		logger = log.With(logger, "client_address", p.Addr.String())
+	}
+	if traceID, ok := tracing.ExtractSampledTraceID(ctx); ok {
+		logger = log.With(logger, "trace_id", traceID)
 	}
 
 	if err == nil {

--- a/middleware/grpc_cluster.go
+++ b/middleware/grpc_cluster.go
@@ -124,7 +124,7 @@ func checkClusterFromIncomingContext(
 	}
 
 	if err == nil {
-		// No error, but request's and server's cluster validation labels  didn't match.
+		// No error, but request's and server's cluster validation labels didn't match.
 		var wrongClusterErr error
 		if !softValidationEnabled {
 			wrongClusterErr = fmt.Errorf("rejected request with wrong cluster validation label %q - it should be %q", reqCluster, expectedCluster)

--- a/middleware/grpc_cluster.go
+++ b/middleware/grpc_cluster.go
@@ -120,7 +120,7 @@ func checkClusterFromIncomingContext(
 	}
 
 	if err == nil {
-		// No error, but the requested cluster didn't match the expectation.
+		// No error, but request's and server's cluster validation labels  didn't match.
 		var wrongClusterErr error
 		if !softValidationEnabled {
 			wrongClusterErr = fmt.Errorf("rejected request with wrong cluster validation label %q - it should be %q", reqCluster, expectedCluster)

--- a/middleware/grpc_cluster_test.go
+++ b/middleware/grpc_cluster_test.go
@@ -128,7 +128,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 		"different request and server clusters give rise to an error with grpcutil.WRONG_CLUSTER_VALIDATION_LABEL cause if soft validation disabled": {
 			incomingContext: newIncomingContext(true, "wrong-cluster"),
 			serverCluster:   "cluster",
-			expectedLogs:    `level=warn msg="request with wrong cluster validation label" method=/Test/Me cluster_validation_label=cluster request_cluster_validation_label=wrong-cluster soft_validation=%v`,
+			expectedLogs:    `level=warn method=/Test/Me cluster_validation_label=cluster soft_validation=%v msg="request with wrong cluster validation label" request_cluster_validation_label=wrong-cluster`,
 			expectedMetrics: `
                                 # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
                                 # TYPE test_server_invalid_cluster_validation_label_requests_total counter
@@ -143,7 +143,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 		"empty request cluster and non-empty server cluster give an error with grpcutil.WRONG_CLUSTER_VALIDATION_LABEL cause if soft validation disabled": {
 			incomingContext: newIncomingContext(true, ""),
 			serverCluster:   "cluster",
-			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
+			expectedLogs:    `level=warn method=/Test/Me cluster_validation_label=cluster soft_validation=%v msg="request with no cluster validation label"`,
 			expectedMetrics: `
                                 # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
                                 # TYPE test_server_invalid_cluster_validation_label_requests_total counter
@@ -158,7 +158,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 		"no request cluster and non-empty server cluster give an error with grpcutil.WRONG_CLUSTER_VALIDATION_LABEL cause if soft validation disabled": {
 			incomingContext: newIncomingContext(false, ""),
 			serverCluster:   "cluster",
-			expectedLogs:    `level=warn msg="request with no cluster validation label" method=/Test/Me cluster_validation_label=cluster soft_validation=%v`,
+			expectedLogs:    `level=warn method=/Test/Me cluster_validation_label=cluster soft_validation=%v msg="request with no cluster validation label"`,
 			expectedMetrics: `
                                 # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
                                 # TYPE test_server_invalid_cluster_validation_label_requests_total counter
@@ -173,7 +173,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 		"if the incoming context contains more than one cluster label an error is returned if soft validation disabled": {
 			incomingContext: metadata.NewIncomingContext(context.Background(), map[string][]string{clusterutil.MetadataClusterValidationLabelKey: {"cluster", "another-cluster"}}),
 			serverCluster:   "cluster",
-			expectedLogs:    `level=warn msg="detected error during cluster validation label extraction" method=/Test/Me cluster_validation_label=cluster soft_validation=%v err="gRPC metadata should contain exactly 1 value for key \"x-cluster\", but it contains [cluster another-cluster]"`,
+			expectedLogs:    `level=warn method=/Test/Me cluster_validation_label=cluster soft_validation=%v msg="detected error during cluster validation label extraction" err="gRPC metadata should contain exactly 1 value for key \"x-cluster\", but it contains [cluster another-cluster]"`,
 			expectedMetrics: `
                                 # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
                                 # TYPE test_server_invalid_cluster_validation_label_requests_total counter
@@ -211,7 +211,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 				if testCase.expectedLogs == "" {
 					require.Empty(t, buf.Bytes())
 				} else {
-					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))))
+					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))), "got %q", buf.String())
 				}
 				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "test_server_invalid_cluster_validation_label_requests_total")
 				require.NoError(t, err)

--- a/middleware/grpc_cluster_test.go
+++ b/middleware/grpc_cluster_test.go
@@ -211,7 +211,7 @@ func TestClusterUnaryServerInterceptor(t *testing.T) {
 				if testCase.expectedLogs == "" {
 					require.Empty(t, buf.Bytes())
 				} else {
-					require.True(t, bytes.Contains(buf.Bytes(), []byte(fmt.Sprintf(testCase.expectedLogs, softValidation))), "got %q", buf.String())
+					require.Contains(t, buf.String(), fmt.Sprintf(testCase.expectedLogs, softValidation))
 				}
 				err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "test_server_invalid_cluster_validation_label_requests_total")
 				require.NoError(t, err)

--- a/middleware/http_cluster.go
+++ b/middleware/http_cluster.go
@@ -147,7 +147,7 @@ func checkClusterFromRequest(
 	}
 
 	if err == nil {
-		// No error, but request's and server's cluster validation labels  didn't match.
+		// No error, but request's and server's cluster validation labels didn't match.
 		var wrongClusterErr error
 		if !softValidationEnabled {
 			wrongClusterErr = fmt.Errorf("rejected request with wrong cluster validation label %q - it should be %q", reqCluster, expectedCluster)

--- a/middleware/http_cluster.go
+++ b/middleware/http_cluster.go
@@ -127,10 +127,9 @@ func checkClusterFromRequest(
 	}
 
 	reqCluster, err := clusterutil.GetClusterFromRequest(r)
-	if reqCluster == expectedCluster {
+	if err == nil && reqCluster == expectedCluster {
 		return nil
 	}
-	// Everything below is for the case when the requested cluster doesn't match the expectation or an error occurred.
 
 	logger = log.With(
 		logger,
@@ -148,6 +147,7 @@ func checkClusterFromRequest(
 	}
 
 	if err == nil {
+		// No error, but the requested cluster didn't match the expectation.
 		var wrongClusterErr error
 		if !softValidationEnabled {
 			wrongClusterErr = fmt.Errorf("rejected request with wrong cluster validation label %q - it should be %q", reqCluster, expectedCluster)

--- a/middleware/http_cluster.go
+++ b/middleware/http_cluster.go
@@ -147,7 +147,7 @@ func checkClusterFromRequest(
 	}
 
 	if err == nil {
-		// No error, but the requested cluster didn't match the expectation.
+		// No error, but request's and server's cluster validation labels  didn't match.
 		var wrongClusterErr error
 		if !softValidationEnabled {
 			wrongClusterErr = fmt.Errorf("rejected request with wrong cluster validation label %q - it should be %q", reqCluster, expectedCluster)


### PR DESCRIPTION
**What this PR does**:

Following #692 this PR updates the internals of `ClusterUnaryServerInterceptor` and `ClusterValidationMiddleware` to log the request's `trace_id` — if the request's trace wasn't sampled.

The idea is that this should make it easier to investigate, where the concerning requests come from.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
