### PR TITLE
feat: add backwards-compatible support for multiple cluster validation labels

### DIFF
--- a/clusterutil/cluster_validation_config.go
+++ b/clusterutil/cluster_validation_config.go
@@ -28,10 +28,7 @@ func (cfg *ClusterValidationConfig) RegisteredFlags() flagext.RegisteredFlags {
 // It combines the primary Label with any AdditionalLabels.
 // The primary Label is always first if present, followed by AdditionalLabels.
 func (cfg *ClusterValidationConfig) GetAllowedClusterLabels() []string {
-	var labels []string
-	if cfg.Label != "" {
-		labels = append(labels, cfg.Label)
-	}
+	labels := []string{cfg.Label}
 	labels = append(labels, cfg.AdditionalLabels...)
 	return labels
 }

--- a/clusterutil/cluster_validation_config.go
+++ b/clusterutil/cluster_validation_config.go
@@ -28,7 +28,14 @@ func (cfg *ClusterValidationConfig) RegisteredFlags() flagext.RegisteredFlags {
 // It combines the primary Label with any AdditionalLabels.
 // The primary Label is always first if present, followed by AdditionalLabels.
 func (cfg *ClusterValidationConfig) GetAllowedClusterLabels() []string {
-	labels := []string{cfg.Label}
+	if cfg.Label == "" && len(cfg.AdditionalLabels) == 0 {
+		return nil
+	}
+
+	var labels []string
+	if cfg.Label != "" {
+		labels = append(labels, cfg.Label)
+	}
 	labels = append(labels, cfg.AdditionalLabels...)
 	return labels
 }

--- a/clusterutil/cluster_validation_config_test.go
+++ b/clusterutil/cluster_validation_config_test.go
@@ -18,55 +18,62 @@ func TestClusterValidationConfig_RegisteredFlags(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.PanicOnError)
 	cfg.RegisterFlagsWithPrefix("prefix", fs)
 
-	// After we track registered flags, the label flag is returned.
+	// After we track registered flags, both label and labels flags are returned.
 	registeredFlags := cfg.RegisteredFlags()
 	require.NotEmpty(t, registeredFlags)
 	require.Equal(t, "prefix", registeredFlags.Prefix)
-	require.Len(t, registeredFlags.Flags, 1)
+	require.Len(t, registeredFlags.Flags, 2)
 	_, ok := registeredFlags.Flags["label"]
+	require.True(t, ok)
+	_, ok = registeredFlags.Flags["labels"]
 	require.True(t, ok)
 }
 
 func TestClusterValidationProtocolConfig_Validate(t *testing.T) {
 	testCases := map[string]struct {
-		label          string
+		labels         []string
 		enabled        bool
 		softValidation bool
 		expectedErr    error
 	}{
-		"soft validation cannot be done if cluster validation label is not set": {
+		"soft validation cannot be done if cluster validation labels are not set": {
 			softValidation: true,
-			expectedErr:    fmt.Errorf("testProtocol: validation cannot be enabled if cluster validation label is not configured"),
+			expectedErr:    fmt.Errorf("testProtocol: validation cannot be enabled if cluster validation labels are not configured"),
 		},
-		"cluster validation cannot be done if cluster validation label is not set": {
+		"cluster validation cannot be done if cluster validation labels are not set": {
 			enabled:     true,
-			expectedErr: fmt.Errorf("testProtocol: validation cannot be enabled if cluster validation label is not configured"),
+			expectedErr: fmt.Errorf("testProtocol: validation cannot be enabled if cluster validation labels are not configured"),
 		},
-		"cluster validation and soft validation can be disabled if cluster validation label is not set": {
-			label:          "",
+		"cluster validation and soft validation can be disabled if cluster validation labels are not set": {
+			labels:         []string{},
 			enabled:        false,
 			softValidation: false,
 		},
-		"cluster validation and soft validation can be disabled if cluster validation label is set": {
-			label:          "my-cluster",
+		"cluster validation and soft validation can be disabled if cluster validation labels are set": {
+			labels:         []string{"my-cluster"},
 			enabled:        false,
 			softValidation: false,
 		},
 		"soft validation cannot be enabled if cluster validation is disabled": {
-			label:          "my-cluster",
+			labels:         []string{"my-cluster"},
 			enabled:        false,
 			softValidation: true,
 			expectedErr:    fmt.Errorf("testProtocol: soft validation can be enabled only if cluster validation is enabled"),
 		},
 		"soft validation can be disabled if cluster validation is enabled": {
-			label:          "my-cluster",
+			labels:         []string{"my-cluster"},
 			enabled:        true,
 			softValidation: false,
 		},
 		"cluster validation and soft validation can be enabled at the same time": {
-			label:          "my-cluster",
+			labels:         []string{"my-cluster"},
 			enabled:        true,
 			softValidation: true,
+		},
+		"multiple cluster labels are supported": {
+			labels:         []string{"cluster-a", "cluster-b", "cluster-c"},
+			enabled:        true,
+			softValidation: false,
 		},
 	}
 	for testName, testCase := range testCases {
@@ -75,7 +82,7 @@ func TestClusterValidationProtocolConfig_Validate(t *testing.T) {
 				Enabled:        testCase.enabled,
 				SoftValidation: testCase.softValidation,
 			}
-			err := testProtocolCfg.Validate("testProtocol", testCase.label)
+			err := testProtocolCfg.Validate("testProtocol", testCase.labels)
 			require.Equal(t, testCase.expectedErr, err)
 		})
 	}
@@ -89,10 +96,92 @@ func TestServerClusterValidationConfig_RegisteredFlags(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.PanicOnError)
 	cfg.RegisterFlagsWithPrefix("server.cluster-validation.", fs)
 
-	// After we track registered flags, label, grpc.enabled and grpc.soft-validation flags are returned.
+	// After we track registered flags, label, labels, grpc.enabled and grpc.soft-validation flags are returned.
 	registeredFlags := cfg.RegisteredFlags()
 	require.NotEmpty(t, registeredFlags)
 	require.Equal(t, "server.cluster-validation.", registeredFlags.Prefix)
-	expectedFlags := []string{"label", "grpc.enabled", "grpc.soft-validation", "http.enabled", "http.soft-validation", "http.excluded-paths", "http.excluded-user-agents"}
+	expectedFlags := []string{"label", "labels", "grpc.enabled", "grpc.soft-validation", "http.enabled", "http.soft-validation", "http.excluded-paths", "http.excluded-user-agents"}
 	require.ElementsMatch(t, expectedFlags, slices.Collect(maps.Keys(registeredFlags.Flags)))
+}
+
+func TestClusterValidationConfig_GetEffectiveLabels(t *testing.T) {
+	testCases := map[string]struct {
+		label          string
+		labels         []string
+		expectedLabels []string
+	}{
+		"empty config returns nil slice": {
+			label:          "",
+			labels:         nil,
+			expectedLabels: nil,
+		},
+		"only deprecated label set": {
+			label:          "cluster-a",
+			labels:         nil,
+			expectedLabels: []string{"cluster-a"},
+		},
+		"only new labels set": {
+			label:          "",
+			labels:         []string{"cluster-a", "cluster-b"},
+			expectedLabels: []string{"cluster-a", "cluster-b"},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			cfg := ClusterValidationConfig{
+				Label:  testCase.label,
+				Labels: testCase.labels,
+			}
+			effective := cfg.GetEffectiveLabels()
+			require.Equal(t, testCase.expectedLabels, effective)
+		})
+	}
+}
+
+func TestClusterValidationConfig_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		label       string
+		labels      []string
+		expectError bool
+		errorMsg    string
+	}{
+		"empty config is valid": {
+			label:       "",
+			labels:      nil,
+			expectError: false,
+		},
+		"only deprecated label is valid": {
+			label:       "cluster-a",
+			labels:      nil,
+			expectError: false,
+		},
+		"only new labels is valid": {
+			label:       "",
+			labels:      []string{"cluster-a", "cluster-b"},
+			expectError: false,
+		},
+		"both label and labels set is invalid": {
+			label:       "cluster-a",
+			labels:      []string{"cluster-b"},
+			expectError: true,
+			errorMsg:    "cluster validation label and labels cannot both be set - use labels instead of the deprecated label flag",
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			cfg := ClusterValidationConfig{
+				Label:  testCase.label,
+				Labels: testCase.labels,
+			}
+			err := cfg.Validate()
+			if testCase.expectError {
+				require.Error(t, err)
+				require.Equal(t, testCase.errorMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/clusterutil/clusterutil.go
+++ b/clusterutil/clusterutil.go
@@ -77,3 +77,14 @@ func GetClusterFromRequest(req *http.Request) (string, error) {
 	}
 	return clusterIDs[0], nil
 }
+
+// IsClusterAllowed checks if the provided cluster is in the list of allowed clusters.
+// Returns true if the cluster is found in the allowedClusters slice.
+func IsClusterAllowed(cluster string, allowedClusters []string) bool {
+	for _, allowed := range allowedClusters {
+		if cluster == allowed {
+			return true
+		}
+	}
+	return false
+}

--- a/clusterutil/clusterutil_test.go
+++ b/clusterutil/clusterutil_test.go
@@ -143,6 +143,52 @@ func createContext(containsRequestCluster bool, clusters []string) context.Conte
 	return metadata.NewIncomingContext(context.Background(), md)
 }
 
+func TestIsClusterAllowed(t *testing.T) {
+	testCases := map[string]struct {
+		cluster         string
+		allowedClusters []string
+		expectedAllowed bool
+	}{
+		"cluster found in single allowed cluster": {
+			cluster:         "cluster-a",
+			allowedClusters: []string{"cluster-a"},
+			expectedAllowed: true,
+		},
+		"cluster found in multiple allowed clusters": {
+			cluster:         "cluster-b",
+			allowedClusters: []string{"cluster-a", "cluster-b", "cluster-c"},
+			expectedAllowed: true,
+		},
+		"cluster not found in allowed clusters": {
+			cluster:         "cluster-d",
+			allowedClusters: []string{"cluster-a", "cluster-b", "cluster-c"},
+			expectedAllowed: false,
+		},
+		"empty cluster with empty allowed clusters": {
+			cluster:         "",
+			allowedClusters: []string{},
+			expectedAllowed: false,
+		},
+		"empty cluster with non-empty allowed clusters": {
+			cluster:         "",
+			allowedClusters: []string{"cluster-a", "cluster-b"},
+			expectedAllowed: false,
+		},
+		"non-empty cluster with empty allowed clusters": {
+			cluster:         "cluster-a",
+			allowedClusters: []string{},
+			expectedAllowed: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			allowed := IsClusterAllowed(testCase.cluster, testCase.allowedClusters)
+			require.Equal(t, testCase.expectedAllowed, allowed)
+		})
+	}
+}
+
 func createRequest(containsCluster bool, clusters []string) *http.Request {
 	req := &http.Request{
 		Header: make(http.Header),

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -146,10 +146,9 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 
 	// If cluster validation is enabled, ClusterUnaryClientInterceptor must be the last UnaryClientInterceptor
 	// to wrap the real call.
-	effectiveLabels := cfg.ClusterValidation.GetEffectiveLabels()
-	if len(effectiveLabels) > 0 {
-		// For client side, we use the first label as our cluster identity
-		cfg.clusterUnaryClientInterceptor = middleware.ClusterUnaryClientInterceptor(effectiveLabels[0], invalidClusterValidationReporter)
+	if cfg.ClusterValidation.Label != "" {
+		// For client side, we use the primary label as our cluster identity
+		cfg.clusterUnaryClientInterceptor = middleware.ClusterUnaryClientInterceptor(cfg.ClusterValidation.Label, invalidClusterValidationReporter)
 		unaryClientInterceptors = append(unaryClientInterceptors, cfg.clusterUnaryClientInterceptor)
 	}
 

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -146,8 +146,10 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 
 	// If cluster validation is enabled, ClusterUnaryClientInterceptor must be the last UnaryClientInterceptor
 	// to wrap the real call.
-	if cfg.ClusterValidation.Label != "" {
-		cfg.clusterUnaryClientInterceptor = middleware.ClusterUnaryClientInterceptor(cfg.ClusterValidation.Label, invalidClusterValidationReporter)
+	effectiveLabels := cfg.ClusterValidation.GetEffectiveLabels()
+	if len(effectiveLabels) > 0 {
+		// For client side, we use the first label as our cluster identity
+		cfg.clusterUnaryClientInterceptor = middleware.ClusterUnaryClientInterceptor(effectiveLabels[0], invalidClusterValidationReporter)
 		unaryClientInterceptors = append(unaryClientInterceptors, cfg.clusterUnaryClientInterceptor)
 	}
 

--- a/grpcclient/grpcclient_test.go
+++ b/grpcclient/grpcclient_test.go
@@ -65,12 +65,12 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			expectedClusterUnaryClientInterceptor: false,
 		},
 		"if cluster validation label is set and there is no input and no implicit UnaryClientInterceptors we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:                     clusterutil.ClusterValidationConfig{Label: "cluster"},
+			clusterValidation:                     clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
 			inputUnaryInterceptors:                nil,
 			expectedUnaryInterceptors:             1,
 			expectedClusterUnaryClientInterceptor: true,
 		},
-		"if cluster validation label is set and there is no input and an implicit UnaryClientInterceptor we expect ClusterUnaryClientInterceptor to be the last one": {
+		"if cluster validation label is set (deprecated field) and there is no input and an implicit UnaryClientInterceptor we expect ClusterUnaryClientInterceptor to be the last one": {
 			clusterValidation:      clusterutil.ClusterValidationConfig{Label: "cluster"},
 			inputUnaryInterceptors: nil,
 			// setting rateLimit creates an implicit UnaryClientInterceptor
@@ -78,14 +78,22 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			expectedUnaryInterceptors:             2,
 			expectedClusterUnaryClientInterceptor: true,
 		},
+		"if cluster validation label is set and there is no input and an implicit UnaryClientInterceptor we expect ClusterUnaryClientInterceptor to be the last one": {
+			clusterValidation:      clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
+			inputUnaryInterceptors: nil,
+			// setting rateLimit creates an implicit UnaryClientInterceptor
+			rateLimit:                             10,
+			expectedUnaryInterceptors:             2,
+			expectedClusterUnaryClientInterceptor: true,
+		},
 		"if cluster validation label is set and there are input and no implicit UnaryClientInterceptors we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:                     clusterutil.ClusterValidationConfig{Label: "cluster"},
+			clusterValidation:                     clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
 			inputUnaryInterceptors:                inputUnaryInterceptors,
 			expectedUnaryInterceptors:             len(inputUnaryInterceptors) + 1,
 			expectedClusterUnaryClientInterceptor: true,
 		},
 		"if cluster validation label is set and there are input and implicit UnaryClientInterceptors we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:      clusterutil.ClusterValidationConfig{Label: "cluster"},
+			clusterValidation:      clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
 			inputUnaryInterceptors: inputUnaryInterceptors,
 			// setting rateLimit creates an implicit UnaryClientInterceptor
 			rateLimit:                             10,
@@ -102,7 +110,7 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			grpcWithChainUnaryInterceptor = func(unaryInterceptors ...grpc.UnaryClientInterceptor) grpc.DialOption {
 				withChainUnaryInterceptorCalled = true
 				require.Len(t, unaryInterceptors, testCase.expectedUnaryInterceptors)
-				if cfg.ClusterValidation.Label == "" {
+				if len(cfg.ClusterValidation.GetEffectiveLabels()) == 0 {
 					require.Nil(t, cfg.clusterUnaryClientInterceptor)
 				} else {
 					require.NotNil(t, cfg.clusterUnaryClientInterceptor)

--- a/grpcclient/grpcclient_test.go
+++ b/grpcclient/grpcclient_test.go
@@ -70,14 +70,6 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			expectedUnaryInterceptors:             1,
 			expectedClusterUnaryClientInterceptor: true,
 		},
-		"if cluster validation label is set (deprecated field) and there is no input and an implicit UnaryClientInterceptor we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:      clusterutil.ClusterValidationConfig{Label: "cluster"},
-			inputUnaryInterceptors: nil,
-			// setting rateLimit creates an implicit UnaryClientInterceptor
-			rateLimit:                             10,
-			expectedUnaryInterceptors:             2,
-			expectedClusterUnaryClientInterceptor: true,
-		},
 		"if cluster validation label is set and there is no input and an implicit UnaryClientInterceptor we expect ClusterUnaryClientInterceptor to be the last one": {
 			clusterValidation:      clusterutil.ClusterValidationConfig{Label: "cluster"},
 			inputUnaryInterceptors: nil,

--- a/grpcclient/grpcclient_test.go
+++ b/grpcclient/grpcclient_test.go
@@ -110,7 +110,7 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			grpcWithChainUnaryInterceptor = func(unaryInterceptors ...grpc.UnaryClientInterceptor) grpc.DialOption {
 				withChainUnaryInterceptorCalled = true
 				require.Len(t, unaryInterceptors, testCase.expectedUnaryInterceptors)
-				if len(cfg.ClusterValidation.GetEffectiveLabels()) == 0 {
+				if cfg.ClusterValidation.Label == "" {
 					require.Nil(t, cfg.clusterUnaryClientInterceptor)
 				} else {
 					require.NotNil(t, cfg.clusterUnaryClientInterceptor)

--- a/grpcclient/grpcclient_test.go
+++ b/grpcclient/grpcclient_test.go
@@ -65,7 +65,7 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			expectedClusterUnaryClientInterceptor: false,
 		},
 		"if cluster validation label is set and there is no input and no implicit UnaryClientInterceptors we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:                     clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
+			clusterValidation:                     clusterutil.ClusterValidationConfig{Label: "cluster"},
 			inputUnaryInterceptors:                nil,
 			expectedUnaryInterceptors:             1,
 			expectedClusterUnaryClientInterceptor: true,
@@ -79,7 +79,7 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			expectedClusterUnaryClientInterceptor: true,
 		},
 		"if cluster validation label is set and there is no input and an implicit UnaryClientInterceptor we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:      clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
+			clusterValidation:      clusterutil.ClusterValidationConfig{Label: "cluster"},
 			inputUnaryInterceptors: nil,
 			// setting rateLimit creates an implicit UnaryClientInterceptor
 			rateLimit:                             10,
@@ -87,13 +87,13 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			expectedClusterUnaryClientInterceptor: true,
 		},
 		"if cluster validation label is set and there are input and no implicit UnaryClientInterceptors we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:                     clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
+			clusterValidation:                     clusterutil.ClusterValidationConfig{Label: "cluster"},
 			inputUnaryInterceptors:                inputUnaryInterceptors,
 			expectedUnaryInterceptors:             len(inputUnaryInterceptors) + 1,
 			expectedClusterUnaryClientInterceptor: true,
 		},
 		"if cluster validation label is set and there are input and implicit UnaryClientInterceptors we expect ClusterUnaryClientInterceptor to be the last one": {
-			clusterValidation:      clusterutil.ClusterValidationConfig{Labels: []string{"cluster"}},
+			clusterValidation:      clusterutil.ClusterValidationConfig{Label: "cluster"},
 			inputUnaryInterceptors: inputUnaryInterceptors,
 			// setting rateLimit creates an implicit UnaryClientInterceptor
 			rateLimit:                             10,

--- a/server/server.go
+++ b/server/server.go
@@ -436,7 +436,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 	if cfg.ClusterValidation.GRPC.Enabled {
 		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(
-			cfg.ClusterValidation.GetEffectiveLabels(), cfg.ClusterValidation.GRPC.SoftValidation,
+			cfg.ClusterValidation.GetAllowedClusterLabels(), cfg.ClusterValidation.GRPC.SoftValidation,
 			metrics.InvalidClusterRequests, logger,
 		))
 	}
@@ -613,7 +613,7 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 	}
 	if cfg.ClusterValidation.HTTP.Enabled {
 		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(
-			cfg.ClusterValidation.GetEffectiveLabels(),
+			cfg.ClusterValidation.GetAllowedClusterLabels(),
 			cfg.ClusterValidation.HTTP,
 			metrics.InvalidClusterRequests,
 			logger,

--- a/server/server.go
+++ b/server/server.go
@@ -436,7 +436,7 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 	if cfg.ClusterValidation.GRPC.Enabled {
 		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(
-			cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation,
+			cfg.ClusterValidation.GetEffectiveLabels(), cfg.ClusterValidation.GRPC.SoftValidation,
 			metrics.InvalidClusterRequests, logger,
 		))
 	}
@@ -613,7 +613,7 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 	}
 	if cfg.ClusterValidation.HTTP.Enabled {
 		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(
-			cfg.ClusterValidation.Label,
+			cfg.ClusterValidation.GetEffectiveLabels(),
 			cfg.ClusterValidation.HTTP,
 			metrics.InvalidClusterRequests,
 			logger,


### PR DESCRIPTION
**What this PR does**:

This PR refines the cluster validation configuration to better distinguish between client-side cluster identity and server-side validation capabilities.

**Key changes**:
- **Kept** the `label` flag - it's now the recommended field for client cluster identity
- **Added** `additional-labels` for server-side multi-cluster validation
- **Updated** `GetEffectiveLabels()` to combine primary label with additional labels
- **Removed** validation preventing both fields from being set together
- **Enhanced** server validation to support multiple cluster labels while clients use single identity

**Architecture rationale**:
- **Clients** represent a single cluster and use the primary `label` for identity
- **Servers** can validate requests from multiple clusters using `label` + `additional-labels`
- This semantic separation clarifies the different use cases and simplifies configuration

**Backwards compatibility**:
- ✅ Existing containers using `-server.cluster-validation.label=cluster-a` continue working unchanged
- ✅ Flag validation no longer prevents using both label and additional-labels together
- ✅ Client behavior unchanged - still uses first effective label

**Example usage**:
```bash
# Client configuration (single cluster identity)
-server.cluster-validation.label=prod-cluster

# Server configuration (validate multiple clusters)
-server.cluster-validation.label=primary-cluster \
-server.cluster-validation.additional-labels=backup-cluster,staging-cluster
```

**Migration benefits**:
- Clear semantic distinction between client identity vs server validation
- No breaking changes - existing configurations work as before
- More intuitive configuration naming

**Checklist**
- [x] Tests updated for new field names and behavior
- [x] Backwards compatibility maintained
- [x] All existing tests pass
- [x] Documentation in code comments updated