### PR TITLE
fix: avoid memory leaks when soft-deleting tenant registries

### DIFF
--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -931,6 +931,14 @@ func (r *TenantRegistries) BuildMetricFamiliesPerTenant() MetricFamiliesPerTenan
 		archivedCopy[k] = v
 	}
 
+	// Snapshot regs under the same lock to avoid a race where a concurrent
+	// RemoveTenantRegistry archives a tenant's metrics and removes it from regs
+	// between the two snapshots, causing metrics to vanish for a scrape.
+	regs := make([]TenantRegistry, len(r.regs))
+	copy(regs, r.regs)
+
+	r.regsMu.Unlock()
+
 	var data MetricFamiliesPerTenant
 	if len(archivedCopy) > 0 {
 		data = append(data, struct {
@@ -941,9 +949,8 @@ func (r *TenantRegistries) BuildMetricFamiliesPerTenant() MetricFamiliesPerTenan
 			metrics: archivedCopy,
 		})
 	}
-	r.regsMu.Unlock()
 
-	for _, entry := range r.Registries() {
+	for _, entry := range regs {
 		m, err := entry.reg.Gather()
 		if err == nil {
 			var mfm MetricFamilyMap // := would shadow err from outer block, and single err check will not work

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -626,11 +626,8 @@ func (h *HistogramDataCollector) Add(hd HistogramData) {
 
 // TenantRegistry holds a Prometheus registry associated to a specific tenant.
 type TenantRegistry struct {
-	tenant string               // Set to "" when registry is soft-removed.
-	reg    *prometheus.Registry // Set to nil, when registry is soft-removed.
-
-	// Set to last result of Gather() call when removing registry.
-	lastGather MetricFamilyMap
+	tenant string
+	reg    *prometheus.Registry
 }
 
 // TenantRegistries holds Prometheus registries for multiple tenants, guaranteeing
@@ -681,27 +678,6 @@ func (r *TenantRegistries) AddTenantRegistry(tenant string, reg *prometheus.Regi
 
 // RemoveTenantRegistry removes all Prometheus registries for a given tenant.
 // If hard is true, registry is removed completely.
-// If hard is false, the latest registry values are preserved for future aggregations.
-func (r *TenantRegistries) RemoveTenantRegistry_Old(tenant string, hard bool) {
-	r.regsMu.Lock()
-	defer r.regsMu.Unlock()
-
-	for idx := 0; idx < len(r.regs); {
-		if tenant != r.regs[idx].tenant {
-			idx++
-			continue
-		}
-
-		if !hard && r.softRemoveTenantRegistry(&r.regs[idx]) {
-			idx++ // keep it
-		} else {
-			r.regs = append(r.regs[:idx], r.regs[idx+1:]...) // remove it.
-		}
-	}
-}
-
-// RemoveTenantRegistry removes all Prometheus registries for a given tenant.
-// If hard is true, registry is removed completely.
 // If hard is false, the latest registry values are preserved in an "archive" registry.
 func (r *TenantRegistries) RemoveTenantRegistry(tenant string, hard bool) {
 	r.regsMu.Lock()
@@ -718,43 +694,6 @@ func (r *TenantRegistries) RemoveTenantRegistry(tenant string, hard bool) {
 		}
 		r.regs = append(r.regs[:idx], r.regs[idx+1:]...) // remove it.
 	}
-}
-
-// Returns true, if we should keep latest metrics. Returns false if we failed to gather latest metrics,
-// and this can be removed completely.
-// TODO: Delete, only used in the old method.
-func (r *TenantRegistries) softRemoveTenantRegistry(ur *TenantRegistry) bool {
-	last, err := ur.reg.Gather()
-	if err != nil {
-		level.Warn(r.logger).Log("msg", "failed to gather metrics from registry", "tenant", ur.tenant, "err", err)
-		return false
-	}
-
-	for ix := 0; ix < len(last); {
-		// Only keep metrics for which we don't want to go down, since that indicates reset (counter, summary, histogram).
-		switch last[ix].GetType() {
-		case dto.MetricType_COUNTER, dto.MetricType_SUMMARY, dto.MetricType_HISTOGRAM:
-			ix++
-		default:
-			// Remove gauges and unknowns.
-			last = append(last[:ix], last[ix+1:]...)
-		}
-	}
-
-	// No metrics left.
-	if len(last) == 0 {
-		return false
-	}
-
-	ur.lastGather, err = NewMetricFamilyMap(last)
-	if err != nil {
-		level.Warn(r.logger).Log("msg", "failed to gather metrics from registry", "tenant", ur.tenant, "err", err)
-		return false
-	}
-
-	ur.tenant = ""
-	ur.reg = nil
-	return true
 }
 
 // archiveTenantRegistry gathers and stores counters/histograms/summaries from a tenant
@@ -925,7 +864,7 @@ func mergeMetricValues(existing, newMetric *dto.Metric, metricType dto.MetricTyp
 			SampleSum:   &mergedSum,
 		}
 
-		// For quantiles, we take the maximum value (summaries with same quantiles should be compatible)
+		// For quantiles, we take the maximum value (summaries with same quantiles should be compatible).
 		if len(existingSummary.GetQuantile()) > 0 || len(newSummary.GetQuantile()) > 0 {
 			quantileMap := make(map[float64]float64)
 			for _, q := range existingSummary.Quantile {
@@ -992,28 +931,19 @@ func (r *TenantRegistries) BuildMetricFamiliesPerTenant() MetricFamiliesPerTenan
 		archivedCopy[k] = v
 	}
 
-	data := MetricFamiliesPerTenant{
-		{
+	var data MetricFamiliesPerTenant
+	if len(archivedCopy) > 0 {
+		data = append(data, struct {
+			tenant  string
+			metrics MetricFamilyMap
+		}{
 			tenant:  "", // Empty tenant name so these metrics are aggregated in totals but not per-tenant.
 			metrics: archivedCopy,
-		},
+		})
 	}
 	r.regsMu.Unlock()
 
 	for _, entry := range r.Registries() {
-		// Set for removed tenants.
-		// TODO: Remove, we're not doing this r.reg = nil thing anymore...
-		if entry.reg == nil {
-			if entry.lastGather != nil {
-				data = append(data, struct {
-					tenant  string
-					metrics MetricFamilyMap
-				}{tenant: "", metrics: entry.lastGather})
-			}
-
-			continue
-		}
-
 		m, err := entry.reg.Gather()
 		if err == nil {
 			var mfm MetricFamilyMap // := would shadow err from outer block, and single err check will not work

--- a/metrics/tenant_registries.go
+++ b/metrics/tenant_registries.go
@@ -738,7 +738,7 @@ func (r *TenantRegistries) archiveTenantRegistry(ur *TenantRegistry) {
 		}
 
 		// Clone-on-write: create new MetricFamily with deduplicated metrics.
-		deduplicated := deduplicateMetrics(v.Metric, m.Metric, m.GetType())
+		deduplicated := deduplicateMetrics(v.Metric, m.Metric, v.GetType())
 		newFamily := &dto.MetricFamily{
 			Name:   v.Name,
 			Help:   v.Help,

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -1420,3 +1420,86 @@ func TestSoftRemoveTenantRegistryDeduplication(t *testing.T) {
 		}
 	}
 }
+
+// TestSoftRemoveAggregatedMetricsNeverDecrease verifies that aggregated metric values
+// (as seen by Prometheus through BuildMetricFamiliesPerTenant) never decrease across
+// the full lifecycle of add → observe → soft-remove → re-add → observe → soft-remove.
+// This is the end-to-end guarantee that prevents counter resets.
+func TestSoftRemoveAggregatedMetricsNeverDecrease(t *testing.T) {
+	tr := NewTenantRegistries(log.NewNopLogger())
+
+	sumOfCounters := func() float64 {
+		return tr.BuildMetricFamiliesPerTenant().GetSumOfCounters("test_counter")
+	}
+
+	sumOfHistogramCounts := func() uint64 {
+		var hd HistogramData
+		for _, entry := range tr.BuildMetricFamiliesPerTenant() {
+			entry.metrics.SumHistogramsTo("test_histogram", &hd)
+		}
+		return hd.Count()
+	}
+
+	sumOfSummaryCounts := func() uint64 {
+		var sd SummaryData
+		for _, entry := range tr.BuildMetricFamiliesPerTenant() {
+			entry.metrics.SumSummariesTo("test_summary", &sd)
+		}
+		return sd.sampleCount
+	}
+
+	var prevCounterSum float64
+	var prevHistCount uint64
+	var prevSummaryCount uint64
+
+	assertNonDecreasing := func(step string) {
+		cs := sumOfCounters()
+		hc := sumOfHistogramCounts()
+		sc := sumOfSummaryCounts()
+		require.GreaterOrEqual(t, cs, prevCounterSum, "%s: counter sum decreased (was %v, now %v)", step, prevCounterSum, cs)
+		require.GreaterOrEqual(t, hc, prevHistCount, "%s: histogram count decreased (was %v, now %v)", step, prevHistCount, hc)
+		require.GreaterOrEqual(t, sc, prevSummaryCount, "%s: summary count decreased (was %v, now %v)", step, prevSummaryCount, sc)
+		prevCounterSum = cs
+		prevHistCount = hc
+		prevSummaryCount = sc
+	}
+
+	for cycle := 0; cycle < 3; cycle++ {
+		// Add tenant and observe some metrics.
+		reg := prometheus.NewRegistry()
+		counter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "test_counter",
+			Help: "Test counter",
+		})
+		histogram := promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name: "test_histogram",
+			Help: "Test histogram",
+		})
+		summary := promauto.With(reg).NewSummary(prometheus.SummaryOpts{
+			Name: "test_summary",
+			Help: "Test summary",
+		})
+
+		tr.AddTenantRegistry("tenant-a", reg)
+		assertNonDecreasing(fmt.Sprintf("cycle %d: after add", cycle))
+
+		// Simulate work.
+		counter.Add(5)
+		histogram.Observe(1)
+		histogram.Observe(2)
+		summary.Observe(1)
+		summary.Observe(2)
+		assertNonDecreasing(fmt.Sprintf("cycle %d: after observe", cycle))
+
+		// Soft-remove.
+		tr.RemoveTenantRegistry("tenant-a", false)
+		assertNonDecreasing(fmt.Sprintf("cycle %d: after soft-remove", cycle))
+	}
+
+	// After 3 cycles of counter.Add(5), the total should be 15.
+	require.Equal(t, float64(15), sumOfCounters(), "expected accumulated counter value across 3 cycles")
+	// After 3 cycles of 2 observations each, the total count should be 6.
+	require.Equal(t, uint64(6), sumOfHistogramCounts(), "expected accumulated histogram count across 3 cycles")
+	// After 3 cycles of 2 observations each, the total count should be 6.
+	require.Equal(t, uint64(6), sumOfSummaryCounts(), "expected accumulated summary count across 3 cycles")
+}

--- a/metrics/tenant_registries_test.go
+++ b/metrics/tenant_registries_test.go
@@ -1353,8 +1353,8 @@ func TestSoftRemoveTenantRegistryDeduplication(t *testing.T) {
 	tr := NewTenantRegistries(log.NewNopLogger())
 
 	// Cycle through the same 10 tenants twice to verify:
-	// 1. Deduplication prevents memory leak (only 10 metrics, not 20)
-	// 2. Values accumulate correctly (counter = 2 after two cycles, not 1)
+	// 1. Deduplication prevents memory leak (only 10 metrics, not 20).
+	// 2. Values accumulate correctly (counter = 2 after two cycles, not 1).
 	for cycle := range 2 {
 		for i := range 10 {
 			r := prometheus.NewRegistry()
@@ -1391,63 +1391,32 @@ func TestSoftRemoveTenantRegistryDeduplication(t *testing.T) {
 
 		require.Equal(t, 0, len(tr.Registries()), "Cycle %d: Expected 0 active registries after removal", cycle)
 
-		// Verify deduplication and accumulation after second cycle
-		if cycle == 1 {
-			// Should have exactly 10 counter metrics (one per user), not 20
-			counterMetrics := tr.archived["test_counter"]
-			require.Equal(t, 10, len(counterMetrics.Metric), "Expected 10 deduplicated counter metrics")
+		// Gauges should never be archived (only counters, histograms, summaries).
+		_, exists := tr.archived["test_gauge"]
+		require.False(t, exists, "Cycle %d: Gauges should not be archived", cycle)
 
-			// Counter values should accumulate: 1 (cycle 0) + 1 (cycle 1) = 2
-			for _, m := range counterMetrics.Metric {
-				require.Equal(t, 2.0, m.GetCounter().GetValue(), "Expected counter value 2.0 after two cycles for user %v", m.GetLabel())
-			}
+		// After first cycle: verify initial archival works.
+		// After second cycle: verify deduplication and accumulation.
+		expectedCount := cycle + 1
 
-			// Gauges should NOT be archived (only counters, histograms, summaries)
-			_, exists := tr.archived["test_gauge"]
-			require.False(t, exists, "Gauges should not be archived")
-
-			// Histograms should accumulate
-			histogramMetrics := tr.archived["test_histogram"]
-			require.Equal(t, 10, len(histogramMetrics.Metric), "Expected 10 deduplicated histogram metrics")
-			for _, m := range histogramMetrics.Metric {
-				require.Equal(t, uint64(2), m.GetHistogram().GetSampleCount(), "Expected histogram sample_count 2 after two cycles")
-			}
-		}
-	}
-}
-
-// BenchmarkSoftRemoveMemoryLeak benchmarks the memory leak scenario:
-// cycling through the same 100 tenants 10 times (simulating churn).
-// With the fix, memory usage should be bounded (only 100 unique metrics archived).
-func BenchmarkSoftRemoveMemoryLeak(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		tr := NewTenantRegistries(log.NewNopLogger())
-
-		// Cycle through same 100 tenants 10 times
-		for cycle := 0; cycle < 10; cycle++ {
-			for tenantID := 0; tenantID < 100; tenantID++ {
-				r := prometheus.NewRegistry()
-				counter := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-					Name: "test_counter",
-					Help: "Test counter help",
-				}, []string{"user"})
-				histogram := promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
-					Name: "test_histogram",
-					Help: "Test help",
-				}, []string{"user"})
-
-				user := fmt.Sprintf("tenant-%d", tenantID)
-				tr.AddTenantRegistry(user, r)
-				counter.WithLabelValues(user).Add(float64(cycle + 1))
-				histogram.WithLabelValues(user).Observe(float64(cycle + 1))
-			}
-
-			for tenantID := 0; tenantID < 100; tenantID++ {
-				tr.RemoveTenantRegistry(fmt.Sprintf("tenant-%d", tenantID), false)
-			}
+		counterMetrics := tr.archived["test_counter"]
+		require.Equal(t, 10, len(counterMetrics.Metric), "Cycle %d: Expected 10 archived counter metrics", cycle)
+		for _, m := range counterMetrics.Metric {
+			require.Equal(t, float64(expectedCount), m.GetCounter().GetValue(), "Cycle %d: Expected counter value %d for user %v", cycle, expectedCount, m.GetLabel())
 		}
 
-		// Verify deduplication worked (should have 100 metrics, not 1000)
-		require.Equal(b, 100, len(tr.archived["test_counter"].Metric), "Memory leak detected! Expected 100 deduplicated metrics")
+		histogramMetrics := tr.archived["test_histogram"]
+		require.Equal(t, 10, len(histogramMetrics.Metric), "Cycle %d: Expected 10 archived histogram metrics", cycle)
+		for _, m := range histogramMetrics.Metric {
+			require.Equal(t, uint64(expectedCount), m.GetHistogram().GetSampleCount(), "Cycle %d: Expected histogram sample_count %d", cycle, expectedCount)
+			require.Equal(t, float64(expectedCount), m.GetHistogram().GetSampleSum(), "Cycle %d: Expected histogram sample_sum %d", cycle, expectedCount)
+		}
+
+		summaryMetrics := tr.archived["test_summary"]
+		require.Equal(t, 10, len(summaryMetrics.Metric), "Cycle %d: Expected 10 archived summary metrics", cycle)
+		for _, m := range summaryMetrics.Metric {
+			require.Equal(t, uint64(expectedCount), m.GetSummary().GetSampleCount(), "Cycle %d: Expected summary sample_count %d", cycle, expectedCount)
+			require.Equal(t, float64(expectedCount), m.GetSummary().GetSampleSum(), "Cycle %d: Expected summary sample_sum %d", cycle, expectedCount)
+		}
 	}
 }


### PR DESCRIPTION
### Description

This PR fixes a [memory leak when soft-deleting tenant registries](https://github.com/grafana/dskit/issues/746) by creating a special `"archived"` registry in the `TenantRegistries` struct.

Instead of keeping user registries around indefinitely after soft deletion, the `TenantRegistries` struct now copies counters, histograms, and summaries into the `archived` registry. This way, memory growth is not unbounded if we need to delete and recreate the same user registry multiple times.

### Testing

I tested this PR with two Mimir Alertmanager instances:
- One from the latest `main`
- Another one importing this `dskit` branch

Both Instances had _strict initialization_ enabled with a grace period of 10 seconds to allow for fast cycles of creating and deleting tenant registries.

I created a script to send bursts of requests for 2.5K tenants to both instances and sleep for 60 seconds. This resulted in registries for these 2.5K tenants being created and deleted every minute.

Results:
- The instance vendoring this fix maintained a steady memory usage
- The instance built from Mimir's latest `main` accumulated more memory on each soft deletion

<img width="2522" height="1049" alt="fix" src="https://github.com/user-attachments/assets/0a588b95-2832-4a21-acf3-701470f36af6" />

Fixes https://github.com/grafana/dskit/issues/746

### 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how soft-deleted tenant registries are retained and aggregated, which can affect scrape-time metric totals and label-series merging if the deduplication/merge logic is incorrect. Concurrency and Prometheus metric-type semantics (histogram buckets/summary quantiles) make this moderately risky despite added tests.
> 
> **Overview**
> Prevents memory growth from soft-deleted tenant registries by **removing** the old per-tenant registry objects and **archiving** only cumulative metric types (counters/histograms/summaries) into a shared `archived` metric map (gauges are intentionally excluded).
> 
> When archiving, metrics are **deduplicated by label set** and merged so values accumulate across tenant lifecycles, and `BuildMetricFamiliesPerTenant()` now includes the archived metrics as an empty-tenant entry while snapshotting `regs`/`archived` under one lock to avoid scrape races.
> 
> Adds end-to-end tests to ensure archived series don’t grow when tenants are repeatedly cycled and that aggregated totals never decrease across add/observe/soft-remove cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81951b26f2e75a19859a3d68742c60fb9d8d5eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->