### PR TITLE
Revert "fix(deps): update module go.yaml.in/yaml/v2 to v3"

### DIFF
--- a/flagext/bytes_test.go
+++ b/flagext/bytes_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func Test_Bytes_String(t *testing.T) {

--- a/flagext/cidr_test.go
+++ b/flagext/cidr_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func Test_CIDRSliceCSV_YamlMarshalling(t *testing.T) {

--- a/flagext/day_test.go
+++ b/flagext/day_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func TestDayValueYAML(t *testing.T) {

--- a/flagext/secret_test.go
+++ b/flagext/secret_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func TestSecretdYAML(t *testing.T) {

--- a/flagext/stringslicecsv_test.go
+++ b/flagext/stringslicecsv_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func Test_StringSliceCSV(t *testing.T) {

--- a/flagext/time_test.go
+++ b/flagext/time_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func TestTimeYAML(t *testing.T) {

--- a/flagext/url_test.go
+++ b/flagext/url_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func TestURLValueYAML(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.38.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.3.0
+	go.yaml.in/yaml/v2 v2.4.3
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/exp v0.0.0-20251125195548-87e1e737ad39
 	golang.org/x/net v0.47.0
@@ -127,7 +128,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect

--- a/kv/client_test.go
+++ b/kv/client_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/grafana/dskit/kv/codec"
 )

--- a/kv/multi_test.go
+++ b/kv/multi_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func boolPtr(b bool) *bool {

--- a/log/level_test.go
+++ b/log/level_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 )
 
 func TestMarshalYAML(t *testing.T) {

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
@@ -51,7 +51,7 @@ func testLoadOverrides(r io.Reader) (interface{}, error) {
 	var overrides = &testOverrides{}
 
 	decoder := yaml.NewDecoder(r)
-	decoder.KnownFields(true)
+	decoder.SetStrict(true)
 	if err := decoder.Decode(&overrides); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reverts grafana/dskit#839

Mimir relies on v3 with with a fork that contains two critical fixes
- decode with options: https://github.com/go-yaml/yaml/pull/691
- zero integer time.Duration: https://github.com/go-yaml/yaml/pull/876

So we can't currently upgrade to v3. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch tests back to `go.yaml.in/yaml/v2` and adjust strict decoding; add direct v2 dependency in `go.mod`.
> 
> - **Dependencies**
>   - Add direct `go.yaml.in/yaml/v2 v2.4.3` in `go.mod` (remove it from indirect list).
> - **Tests**
>   - Replace imports of `go.yaml.in/yaml/v3` with `v2` across `flagext/*_test.go`, `kv/*_test.go`, and `log/level_test.go`.
>   - In `runtimeconfig/manager_test.go`, switch decoder strictness from `KnownFields(true)` to `SetStrict(true)` to match `v2` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50459a65147886e410f4c6675b7230993369d945. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->