### PR TITLE
feat(ring): support for owning multiple partitions

### DIFF
--- a/ring/multi_partition_instance_ring.go
+++ b/ring/multi_partition_instance_ring.go
@@ -73,7 +73,7 @@ func (r *MultiPartitionInstanceRing) GetReplicationSetForPartitionAndOperation(p
 	zonesBuffer = uniqueZonesFromInstances(instances, zonesBuffer[:0])
 	uniqueZones := len(zonesBuffer)
 
-	instances = highestPreferrablyNonReadOnlyFromEachZone(instances, ownerIDs, zonesBuffer)
+	instances = highestPreferablyNonReadOnlyFromEachZone(instances, ownerIDs, zonesBuffer)
 
 	return ReplicationSet{
 		Instances: instances,
@@ -91,7 +91,7 @@ func (r *MultiPartitionInstanceRing) GetReplicationSetForPartitionAndOperation(p
 
 // this method expects instanceIDs to be in the same order as instances.
 // instanceIDs should hold the parsed multi-partition owner IDs.
-func highestPreferrablyNonReadOnlyFromEachZone(instances []InstanceDesc, instanceIDs []string, instanceZones []string) []InstanceDesc {
+func highestPreferablyNonReadOnlyFromEachZone(instances []InstanceDesc, instanceIDs []string, instanceZones []string) []InstanceDesc {
 	var stackAllInstances [16]InstanceDesc
 	allInstances := append(stackAllInstances[:0], instances...)
 	instances = instances[:0] // Reset, this is what we're going to return.

--- a/ring/multi_partition_instance_ring.go
+++ b/ring/multi_partition_instance_ring.go
@@ -1,0 +1,158 @@
+package ring
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+)
+
+// MultiPartitionInstanceRing holds a partitions ring and a instances ring,
+// and provide functions to look up the intersection of the two (e.g. healthy instances by partition).
+// The difference between this and PartitionInstanceRing is that this ring supports multi-partition owners, i.e. an instance can own multiple partitions.
+type MultiPartitionInstanceRing struct {
+	partitionsRingReader PartitionRingReader
+	instancesRing        InstanceRingReader
+	heartbeatTimeout     time.Duration
+}
+
+func NewMultiPartitionInstanceRing(partitionsRingWatcher PartitionRingReader, instancesRing InstanceRingReader, heartbeatTimeout time.Duration) *MultiPartitionInstanceRing {
+	return &MultiPartitionInstanceRing{
+		partitionsRingReader: partitionsRingWatcher,
+		instancesRing:        instancesRing,
+		heartbeatTimeout:     heartbeatTimeout,
+	}
+}
+
+func (r *MultiPartitionInstanceRing) PartitionRing() *PartitionRing {
+	return r.partitionsRingReader.PartitionRing()
+}
+
+// GetReplicationSetForPartitionAndOperation returns a ReplicationSet for the input partition. If the partition doesn't
+// exist or there are no healthy owners for the partition, an error is returned.
+// It will pick the highest instance from each zone when building the replication set,
+// non-read-only instances are preferred over read-only instances (this is more important than picking the highest instance).
+func (r *MultiPartitionInstanceRing) GetReplicationSetForPartitionAndOperation(partitionID int32, op Operation) (ReplicationSet, error) {
+	const maxExpectedZones = 8 // Just enough to cover all needs. Allocating 2 or 8 elements on the stack won't make any performance difference.
+	var stackZonesBuffer [maxExpectedZones]string
+	zonesBuffer := stackZonesBuffer[:0]
+
+	now := time.Now()
+
+	var ownerIDs []string
+	var stackOwnerIDs [maxExpectedZones]string
+	ownerIDs = r.PartitionRing().MultiPartitionOwnerIDs(partitionID, stackOwnerIDs[:0])
+	instances := make([]InstanceDesc, 0, len(ownerIDs))
+
+	if len(ownerIDs) == 0 {
+		return ReplicationSet{}, fmt.Errorf("%w: no owners found for partition %d", ErrEmptyRing, partitionID)
+	}
+
+	for _, instanceID := range ownerIDs {
+		instance, err := r.instancesRing.GetInstance(instanceID)
+		if err != nil {
+			// If an instance doesn't exist in the instances ring we don't return an error
+			// but lookup for other instances of the partition.
+			continue
+		}
+
+		if !instance.IsHealthy(op, r.heartbeatTimeout, now) {
+			continue
+		}
+
+		instances = append(instances, instance)
+		// Store this in the same position as the instance, so we can use it to compare later.
+		// We only need this when r.pickHighestZoneOwner=true, but it's probably cheaper to do it than to check it.
+		ownerIDs[len(instances)-1] = instanceID
+	}
+
+	if len(instances) == 0 {
+		return ReplicationSet{}, fmt.Errorf("partition %d: %w", partitionID, ErrTooManyUnhealthyInstances)
+	}
+
+	// Count the number of unique zones among instances.
+	zonesBuffer = uniqueZonesFromInstances(instances, zonesBuffer[:0])
+	uniqueZones := len(zonesBuffer)
+
+	instances = highestPreferrablyNonReadOnlyFromEachZone(instances, ownerIDs, zonesBuffer)
+
+	return ReplicationSet{
+		Instances: instances,
+
+		// Partitions has no concept of zone, but we enable it in order to support ring's requests
+		// minimization feature.
+		ZoneAwarenessEnabled: true,
+
+		// We need response from at least 1 owner. The assumption is that we have 1 owner per zone
+		// but it's not guaranteed (depends on how the application was deployed). The safest thing
+		// we can do here is to just request a successful response from at least 1 zone.
+		MaxUnavailableZones: uniqueZones - 1,
+	}, nil
+}
+
+// this method expects instanceIDs to be in the same order as instances.
+// instanceIDs should hold the parsed multi-partition owner IDs.
+func highestPreferrablyNonReadOnlyFromEachZone(instances []InstanceDesc, instanceIDs []string, instanceZones []string) []InstanceDesc {
+	var stackAllInstances [16]InstanceDesc
+	allInstances := append(stackAllInstances[:0], instances...)
+	instances = instances[:0] // Reset, this is what we're going to return.
+	for _, zone := range instanceZones {
+		highest := -1
+		for i, instance := range allInstances {
+			if instance.Zone != zone {
+				// Not our zone.
+				continue
+			}
+
+			// Always pick the first one.
+			if highest == -1 {
+				highest = i
+				continue
+			}
+
+			// If highest is read-only, and this one is not, pick it without checking the order.
+			if allInstances[highest].ReadOnly && !instance.ReadOnly {
+				highest = i
+				continue
+			}
+
+			// If this one is read only, and highest is not, skip it.
+			if instance.ReadOnly && !allInstances[highest].ReadOnly {
+				continue
+			}
+
+			// If this one has a lower index than the one we have, skip it.
+			if indexFromInstanceSuffix(instanceIDs[i]) < indexFromInstanceSuffix(instanceIDs[highest]) {
+				continue
+			}
+
+			// This one is better than the one we have.
+			highest = i
+		}
+
+		// We know there's always a highest instance for a zone, because zones were calculated from instances.
+		instances = append(instances, allInstances[highest])
+	}
+	return instances
+}
+
+// indexFromInstanceSuffix returns the index from the instance suffix. The suffix is expected to be a number.
+func indexFromInstanceSuffix(instance string) int {
+	digitsSuffixLen := 0
+	for digitsSuffixLen < len(instance) {
+		i := len(instance) - digitsSuffixLen - 1
+		if instance[i] >= '0' && instance[i] <= '9' {
+			digitsSuffixLen++
+		} else {
+			break
+		}
+	}
+	if digitsSuffixLen == 0 {
+		return math.MaxInt64
+	}
+	index, err := strconv.Atoi(instance[len(instance)-digitsSuffixLen:])
+	if err != nil {
+		return math.MaxInt64 // Shouldn't happen, we already made sure that the suffix is a number.
+	}
+	return index
+}

--- a/ring/multi_partition_instance_ring.go
+++ b/ring/multi_partition_instance_ring.go
@@ -91,6 +91,7 @@ func (r *MultiPartitionInstanceRing) GetReplicationSetForPartitionAndOperation(p
 
 // this method expects instanceIDs to be in the same order as instances.
 // instanceIDs should hold the parsed multi-partition owner IDs.
+// instances input slice is updated in place and returned.
 func highestPreferablyNonReadOnlyFromEachZone(instances []InstanceDesc, instanceIDs []string, instanceZones []string) []InstanceDesc {
 	var stackAllInstances [16]InstanceDesc
 	allInstances := append(stackAllInstances[:0], instances...)

--- a/ring/multi_partition_instance_ring.go
+++ b/ring/multi_partition_instance_ring.go
@@ -62,7 +62,6 @@ func (r *MultiPartitionInstanceRing) GetReplicationSetForPartitionAndOperation(p
 
 		instances = append(instances, instance)
 		// Store this in the same position as the instance, so we can use it to compare later.
-		// We only need this when r.pickHighestZoneOwner=true, but it's probably cheaper to do it than to check it.
 		ownerIDs[len(instances)-1] = instanceID
 	}
 

--- a/ring/multi_partition_instance_ring_test.go
+++ b/ring/multi_partition_instance_ring_test.go
@@ -1,0 +1,190 @@
+package ring
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiPartitionInstanceRing_GetReplicationSetForPartitionAndOperation_HighestPreferrablyNonReadOnlyFromEachZone(t *testing.T) {
+	now := time.Now()
+	op := NewOp([]InstanceState{ACTIVE}, nil)
+	heartbeatTimeout := time.Minute
+
+	type comparableReplicationSet struct {
+		instances           []string
+		maxUnavailableZones int
+	}
+
+	const testPartitionID = 1
+
+	tests := map[string]struct {
+		partitionsRing PartitionRingDesc
+		instancesRing  *Desc
+		expectedErr    error
+		expectedSet    comparableReplicationSet
+	}{
+		"should return error on empty partitions ring": {
+			partitionsRing: PartitionRingDesc{},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+			}},
+			expectedErr: ErrEmptyRing,
+		},
+		"should return error on empty instances ring": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 2): {OwnedPartition: 2},
+				},
+			},
+			instancesRing: &Desc{},
+			expectedErr:   ErrTooManyUnhealthyInstances,
+		},
+		"should return replication sets with at least 1 instance for the partition, if the partition has at least 1 healthy instance": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 2): {OwnedPartition: 2},
+					multiPartitionOwnerInstanceID("instance-zone-b-1", 1): {OwnedPartition: 1},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-b-1": {Id: "instance-zone-b-1", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+			}},
+			expectedSet: comparableReplicationSet{instances: []string{"instance-zone-a-1", "instance-zone-b-1"}, maxUnavailableZones: 1},
+		},
+		"should return error if there are no healthy instances for the partition": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 2): {OwnedPartition: 2},
+					multiPartitionOwnerInstanceID("instance-zone-b-1", 1): {OwnedPartition: 1},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy.
+				"instance-zone-b-1": {Id: "instance-zone-b-1", State: ACTIVE, Zone: "b", Timestamp: now.Add(-3 * time.Minute).Unix()}, // Unhealthy.
+			}},
+			expectedErr: ErrTooManyUnhealthyInstances,
+		},
+		"should return the replication set excluding unhealthy instances as long as there's at least 1 healthy instance for the partition": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 2): {OwnedPartition: 2},
+					multiPartitionOwnerInstanceID("instance-zone-b-1", 1): {OwnedPartition: 1},
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Add(-2 * time.Minute).Unix()}, // Unhealthy.
+				"instance-zone-b-1": {Id: "instance-zone-b-1", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},                       // Healthy.
+			}},
+			expectedSet: comparableReplicationSet{instances: []string{"instance-zone-b-1"}, maxUnavailableZones: 0},
+		},
+		"should return the highest owner from each zone for the partition": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-a-2", 1): {OwnedPartition: 1}, // Highest owner in zone 'a'.
+					multiPartitionOwnerInstanceID("instance-zone-b-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-b-2", 2): {OwnedPartition: 2}, // Different partition.
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-b-1": {Id: "instance-zone-b-1", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+				"instance-zone-b-2": {Id: "instance-zone-b-2", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+			}},
+			expectedSet: comparableReplicationSet{instances: []string{"instance-zone-a-2", "instance-zone-b-1"}, maxUnavailableZones: 1},
+		},
+		"should return the highest non read-only owner from each zone for the partition": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					multiPartitionOwnerInstanceID("instance-zone-a-1", 1): {OwnedPartition: 1}, // Highest non-read-only owner in zone 'a'.
+					multiPartitionOwnerInstanceID("instance-zone-a-2", 1): {OwnedPartition: 1}, // Highest owner in zone 'a' but it's read-only.
+					multiPartitionOwnerInstanceID("instance-zone-b-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-b-2", 2): {OwnedPartition: 2}, // Different partition.
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "a", Timestamp: now.Unix(), ReadOnly: true}, // Read-only.
+				"instance-zone-b-1": {Id: "instance-zone-b-1", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+				"instance-zone-b-2": {Id: "instance-zone-b-2", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+			}},
+			expectedSet: comparableReplicationSet{instances: []string{"instance-zone-a-1", "instance-zone-b-1"}, maxUnavailableZones: 1},
+		},
+		"should return the read-only owner if it's the only one": {
+			partitionsRing: PartitionRingDesc{
+				Partitions: map[int32]PartitionDesc{
+					1: {State: PartitionActive},
+					2: {State: PartitionInactive},
+				},
+				Owners: map[string]OwnerDesc{
+					multiPartitionOwnerInstanceID("instance-zone-a-2", 1): {OwnedPartition: 1}, // Read-only but it's the only owner in zone 'a'.
+					multiPartitionOwnerInstanceID("instance-zone-b-1", 1): {OwnedPartition: 1},
+					multiPartitionOwnerInstanceID("instance-zone-b-2", 2): {OwnedPartition: 2}, // Different partition.
+				},
+			},
+			instancesRing: &Desc{Ingesters: map[string]InstanceDesc{
+				"instance-zone-a-1": {Id: "instance-zone-a-1", State: ACTIVE, Zone: "a", Timestamp: now.Unix()},                 // Does not own the partition.
+				"instance-zone-a-2": {Id: "instance-zone-a-2", State: ACTIVE, Zone: "a", Timestamp: now.Unix(), ReadOnly: true}, // Read-only.
+				"instance-zone-b-1": {Id: "instance-zone-b-1", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+				"instance-zone-b-2": {Id: "instance-zone-b-2", State: ACTIVE, Zone: "b", Timestamp: now.Unix()},
+			}},
+			expectedSet: comparableReplicationSet{instances: []string{"instance-zone-a-2", "instance-zone-b-1"}, maxUnavailableZones: 1},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			partitionsRing := NewPartitionRing(testData.partitionsRing)
+			instancesRing := &Ring{ringDesc: testData.instancesRing}
+			r := NewMultiPartitionInstanceRing(newStaticPartitionRingReader(partitionsRing), instancesRing, heartbeatTimeout)
+
+			set, err := r.GetReplicationSetForPartitionAndOperation(testPartitionID, op)
+			require.ErrorIs(t, err, testData.expectedErr)
+			if testData.expectedErr != nil {
+				return
+			}
+
+			// Build the actual replication sets to compare with the expected ones.
+			instanceIDs := set.GetIDs()
+			slices.Sort(instanceIDs)
+			actual := comparableReplicationSet{instances: instanceIDs, maxUnavailableZones: set.MaxUnavailableZones}
+
+			assert.Equal(t, testData.expectedSet, actual)
+		})
+	}
+}

