### PR TITLE
fix: only log when new partition or previous state have it unlocked

### DIFF
--- a/ring/partition_ring_watcher.go
+++ b/ring/partition_ring_watcher.go
@@ -115,7 +115,7 @@ func (w *PartitionRingWatcher) updatePartitionRing(desc *PartitionRingDesc) {
 		if !existedBefore || partition.StateChangeLocked != oldPartition.StateChangeLocked {
 			if partition.StateChangeLocked {
 				level.Warn(w.logger).Log("msg", "partition state change is locked", "partition_id", partitionID, "partition_state", state)
-			} else {
+			} else if existedBefore {
 				level.Info(w.logger).Log("msg", "partition state change is unlocked", "partition_id", partitionID, "partition_state", state)
 			}
 		}


### PR DESCRIPTION


**What this PR does**:

In the previous PR https://github.com/grafana/dskit/pull/799 we added logging when we see a partition state change locked. Turns out it's too verbose. 

In this PR we only log when previous partition does not exist or the lock state changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Logs partition state-change lock/unlock only when a partition is new or its lock status changes, reducing log verbosity.
> 
> - **Ring watcher (`ring/partition_ring_watcher.go`)**:
>   - Log partition state-change lock status only when a partition is new or the `StateChangeLocked` flag changes.
>   - Emit warn on lock and info on unlock, including `partition_id` and current `partition_state`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b6a29446189daec30d5873628bb4eabceb747dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->