### PR TITLE
ci: Run conventional commit check on PR edits

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -2,6 +2,7 @@ name: Check conventional commits
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
• Add `edited` trigger type to conventional commit CI workflow to validate PR titles when they are modified