--- a/ring/partition_instance_lifecycler.go
+++ b/ring/partition_instance_lifecycler.go
@@ -34,6 +34,10 @@ type PartitionInstanceLifecyclerConfig struct {
 	// InstanceID is the ID of the instance managed by the lifecycler.
 	InstanceID string
 
+	// MultiPartitionOwnership is the flag that indicates whether the lifecycler should allow owning multiple partitions.
+	// This changes the InstanceID used to register the owner in the ring.
+	MultiPartitionOwnership bool
+
 	// WaitOwnersCountOnPending is the minimum number of owners to wait before switching a
 	// PENDING partition to ACTIVE.
 	WaitOwnersCountOnPending int
@@ -205,13 +209,13 @@ func (l *PartitionInstanceLifecycler) stopping(_ error) error {
 	// Remove the instance from partition owners, if configured to do so.
 	if l.RemoveOwnerOnShutdown() {
 		err := l.updateRing(context.Background(), func(ring *PartitionRingDesc) (bool, error) {
-			return ring.RemoveOwner(l.cfg.InstanceID), nil
+			return ring.RemoveOwner(l.partitionOwnerID()), nil
 		})
 
 		if err != nil {
-			level.Error(l.logger).Log("msg", "failed to remove instance from partition owners on shutdown", "instance", l.cfg.InstanceID, "partition", l.cfg.PartitionID, "err", err)
+			level.Error(l.logger).Log("msg", "failed to remove instance from partition owners on shutdown", "instance", l.cfg.InstanceID, "partition_owner_id", l.partitionOwnerID(), "partition", l.cfg.PartitionID, "err", err)
 		} else {
-			level.Info(l.logger).Log("msg", "instance removed from partition owners", "instance", l.cfg.InstanceID, "partition", l.cfg.PartitionID)
+			level.Info(l.logger).Log("msg", "instance removed from partition owners", "instance", l.cfg.InstanceID, "partition_owner_id", l.partitionOwnerID(), "partition", l.cfg.PartitionID)
 		}
 	}
 
@@ -261,6 +265,15 @@ func (l *PartitionInstanceLifecycler) updateRing(ctx context.Context, update fun
 	})
 }
 
