### PR TITLE
Use hashicorp/go-metrics instead of legacy armon package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.24.2
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/armon/go-metrics v0.4.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cristalhq/hedgedhttp v0.9.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -28,6 +27,7 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
 	github.com/hashicorp/consul/api v1.15.3
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-metrics v0.5.4
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/golang-lru/v2 v2.0.5
 	github.com/hashicorp/memberlist v0.3.1
@@ -71,6 +71,7 @@ require (
 
 require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
@@ -86,7 +87,6 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
-	github.com/hashicorp/go-metrics v0.5.4 // indirect
 	github.com/hashicorp/go-msgpack/v2 v2.1.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect

--- a/kv/memberlist/metrics.go
+++ b/kv/memberlist/metrics.go
@@ -3,9 +3,9 @@ package memberlist
 import (
 	"time"
 
-	armonmetrics "github.com/armon/go-metrics"
-	armonprometheus "github.com/armon/go-metrics/prometheus"
 	"github.com/go-kit/log/level"
+	"github.com/hashicorp/go-metrics"
+	metricsprometheus "github.com/hashicorp/go-metrics/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -202,16 +202,15 @@ func (m *KV) createAndRegisterMetrics() {
 
 	m.registerer.MustRegister(m)
 
-	// memberlist uses armonmetrics package for internal usage
-	// here we configure armonmetrics to use prometheus.
-	opts := armonprometheus.PrometheusOpts{
+	// memberlist uses hashicorp/go-metrics module for internal usage
+	// here we configure go-metrics to use prometheus.
+	opts := metricsprometheus.PrometheusOpts{
 		Expiration: 0, // Don't expire metrics.
 		Registerer: m.registerer,
 	}
-
-	sink, err := armonprometheus.NewPrometheusSinkFrom(opts)
+	sink, err := metricsprometheus.NewPrometheusSinkFrom(opts)
 	if err == nil {
-		cfg := armonmetrics.DefaultConfig("")
+		cfg := metrics.DefaultConfig("")
 		cfg.EnableHostname = false         // no need to put hostname into metric
 		cfg.EnableHostnameLabel = false    // no need to put hostname into labels
 		cfg.EnableServiceLabel = false     // Don't put service name into a label. (We don't set service name anyway).
@@ -219,7 +218,7 @@ func (m *KV) createAndRegisterMetrics() {
 		cfg.EnableTypePrefix = true        // to make better sense of internal memberlist metrics
 		cfg.TimerGranularity = time.Second // timers are in seconds in prometheus world
 
-		_, err = armonmetrics.NewGlobal(cfg, sink)
+		_, err = metrics.NewGlobal(cfg, sink)
 	}
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:

Upgrade to [hashicorp/go-metrics](https://github.com/hashicorp/go-metrics) instead of legacy armon package (which is replaced by the former). hashicorp/go-metrics is already used by grafana/memberlist, but I forgot to switch dskit's usage of the module when I upgraded grafana/memberlist in #362.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
