### PR TITLE
chore: fix SPDX license on route_injector

### DIFF
--- a/middleware/route_injector.go
+++ b/middleware/route_injector.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-License-Identifier: Apache-2.0
 
 package middleware
 

--- a/middleware/route_injector_test.go
+++ b/middleware/route_injector_test.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-License-Identifier: Apache-2.0
 // Provenance-includes-location: https://github.com/weaveworks/common/blob/main/middleware/instrument_test.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: Weaveworks Ltd.


### PR DESCRIPTION
#527 added these files, but included a mismatched SPDX header since this repository is Apache 2.0.
