### PR TITLE
feat(ring): add ReadOnly state handling to BasicLifecycler

### DIFF
--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -337,10 +337,15 @@ func (l *BasicLifecycler) registerInstance(ctx context.Context) error {
 			registeredAt = time.Now()
 		}
 
+		readOnly, readOnlyUpdatedTimestamp := instanceDesc.GetReadOnlyState()
+		if readOnlyUpdatedTimestamp.IsZero() {
+			// Store the zero timestamp as 0 in the ring, not as -62135596800.
+			readOnlyUpdatedTimestamp = time.Unix(0, 0)
+		}
 		// Always overwrite the instance in the ring (even if already exists) because some properties
 		// may have changed (stated, tokens, zone, address) and even if they didn't the heartbeat at
 		// least did.
-		instanceDesc = ringDesc.AddIngester(l.cfg.ID, l.cfg.Addr, l.cfg.Zone, tokens, state, registeredAt, false, time.Time{})
+		instanceDesc = ringDesc.AddIngester(l.cfg.ID, l.cfg.Addr, l.cfg.Zone, tokens, state, registeredAt, readOnly, readOnlyUpdatedTimestamp)
 		return ringDesc, true, nil
 	})
 

--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -467,7 +467,8 @@ func (l *BasicLifecycler) updateInstance(ctx context.Context, update func(*Desc,
 			// a resharding of tenants among instances: to guarantee query correctness we need to update the
 			// registration timestamp to current time.
 			registeredAt := time.Now()
-			instanceDesc = ringDesc.AddIngester(l.cfg.ID, l.cfg.Addr, l.cfg.Zone, l.GetTokens(), l.GetState(), registeredAt, false, time.Time{})
+			readOnly, readOnlyUpdatedTimestamp := l.GetReadOnlyState()
+			instanceDesc = ringDesc.AddIngester(l.cfg.ID, l.cfg.Addr, l.cfg.Zone, l.GetTokens(), l.GetState(), registeredAt, readOnly, readOnlyUpdatedTimestamp)
 		}
 
 		prevTimestamp := instanceDesc.Timestamp

--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -153,6 +153,20 @@ func (l *BasicLifecycler) GetState() InstanceState {
 	return l.currInstanceDesc.GetState()
 }
 
+func (l *BasicLifecycler) GetReadOnlyState() (bool, time.Time) {
+	l.currState.RLock()
+	defer l.currState.RUnlock()
+
+	if l.currInstanceDesc == nil {
+		return false, time.Time{}
+	}
+
+	if l.currInstanceDesc.ReadOnly {
+		return true, time.Unix(l.currInstanceDesc.ReadOnlyUpdatedTimestamp, 0)
+	}
+	return false, time.Time{}
+}
+
 func (l *BasicLifecycler) GetTokens() Tokens {
 	l.currState.RLock()
 	defer l.currState.RUnlock()
@@ -189,6 +203,12 @@ func (l *BasicLifecycler) IsRegistered() bool {
 func (l *BasicLifecycler) ChangeState(ctx context.Context, state InstanceState) error {
 	return l.run(func() error {
 		return l.changeState(ctx, state)
+	})
+}
+
+func (l *BasicLifecycler) ChangeReadOnlyState(ctx context.Context, readOnly bool) error {
+	return l.run(func() error {
+		return l.changeReadOnlyState(ctx, readOnly)
 	})
 }
 
@@ -509,6 +529,26 @@ func (l *BasicLifecycler) changeState(ctx context.Context, state InstanceState) 
 
 	if err != nil {
 		level.Warn(l.logger).Log("msg", "failed to change instance state in the ring", "from", l.GetState(), "to", state, "err", err)
+	}
+
+	return err
+}
+
+func (l *BasicLifecycler) changeReadOnlyState(ctx context.Context, readOnly bool) error {
+	err := l.updateInstance(ctx, func(_ *Desc, i *InstanceDesc) bool {
+		// No-op if the state hasn't changed.
+		if i.ReadOnly == readOnly {
+			return false
+		}
+
+		i.ReadOnly = readOnly
+		i.ReadOnlyUpdatedTimestamp = time.Now().Unix()
+		return true
+	})
+
+	if err != nil {
+		from, _ := l.GetReadOnlyState()
+		level.Warn(l.logger).Log("msg", "failed to change instance read-only state in the ring", "from", from, "to", readOnly, "err", err)
 	}
 
 	return err


### PR DESCRIPTION
**What this PR does**:

This adds the ReadOnly property handling to BasicLifecycler.

**Which issue(s) this PR fixes**:

Required for usage-tracker implementation in Mimir.

**Checklist**
- [x] Tests updated
