### PR TITLE
fix(tracing): Unset OTEL_TRACES_SAMPLER when it's jaeger_remote

### DIFF
--- a/tracing/otel.go
+++ b/tracing/otel.go
@@ -56,7 +56,7 @@ func NewOTelFromEnv(serviceName string, logger log.Logger, opts ...OTelOption) (
 		tracesdk.WithBatcher(exp),
 		tracesdk.WithResource(resource),
 	}
-	if jaegerRemoteSampler, ok, err := MaybeJaegerRemoteSamplerFromEnv(serviceName); err != nil {
+	if jaegerRemoteSampler, ok, err := maybeJaegerRemoteSamplerFromEnv(serviceName); err != nil {
 		return nil, fmt.Errorf("failed to create Jaeger remote sampler: %w", err)
 	} else if ok {
 		options = append(options, tracesdk.WithSampler(jaegerRemoteSampler))
@@ -160,7 +160,7 @@ func NewResource(serviceName string, customAttributes []attribute.KeyValue) (*re
 	)
 }
 
-// MaybeJaegerRemoteSamplerFromEnv checks the environment variables to see
+// maybeJaegerRemoteSamplerFromEnv checks the environment variables to see
 // if `jaeger_remote` or `parentbased_jaeger_remote` sampler is configured through OTEL_TRACES_SAMPLER.
 //
 // This extends go.opentelemetry.io/otel/sdk/trace/sampler_env.go `samplerFromEnv()` with support for Jaeger remote samplers as per docs in:
@@ -170,8 +170,8 @@ func NewResource(serviceName string, customAttributes []attribute.KeyValue) (*re
 // If the environment variable is set to "jaeger_remote" or "parentbased_jaeger_remote",
 // but `OTEL_TRACES_SAMPLER_ARG` is not in the correct format (according to the docs mentioned above), then an error is returned.
 //
-// When MaybeJaegerRemoteSamplerFromEnv finds a supported Jaeger remote sampler OTEL_TRACES_SAMPLER value, it unsets that environment variable.
-func MaybeJaegerRemoteSamplerFromEnv(serviceName string) (tracesdk.Sampler, bool, error) {
+// When maybeJaegerRemoteSamplerFromEnv finds a supported Jaeger remote sampler OTEL_TRACES_SAMPLER value, it unsets that environment variable.
+func maybeJaegerRemoteSamplerFromEnv(serviceName string) (tracesdk.Sampler, bool, error) {
 	samplerName, ok := os.LookupEnv("OTEL_TRACES_SAMPLER")
 	if !ok {
 		return nil, false, nil

--- a/tracing/otel_test.go
+++ b/tracing/otel_test.go
@@ -153,7 +153,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 		os.Unsetenv("OTEL_TRACES_SAMPLER")
 		os.Unsetenv("OTEL_TRACES_SAMPLER_ARG")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, sampler)
@@ -165,7 +165,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 		os.Setenv("OTEL_TRACES_SAMPLER", "jaeger_remote")
 		os.Setenv("OTEL_TRACES_SAMPLER_ARG", "endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.NotNil(t, sampler)
@@ -184,7 +184,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 		os.Setenv("OTEL_TRACES_SAMPLER", "parentbased_jaeger_remote")
 		os.Setenv("OTEL_TRACES_SAMPLER_ARG", "endpoint=http://localhost:14250,pollingIntervalMs=5000")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.NotNil(t, sampler)
@@ -199,7 +199,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 		os.Setenv("OTEL_TRACES_SAMPLER", "jaeger_remote")
 		os.Unsetenv("OTEL_TRACES_SAMPLER_ARG")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.Error(t, err)
 		require.False(t, ok)
 		require.Nil(t, sampler)
@@ -212,7 +212,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 		os.Setenv("OTEL_TRACES_SAMPLER", "jaeger_remote")
 		os.Setenv("OTEL_TRACES_SAMPLER_ARG", "pollingIntervalMs=5000,initialSamplingRate=0.25")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.Error(t, err)
 		require.False(t, ok)
 		require.Nil(t, sampler)
@@ -225,7 +225,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 		os.Setenv("OTEL_TRACES_SAMPLER", "jaeger_remote")
 		os.Setenv("OTEL_TRACES_SAMPLER_ARG", "endpoint=http://localhost:14250,pollingIntervalMs=invalid")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.Error(t, err)
 		require.False(t, ok)
 		require.Nil(t, sampler)
@@ -238,7 +238,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 		os.Setenv("OTEL_TRACES_SAMPLER", "jaeger_remote")
 		os.Setenv("OTEL_TRACES_SAMPLER_ARG", "endpoint=http://localhost:14250,initialSamplingRate=2.0")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.Error(t, err)
 		require.False(t, ok)
 		require.Nil(t, sampler)
@@ -250,7 +250,7 @@ func TestMaybeJaegerRemoteSamplerFromEnv(t *testing.T) {
 
 		os.Setenv("OTEL_TRACES_SAMPLER", "always_on")
 
-		sampler, ok, err := MaybeJaegerRemoteSamplerFromEnv("test-service")
+		sampler, ok, err := maybeJaegerRemoteSamplerFromEnv("test-service")
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, sampler)


### PR DESCRIPTION
After configuring our custom jaeger_remote or parentbased_jaeger_remote we should unset the OTEL_TRACES_SAMPLER, otherwise the SDK complains in the logs about 'unknown sampler: jaeger_remote', which is confusing for the users.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
