### PR TITLE
fix(runtimeconfig): treat nil values in config merge as zero maps when merging

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -268,9 +268,22 @@ func mergeConfigMaps(a, b map[string]interface{}, path string) (_ map[string]int
 		out[k] = v
 	}
 	for k, v := range b {
-		_, aHasKey := a[k]
+		aVal, aHasKey := a[k]
+		bVal, bHasKey := b[k]
+
 		_, aIsMap := a[k].(map[string]interface{})
 		_, bIsMap := b[k].(map[string]interface{})
+
+		if aHasKey && aVal == nil && bIsMap {
+			aIsMap = true
+			out[k] = make(map[string]interface{})
+		}
+
+		if bHasKey && bVal == nil && aIsMap {
+			bIsMap = true
+			v = make(map[string]interface{})
+		}
+
 		if aHasKey && aIsMap != bIsMap {
 			return nil, errors.Errorf("conflicting types for %q: %T != %T", path+"."+k, a[k], b[k])
 		}


### PR DESCRIPTION
**What this PR does**:

This PR fixes an issue when merging config files where one file has a `null` value and the other a zero or non-zero map.

Example:

`config1.yaml`:
```yaml
overrides:
  limits: null
```

`config2.yaml`:
```yaml
overrides:
  limits:
    limit_a: 1
```

**Checklist**
- [x] Tests updated
