### PR TITLE
feat: track all bytes sent and received in the memberlist TCP transport

### DIFF
--- a/kv/memberlist/tcp_transport_conn.go
+++ b/kv/memberlist/tcp_transport_conn.go
@@ -1,0 +1,104 @@
+package memberlist
+
+import (
+	"net"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+const (
+	// flushThreshold is the number of bytes after which we flush the local counters
+	// to the Prometheus counters. This reduces the frequency of expensive Prometheus
+	// counters updates.
+	flushThreshold = 64 * 1024 // 64KB
+)
+
+// meteredConn wraps a net.Conn to track the number of bytes sent and received.
+// It periodically flushes the byte counts to Prometheus counters when a threshold
+// is reached, and always flushes on Close() to ensure accurate tracking for
+// short-lived connections.
+type meteredConn struct {
+	net.Conn
+
+	sentBytesCounter     prometheus.Counter
+	receivedBytesCounter prometheus.Counter
+
+	sentBytesLocal     atomic.Int64
+	receivedBytesLocal atomic.Int64
+}
+
+// newMeteredConn creates a new metered connection wrapper.
+func newMeteredConn(conn net.Conn, sentBytes, receivedBytes prometheus.Counter) *meteredConn {
+	return &meteredConn{
+		Conn:                 conn,
+		sentBytesCounter:     sentBytes,
+		receivedBytesCounter: receivedBytes,
+	}
+}
+
+// Read implement net.Conn.
+func (c *meteredConn) Read(b []byte) (n int, err error) {
+	n, err = c.Conn.Read(b)
+	if n > 0 {
+		c.addReceivedBytes(int64(n))
+	}
+	return n, err
+}
+
+// Write implement net.Conn.
+func (c *meteredConn) Write(b []byte) (n int, err error) {
+	n, err = c.Conn.Write(b)
+	if n > 0 {
+		c.addSentBytes(int64(n))
+	}
+	return n, err
+}
+
+// Close implement net.Conn.
+func (c *meteredConn) Close() error {
+	c.flush()
+	return c.Conn.Close()
+}
+
+// SetDeadline implements net.Conn.
+func (c *meteredConn) SetDeadline(t time.Time) error {
+	return c.Conn.SetDeadline(t)
+}
+
+// SetReadDeadline implements net.Conn.
+func (c *meteredConn) SetReadDeadline(t time.Time) error {
+	return c.Conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline implements net.Conn.
+func (c *meteredConn) SetWriteDeadline(t time.Time) error {
+	return c.Conn.SetWriteDeadline(t)
+}
+
+// addSentBytes adds bytes to the local sent counter and flushes to Prometheus if threshold is reached.
+func (c *meteredConn) addSentBytes(n int64) {
+	newTotal := c.sentBytesLocal.Add(n)
+	if newTotal >= flushThreshold {
+		c.flush()
+	}
+}
+
+// addReceivedBytes adds bytes to the local received counter and flushes to Prometheus if threshold is reached.
+func (c *meteredConn) addReceivedBytes(n int64) {
+	newTotal := c.receivedBytesLocal.Add(n)
+	if newTotal >= flushThreshold {
+		c.flush()
+	}
+}
+
+// flush flushes any remaining local byte counters to the Prometheus counters.
+func (c *meteredConn) flush() {
+	if sentBytes := c.sentBytesLocal.Swap(0); sentBytes > 0 {
+		c.sentBytesCounter.Add(float64(sentBytes))
+	}
+	if receivedBytes := c.receivedBytesLocal.Swap(0); receivedBytes > 0 {
+		c.receivedBytesCounter.Add(float64(receivedBytes))
+	}
+}

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -1,6 +1,8 @@
 package memberlist
 
 import (
+	"fmt"
+	"io"
 	"net"
 	"strings"
 	"sync"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -191,4 +194,110 @@ func TestNonIPsAreRejected(t *testing.T) {
 	cfg := TCPTransportConfig{BindAddrs: flagext.StringSlice{"localhost"}}
 	_, err := NewTCPTransport(cfg, nil, nil)
 	require.EqualError(t, err, `could not parse bind addr "localhost" as IP address`)
+}
+
+func TestTCPTransport_SentAndReceivedBytesMetrics(t *testing.T) {
+	setup := func(t *testing.T) (senderTransport, receiverTransport *TCPTransport, receiverAddr string, testData []byte) {
+		logs := &concurrency.SyncBuffer{}
+		logger := log.NewLogfmtLogger(logs)
+
+		reg := prometheus.NewPedanticRegistry()
+
+		// Set up the receiver transport
+		receiverCfg := TCPTransportConfig{}
+		flagext.DefaultValues(&receiverCfg)
+		receiverCfg.BindAddrs = getLocalhostAddrs()
+		receiverCfg.BindPort = 0 // Use random port
+		receiverCfg.MetricsNamespace = "receiver"
+
+		receiverTransport, err := NewTCPTransport(receiverCfg, logger, reg)
+		require.NoError(t, err)
+
+		// Get the advertised address
+		receiverIP, receiverPort, err := receiverTransport.FinalAdvertiseAddr("", receiverTransport.GetAutoBindPort())
+		require.NoError(t, err)
+		receiverAddr = net.JoinHostPort(receiverIP.String(), fmt.Sprintf("%d", receiverPort))
+
+		// Set up the sender transport
+		senderCfg := TCPTransportConfig{}
+		flagext.DefaultValues(&senderCfg)
+		senderCfg.BindAddrs = getLocalhostAddrs()
+		senderCfg.BindPort = 0 // Use random port
+		senderCfg.MetricsNamespace = "sender"
+
+		senderTransport, err = NewTCPTransport(senderCfg, logger, reg)
+		require.NoError(t, err)
+
+		// Prepare test data - use a size larger than flush threshold to test periodic flushing
+		testData = make([]byte, 128*1024) // 128KB
+		for i := range testData {
+			testData[i] = byte(i % 256)
+		}
+
+		return senderTransport, receiverTransport, receiverAddr, testData
+	}
+
+	t.Run("WriteTo() packet mode", func(t *testing.T) {
+		senderTransport, receiverTransport, receiverAddr, testData := setup(t)
+
+		// Send a packet from sender to receiver
+		_, err := senderTransport.WriteTo(testData, receiverAddr)
+		require.NoError(t, err)
+
+		// Wait for the packet to be received
+		select {
+		case pkt := <-receiverTransport.PacketCh():
+			require.Equal(t, testData, pkt.Buf)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for packet")
+		}
+
+		// Shutdown transports to ensure all connections are closed and metrics are flushed
+		require.NoError(t, senderTransport.Shutdown())
+		require.NoError(t, receiverTransport.Shutdown())
+
+		// Ensure metrics are tracked.
+		assert.GreaterOrEqual(t, testutil.ToFloat64(senderTransport.sentBytes), float64(len(testData)), "sender should have sent at least the test data size")
+		assert.GreaterOrEqual(t, testutil.ToFloat64(receiverTransport.receivedBytes), float64(len(testData)), "receiver should have received at least the test data size")
+	})
+
+	t.Run("DialTimeout() stream mode", func(t *testing.T) {
+		senderTransport, receiverTransport, receiverAddr, testData := setup(t)
+
+		// Open a stream connection from sender to receiver
+		conn, err := senderTransport.DialTimeout(receiverAddr, 5*time.Second)
+		require.NoError(t, err)
+
+		// Wait for the receiver to accept the stream connection
+		var receiverConn net.Conn
+		select {
+		case receiverConn = <-receiverTransport.StreamCh():
+			require.NotNil(t, receiverConn)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for stream connection")
+		}
+
+		// Write data from sender to receiver
+		n, err := conn.Write(testData)
+		require.NoError(t, err)
+		require.Equal(t, len(testData), n)
+
+		// Read data on the receiver side
+		receivedData := make([]byte, len(testData))
+		_, err = io.ReadFull(receiverConn, receivedData)
+		require.NoError(t, err)
+		require.Equal(t, testData, receivedData)
+
+		// Close connections
+		require.NoError(t, conn.Close())
+		require.NoError(t, receiverConn.Close())
+
+		// Shutdown transports to ensure all connections are closed and metrics are flushed
+		require.NoError(t, senderTransport.Shutdown())
+		require.NoError(t, receiverTransport.Shutdown())
+
+		// Ensure metrics are tracked.
+		assert.GreaterOrEqual(t, testutil.ToFloat64(senderTransport.sentBytes), float64(len(testData)), "sender should have sent at least the test data size")
+		assert.GreaterOrEqual(t, testutil.ToFloat64(receiverTransport.receivedBytes), float64(len(testData)), "receiver should have received at least the test data size")
+	})
 }


### PR DESCRIPTION
**What this PR does**:

We currently don't have a single metric tracking all bytes sent/received using the memberlist TCP transport. Currently there are 2 distinct type of metrics:

- `memberlist_tcp_transport_packets_sent_bytes_total` and `memberlist_tcp_transport_packets_received_bytes_total`
- `memberlist_client_state_pulls_bytes_total` and `memberlist_client_state_pushes_bytes_total`

These metrics don't track pings, but to be honest pings are a small amount of data transferred.

That being said, to keep it easier to query, in this PR I propose to add a new set of metrics tracking all data transfer by memberlist TCP transport. I'm doing it by wrapping the `net.Conn` created by the `TCPTransport`. I think it's easier to reason about, and avoid asking questions like "is everything tracked if we sum packets + state pulls/pushes metrics or not?". I also understand that in practice the new metric is not much different than summing the other metrics we already have. I'm fine to close this PR if there are objections.

In the meanwhile I've tested it in a dev Mimir cluster and looks working:

<img width="2376" height="849" alt="Screenshot 2025-10-22 at 20 18 20" src="https://github.com/user-attachments/assets/a8e6bf36-3616-411b-a4db-63e6f55cd00e" />


**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
