### PR TITLE
fix: tracing: correctly handle `JAEGER_SAMPLER_TYPE=probabilistic`

### DIFF
--- a/tracing/otel_jaeger.go
+++ b/tracing/otel_jaeger.go
@@ -254,7 +254,7 @@ func (cfg otelJaegerConfig) initJaegerTracerProvider(serviceName string, logger 
 			sampler = tracesdk.NeverSample()
 		}
 	} else if cfg.samplerType == "probabilistic" {
-		tracesdk.TraceIDRatioBased(cfg.samplerParam)
+		sampler = tracesdk.TraceIDRatioBased(cfg.samplerParam)
 	} else if cfg.samplerType == "remote" {
 		sampler = jaegerremote.New(serviceName, jaegerremote.WithSamplingServerURL(cfg.samplingServerURL),
 			jaegerremote.WithInitialSampler(tracesdk.TraceIDRatioBased(cfg.samplerParam)))


### PR DESCRIPTION
**What this PR does**:

This PR fixes an issue where the tracing sampler would not be configured correctly if tracing is being configured from Jaeger environment variables and the `JAEGER_SAMPLER_TYPE` environment variable was set to `probabilistic`.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/dskit/pull/681 and https://github.com/grafana/dskit/pull/700.

**Checklist**
- [ ] Tests updated
