### PR TITLE
feat: add grpcutil.IsErrorCode

### DIFF
--- a/grpcutil/status.go
+++ b/grpcutil/status.go
@@ -85,3 +85,15 @@ func IsCanceled(err error) bool {
 	statusCode := ErrorToStatusCode(err)
 	return statusCode == codes.Canceled
 }
+
+// IsErrorCode returns whether err is any of the codes.
+func IsErrorCode(err error, codes ...codes.Code) bool {
+	if errStatus, ok := ErrorToStatus(err); ok {
+		for _, code := range codes {
+			if errStatus.Code() == code {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/grpcutil/status_test.go
+++ b/grpcutil/status_test.go
@@ -181,3 +181,23 @@ func TestIsCanceled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsErrorCode(t *testing.T) {
+	err := status.Error(codes.Internal, msgErr)
+
+	t.Run("error matches", func(t *testing.T) {
+		require.True(t, IsErrorCode(err, codes.Internal))
+		require.True(t, IsErrorCode(err, codes.Canceled, codes.Internal, codes.Unavailable))
+	})
+
+	t.Run("error does not match", func(t *testing.T) {
+		// Error doesn't match any of the provided codes
+		require.False(t, IsErrorCode(err, codes.Canceled))
+		require.False(t, IsErrorCode(err, codes.Canceled, codes.Unavailable))
+	})
+
+	t.Run("error is not a gRPC error", func(t *testing.T) {
+		nonGRPCErr := errors.New(msgErr)
+		require.False(t, IsErrorCode(nonGRPCErr, codes.Internal))
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Adds a grpcutil function, `IsErrorCode`, for checking if an error is a grpc status error with any of the matching codes.

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 0ee0107423d37e5e874b0653b908b9870043b3cc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->