### PR TITLE
fix: dns: ignore non-SRV answers for SRV queries

### DIFF
--- a/dns/miekgdns2/resolver.go
+++ b/dns/miekgdns2/resolver.go
@@ -128,7 +128,13 @@ func (r *Resolver) lookupSRV(ctx context.Context, conf *dns.ClientConfig, servic
 				Port:     addr.Port,
 			})
 		default:
-			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+			// Ignore unexpected non-SRV responses. This matches the behavior of the
+			// built-in go resolver. See https://github.com/grafana/mimir/issues/12713
+			level.Debug(r.logger).Log(
+				"msg", "unexpected non-SRV response record",
+				"target", target,
+				"record", record,
+			)
 		}
 	}
 

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -63,7 +63,7 @@ func (t ResolverType) toResolver(logger log.Logger) ipLookupResolver {
 	case GolangResolverType:
 		r = &godns.Resolver{Resolver: net.DefaultResolver}
 	case MiekgdnsResolverType:
-		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath}
+		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath, Logger: logger}
 	case MiekgdnsResolverType2:
 		level.Info(logger).Log("msg", "using experimental DNS resolver type", "type", t)
 		r = miekgdns2.NewResolver(miekgdns2.DefaultResolvConfPath, logger)


### PR DESCRIPTION
Manual backport of #775

Some DNS servers include A or AAAA records as answers for SRV queries. This changes our resolver to ignore any non-SRV answers returned from a SRV query. This matches the behavior of the built-in go resolver.

See grafana/mimir#12713