+// partitionOwnerID returns the instance ID used to register the owner in the ring.
+func (l *PartitionInstanceLifecycler) partitionOwnerID() string {
+	if l.cfg.MultiPartitionOwnership {
+		return multiPartitionOwnerInstanceID(l.cfg.InstanceID, l.cfg.PartitionID)
+	}
+
+	return l.cfg.InstanceID
+}
+
 func (l *PartitionInstanceLifecycler) createPartitionAndRegisterOwner(ctx context.Context) error {
 	return l.updateRing(ctx, func(ring *PartitionRingDesc) (bool, error) {
 		now := time.Now()
@@ -281,7 +294,7 @@ func (l *PartitionInstanceLifecycler) createPartitionAndRegisterOwner(ctx contex
 		}
 
 		// Ensure the instance is added as partition owner.
-		if ring.AddOrUpdateOwner(l.cfg.InstanceID, OwnerActive, l.cfg.PartitionID, now) {
+		if ring.AddOrUpdateOwner(l.partitionOwnerID(), OwnerActive, l.cfg.PartitionID, now) {
 			changed = true
 		}
 
@@ -329,7 +342,7 @@ func (l *PartitionInstanceLifecycler) waitPartitionAndRegisterOwner(ctx context.
 
 	// Ensure the instance is added as partition owner.
 	return l.updateRing(ctx, func(ring *PartitionRingDesc) (bool, error) {
-		return ring.AddOrUpdateOwner(l.cfg.InstanceID, OwnerActive, l.cfg.PartitionID, time.Now()), nil
+		return ring.AddOrUpdateOwner(l.partitionOwnerID(), OwnerActive, l.cfg.PartitionID, time.Now()), nil
 	})
 }
 

--- a/ring/partition_instance_lifecycler_test.go
+++ b/ring/partition_instance_lifecycler_test.go
@@ -326,7 +326,7 @@ func TestPartitionInstanceLifecycler(t *testing.T) {
 			2: {multiPartitionOwnerInstanceID(instanceID1, 2)},
 		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
 
-		// Shutdown lifecyclerInstance1Partition1, this should *NOT* the owner for partition 2.
+		// Shutdown lifecyclerInstance1Partition2, this should *NOT* remove the owner for partition 2, because "remove on shutdown" was disabled.
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecyclerInstance1Partition2))
 		assertMapElementsMatch(t, map[int32][]string{
 			1: {multiPartitionOwnerInstanceID(instanceID2, 1)},

--- a/ring/partition_instance_lifecycler_test.go
+++ b/ring/partition_instance_lifecycler_test.go
@@ -1,7 +1,10 @@
 package ring
 
 import (
+	"cmp"
 	"context"
+	"maps"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -269,6 +272,86 @@ func TestPartitionInstanceLifecycler(t *testing.T) {
 			return lifecycler.State() == services.Failed
 		}, time.Second, eventuallyTick)
 	})
+
+	t.Run("should register and unregister with multi-owner ID when multiple partition ownership is enabled", func(t *testing.T) {
+		t.Parallel()
+
+		const instanceID1 = "instance-zone-a-1"
+		const instanceID2 = "instance-zone-b-1"
+
+		lifecyclerInstance1Partition1Config := createTestMultipartitionOwnershipPartitionInstanceLifecyclerConfig(1, instanceID1)
+		lifecyclerInstance1Partition2Config := createTestMultipartitionOwnershipPartitionInstanceLifecyclerConfig(2, instanceID1)
+		lifecyclerInstance2Partition1Config := createTestMultipartitionOwnershipPartitionInstanceLifecyclerConfig(1, instanceID2)
+
+		store, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+		t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+		// Start instance-zone-a-1 lifecycler for partition 1.
+		lifecyclerInstance1Partition1 := NewPartitionInstanceLifecycler(lifecyclerInstance1Partition1Config, "test", ringKey, store, logger, nil)
+		lifecyclerInstance1Partition1.SetRemoveOwnerOnShutdown(true)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, lifecyclerInstance1Partition1))
+
+		assertMapElementsMatch(t, map[int32][]string{
+			1: {multiPartitionOwnerInstanceID(instanceID1, 1)},
+		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+
+		// Start instance-zone-a-1 lifecycler for partition 2.
+		lifecyclerInstance1Partition2 := NewPartitionInstanceLifecycler(lifecyclerInstance1Partition2Config, "test", ringKey, store, logger, nil)
+		lifecyclerInstance1Partition2.SetRemoveOwnerOnShutdown(false)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, lifecyclerInstance1Partition2))
+
+		assertMapElementsMatch(t, map[int32][]string{
+			1: {multiPartitionOwnerInstanceID(instanceID1, 1)},
+			2: {multiPartitionOwnerInstanceID(instanceID1, 2)},
+		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+
+		// Start instance-zone-b-1 lifecycler for partition 1.
+		lifecyclerInstance2Partition1 := NewPartitionInstanceLifecycler(lifecyclerInstance2Partition1Config, "test", ringKey, store, logger, nil)
+		lifecyclerInstance2Partition1.SetRemoveOwnerOnShutdown(true)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, lifecyclerInstance2Partition1))
+
+		assertMapElementsMatch(t, map[int32][]string{
+			1: {
+				multiPartitionOwnerInstanceID(instanceID1, 1),
+				multiPartitionOwnerInstanceID(instanceID2, 1),
+			},
+			2: {multiPartitionOwnerInstanceID(instanceID1, 2)},
+		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+
+		// Shutdown lifecyclerInstance1Partition1, this should remove the owner for partition 1.
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecyclerInstance1Partition1))
+
+		assertMapElementsMatch(t, map[int32][]string{
+			1: {multiPartitionOwnerInstanceID(instanceID2, 1)},
+			2: {multiPartitionOwnerInstanceID(instanceID1, 2)},
+		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+
+		// Shutdown lifecyclerInstance1Partition1, this should *NOT* the owner for partition 2.
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecyclerInstance1Partition2))
+		assertMapElementsMatch(t, map[int32][]string{
+			1: {multiPartitionOwnerInstanceID(instanceID2, 1)},
+			2: {multiPartitionOwnerInstanceID(instanceID1, 2)},
+		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+
+		// Shutdown lifecyclerInstance2Partition1, this should remove the owner for partition 1.
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecyclerInstance2Partition1))
+		assertMapElementsMatch(t, map[int32][]string{
+			2: {multiPartitionOwnerInstanceID(instanceID1, 2)},
+		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+	})
+}
+
+func assertMapElementsMatch[K cmp.Ordered, V any, S ~[]V](t *testing.T, expected map[K]S, actual map[K]S) {
+	t.Helper()
+	expectedKeys := slices.Sorted(maps.Keys(expected))
+	actualKeys := slices.Sorted(maps.Keys(actual))
+	require.Equal(t, expectedKeys, actualKeys, "expected keys do not match actual keys")
+
+	for _, k := range expectedKeys {
+		expectedValues := expected[k]
+		actualValues := actual[k]
+		assert.ElementsMatch(t, expectedValues, actualValues, "for key %v", k)
+	}
 }
 
 func TestPartitionInstanceLifecycler_GetAndChangePartitionState(t *testing.T) {
@@ -343,6 +426,18 @@ func createTestPartitionInstanceLifecyclerConfig(partitionID int32, instanceID s
 	return PartitionInstanceLifecyclerConfig{
 		PartitionID:                          partitionID,
 		InstanceID:                           instanceID,
+		WaitOwnersCountOnPending:             0,
+		WaitOwnersDurationOnPending:          0,
+		DeleteInactivePartitionAfterDuration: 0,
+		PollingInterval:                      10 * time.Millisecond,
+	}
+}
+
+func createTestMultipartitionOwnershipPartitionInstanceLifecyclerConfig(partitionID int32, instanceID string) PartitionInstanceLifecyclerConfig {
+	return PartitionInstanceLifecyclerConfig{
+		PartitionID:                          partitionID,
+		InstanceID:                           instanceID,
+		MultiPartitionOwnership:              true,
 		WaitOwnersCountOnPending:             0,
 		WaitOwnersDurationOnPending:          0,
 		DeleteInactivePartitionAfterDuration: 0,

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -370,7 +370,7 @@ func (r *PartitionRing) MultiPartitionOwnerIDs(partitionID int32, buf []string) 
 	}
 
 	for i, ownerID := range ids {
-		if p := strings.IndexByte(ownerID, '/'); p != -1 {
+		if p := strings.LastIndexByte(ownerID, '/'); p != -1 {
 			buf[i] = ownerID[:p]
 		} else {
 			// This isn't expected here: all owner IDs should have a suffix when multiple partitions can be owned.

--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	shardUtil "github.com/grafana/dskit/ring/shard"
@@ -354,6 +355,31 @@ func (r *PartitionRing) PartitionOwnerIDsCopy(partitionID int32) []string {
 	return slices.Clone(ids)
 }
 
+// MultiPartitionOwnerIDs returns the ownerIDs of the given partitionID removing the suffix added to support ownership of multiple partitions.
+// The slice returned will try to use the provided buf, and it can be modified (it will modify the buf if it was used).
+func (r *PartitionRing) MultiPartitionOwnerIDs(partitionID int32, buf []string) []string {
+	ids := r.ownersByPartition[partitionID]
+	if len(ids) == 0 {
+		return nil
+	}
+
+	if cap(buf) < len(ids) {
+		buf = make([]string, len(ids))
+	} else {
+		buf = buf[:len(ids)]
+	}
+
+	for i, ownerID := range ids {
+		if p := strings.IndexByte(ownerID, '/'); p != -1 {
+			buf[i] = ownerID[:p]
+		} else {
+			// This isn't expected here: all owner IDs should have a suffix when multiple partitions can be owned.
+			buf[i] = ownerID
+		}
+	}
+	return buf
+}
+
 func (r *PartitionRing) String() string {
 	buf := bytes.Buffer{}
 	for pid, pd := range r.desc.Partitions {
@@ -483,4 +509,8 @@ func (r *ActivePartitionBatchRing) Get(key uint32, _ Operation, bufInstances []I
 		MaxUnavailableZones:  0,
 		ZoneAwarenessEnabled: false,
 	}, nil
+}
+
+func multiPartitionOwnerInstanceID(instanceID string, partitionID int32) string {
+	return instanceID + "/" + strconv.Itoa(int(partitionID))
 }

--- a/ring/partition_ring_editor.go
+++ b/ring/partition_ring_editor.go
@@ -32,6 +32,12 @@ func (l *PartitionRingEditor) ChangePartitionState(ctx context.Context, partitio
 	})
 }
 
+func (l *PartitionRingEditor) RemoveMultiPartitionOwner(ctx context.Context, instanceID string, partitionID int32) error {
+	return l.updateRing(ctx, func(ring *PartitionRingDesc) (bool, error) {
+		return ring.RemoveOwner(multiPartitionOwnerInstanceID(instanceID, partitionID)), nil
+	})
+}
+
 func (l *PartitionRingEditor) updateRing(ctx context.Context, update func(ring *PartitionRingDesc) (bool, error)) error {
 	return l.store.CAS(ctx, l.ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := GetOrCreatePartitionRingDesc(in)

--- a/ring/partition_ring_editor_test.go
+++ b/ring/partition_ring_editor_test.go
@@ -48,3 +48,40 @@ func TestPartitionRingEditor_ChangePartitionState(t *testing.T) {
 	require.Equal(t, PartitionInactive, getPartitionStateFromStore(t, store, ringKey, 1))
 	require.Equal(t, PartitionActive, getPartitionStateFromStore(t, store, ringKey, 2))
 }
+
+func TestPartitionRingEditor_RemoveMultiPartitionOwner(t *testing.T) {
+	ctx := context.Background()
+
+	store, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	// Init the ring with a partition and an owner.
+	require.NoError(t, store.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		desc := GetOrCreatePartitionRingDesc(in)
+		desc.AddPartition(1, PartitionActive, time.Now())
+		desc.AddOrUpdateOwner(multiPartitionOwnerInstanceID("instance-1", 1), OwnerActive, 1, time.Now())
+		desc.AddOrUpdateOwner(multiPartitionOwnerInstanceID("instance-1", 2), OwnerActive, 2, time.Now())
+		desc.AddOrUpdateOwner(multiPartitionOwnerInstanceID("instance-2", 1), OwnerActive, 1, time.Now())
+		desc.AddOrUpdateOwner(multiPartitionOwnerInstanceID("instance-2", 2), OwnerActive, 2, time.Now())
+		return desc, true, nil
+	}))
+
+	// This is what we should've built above.
+	assertMapElementsMatch(t, map[int32][]string{
+		1: {multiPartitionOwnerInstanceID("instance-1", 1), multiPartitionOwnerInstanceID("instance-2", 1)},
+		2: {multiPartitionOwnerInstanceID("instance-1", 2), multiPartitionOwnerInstanceID("instance-2", 2)},
+	}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+
+	// Start editor.
+	editor := NewPartitionRingEditor(ringKey, store)
+
+	// Remove the instance-1 as an owner of partition 1.
+	require.NoError(t, editor.RemoveMultiPartitionOwner(ctx, "instance-1", 1))
+
+	// Verify the owner is removed.
+	// This is what we should've built above.
+	assertMapElementsMatch(t, map[int32][]string{
+		1: {multiPartitionOwnerInstanceID("instance-2", 1)},
+		2: {multiPartitionOwnerInstanceID("instance-1", 2), multiPartitionOwnerInstanceID("instance-2", 2)},
+	}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
+}


### PR DESCRIPTION
**What this PR does**:

This adds a new `MultiPartitionInstanceRing` as an alternative to `PartitionInstanceRing` in which the instances can own more than one partition. It uses the same instance PartitionRing desc, so we leverage that by setting a different instance ID as owner of each partition.

The convention is enclosed in this implementation and consists of adding a suffix `/<partition>` to the instance ID when it owns `partition`. We initially added this as an option to `PartitionInstanceRing`, however most of the code actually differs, and the fact that you could instantiate a `PartitionInstanceRing` and use it in a multi-partition context introduced subtle bugs in the code. By adding a specific type to this we enforce that each implementation will consistently use one or another.

We do add this as an option to `PartitionInstanceLifecycler`, because there most of the code is shared. 

`PartitionRing` exposes a new method `MultiPartitionOwnerIDs` that will list the real (non-suffixed) instance IDs of partition owners ready to be used by any code.

Finally, we also add a method to `PartitionRingEditor` to remove an instance ID as an owner of a partition, required to perform the periodic cleanup of the stale instances in the ring by users of this library.

**Checklist**
- [x] Tests updated
