### PR TITLE
fix: dns: ignore non-SRV answers for SRV queries

### DIFF
--- a/dns/miekgdns/resolver.go
+++ b/dns/miekgdns/resolver.go
@@ -128,7 +128,13 @@ func (r *Resolver) lookupSRV(ctx context.Context, conf *dns.ClientConfig, servic
 				Port:     addr.Port,
 			})
 		default:
-			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+			// Ignore unexpected non-SRV responses. This matches the behavior of the
+			// built-in go resolver. See https://github.com/grafana/mimir/issues/12713
+			level.Debug(r.logger).Log(
+				"msg", "unexpected non-SRV response record",
+				"target", target,
+				"record", record,
+			)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does**:

Some DNS servers include A or AAAA records as answers for SRV queries. This changes our resolver to ignore any non-SRV answers returned from a SRV query. This matches the behavior of the built-in go resolver.

**Which issue(s) this PR fixes**:

See https://github.com/grafana/mimir/issues/12713

**Checklist**
- [X] Tests updated
