### PR TITLE
fix(grpc): Make recording max streams per connection more performant

### DIFF
--- a/middleware/grpc_stats.go
+++ b/middleware/grpc_stats.go
@@ -143,7 +143,13 @@ func (st *StreamTracker) CloseStream(connID string) {
 	if res := conn.Dec(); res == 0 {
 		// Delete the entry if it's empty.
 		st.mu.Lock()
-		delete(st.connMap, connID)
+
+		// Get the entry again to avoid race condition.
+		conn = st.connMap[connID]
+		if conn == nil || conn.Load() == 0 {
+			delete(st.connMap, connID)
+		}
+
 		st.mu.Unlock()
 	}
 }

--- a/middleware/grpc_stats.go
+++ b/middleware/grpc_stats.go
@@ -8,20 +8,25 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/btree"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc/stats"
 )
 
 // NewStatsHandler creates handler that can be added to gRPC server options to track received and sent message sizes.
-func NewStatsHandler(receivedPayloadSize, sentPayloadSize *prometheus.HistogramVec, inflightRequests *prometheus.GaugeVec, grpcConcurrentStreamsByConnMax *prometheus.GaugeVec) stats.Handler {
+func NewStatsHandler(reg prometheus.Registerer, receivedPayloadSize, sentPayloadSize *prometheus.HistogramVec, inflightRequests *prometheus.GaugeVec, grpcConcurrentStreamsByConnMax *prometheus.Desc) stats.Handler {
+	var streamTracker *StreamTracker
+	if grpcConcurrentStreamsByConnMax != nil {
+		streamTracker = NewStreamTracker(grpcConcurrentStreamsByConnMax)
+		reg.MustRegister(streamTracker)
+	}
+
 	return &grpcStatsHandler{
 		receivedPayloadSize: receivedPayloadSize,
 		sentPayloadSize:     sentPayloadSize,
 		inflightRequests:    inflightRequests,
 
-		grpcConcurrentStreamsTracker:        NewStreamTracker(),
-		grpcConcurrentStreamsByConnMaxGauge: grpcConcurrentStreamsByConnMax,
+		grpcConcurrentStreamsTracker: streamTracker,
 	}
 }
 
@@ -30,8 +35,7 @@ type grpcStatsHandler struct {
 	sentPayloadSize     *prometheus.HistogramVec
 	inflightRequests    *prometheus.GaugeVec
 
-	grpcConcurrentStreamsTracker        *StreamTracker
-	grpcConcurrentStreamsByConnMaxGauge *prometheus.GaugeVec
+	grpcConcurrentStreamsTracker *StreamTracker
 }
 
 // Custom type to hide it from other packages.
@@ -61,13 +65,11 @@ func (g *grpcStatsHandler) HandleRPC(ctx context.Context, rpcStats stats.RPCStat
 		g.inflightRequests.WithLabelValues(gRPC, fullMethodName).Inc()
 		if hasConnID {
 			g.grpcConcurrentStreamsTracker.OpenStream(connID)
-			g.grpcConcurrentStreamsByConnMaxGauge.WithLabelValues().Set(float64(g.grpcConcurrentStreamsTracker.MaxStreams()))
 		}
 	case *stats.End:
 		g.inflightRequests.WithLabelValues(gRPC, fullMethodName).Dec()
 		if hasConnID {
 			g.grpcConcurrentStreamsTracker.CloseStream(connID)
-			g.grpcConcurrentStreamsByConnMaxGauge.WithLabelValues().Set(float64(g.grpcConcurrentStreamsTracker.MaxStreams()))
 		}
 	case *stats.InHeader:
 		// Ignore incoming headers.
@@ -85,84 +87,84 @@ func (g *grpcStatsHandler) HandleRPC(ctx context.Context, rpcStats stats.RPCStat
 }
 
 func (g *grpcStatsHandler) TagConn(ctx context.Context, conn *stats.ConnTagInfo) context.Context {
-	return context.WithValue(ctx, contextKeyConnID, conn.LocalAddr.String()+":"+conn.RemoteAddr.String())
+	if g.grpcConcurrentStreamsTracker != nil {
+		return context.WithValue(ctx, contextKeyConnID, conn.LocalAddr.String()+":"+conn.RemoteAddr.String())
+	}
+	return ctx
 }
 
 func (g *grpcStatsHandler) HandleConn(_ context.Context, _ stats.ConnStats) {
 	// Not interested.
 }
 
-// streamEntry represents a connection and its stream count.
-type streamEntry struct {
-	streamCount int
-	connID      string
-}
-
-// Less defines the sort order: descending by streamCount, then ascending by connID.
-func (a streamEntry) Less(b btree.Item) bool {
-	bb := b.(streamEntry)
-	if a.streamCount != bb.streamCount {
-		return a.streamCount > bb.streamCount // descending order
-	}
-	return a.connID < bb.connID
-}
-
 // StreamTracker tracks the number of streams per connection and the max.
 type StreamTracker struct {
+	grpcConcurrentStreamsByConnMax *prometheus.Desc
+
 	mu      sync.RWMutex
-	tree    *btree.BTree           // sorted set of stream counts
-	connMap map[string]streamEntry // connID -> entry
+	connMap map[string]*atomic.Int32
 }
 
-func NewStreamTracker() *StreamTracker {
+func NewStreamTracker(grpcConcurrentStreamsByConnMax *prometheus.Desc) *StreamTracker {
 	return &StreamTracker{
-		tree:    btree.New(2), // degree 2 is fine for small datasets
-		connMap: make(map[string]streamEntry),
+		grpcConcurrentStreamsByConnMax: grpcConcurrentStreamsByConnMax,
+		connMap:                        make(map[string]*atomic.Int32),
 	}
+}
+
+func (st *StreamTracker) createOrGetConnEntry(connID string) *atomic.Int32 {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	got, ok := st.connMap[connID] // Do not overwrite new entries.
+	if !ok {
+		st.connMap[connID] = atomic.NewInt32(0)
+		return st.connMap[connID]
+	}
+	return got
 }
 
 func (st *StreamTracker) OpenStream(connID string) {
-	st.mu.Lock()
-	defer st.mu.Unlock()
-
-	entry, exists := st.connMap[connID]
-	if exists {
-		st.tree.Delete(entry)
-		entry.streamCount++
-	} else {
-		entry = streamEntry{streamCount: 1, connID: connID}
+	st.mu.RLock()
+	conn, ok := st.connMap[connID]
+	st.mu.RUnlock()
+	if !ok {
+		conn = st.createOrGetConnEntry(connID)
 	}
-	st.connMap[connID] = entry
-	st.tree.ReplaceOrInsert(entry)
+	conn.Inc()
 }
 
 func (st *StreamTracker) CloseStream(connID string) {
-	st.mu.Lock()
-	defer st.mu.Unlock()
-
-	entry, exists := st.connMap[connID]
-	if !exists {
-		return // no-op
+	st.mu.RLock()
+	conn := st.connMap[connID]
+	st.mu.RUnlock()
+	if conn == nil {
+		return
 	}
-
-	st.tree.Delete(entry)
-	entry.streamCount--
-	if entry.streamCount == 0 {
+	if res := conn.Dec(); res == 0 {
+		// Delete the entry if it's empty.
+		st.mu.Lock()
 		delete(st.connMap, connID)
-	} else {
-		st.connMap[connID] = entry
-		st.tree.ReplaceOrInsert(entry)
+		st.mu.Unlock()
 	}
 }
 
 // MaxStreams returns the number of streams in the connection with the most streams.
 func (st *StreamTracker) MaxStreams() int {
+	var max int32 = 0
 	st.mu.RLock()
-	defer st.mu.RUnlock()
-
-	if st.tree.Len() == 0 {
-		return 0
+	for _, conn := range st.connMap {
+		if conn.Load() > max {
+			max = conn.Load()
+		}
 	}
-	entry := st.tree.Min().(streamEntry) // Min returns the first item in the tree which is the one with the most streams here (descending order)
-	return entry.streamCount
+	st.mu.RUnlock()
+	return int(max)
+}
+
+func (st *StreamTracker) Describe(ch chan<- *prometheus.Desc) {
+	ch <- st.grpcConcurrentStreamsByConnMax
+}
+
+func (st *StreamTracker) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(st.grpcConcurrentStreamsByConnMax, prometheus.GaugeValue, float64(st.MaxStreams()))
 }

--- a/middleware/grpc_stats.go
+++ b/middleware/grpc_stats.go
@@ -14,9 +14,15 @@ import (
 )
 
 // NewStatsHandler creates handler that can be added to gRPC server options to track received and sent message sizes.
-func NewStatsHandler(reg prometheus.Registerer, receivedPayloadSize, sentPayloadSize *prometheus.HistogramVec, inflightRequests *prometheus.GaugeVec, grpcConcurrentStreamsByConnMax *prometheus.Desc) stats.Handler {
+func NewStatsHandler(reg prometheus.Registerer, receivedPayloadSize, sentPayloadSize *prometheus.HistogramVec, inflightRequests *prometheus.GaugeVec, collectMaxStreamsByConn bool) stats.Handler {
 	var streamTracker *StreamTracker
-	if grpcConcurrentStreamsByConnMax != nil {
+	if collectMaxStreamsByConn {
+		grpcConcurrentStreamsByConnMax := prometheus.NewDesc(
+			"grpc_concurrent_streams_by_conn_max",
+			"The current number of concurrent streams in the connection with the most concurrent streams.",
+			[]string{},
+			prometheus.Labels{},
+		)
 		streamTracker = NewStreamTracker(grpcConcurrentStreamsByConnMax)
 		reg.MustRegister(streamTracker)
 	}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -16,18 +16,17 @@ import (
 )
 
 type Metrics struct {
-	TCPConnections                 *prometheus.GaugeVec
-	TCPConnectionsLimit            *prometheus.GaugeVec
-	GRPCConcurrentStreamsByConnMax *prometheus.Desc
-	GRPCConcurrentStreamsLimit     *prometheus.GaugeVec
-	RequestDuration                *prometheus.HistogramVec
-	PerTenantRequestDuration       *prometheus.HistogramVec
-	PerTenantRequestTotal          *prometheus.CounterVec
-	ReceivedMessageSize            *prometheus.HistogramVec
-	SentMessageSize                *prometheus.HistogramVec
-	InflightRequests               *prometheus.GaugeVec
-	RequestThroughput              *prometheus.HistogramVec
-	InvalidClusterRequests         *prometheus.CounterVec
+	TCPConnections             *prometheus.GaugeVec
+	TCPConnectionsLimit        *prometheus.GaugeVec
+	GRPCConcurrentStreamsLimit *prometheus.GaugeVec
+	RequestDuration            *prometheus.HistogramVec
+	PerTenantRequestDuration   *prometheus.HistogramVec
+	PerTenantRequestTotal      *prometheus.CounterVec
+	ReceivedMessageSize        *prometheus.HistogramVec
+	SentMessageSize            *prometheus.HistogramVec
+	InflightRequests           *prometheus.GaugeVec
+	RequestThroughput          *prometheus.HistogramVec
+	InvalidClusterRequests     *prometheus.CounterVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
@@ -45,12 +44,6 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Name:      "tcp_connections_limit",
 			Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
 		}, []string{"protocol"}),
-		GRPCConcurrentStreamsByConnMax: prometheus.NewDesc(
-			"grpc_concurrent_streams_by_connection_max",
-			"The current number of concurrent streams in the connection with the most.",
-			[]string{},
-			prometheus.Labels{},
-		),
 		GRPCConcurrentStreamsLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "grpc_concurrent_streams_limit",

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -18,7 +18,7 @@ import (
 type Metrics struct {
 	TCPConnections                 *prometheus.GaugeVec
 	TCPConnectionsLimit            *prometheus.GaugeVec
-	GRPCConcurrentStreamsByConnMax *prometheus.GaugeVec
+	GRPCConcurrentStreamsByConnMax *prometheus.Desc
 	GRPCConcurrentStreamsLimit     *prometheus.GaugeVec
 	RequestDuration                *prometheus.HistogramVec
 	PerTenantRequestDuration       *prometheus.HistogramVec
@@ -45,11 +45,12 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Name:      "tcp_connections_limit",
 			Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
 		}, []string{"protocol"}),
-		GRPCConcurrentStreamsByConnMax: factory.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: cfg.MetricsNamespace,
-			Name:      "grpc_concurrent_streams_by_connection_max",
-			Help:      "The current number of concurrent streams in the connection with the most.",
-		}, []string{}),
+		GRPCConcurrentStreamsByConnMax: prometheus.NewDesc(
+			"grpc_concurrent_streams_by_connection_max",
+			"The current number of concurrent streams in the connection with the most.",
+			[]string{},
+			prometheus.Labels{},
+		),
 		GRPCConcurrentStreamsLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "grpc_concurrent_streams_limit",

--- a/server/server.go
+++ b/server/server.go
@@ -491,7 +491,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 				metrics.ReceivedMessageSize,
 				metrics.SentMessageSize,
 				metrics.InflightRequests,
-				metrics.GRPCConcurrentStreamsByConnMax,
+				cfg.GRPCCollectMaxStreamsByConn,
 			)),
 		)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -82,15 +82,16 @@ type Config struct {
 	// for details. A generally useful value is 1.1.
 	MetricsNativeHistogramFactor float64 `yaml:"-"`
 
-	HTTPListenNetwork    string `yaml:"http_listen_network"`
-	HTTPListenAddress    string `yaml:"http_listen_address"`
-	HTTPListenPort       int    `yaml:"http_listen_port"`
-	HTTPConnLimit        int    `yaml:"http_listen_conn_limit"`
-	GRPCListenNetwork    string `yaml:"grpc_listen_network"`
-	GRPCListenAddress    string `yaml:"grpc_listen_address"`
-	GRPCListenPort       int    `yaml:"grpc_listen_port"`
-	GRPCConnLimit        int    `yaml:"grpc_listen_conn_limit"`
-	ProxyProtocolEnabled bool   `yaml:"proxy_protocol_enabled"`
+	HTTPListenNetwork           string `yaml:"http_listen_network"`
+	HTTPListenAddress           string `yaml:"http_listen_address"`
+	HTTPListenPort              int    `yaml:"http_listen_port"`
+	HTTPConnLimit               int    `yaml:"http_listen_conn_limit"`
+	GRPCListenNetwork           string `yaml:"grpc_listen_network"`
+	GRPCListenAddress           string `yaml:"grpc_listen_address"`
+	GRPCListenPort              int    `yaml:"grpc_listen_port"`
+	GRPCConnLimit               int    `yaml:"grpc_listen_conn_limit"`
+	GRPCCollectMaxStreamsByConn bool   `yaml:"grpc_collect_max_streams_by_conn"`
+	ProxyProtocolEnabled        bool   `yaml:"proxy_protocol_enabled"`
 
 	CipherSuites  string    `yaml:"tls_cipher_suites"`
 	MinVersion    string    `yaml:"tls_min_version"`
@@ -189,6 +190,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.GRPCListenAddress, "server.grpc-listen-address", "", "gRPC server listen address.")
 	f.IntVar(&cfg.GRPCListenPort, "server.grpc-listen-port", 9095, "gRPC server listen port.")
 	f.IntVar(&cfg.GRPCConnLimit, "server.grpc-conn-limit", 0, "Maximum number of simultaneous grpc connections, <=0 to disable")
+	f.BoolVar(&cfg.GRPCCollectMaxStreamsByConn, "server.grpc-collect-max-streams-by-conn", true, "If true, the max streams by connection gauge will be collected.")
 	f.BoolVar(&cfg.RegisterInstrumentation, "server.register-instrumentation", true, "Register the intrumentation handlers (/metrics etc).")
 	f.BoolVar(&cfg.ReportGRPCCodesInInstrumentationLabel, "server.report-grpc-codes-in-instrumentation-label-enabled", false, "If set to true, gRPC statuses will be reported in instrumentation labels with their string representations. Otherwise, they will be reported as \"error\".")
 	f.DurationVar(&cfg.ServerGracefulShutdownTimeout, "server.graceful-shutdown-timeout", 30*time.Second, "Timeout for graceful shutdowns")
@@ -273,6 +275,8 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	if logger == nil {
 		logger = log.NewGoKitWithLevel(cfg.LogLevel, cfg.LogFormat)
 	}
+
+	reg := cfg.registererOrDefault()
 
 	gatherer := cfg.Gatherer
 	if gatherer == nil {
@@ -483,6 +487,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	if cfg.GRPCServerStatsTrackingEnabled {
 		grpcOptions = append(grpcOptions,
 			grpc.StatsHandler(middleware.NewStatsHandler(
+				reg,
 				metrics.ReceivedMessageSize,
 				metrics.SentMessageSize,
 				metrics.InflightRequests,


### PR DESCRIPTION
Improves https://github.com/grafana/dskit/pull/685 

- Expose the option under `-server.grpc-collect-max-streams-by-conn=true|false`
- Instead of computing the maximum every time a stream is closed or opened, defer to when metrics are collected
- Use a read mutex instead of a write mutex on all operations

Details on the performance improvement:

Instead of fully locking on every open/close, it will, do a read-level lock, grab an atomic integer from a map of connections, and unlock immediately after. If it's just a matter of incrementing or decrementing the count, then we don't need to lock again. If we need to create or delete the connection in the map, then we need to lock (this shouldn't happen too often)

New benchmark:
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/middleware
cpu: Apple M3 Pro
BenchmarkStreamTracker/OpenStreamOnExistingConn-11          	62238513	        18.91 ns/op	       0 B/op	       0 allocs/op
BenchmarkStreamTracker/OpenStreamOnNewConn-11               	62958250	        18.89 ns/op	       0 B/op	       0 allocs/op
BenchmarkStreamTracker/MaxStreams-11                        	   98572	     12306 ns/op	       0 B/op	       0 allocs/op
BenchmarkStreamTracker/CloseStream-11                       	52800052	        25.49 ns/op	       0 B/op	       0 allocs/op
PASS
coverage: 3.7% of statements
ok  	github.com/grafana/dskit/middleware	7.421s
```

It's over 10x faster (compare with https://github.com/grafana/dskit/pull/685#issuecomment-2847088263) on each request and the locking is now a RLock in all functions. 

`MaxStreams` now takes much more time but it's still a fraction of a millisecond, and it will be done also on a read lock once for every collection
