### PR TITLE
feat(metrics): add per-tenant histogram collection support

### DIFF
--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -360,6 +360,17 @@ func (d MetricFamiliesPerTenant) SendSumOfHistograms(out chan<- prometheus.Metri
 	out <- hd.Metric(desc)
 }
 
+func (d MetricFamiliesPerTenant) SendSumOfHistogramsPerTenant(out chan<- prometheus.Metric, desc *prometheus.Desc, histogramName string) {
+	for _, tenantEntry := range d {
+		if tenantEntry.tenant == "" {
+			continue
+		}
+
+		data := tenantEntry.metrics.SumHistograms(histogramName)
+		out <- data.Metric(desc, tenantEntry.tenant)
+	}
+}
+
 func (d MetricFamiliesPerTenant) SendSumOfHistogramsWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, histogramName string, labelNames ...string) {
 	type histogramResult struct {
 		data        HistogramData


### PR DESCRIPTION
> This builds on top of https://github.com/grafana/dskit/pull/735 just so that i can test native histograms as well

Implements per-tenant histogram collection functionality by adding SendSumOfHistogramsPerTenant method.

Adds the missing per-tenant collection capability for histograms, bringing it in line with other metrics (counters, gauges, summaries). This allows users to get separate histogram metrics for each tenant rather than only aggregated cross-tenant histograms.

Follows established pattern from SendSumOfSummariesPerTenant and includes comprehensive test coverage for both classic and native histograms.