### PR TITLE
chore: Remove debug log statements from memberlist

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -579,7 +579,6 @@ func (m *KV) running(ctx context.Context) error {
 		case <-obsoleteEntriesTickerChan:
 			// cleanupObsoleteEntries is normally called during push/pull, but if there are no other
 			// nodes to push/pull with, we can call it periodically to make sure we remove unused entries from memory.
-			level.Debug(m.logger).Log("msg", "initiating cleanup of obsolete entries")
 			m.cleanupObsoleteEntries()
 
 		case <-ctx.Done():
@@ -1757,7 +1756,6 @@ func (m *KV) cleanupObsoleteEntries() {
 
 	for k, v := range m.store {
 		if v.Deleted && time.Since(v.UpdateTime) > m.cfg.ObsoleteEntriesTimeout {
-			level.Info(m.logger).Log("msg", "deleting entry from KV store", "key", k)
 			delete(m.store, k)
 		}
 	}


### PR DESCRIPTION
Remove debug log statements from memberlist client cleanup operations.

These log statements were producing excessive logging during normal operations and are not needed.