### PR TITLE
fix: fix panic in containsZone()

### DIFF
--- a/kv/memberlist/node_zone_aware_routing.go
+++ b/kv/memberlist/node_zone_aware_routing.go
@@ -229,7 +229,7 @@ func containsZone(zones []string, zone string) bool {
 		return slices.Contains(zones, zone)
 	}
 	optimisticIndex := int(zone[len(zone)-1]) - 'a'
-	if len(zones) <= optimisticIndex {
+	if optimisticIndex < 0 || len(zones) <= optimisticIndex {
 		return slices.Contains(zones, zone)
 	}
 


### PR DESCRIPTION
**What this PR does**:

Fix panic found by cursor that, at this point, is definitely better than us:
https://github.com/grafana/mimir/pull/13664#discussion_r2569365992

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
