### PR TITLE
fix: improve ring.doMultiUntilQuorumWithoutSuccessfulContextCancellation() cancellation error

### DIFF
--- a/ring/replication_set.go
+++ b/ring/replication_set.go
@@ -475,7 +475,7 @@ func doMultiUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.C
 					returnErr = setErr
 
 					// Interrupt the execution of all workers.
-					cancelWorkersCtx(setErr)
+					cancelWorkersCtx(fmt.Errorf("request canceled because quorum was not reached in another replication set due to error: %w", setErr))
 				})
 
 				return

--- a/ring/replication_set_test.go
+++ b/ring/replication_set_test.go
@@ -1715,7 +1715,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 						assert.ErrorIs(t, ctx.Err(), context.Canceled)
 
 						// Depending on timing we may either get the actual error or quorum not reached.
-						assert.Contains(t, []string{errMock.Error(), "context canceled: quorum cannot be reached"}, context.Cause(ctx).Error())
+						assert.Contains(t, []string{fmt.Sprintf("request canceled because quorum was not reached in another replication set due to error: %s", errMock.Error()), "context canceled: quorum cannot be reached"}, context.Cause(ctx).Error())
 						return "", ctx.Err()
 					case <-time.After(time.Second):
 						t.Error("expected the context to get canceled but it wasn't")
@@ -1728,7 +1728,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 				assert.Nil(t, results)
 
 				assert.ErrorIs(t, workersCtx.Err(), context.Canceled)
-				assert.EqualError(t, context.Cause(workersCtx), errMock.Error())
+				assert.ErrorContains(t, context.Cause(workersCtx), errMock.Error())
 
 				// Ensure all callback functions terminated.
 				callbacksEnded.Wait()
@@ -1756,7 +1756,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					assert.ErrorIs(t, ctx.Err(), context.Canceled)
-					assert.EqualError(t, context.Cause(ctx), expectedErr)
+					assert.ErrorContains(t, context.Cause(ctx), expectedErr)
 					return "", ctx.Err()
 				case <-time.After(time.Second):
 					t.Error("expected the context to get canceled but it wasn't")
@@ -1772,7 +1772,7 @@ func TestDoMultiUntilQuorumWithoutSuccessfulContextCancellation(t *testing.T) {
 		assert.Nil(t, results)
 
 		assert.ErrorIs(t, workersCtx.Err(), context.Canceled)
-		assert.EqualError(t, context.Cause(workersCtx), expectedErr)
+		assert.ErrorContains(t, context.Cause(workersCtx), expectedErr)
 	})
 
 	t.Run("should interrupt execution if caller context is canceled", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

We spent several hours chasing what looked like a bug just because we've been tricked by the error message used to cancel  workers in `doMultiUntilQuorumWithoutSuccessfulContextCancellation()`: the error causing a replication set quorum to fail is used as cause to cancel the context of other workers, that can also log that error causing misunderstandings.

In this PR I'm proposing a very simple change: wrap the cause specifying that the error is coming from another replication set that didn't reach quorum.

**Which issue(s) this PR fixes**:

Relates to https://github.com/grafana/mimir/issues/13823

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap worker cancellation cause with a descriptive message when another replication set fails quorum, and update tests to assert wrapped errors.
> 
> - **Ring / Replication**:
>   - Wrap `cancelWorkersCtx` cause in `doMultiUntilQuorumWithoutSuccessfulContextCancellation()` with: `"request canceled because quorum was not reached in another replication set due to error: %w"`.
> - **Tests** (`ring/replication_set_test.go`):
>   - Update expectations to match wrapped cancellation errors (switch some `EqualError` to `ErrorContains`; adjust `context.Cause(...)` assertions accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12046d1bf49495768c2c1a5dbb338fec3c1ebf9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->