### PR TITLE
fix: dns: log non-SRV responses instead of returning an error

### DIFF
--- a/dns/miekgdns2/resolver.go
+++ b/dns/miekgdns2/resolver.go
@@ -128,7 +128,11 @@ func (r *Resolver) lookupSRV(ctx context.Context, conf *dns.ClientConfig, servic
 				Port:     addr.Port,
 			})
 		default:
-			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+			level.Warn(r.logger).Log(
+				"msg", "unexpected non-SRV response record",
+				"target", target,
+				"record", fmt.Sprintf("%+v", record),
+			)
 		}
 	}
 


### PR DESCRIPTION
Debugging https://github.com/grafana/mimir/issues/12713

