### PR TITLE
fix(ring): initialize logger when building ring for a shard

### DIFF
--- a/ring/ring.go
+++ b/ring/ring.go
@@ -1130,6 +1130,7 @@ func (r *Ring) buildRingForTheShard(shard map[string]InstanceDesc) *Ring {
 	ring := &Ring{
 		cfg:                                     r.cfg,
 		strategy:                                r.strategy,
+		logger:                                  r.logger,
 		ringDesc:                                shardDesc,
 		ringTokens:                              shardTokens,
 		ringTokensByZone:                        shardTokensByZone,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures subrings built via `buildRingForTheShard` inherit the parent ring's `logger`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90c5da6f33b89022002735b14050361b2bc8b5f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->