### PR TITLE
Tracing: stop adding HTTP headers as tracing attributes

### DIFF
--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -92,7 +92,6 @@ func (t Tracer) wrapWithOTel(next http.Handler) http.Handler {
 				labeler.Add(attribute.String("http.content_type", ct))
 			}
 
-			labeler.Add(attribute.String("headers", fmt.Sprintf("%v", r.Header)))
 			// add a tag with the client's sourceIPs to the span, if a
 			// SourceIPExtractor is given.
 			if t.SourceIPs != nil {


### PR DESCRIPTION
When I added the OTel tracing in https://github.com/grafana/dskit/pull/681 I went too far and added headers as tracing attributes.

As @bboreham pointed out, this could log potentially sensitive headers like auth tokens.

This is a quick fix to remove that from traces, we can add an allowlist or a blocklist in the future as a feature.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
