### PR TITLE
feat: tracing: add support for `jaeger-debug-id` HTTP header when using OpenTelemetry instrumentation

### DIFF
--- a/tracing/otel_jaeger.go
+++ b/tracing/otel_jaeger.go
@@ -40,6 +40,8 @@ const (
 	envJaegerDefaultSamplingServerPort = 5778
 	envJaegerDefaultUDPSpanServerHost  = "localhost"
 	envJaegerDefaultUDPSpanServerPort  = "6831"
+
+	jaegerDebugIdHeader string = "Jaeger-Debug-Id"
 )
 
 // NewOTelOrJaegerFromEnv is a convenience function to allow OTel tracing configuration via environment variables.
@@ -313,4 +315,49 @@ func (cfg otelJaegerConfig) initJaegerTracerProvider(serviceName string, logger 
 		}
 		return nil
 	}), nil
+}
+
+type contextKey int
+
+var jaegerDebugIdKey = contextKey(0)
+
+type JaegerDebuggingPropagator struct{}
+
+func (j JaegerDebuggingPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	// Nothing to do, we don't want to propagate the header.
+}
+
+func (j JaegerDebuggingPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	debugId := carrier.Get(jaegerDebugIdHeader)
+
+	if debugId == "" {
+		return ctx
+	}
+
+	return context.WithValue(ctx, jaegerDebugIdKey, debugId)
+}
+
+func (j JaegerDebuggingPropagator) Fields() []string {
+	return []string{jaegerDebugIdHeader}
+}
+
+type JaegerDebuggingSampler struct {
+	inner tracesdk.Sampler
+}
+
+func (j *JaegerDebuggingSampler) ShouldSample(parameters tracesdk.SamplingParameters) tracesdk.SamplingResult {
+	debugID, haveDebugID := parameters.ParentContext.Value(jaegerDebugIdKey).(string)
+	innerResult := j.inner.ShouldSample(parameters)
+	if !haveDebugID {
+		return innerResult
+	}
+
+	innerResult.Decision = tracesdk.RecordAndSample
+	attr := attribute.String("jaeger-debug-id", debugID)
+	innerResult.Attributes = append(innerResult.Attributes, attr)
+	return innerResult
+}
+
+func (j *JaegerDebuggingSampler) Description() string {
+	return "JaegerDebuggingSampler"
 }

--- a/tracing/otel_test.go
+++ b/tracing/otel_test.go
@@ -264,7 +264,7 @@ func TestOTelPropagatorsFromEnv(t *testing.T) {
 		os.Unsetenv("OTEL_PROPAGATORS")
 
 		propagators := OTelPropagatorsFromEnv()
-		require.Len(t, propagators, 3)
+		require.Len(t, propagators, 4)
 	})
 
 	t.Run("custom propagators from env", func(t *testing.T) {
@@ -291,7 +291,7 @@ func TestOTelPropagatorsFromEnv(t *testing.T) {
 		os.Setenv("OTEL_PROPAGATORS", "jaeger")
 
 		propagators := OTelPropagatorsFromEnv()
-		require.Len(t, propagators, 1)
+		require.Len(t, propagators, 2)
 	})
 }
 


### PR DESCRIPTION
**What this PR does**:

This PR adds support for the `jaeger-debug-id` HTTP header when using OpenTelemetry instrumentation.

This is a feature that was present prior to our transition to the OpenTelemetry libraries. It's useful when debugging, as it forces sampling of the trace, and adds an attribute to the trace span that makes it easy to locate.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
