### PR TITLE
feat(middleware): add excludedUserAgents support to ClusterValidationMiddleware

### DIFF
--- a/clusterutil/cluster_validation_config.go
+++ b/clusterutil/cluster_validation_config.go
@@ -24,9 +24,9 @@ func (cfg *ClusterValidationConfig) RegisteredFlags() flagext.RegisteredFlags {
 
 type ServerClusterValidationConfig struct {
 	ClusterValidationConfig `yaml:",inline"`
-	GRPC                    ClusterValidationProtocolConfig                  `yaml:"grpc" category:"experimental"`
-	HTTP                    ClusterValidationProtocolWithExcludedPathsConfig `yaml:"http" category:"experimental"`
-	registeredFlags         flagext.RegisteredFlags                          `yaml:"-"`
+	GRPC                    ClusterValidationProtocolConfig        `yaml:"grpc" category:"experimental"`
+	HTTP                    ClusterValidationProtocolConfigForHTTP `yaml:"http" category:"experimental"`
+	registeredFlags         flagext.RegisteredFlags                `yaml:"-"`
 }
 
 func (cfg *ServerClusterValidationConfig) Validate() error {
@@ -75,12 +75,14 @@ func (cfg *ClusterValidationProtocolConfig) RegisterFlagsWithPrefix(prefix strin
 	f.BoolVar(&cfg.Enabled, enabledFlag, false, "When enabled, cluster label validation is executed: configured cluster validation label is compared with the cluster validation label received through the requests.")
 }
 
-type ClusterValidationProtocolWithExcludedPathsConfig struct {
+type ClusterValidationProtocolConfigForHTTP struct {
 	ClusterValidationProtocolConfig `yaml:",inline"`
 	ExcludedPaths                   flagext.StringSliceCSV `yaml:"excluded_paths" category:"experimental"`
+	ExcludedUserAgents              flagext.StringSliceCSV `yaml:"excluded_user_agents" category:"experimental"`
 }
 
-func (cfg *ClusterValidationProtocolWithExcludedPathsConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+func (cfg *ClusterValidationProtocolConfigForHTTP) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	cfg.ClusterValidationProtocolConfig.RegisterFlagsWithPrefix(prefix, f)
 	f.Var(&cfg.ExcludedPaths, prefix+"excluded-paths", "Comma-separated list of url paths that are excluded from the cluster validation check.")
+	f.Var(&cfg.ExcludedUserAgents, prefix+"excluded-user-agents", "Comma-separated list of user agents that are excluded from the cluster validation check.")
 }

--- a/middleware/http_cluster_test.go
+++ b/middleware/http_cluster_test.go
@@ -285,7 +285,7 @@ func TestClusterValidationMiddleware(t *testing.T) {
 				}
 				handler := Merge(
 					routeInjector,
-					ClusterValidationMiddleware(testCase.serverCluster, nil, softValidation, NewInvalidClusterRequests(reg, "test"), logger),
+					ClusterValidationMiddleware(testCase.serverCluster, nil, nil, softValidation, NewInvalidClusterRequests(reg, "test"), logger),
 				).Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}))
@@ -393,7 +393,7 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 			}
 			handler := Merge(
 				routeInjector,
-				ClusterValidationMiddleware("server-cluster", testCase.excludedPaths, testCase.softValidation, NewInvalidClusterRequests(reg, "test"), log.NewNopLogger()),
+				ClusterValidationMiddleware("server-cluster", testCase.excludedPaths, nil, testCase.softValidation, NewInvalidClusterRequests(reg, "test"), log.NewNopLogger()),
 			).Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
