### PR TITLE
fix: fix TestZoneAwareRouting_EndToEnd flakyness

### DIFF
--- a/kv/memberlist/node_zone_aware_routing_test.go
+++ b/kv/memberlist/node_zone_aware_routing_test.go
@@ -312,8 +312,8 @@ func TestZoneAwareRouting_EndToEnd(t *testing.T) {
 			memberB2 := NewKV(makeConfig(bridgeAAddr, "zone-b", "member"), log.WithPrefix(logger, "instance", "member-zone-b-2"), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
 
 			// Start services in what we consider the worst case scenario:
-			// zone-b members first, so they don't see any zone-b bridge at startup,
-			// but they're also not allowed to initiate a push/pull to any zone-a member or bridge.
+			// zone-b members first, so they don't see any zone-b bridge at startup, but they're also
+			// not allowed to initiate a push/pull or gossip to any zone-a member or bridge.
 			zoneBMembers, err := services.NewManager(memberB1, memberB2)
 			require.NoError(t, err)
 			require.NoError(t, services.StartManagerAndAwaitHealthy(ctx, zoneBMembers))
@@ -321,7 +321,7 @@ func TestZoneAwareRouting_EndToEnd(t *testing.T) {
 				require.NoError(t, services.StopManagerAndAwaitStopped(ctx, zoneBMembers))
 			})
 
-			// The start other nodes.
+			// Then start other nodes.
 			otherMembers, err := services.NewManager(memberA1, memberA2, bridgeB)
 			require.NoError(t, err)
 			require.NoError(t, services.StartManagerAndAwaitHealthy(ctx, otherMembers))


### PR DESCRIPTION
**What this PR does**:

This PR fixes `TestZoneAwareRouting_EndToEnd` flakyness. If gossiping is completely disabled (as in the test "state sync via push/pull") then you may end up in a split brain situation, unless the periodic rejoin is enabled (in the test it was not).

In this PR I've changed the order in which nodes are started to consistently reproduce the split brain scenario, and then I've enabled rejoin interval to fix it.

Separately, I'm brainstorming if we can end up in a similar situation in a real world scenario: I don't think so because gossiping is the primarily method to transfer state (and it doesn't suffer it), but I will keep thinking about it.

**Which issue(s) this PR fixes**:

Fixes #784 

**Checklist**
- [x] Tests updated
