### PR TITLE
tracing.NewOTelOrJaegerFromEnv should not fail if no env was provided

### DIFF
--- a/tracing/internal/oteltest/otelorjaegerfromenv/config_test.go
+++ b/tracing/internal/oteltest/otelorjaegerfromenv/config_test.go
@@ -1,0 +1,50 @@
+package otelorjaegerfromenv
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/tracing"
+)
+
+func TestTracingNewOTelOrJaegerFromEnvDoesNotFailWithNoEnv(t *testing.T) {
+	// Make sure no tracing env is set for the test.
+	defer unsetAndRestoreDeferred(
+		"JAEGER_AGENT_HOST",
+		"JAEGER_ENDPOINT",
+		"JAEGER_SAMPLER_MANAGER_HOST_PORT",
+		"OTEL_TRACES_EXPORTER",
+	)()
+
+	closer, err := tracing.NewOTelOrJaegerFromEnv("test-service", log.NewNopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := closer.Close()
+		require.NoError(t, err)
+	})
+}
+
+func unsetAndRestoreDeferred(vars ...string) func() {
+	originalValues := make(map[string]string)
+	for _, k := range vars {
+		originalValues[k] = os.Getenv(k)
+		os.Unsetenv(k)
+	}
+
+	return func() {
+		for _, v := range vars {
+			if originalValue, exists := originalValues[v]; exists {
+				if originalValue == "" {
+					os.Unsetenv(v)
+				} else {
+					os.Setenv(v, originalValue)
+				}
+			} else {
+				os.Unsetenv(v)
+			}
+		}
+	}
+}

--- a/tracing/internal/oteltest/otelorjaegerfromenv/config_test.go
+++ b/tracing/internal/oteltest/otelorjaegerfromenv/config_test.go
@@ -36,12 +36,8 @@ func unsetAndRestoreDeferred(vars ...string) func() {
 
 	return func() {
 		for _, v := range vars {
-			if originalValue, exists := originalValues[v]; exists {
-				if originalValue == "" {
-					os.Unsetenv(v)
-				} else {
-					os.Setenv(v, originalValue)
-				}
+			if originalValue := originalValues[v]; originalValue != "" {
+				os.Setenv(v, originalValue)
 			} else {
 				os.Unsetenv(v)
 			}

--- a/tracing/opentracing.go
+++ b/tracing/opentracing.go
@@ -35,7 +35,7 @@ func NewFromEnv(serviceName string, options ...jaegercfg.Option) (io.Closer, err
 	}
 
 	if cfg.Sampler.SamplingServerURL == "" && cfg.Reporter.LocalAgentHostPort == "" && cfg.Reporter.CollectorEndpoint == "" {
-		return nil, ErrBlankTraceConfiguration
+		return nil, ErrBlankJaegerTraceConfiguration
 	}
 
 	return installJaeger(serviceName, cfg, options...)

--- a/tracing/otel_jaeger.go
+++ b/tracing/otel_jaeger.go
@@ -45,23 +45,18 @@ const (
 // - JAEGER_AGENT_HOST
 // - JAEGER_ENDPOINT
 // - JAEGER_SAMPLER_MANAGER_HOST_PORT
-// Otherwise, it will initialize tracing with the OTel auto exporter, as per OTel docs, if any of the following environment variables are set:
-// - OTEL_EXPORTER_OTLP_ENDPOINT
-// - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-// - OTEL_TRACES_SAMPLER
-// - OTEL_TRACES_EXPORTER
+//
+// Otherwise, it will initialize tracing with the OTel auto exporter using the environment variables defined in the OTel docs
+// If you want to explicitly disable OTel auto exporter, you can set the environment variable `OTEL_TRACES_EXPORTER` to `none`.
 func NewOTelOrJaegerFromEnv(serviceName string, logger log.Logger, opts ...OTelOption) (io.Closer, error) {
 	if env, found := findNonEmptyEnv(envJaegerAgentHost, envJaegerEndpoint, envJaegerSamplerManagerHostPort); found {
 		level.Info(logger).Log("msg", "Configuring tracing with Jaeger exporter", "detected_env_var", env)
 		return newOTelFromJaegerEnv(serviceName, logger, opts...)
 	}
-	if env, found := findNonEmptyEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_TRACES_SAMPLER", "OTEL_TRACES_EXPORTER"); found {
-		level.Info(logger).Log("msg", "Configuring tracing with OTel auto exporter", "detected_env_var", env)
-		return NewOTelFromEnv(serviceName, logger, opts...)
-	}
-	level.Info(logger).Log("msg", "No Jaeger or OTel auto exporter configuration found, tracing will not be configured")
 
-	return ioCloser(func() error { return nil }), ErrBlankTraceConfiguration
+	level.Info(logger).Log("msg", "Configuring tracing with OTel auto exporter")
+
+	return NewOTelFromEnv(serviceName, logger, opts...)
 }
 
 func findNonEmptyEnv(envVars ...string) (string, bool) {
@@ -90,7 +85,7 @@ func newOTelFromJaegerEnv(serviceName string, logger log.Logger, options ...OTel
 		return nil, errors.Wrap(err, "could not load jaeger tracer configuration")
 	}
 	if cfg.samplingServerURL == "" && cfg.agentHostPort == "" && cfg.jaegerEndpoint == "" {
-		return nil, ErrBlankTraceConfiguration
+		return nil, ErrBlankJaegerTraceConfiguration
 	}
 	return cfg.initJaegerTracerProvider(serviceName, logger, options...)
 }

--- a/tracing/otel_jaeger.go
+++ b/tracing/otel_jaeger.go
@@ -46,7 +46,7 @@ const (
 // - JAEGER_ENDPOINT
 // - JAEGER_SAMPLER_MANAGER_HOST_PORT
 //
-// Otherwise, it will initialize tracing with the OTel auto exporter using the environment variables defined in the OTel docs
+// Otherwise, it will initialize tracing with the OTel auto exporter using the environment variables defined in the OTel docs.
 // If you want to explicitly disable OTel auto exporter, you can set the environment variable `OTEL_TRACES_EXPORTER` to `none`.
 func NewOTelOrJaegerFromEnv(serviceName string, logger log.Logger, opts ...OTelOption) (io.Closer, error) {
 	if env, found := findNonEmptyEnv(envJaegerAgentHost, envJaegerEndpoint, envJaegerSamplerManagerHostPort); found {

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	// ErrBlankTraceConfiguration is an error to notify client to provide valid trace report agent or config server
-	ErrBlankTraceConfiguration = errors.New("no OTel or Jaeger tracing environment variables configured")
+	// ErrBlankJaegerTraceConfiguration is an error to notify client to provide valid trace report agent or config server.
+	ErrBlankJaegerTraceConfiguration = errors.New("no Jaeger trace report agent, config server, or collector endpoint specified")
 )
 
 // ExtractTraceID extracts the trace id, if any from the context.


### PR DESCRIPTION
Follow up on https://github.com/grafana/dskit/pull/704

This function should not fail if no tracing env was provided, that's what the old tracing.NewFromEnv() did.

Previous behaviour was to just setup a Jaeger exporter pointing to localhost, we'll do the default OTEL exporter behaviour now.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
