### PR TITLE
fix(tracing): Make Jaeger-env OTel sampler parentbased

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/gogo/status v1.1.0
 	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.4
-	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grafana/gomemcache v0.0.0-20250318131618-74242eea118d
@@ -85,6 +84,7 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gomodule/redigo v1.8.9 // indirect
+	github.com/google/btree v1.1.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/tracing/otel_jaeger.go
+++ b/tracing/otel_jaeger.go
@@ -208,10 +208,11 @@ func parseOTelJaegerConfig() (otelJaegerConfig, error) {
 	}
 
 	if e := os.Getenv(envJaegerSamplerNotParentBased); e != "" {
-		if e != "true" && e != "false" {
-			return cfg, errors.Errorf("invalid value for %s: %s, expected 'true' or 'false'", envJaegerSamplerNotParentBased, e)
+		if value, err := strconv.ParseBool(e); err == nil {
+			cfg.samplerNotParentBased = value
+		} else {
+			return cfg, errors.Wrapf(err, "cannot parse env var %s=%s", envJaegerSamplerNotParentBased, e)
 		}
-		cfg.samplerNotParentBased = e == "true"
 	}
 
 	return cfg, nil

--- a/tracing/otel_jaeger.go
+++ b/tracing/otel_jaeger.go
@@ -31,6 +31,7 @@ const (
 	envJaegerTags                      = "JAEGER_TAGS"
 	envJaegerSamplerManagerHostPort    = "JAEGER_SAMPLER_MANAGER_HOST_PORT"
 	envJaegerSamplerParam              = "JAEGER_SAMPLER_PARAM"
+	envJaegerSamplerNotParentBased     = "JAEGER_SAMPLER_NOT_PARENT_BASED"
 	envJaegerEndpoint                  = "JAEGER_ENDPOINT"
 	envJaegerAgentPort                 = "JAEGER_AGENT_PORT"
 	envJaegerSamplerType               = "JAEGER_SAMPLER_TYPE"
@@ -119,15 +120,16 @@ func parseJaegerTags(sTags string) ([]attribute.KeyValue, error) {
 }
 
 type otelJaegerConfig struct {
-	agentHost            string
-	jaegerEndpoint       string
-	agentPort            string
-	samplerType          string
-	samplingServerURL    string
-	samplerParam         float64
-	jaegerTags           []attribute.KeyValue
-	agentHostPort        string
-	reporterMaxQueueSize int
+	agentHost             string
+	jaegerEndpoint        string
+	agentPort             string
+	samplerType           string
+	samplingServerURL     string
+	samplerParam          float64
+	samplerNotParentBased bool
+	jaegerTags            []attribute.KeyValue
+	agentHostPort         string
+	reporterMaxQueueSize  int
 }
 
 // parseOTelJaegerConfig facilitates initialization that is compatible with Jaeger's InitGlobalTracer method.
@@ -204,6 +206,14 @@ func parseOTelJaegerConfig() (otelJaegerConfig, error) {
 			return cfg, errors.Wrapf(err, "cannot parse env var %s=%s", envJaegerReporterMaxQueueSize, e)
 		}
 	}
+
+	if e := os.Getenv(envJaegerSamplerNotParentBased); e != "" {
+		if e != "true" && e != "false" {
+			return cfg, errors.Errorf("invalid value for %s: %s, expected 'true' or 'false'", envJaegerSamplerNotParentBased, e)
+		}
+		cfg.samplerNotParentBased = e == "true"
+	}
+
 	return cfg, nil
 }
 
@@ -252,6 +262,11 @@ func (cfg otelJaegerConfig) initJaegerTracerProvider(serviceName string, logger 
 		attribute.String("samplingServerURL", cfg.samplingServerURL),
 	)
 	customAttrs = append(customAttrs, otelCfg.resourceAttributes...)
+	if !cfg.samplerNotParentBased {
+		sampler = tracesdk.ParentBased(sampler)
+	} else {
+		customAttrs = append(customAttrs, attribute.Bool("samplerNotParentBased", true))
+	}
 
 	res, err := NewResource(serviceName, customAttrs)
 	if err != nil {


### PR DESCRIPTION
When configuring OTel tracing library with Jaeger environment variables we were not making the sampler parent-based, which means that each one of our components took it's own decision about sampling, and almost nothing is sampled.

This makes it parentbased by default, except if 'JAEGER_SAMPLER_NOT_PARENT_BASED=true' env is provided (in case someone needs this).

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
