### PR TITLE
feat(server): add support for multiple gRPC tap handles

### DIFF
--- a/grpcutil/taphandle.go
+++ b/grpcutil/taphandle.go
@@ -1,0 +1,25 @@
+package grpcutil
+
+import (
+	"context"
+
+	"google.golang.org/grpc/tap"
+)
+
+// ComposeTapHandles allows multiple tap handles to be composed, since only one may be specified by gRPC server.
+func ComposeTapHandles(handles []tap.ServerInHandle) tap.ServerInHandle {
+	if len(handles) == 1 {
+		return handles[0]
+	}
+
+	return func(ctx context.Context, info *tap.Info) (context.Context, error) {
+		var err error
+		for _, h := range handles {
+			ctx, err = h(ctx, info)
+			if err != nil {
+				return ctx, err
+			}
+		}
+		return ctx, nil
+	}
+}

--- a/grpcutil/taphandle_test.go
+++ b/grpcutil/taphandle_test.go
@@ -1,0 +1,74 @@
+package grpcutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/tap"
+)
+
+type ctxKey int
+
+const (
+	ctxKey1 ctxKey = 1
+	ctxKey2 ctxKey = 2
+)
+
+func TestComposeTapHandles(t *testing.T) {
+	t.Run("single handle is not composed", func(t *testing.T) {
+		called := false
+		h := func(ctx context.Context, info *tap.Info) (context.Context, error) {
+			called = true
+			return ctx, nil
+		}
+
+		composed := ComposeTapHandles([]tap.ServerInHandle{h})
+
+		ctx, err := composed(context.Background(), &tap.Info{})
+		assert.NoError(t, err)
+		assert.NotNil(t, ctx)
+		assert.True(t, called)
+	})
+
+	t.Run("multiple handles are composed", func(t *testing.T) {
+		var results []int
+		h1 := func(ctx context.Context, info *tap.Info) (context.Context, error) {
+			results = append(results, 1)
+			return context.WithValue(ctx, ctxKey1, true), nil
+		}
+		h2 := func(ctx context.Context, info *tap.Info) (context.Context, error) {
+			results = append(results, 2)
+			return context.WithValue(ctx, ctxKey2, true), nil
+		}
+
+		composed := ComposeTapHandles([]tap.ServerInHandle{h1, h2})
+
+		ctx, err := composed(context.Background(), &tap.Info{})
+		assert.NoError(t, err)
+		assert.True(t, ctx.Value(ctxKey1).(bool))
+		assert.True(t, ctx.Value(ctxKey2).(bool))
+		assert.Equal(t, []int{1, 2}, results, "handles should be called in results")
+	})
+
+	t.Run("error short-circuits execution", func(t *testing.T) {
+		var results []int
+		h1 := func(ctx context.Context, info *tap.Info) (context.Context, error) {
+			results = append(results, 1)
+			return ctx, errors.New("boom")
+		}
+		h2 := func(ctx context.Context, info *tap.Info) (context.Context, error) {
+			results = append(results, 2)
+			return ctx, nil
+		}
+
+		composed := ComposeTapHandles([]tap.ServerInHandle{h1, h2})
+
+		ctx, err := composed(context.Background(), &tap.Info{})
+		assert.Error(t, err)
+		assert.EqualError(t, err, "boom")
+		assert.NotNil(t, ctx)
+		assert.Equal(t, []int{1}, results, "second handle should not be called after error")
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds support for multiple tap handles, which are composed when needed. This allows tap handles to be defined at different places in code that uses a server, including via the dskit server itself, to be supported, since gRPC only allows a single tap handle to be configured.

A use case for this is where an outer tap handle propagates gRPC metadata to a context, similar to what middleware might do, and then the inner tap handle performs some limiting operation making use of the context. This is necessary since normal interceptors, which might propagate a context, are called after the tap handle.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated
