### PR TITLE
fix: middleware: ensure sensitive HTTP headers are never included in logs or traces

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -30,9 +30,11 @@ type Log struct {
 }
 
 var AlwaysExcludedHeaders = map[string]bool{
-	"Cookie":        true,
-	"X-Csrf-Token":  true,
-	"Authorization": true,
+	"Cookie":         true,
+	"X-Csrf-Token":   true,
+	"Authorization":  true,
+	"X-Grafana-Id":   true,
+	"X-Access-Token": true,
 }
 
 func NewLogMiddleware(log log.Logger, logRequestHeaders bool, logRequestAtInfoLevel bool, sourceIPs *SourceIPExtractor, headersList []string) Log {

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -143,7 +143,7 @@ func TestLoggingRequestsAtInfoLevel(t *testing.T) {
 }
 
 func TestLoggingRequestWithExcludedHeaders(t *testing.T) {
-	defaultHeaders := []string{"Authorization", "Cookie", "X-Csrf-Token"}
+	defaultHeaders := []string{"Authorization", "Cookie", "X-Csrf-Token", "X-Grafana-Id", "X-Access-Token"}
 	for _, tc := range []struct {
 		name              string
 		setHeaderList     []string

--- a/server/internal/oteltest/server_otel_test.go
+++ b/server/internal/oteltest/server_otel_test.go
@@ -149,12 +149,16 @@ func TestOTelTracing(t *testing.T) {
 				"X-Unexpected-Header": "42",
 				"X-Excluded-Header":   "private",
 				"Authorization":       "should always be excluded",
+				"X-Access-Token":      "should also always be excluded",
+				"X-Grafana-Id":        "also excluded",
 			},
 			expectedAttributesByOpName: map[string][]attribute.KeyValue{
 				expectedOpNameHelloPathParamHTTPSpan: append(expectedAttrsHelloPathParamHTTPSpan,
 					attribute.StringSlice("http.header.X-Unexpected-Header", []string{"42"}),
 					attribute.String("http.header.X-Excluded-Header.present", "true"),
 					attribute.String("http.header.Authorization.present", "true"),
+					attribute.String("http.header.X-Access-Token.present", "true"),
+					attribute.String("http.header.X-Grafana-Id.present", "true"),
 				),
 			},
 


### PR DESCRIPTION
**What this PR does**:

The `X-Grafana-Id` and `X-Access-Token` HTTP headers contain authentication tokens and so should never be logged, just like the `Authorization` header.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
