### PR TITLE
feat(runtimeconfig): Introduce preprocessor hook to runtimeconfig.Manager

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -24,6 +24,9 @@ import (
 	"github.com/grafana/dskit/services"
 )
 
+// Preprocessor optionally processes and changes config prior to parsing.
+type Preprocessor func(b []byte) ([]byte, error)
+
 // Loader loads the configuration from files.
 type Loader func(r io.Reader) (interface{}, error)
 
@@ -33,8 +36,9 @@ type Config struct {
 	ReloadPeriod time.Duration `yaml:"period" category:"advanced"`
 	// LoadPath contains the path to the runtime config files.
 	// Requires a non-empty value
-	LoadPath flagext.StringSliceCSV `yaml:"file"`
-	Loader   Loader                 `yaml:"-"`
+	LoadPath     flagext.StringSliceCSV `yaml:"file"`
+	Preprocessor Preprocessor           `yaml:"-"`
+	Loader       Loader                 `yaml:"-"`
 }
 
 // RegisterFlags registers flags.
@@ -162,6 +166,14 @@ func (om *Manager) loadConfig() error {
 		if err != nil {
 			om.configLoadSuccess.Set(0)
 			return errors.Wrapf(err, "read file %q", f)
+		}
+
+		if om.cfg.Preprocessor != nil {
+			buf, err = om.cfg.Preprocessor(buf)
+			if err != nil {
+				om.configLoadSuccess.Set(0)
+				return errors.Wrapf(err, "preprocess file %q", f)
+			}
 		}
 
 		rawData[f] = buf


### PR DESCRIPTION
**What this PR does**:

This PR adds a new optional hook to the `runtimeconfig.Manager` that allows reading or editing of the runtime config file.

The eventual goal of this is to add support for environment variable expansion in runtime config files, i.e.  `-runtime-config.expand-env` as a counterpart to  the common `config.expand-env`.

**Why not just add runtime-config.expand-env directly?**

TL;DR: inconsistency between databases.

Different databases use completely different syntax for environment variable expansion, i.e. [Loki](https://github.com/grafana/loki/blob/3697cb9085cac9d3319c74130a78dd1dc088713f/pkg/util/cfg/files.go#L50C14-L50C30) and [Tempo](https://github.com/grafana/tempo/blame/73a41f934c3d26055b62bfabe2913b74f77f854b/modules/overrides/runtime_config_overrides.go#L81C14-L81C22) use [drone/envsubst](https://github.com/drone/envsubst/blob/master/eval.go). Mimir uses a different separator for default values (`:` instead of `:-`) as well as a large set of other edge case differences.

Tempo already implements env var substitution in runtime config files, but it does so with a dangerous interface cast, and is bound to the main `config.expand-env` flag and not a separate one for runtime config. I'm not certain other databases can do this for backward compatibility reasons and may need a separate flag to control it. This approach also reduces risk of panics depending on dskit changes.

Overall it felt that preferring local consistency over global consistency was easier to work with for all projects.  The alternatives mean having different syntaxes for expansion in the same project, or incurring edge case breaking changes.

**Which issue(s) this PR fixes**:

Contrib https://github.com/grafana/mimir/issues/11754

**Checklist**
- [x] Tests updated
