### PR TITLE
fix(tracing): do not setup OTel tracing if environment variables were not provided

### DIFF
--- a/tracing/internal/notracingtest/no_tracing_test.go
+++ b/tracing/internal/notracingtest/no_tracing_test.go
@@ -42,11 +42,18 @@ func TestNoTracingConfigured(t *testing.T) {
 
 func ensureTracingDoesNotLogErrors(t *testing.T, logger mockLogger) {
 	tracer := otel.Tracer("test")
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		for t.Context().Err() == nil {
-			// Generate A LOT of spans, so exporter will be forced to export them if configured.
-			_, sp := tracer.Start(context.Background(), "test-operation")
-			sp.End()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				// Generate A LOT of spans, so exporter will be forced to export them if configured.
+				_, sp := tracer.Start(context.Background(), "test-operation")
+				sp.End()
+			}
 		}
 	}()
 

--- a/tracing/internal/notracingtest/no_tracing_test.go
+++ b/tracing/internal/notracingtest/no_tracing_test.go
@@ -1,0 +1,98 @@
+package notracingtest
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+
+	"github.com/grafana/dskit/tracing"
+)
+
+func TestNoTracingConfigured(t *testing.T) {
+	// Make sure no tracing env is set for the test.
+	defer unsetAndRestoreDeferred(
+		"JAEGER_AGENT_HOST",
+		"JAEGER_ENDPOINT",
+		"JAEGER_SAMPLER_MANAGER_HOST_PORT",
+		"OTEL_TRACES_EXPORTER",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	)()
+	logger := make(mockLogger, 100)
+
+	t.Run("tracing.NewOTelOrJaegerFromEnv", func(t *testing.T) {
+		closer, err := tracing.NewOTelOrJaegerFromEnv("test", logger)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+		ensureTracingDoesNotLogErrors(t, logger)
+	})
+	t.Run("tracing.NewOTelFromEnv", func(t *testing.T) {
+		closer, err := tracing.NewOTelFromEnv("test", logger)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+		ensureTracingDoesNotLogErrors(t, logger)
+	})
+}
+
+func ensureTracingDoesNotLogErrors(t *testing.T, logger mockLogger) {
+	tracer := otel.Tracer("test")
+	go func() {
+		for t.Context().Err() == nil {
+			// Generate A LOT of spans, so exporter will be forced to export them if configured.
+			_, sp := tracer.Start(context.Background(), "test-operation")
+			sp.End()
+		}
+	}()
+
+	// There's no way to figure out whether OTel tracer provider is configured or not, so we'll just observe the logs.
+	timeout := time.After(time.Second)
+	select {
+	case log := <-logger:
+		// If we let opentracing configure itself, it will log about the configuration, which isn't a big deal,
+		// but then for each span batch exported it will complain about localhost:4318 not accepting traces.
+		t.Errorf("Unexpected log: %v", log)
+		// Read more logs, if any.
+	logs:
+		for {
+			select {
+			case log = <-logger:
+				t.Errorf("Unexpected log: %v", log)
+			case <-timeout:
+				break logs
+			}
+		}
+	case <-timeout:
+		// No logs are expected.
+	}
+}
+
+func unsetAndRestoreDeferred(vars ...string) func() {
+	originalValues := make(map[string]string)
+	for _, k := range vars {
+		originalValues[k] = os.Getenv(k)
+		os.Unsetenv(k)
+	}
+
+	return func() {
+		for _, v := range vars {
+			if originalValue := originalValues[v]; originalValue != "" {
+				os.Setenv(v, originalValue)
+			} else {
+				os.Unsetenv(v)
+			}
+		}
+	}
+}
+
+type mockLogger chan []any
+
+func (m mockLogger) Log(keyvals ...any) error {
+	m <- keyvals
+	return nil
+}

--- a/tracing/otel.go
+++ b/tracing/otel.go
@@ -35,6 +35,11 @@ var tracer = otel.Tracer("dskit/tracing")
 // Refer to official OTel SDK configuration docs to see the available options.
 // https://opentelemetry.io/docs/languages/sdk-configuration/general/
 func NewOTelFromEnv(serviceName string, logger log.Logger, opts ...OTelOption) (io.Closer, error) {
+	if os.Getenv("OTEL_TRACES_EXPORTER") == "" && os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" && os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") == "" {
+		// No tracing is configured, so don't initialize the tracer as it would complain on every span about localhost:4718 not accepting traces.
+		return ioCloser(func() error { return nil }), nil
+	}
+
 	level.Info(logger).Log("msg", "initialising OpenTelemetry tracer")
 
 	exp, err := autoexport.NewSpanExporter(context.Background())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

OTel will setup the entire tracing stack by default, pointing at localhost:4318, and then it will try to export spans there, and it will fail, and it will log an error for each one of those failures. But maybe we just didn't want to setup tracing?

This changes the setup functions to skip setup if no enviroment variable was provided to export them, this is something that Tempo does in their main()

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