@@ -403,6 +403,115 @@ func TestClusterValidationMiddlewareWithExcludedPaths(t *testing.T) {
 			req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:8080/%s", testCase.requestPath), nil)
 			require.NoError(t, err)
 			req.Header[clusterutil.ClusterValidationLabelHeader] = []string{"client-cluster"}
+
+			handler.ServeHTTP(recorder, req)
+			require.Equal(t, testCase.expectedStatusCode, recorder.Code)
+			if recorder.Code != http.StatusOK {
+				var clusterValidationErr clusterValidationError
+				err = json.Unmarshal(recorder.Body.Bytes(), &clusterValidationErr)
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedErrorMessage, clusterValidationErr.ClusterValidationErrorMessage)
+			}
+			err = testutil.GatherAndCompare(reg, strings.NewReader(testCase.expectedMetrics), "test_server_invalid_cluster_validation_label_requests_total")
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestClusterValidationMiddlewareWithExcludedUserAgents(t *testing.T) {
+	const urlPath = "Test/Me"
+	testCases := map[string]struct {
+		softValidation       bool
+		userAgent            string
+		route                string
+		excludedUserAgents   []string
+		expectedStatusCode   int
+		expectedErrorMessage string
+		expectedMetrics      string
+	}{
+		"when soft validation is enabled and user agent is excluded no error is returned": {
+			softValidation:       true,
+			userAgent:            "curl/8.7.1",
+			excludedUserAgents:   []string{"curl/.*", "wget/.*"},
+			expectedStatusCode:   http.StatusOK,
+			expectedErrorMessage: "",
+		},
+		"when soft validation is disabled and user agent is excluded no error is returned": {
+			softValidation:       false,
+			userAgent:            "curl/8.7.1",
+			excludedUserAgents:   []string{"curl/.*", "wget/.*"},
+			expectedStatusCode:   http.StatusOK,
+			expectedErrorMessage: "",
+		},
+		"when soft validation is disabled and user agent matches different pattern no error is returned": {
+			softValidation:       false,
+			userAgent:            "wget/1.21.3",
+			excludedUserAgents:   []string{"curl/.*", "wget/.*"},
+			expectedStatusCode:   http.StatusOK,
+			expectedErrorMessage: "",
+		},
+		"when soft validation is enabled and user agent is not excluded no error is returned": {
+			softValidation:       true,
+			userAgent:            "Mozilla/5.0",
+			route:                "/" + urlPath,
+			excludedUserAgents:   []string{"curl/.*", "wget/.*"},
+			expectedStatusCode:   http.StatusOK,
+			expectedErrorMessage: "",
+			expectedMetrics: `
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="test_argument",protocol="http",request_cluster_validation_label="client-cluster"} 1
+			`,
+		},
+		"when soft validation is disabled and user agent is not excluded an error is returned": {
+			softValidation:       false,
+			userAgent:            "Mozilla/5.0",
+			route:                "/" + urlPath,
+			excludedUserAgents:   []string{"curl/.*", "wget/.*"},
+			expectedStatusCode:   http.StatusNetworkAuthenticationRequired,
+			expectedErrorMessage: `rejected request with wrong cluster validation label "client-cluster" - it should be "server-cluster"`,
+			expectedMetrics: `
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="test_argument",protocol="http",request_cluster_validation_label="client-cluster"} 1
+			`,
+		},
+		"when no user agent is provided and user agents are excluded validation proceeds normally": {
+			softValidation:       false,
+			userAgent:            "",
+			route:                "/" + urlPath,
+			excludedUserAgents:   []string{"curl/.*", "wget/.*"},
+			expectedStatusCode:   http.StatusNetworkAuthenticationRequired,
+			expectedErrorMessage: `rejected request with wrong cluster validation label "client-cluster" - it should be "server-cluster"`,
+			expectedMetrics: `
+                                # HELP test_server_invalid_cluster_validation_label_requests_total Number of requests received by server with invalid cluster validation label.
+                                # TYPE test_server_invalid_cluster_validation_label_requests_total counter
+                                test_server_invalid_cluster_validation_label_requests_total{cluster_validation_label="server-cluster",method="test_argument",protocol="http",request_cluster_validation_label="client-cluster"} 1
+			`,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			router := mux.NewRouter()
+			routeInjector := RouteInjector{
+				RouteMatcher: router,
+			}
+			handler := Merge(
+				routeInjector,
+				ClusterValidationMiddleware("server-cluster", nil, testCase.excludedUserAgents, testCase.softValidation, NewInvalidClusterRequests(reg, "test"), log.NewNopLogger()),
+			).Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			router.Handle("/Test/{argument}", handler)
+
+			recorder := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:8080/%s", urlPath), nil)
+			require.NoError(t, err)
+			req.Header[clusterutil.ClusterValidationLabelHeader] = []string{"client-cluster"}
+			if testCase.userAgent != "" {
+				req.Header.Set("User-Agent", testCase.userAgent)
+			}
 
 			handler.ServeHTTP(recorder, req)
 			require.Equal(t, testCase.expectedStatusCode, recorder.Code)

--- a/server/server.go
+++ b/server/server.go
@@ -607,7 +607,7 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 	}
 	if cfg.ClusterValidation.HTTP.Enabled {
 		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(
-			cfg.ClusterValidation.Label, cfg.ClusterValidation.HTTP.ExcludedPaths,
+			cfg.ClusterValidation.Label, cfg.ClusterValidation.HTTP.ExcludedPaths, nil,
 			cfg.ClusterValidation.HTTP.SoftValidation,
 			metrics.InvalidClusterRequests, logger,
 		))


### PR DESCRIPTION
## Summary
Add support for excluding requests from cluster validation based on User-Agent header patterns. This allows requests from specific user agents (like curl, wget, etc.) to bypass cluster validation checks, similar to the existing excludedPaths functionality.