### PR TITLE
feat(ring): add replica tracking for DoUntilQuorum calls

### DIFF
--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -2071,6 +2071,21 @@ func TestReplicationSet_ZoneCount(t *testing.T) {
 	}
 }
 
+func TestContextWithAvailableReplicas(t *testing.T) {
+	t.Run("when available replicas exists in a context", func(t *testing.T) {
+		ctx := ContextWithAvailableReplicas(context.Background(), 5)
+		replicas, ok := GetAvailableReplicas(ctx)
+		require.Equal(t, 5, replicas)
+		require.True(t, ok)
+	})
+
+	t.Run("when available replicas does not exist in a context", func(t *testing.T) {
+		replicas, ok := GetAvailableReplicas(context.Background())
+		require.Equal(t, 0, replicas)
+		require.False(t, ok)
+	})
+}
+
 func BenchmarkReplicationSetZoneCount(b *testing.B) {
 	for _, instancesPerZone := range []int{1, 2, 5, 10, 100, 300} {
 		for _, zones := range []int{1, 2, 3} {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds an "available replicas" value to the context used for `DoUntilQuorum` calls when the replicaset contains only a single replica. This will allow the context to be propagated to server side recipients (separate PR) so they can take informed decisions about whether to reject a request, being the only replica available.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
