### PR TITLE
docs: service docs fixes and improvements

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -1,32 +1,33 @@
 # Services
 
-This is a Go implementation of [services model](https://github.com/google/guava/wiki/ServiceExplained) from [Google Guava](https://github.com/google/guava) library.
+This is a Go implementation of the [services model](https://github.com/google/guava/wiki/ServiceExplained) from the [Google Guava](https://github.com/google/guava) library.
 
-It provides a `Service` interface (with implementation in the `BasicService` type) and a `Manager` for managing group of services at once.
+It provides a `Service` interface (with implementation in the `BasicService` type) and a `Manager` for managing a group of services at once.
 
-Main benefits of this model are:
+The main benefits of this model are:
 
-- Services have well-defined explicit states. Services are not supposed to start any work until they are started, and they are supposed to enter the Running state only if they have successfully done all initialization in the Starting state.
-- States are observable by clients. A Client can not only see the state, but also wait for Running or Terminated states.
+- Services have well-defined explicit states. Services don't start any work until they are started and only enter the `Running` state if they have successfully done all initialization in the `Starting` state.
+- States are observable by clients. A client can see the state and also wait for `Running` or `Terminated` states.
 - If more observability is needed, clients can register state listeners.
-- Service startup and shutdown is done asynchronously. This allows for nice parallelization of startup or shutdown of multiple services.
+- Service startup and shutdown are done asynchronously. This allows for nice parallelization of startup or shutdown of multiple services.
 - Services that depend on each other can simply wait for other services to be in the correct state before using them.
 
 ## Service interface
 
-As the user of the service, here is what you need to know:
+As a user of the service, here is what you need to know.
+
 Each service starts in the `New` state.
-In this state, the service is only instantiated, and ready to be started.
+In this state, the service is only instantiated and ready to be started.
 
 Start a service by calling its `StartAsync` method. This makes the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.
 Starting is done asynchronously, so that a client can do other work while the service is starting, for example, starting more services.
 
-A service spends most of its time in the `Running` state, in which it provides it services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
+A service spends most of its time in the `Running` state, in which it provides its services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 
-Clients can stop the service by calling `StopAsync`, which tells the service to stop. The service transitions to the `Stopping` state (in which it does the necessary cleanup) and eventually the `Terminated` state.
-If a service fails in its `Starting`, `Running`, or `Stopping` state, it ends up in the `Failed` state instead of Terminated.
+Clients can stop the service by calling `StopAsync`, which tells the service to stop. The service transitions to the `Stopping` state (in which it does the necessary cleanup) and eventually to the `Terminated` state.
+If a service fails in its `Starting`, `Running`, or `Stopping` state, it ends up in the `Failed` state instead of `Terminated`.
 
-Once a service is in a `Terminated` or `Failed` state, it cannot be restarted, these states are terminal.
+Once a service is in a `Terminated` or `Failed` state, it cannot be restarted; these states are terminal.
 
 Full state diagram:
 
@@ -52,18 +53,18 @@ The API, states, and semantics are implemented to correspond to the [Service cla
 ## Manager
 
 Multiple services can be managed via a `Manager` (corresponds to the [ServiceManager](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/ServiceManager.html) in Guava library).
-A Manager is initialized with a list of New services.
-It can start the services, and wait until all services are running (= "Healthy" state).
-A Manager can also be stopped, which also stops all of its services.
-When all services are in their `Terminated` or `Final` states, the manager is said to be `Stopped`.
+A `Manager` is initialized with a list of `New` services.
+It can start the services and wait until all services are running (= "Healthy" state).
+A `Manager` can also be stopped, which also stops all of its services.
+When all services are in their `Terminated` or `Failed` states, the `Manager` is said to be "stopped."
 
-## Implementing custom Service
+## Implementing a custom service
 
 As a developer who wants to implement your own service, there are several possibilities.
 
 ### Using `NewService`
 
-The easiest possible way to create a service is using the `NewService` function with three functions called `StartingFn`, `RunningFn` and `StoppingFn`.
+The easiest possible way to create a service is using the `NewService` function with three functions as arguments called `StartingFn`, `RunningFn` and `StoppingFn`.
 The returned service is in the `New` state.
 When it transitions to the `Starting` state (by calling `StartAsync`), `StartingFn` is called.
 When `StartingFn` finishes with no error, the service transitions to the `Running` state and `RunningFn` is called.
@@ -74,14 +75,14 @@ Any of the functions can be `nil`, in which case the service simply moves to the
 
 ### Using `NewIdleService`
 
-The Idle service needs to run custom code during `Starting` or `Stopping` states, but not in the `Running` state.
+This "idle" service needs to run custom code during `Starting` or `Stopping` states, but not in the `Running` state.
 The service remains in the `Running` state until explicitly stopped using `StopAsync`.
 
 Example usage is a service that registers some HTTP or gRPC handlers.
 
 ### Using `NewTimerService`
 
-The Timer service runs a supplied function on every tick. If this function returns an error, the service fails.
+This service runs a supplied function once every tick interval, defined by a `time.Duration` argument. If this function returns an error, the service fails.
 Otherwise, the service continues calling the supplied function until stopped using `StopAsync`.
 
 ### Using `BasicService` struct
@@ -101,11 +102,12 @@ func newExampleServ() *exampleService {
 	s := &exampleService{
 		ch: make(chan string),
 	}
-    s.BasicService = NewBasicService(nil, s.collect, nil) // StartingFn, RunningFn, StoppingFn
+    s.BasicService = NewBasicService(nil, s.collect, nil) // `StartingFn`, `RunningFn`, `StoppingFn`
 	return s
 }
 
-// used as Running function. When the service is stopped, the context is canceled, so we react on it.
+// This is used as the `RunningFn` function. When the service is stopped,
+// the context is canceled, so we can react to it.
 func (s *exampleService) collect(ctx context.Context) error {
 	for {
 		select {
@@ -119,40 +121,40 @@ func (s *exampleService) collect(ctx context.Context) error {
 
 // External method called by clients of the service.
 func (s *exampleService) Send(msg string) bool {
-	ctx := s.ServiceContext() // provided by BasicService. Not part of the Service interface.
+	ctx := s.ServiceContext() // provided by `BasicService`, not part of the `Service` interface.
 	if ctx == nil {
-		// Service is not yet started
+		// `Service` is not yet started.
 		return false
 	}
 	select {
 	case s.ch <- msg:
 		return true
 	case <-ctx.Done():
-		// Service is not running anymore.
+		// `Service` is not running anymore.
 		return false
 	}
 }
 ```
 
-Now `exampleService` is a service that can be started, observed for state changes, or stopped. As long as the service is in Running state, clients can call its `Send` method:
+Now `exampleService` is a service that can be started, observed for state changes, or stopped. As long as the service is in the `Running` state, clients can call its `Send` method:
 
 ```go
 s := newExampleServ()
 s.StartAsync(context.Background())
 s.AwaitRunning(context.Background())
-// now collect() is running
+// Now collect() is running.
 s.Send("A")
 s.Send("B")
 s.Send("C")
 s.StopAsync()
 s.AwaitTerminated(context.Background())
-// now the service is finished, and we can access s.log
+// Now the service is finished, and we can access s.log.
 ```
 
-After a service is stopped (in the Terminated or Failed states, although here the "running" function doesn't return an error, so only the Terminated state is possible), all collected messages can be read from the `log` field.
-Notice that no further synchronization is necessary in this case... when the service is stopped and a client has observed that via `AwaitTerminated`, any access to `log` is safe.
+After a service is stopped (in the `Terminated` or `Failed` states, although here the `RunningFn` function doesn't return an error, so only the `Terminated` state is possible), all collected messages can be read from the `log` field.
+Notice that no further synchronization is necessary in this case; when the service is stopped and a client has observed that via `AwaitTerminated`, any access to `log` is safe.
 
-(This example is adapted from the unit tests in basic_service_test.go)
+(This example is adapted from the unit tests in `basic_service_test.go`)
 
 This may seem like a lot of extra code, and for such a simple usage it probably is.
-The real benefit comes when one starts combining multiple services into a manager, observe them as a group, or let services depend on each other via Await methods.
+The real benefit comes when one starts combining multiple services into a `Manager`, observes them as a group, or lets services depend on each other via `Await` methods.

--- a/services/README.md
+++ b/services/README.md
@@ -23,7 +23,7 @@ Starting is done asynchronously, so that a client can do other work while the se
 
 A service spends most of its time in the `Running` state, in which it provides it services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 
-Clients can stop the service by calling `StopAsync`, which tells the service to stop. `Service` will transition to the `Stopping` state (in which it does the necessary cleanup) and eventually the `Terminated` state.
+Clients can stop the service by calling `StopAsync`, which tells the service to stop. The service transitions to the `Stopping` state (in which it does the necessary cleanup) and eventually the `Terminated` state.
 If a service fails in its `Starting`, `Running` or `Stopping` state, it will end up in the `Failed` state instead of Terminated.
 
 Once a service is in a `Terminated` or `Failed` state, it cannot be restarted, these states are terminal.

--- a/services/README.md
+++ b/services/README.md
@@ -151,7 +151,7 @@ s.AwaitTerminated(context.Background())
 // Now the service is finished, and we can access s.log.
 ```
 
-After a service is stopped (in the `Terminated` or `Failed` states, although here the `RunningFn` function doesn't return an error, so only the `Terminated` state is possible), all collected messages can be read from the `log` field.
+After a service is stopped, i.e. in the `Terminated` or `Failed` state, all collected messages can be read from the `log` field. However in this case the `RunningFn` function doesn't return an error, so only the `Terminated` state is possible.
 Notice that no further synchronization is necessary in this case; when the service is stopped and a client has observed that via `AwaitTerminated`, any access to `log` is safe.
 
 (This example is adapted from the unit tests in `basic_service_test.go`)

--- a/services/README.md
+++ b/services/README.md
@@ -2,57 +2,60 @@
 
 This is a Go implementation of [services model](https://github.com/google/guava/wiki/ServiceExplained) from [Google Guava](https://github.com/google/guava) library.
 
-It provides `Service` interface (with implementation in `BasicService` type) and `Manager` for managing group of services at once.
+It provides a `Service` interface (with implementation in the `BasicService` type) and a `Manager` for managing group of services at once.
 
 Main benefits of this model are:
 
-- Services have well-defined explicit states. Services are not supposed to start any work until they are started, and they are supposed to enter Running state only if they have successfully done all initialization in Starting state.
-- States are observable by clients. Client can not only see the state, but also wait for Running or Terminated state.
+- Services have well-defined explicit states. Services are not supposed to start any work until they are started, and they are supposed to enter the Running state only if they have successfully done all initialization in the Starting state.
+- States are observable by clients. A Client can not only see the state, but also wait for Running or Terminated states.
 - If more observability is needed, clients can register state listeners.
 - Service startup and shutdown is done asynchronously. This allows for nice parallelization of startup or shutdown of multiple services.
-- Services that depend on each other can simply wait for other service to be in correct state before using it.
+- Services that depend on each other can simply wait for other services to be in the correct state before using them.
 
 ## Service interface
 
 As the user of the service, here is what you need to know:
-Each service starts in New state.
-In this state, service is not yet doing anything. It is only instantiated, and ready to be started.
+Each service starts in the New state.
+In this state, the service is not yet doing anything. It is only instantiated, and ready to be started.
 
-Service is started by calling its `StartAsync` method. This will make service transition to `Starting` state, and eventually to `Running` state, if starting is successful.
-Starting is done asynchronously, so that client can do other work while service is starting, for example start more services.
+A Service is started by calling its `StartAsync` method. This will make the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.
+Starting is done asynchronously, so that a client can do other work while the service is starting, for example starting more services.
 
-Service spends most of its time in `Running` state, in which it provides it services to the clients. What exactly it does depends on service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
+A Service spends most of its time in the `Running` state, in which it provides it services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 
-Clients can stop the service by calling `StopAsync`, which tells service to stop. `Service` will transition to `Stopping` state (in which it does the necessary cleanup) and eventually `Terminated` state.
-If service fails in its `Starting`, `Running` or `Stopping` state, it will end up in `Failed` state instead of Terminated.
+Clients can stop the service by calling `StopAsync`, which tells the service to stop. `Service` will transition to the `Stopping` state (in which it does the necessary cleanup) and eventually the `Terminated` state.
+If a service fails in its `Starting`, `Running` or `Stopping` state, it will end up in the `Failed` state instead of Terminated.
 
-Once service is in `Terminated` or `Failed` state, it cannot be restarted, these states are terminal.
+Once a service is in a `Terminated` or `Failed` state, it cannot be restarted, these states are terminal.
 
 Full state diagram:
 
-```text
-   ┌────────────────────────────────────────────────────────────────────┐
-   │                                                                    │
-   │                                                                    ▼
-┌─────┐      ┌──────────┐      ┌─────────┐     ┌──────────┐      ┌────────────┐
-│ New │─────▶│ Starting │─────▶│ Running │────▶│ Stopping │───┬─▶│ Terminated │
-└─────┘      └──────────┘      └─────────┘     └──────────┘   │  └────────────┘
-                   │                                          │
-                   │                                          │
-                   │                                          │   ┌────────┐
-                   └──────────────────────────────────────────┴──▶│ Failed │
-                                                                  └────────┘
+
+```mermaid
+flowchart LR
+  new[New]
+  starting[Starting]
+  running[Running]
+  stopping[Stopping]
+  terminated[Terminated]
+  failed[Failed]
+  new --> starting --> running --> stopping --> terminated
+  new --> terminated
+  starting --> failed
+  running --> failed
+  stopping --> failed
+	
 ```
 
-API and states and semantics are implemented to correspond to [Service class](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/Service.html) in Guava library.
+The API, states, and semantics are implemented to correspond to the [Service class](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/Service.html) in the Guava library.
 
 ## Manager
 
-Multiple services can be managed via `Manager` (corresponds to [ServiceManager](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/ServiceManager.html) in Guava library).
-Manager is initialized with list of New services.
+Multiple services can be managed via a `Manager` (corresponds to the [ServiceManager](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/ServiceManager.html) in Guava library).
+A Manager is initialized with a list of New services.
 It can start the services, and wait until all services are running (= "Healthy" state).
-Manager can also be stopped – which triggers stopping of all its services.
-When all services are in their terminal states (Terminated or Final), manager is said to be Stopped.
+A Manager can also be stopped – which triggers the stopping of all its services.
+When all services are in their terminal states (Terminated or Final), the manager is said to be Stopped.
 
 ## Implementing custom Service
 
@@ -60,31 +63,31 @@ As a developer who wants to implement your own service, there are several possib
 
 ### Using `NewService`
 
-The easiest possible way to create a service is using `NewService` function with three functions called `StartingFn`, `RunningFn` and `StoppingFn`.
-Returned service will be in `New` state.
-When it transitions to `Starting` state (by calling `StartAsync`), `StartingFn` is called.
-When `StartingFn` finishes with no error, service transitions to `Running` state and `RunningFn` is called.
-When `RunningFn` finishes, services transitions to `Stopping` state, and `StoppingFn` is called.
-After `StoppingFn` is done, service ends in `Terminated` state (if none of the functions returned error), or `Failed` state, if there were errors.
+The easiest possible way to create a service is using the `NewService` function with three functions called `StartingFn`, `RunningFn` and `StoppingFn`.
+The returned service will be in the `New` state.
+When it transitions to the `Starting` state (by calling `StartAsync`), `StartingFn` is called.
+When `StartingFn` finishes with no error, the service transitions to the `Running` state and `RunningFn` is called.
+When `RunningFn` finishes, services transition to the `Stopping` state, and `StoppingFn` is called.
+After `StoppingFn` is done, the service ends in `Terminated` state (if none of the functions returned an error), or the `Failed` state, if there were errors.
 
-Any of the functions can be `nil`, in which case service simply moves to the next state.
+Any of the functions can be `nil`, in which case the service simply moves to the next state.
 
 ### Using `NewIdleService`
 
-"Idle" service is a service which needs to run custom code during `Starting` or `Stopping` state, but not in `Running` state.
-Service will remain in `Running` state until explicitly stopped via `StopAsync`.
+The Idle service is a service that needs to run custom code during `Starting` or `Stopping` states, but not in the `Running` state.
+The service will remain in the `Running` state until explicitly stopped via `StopAsync`.
 
 Example usage is a service that registers some HTTP or gRPC handlers.
 
 ### Using `NewTimerService`
 
-Timer service runs supplied function on every tick. If this function returns error, service will fail.
-Otherwise service will continue calling supplied function until stopped via `StopAsync`.
+The Timer service runs a supplied function on every tick. If this function returns an error, the service will fail.
+Otherwise the service will continue calling the supplied function until stopped via `StopAsync`.
 
 ### Using `BasicService` struct
 
-All previous options use `BasicService` type internally, and it is `BasicService` which implements semantics of `Service` interface.
-This struct can also be embedded into custom struct, and then initialized with starting/running/stopping functions via `InitBasicService`:
+All previous options use the `BasicService` type internally, and it is `BasicService` that implements the semantics of the `Service` interface.
+This struct can also be embedded into a custom struct, and then initialized with starting/running/stopping functions via `InitBasicService`:
 
 ```go
 type exampleService struct {
@@ -102,7 +105,7 @@ func newExampleServ() *exampleService {
 	return s
 }
 
-// used as Running function. When service is stopped, context is canceled, so we react on it.
+// used as Running function. When the service is stopped, the context is canceled, so we react on it.
 func (s *exampleService) collect(ctx context.Context) error {
 	for {
 		select {
@@ -114,9 +117,9 @@ func (s *exampleService) collect(ctx context.Context) error {
 	}
 }
 
-// External method called by clients of the Service.
+// External method called by clients of the service.
 func (s *exampleService) Send(msg string) bool {
-	ctx := s.ServiceContext() // provided by BasicService. Not part of Service interface.
+	ctx := s.ServiceContext() // provided by BasicService. Not part of the Service interface.
 	if ctx == nil {
 		// Service is not yet started
 		return false
@@ -131,7 +134,7 @@ func (s *exampleService) Send(msg string) bool {
 }
 ```
 
-Now `exampleService` is a service that can be started, observed for state changes, or stopped. As long as service is in Running state, clients can call its `Send` method:
+Now `exampleService` is a service that can be started, observed for state changes, or stopped. As long as the service is in Running state, clients can call its `Send` method:
 
 ```go
 s := newExampleServ()
@@ -143,13 +146,13 @@ s.Send("B")
 s.Send("C")
 s.StopAsync()
 s.AwaitTerminated(context.Background())
-// now service is finished, and we can access s.log
+// now the service is finished, and we can access s.log
 ```
 
-After service is stopped (in Terminated or Failed state, although here the "running" function doesn't return error, so only Terminated state is possible), all collected messages can be read from `log` field.
-Notice that no further synchronization is necessary in this case... when service is stopped and client has observed that via `AwaitTerminated`, any access to `log` is safe.
+After a service is stopped (in the Terminated or Failed states, although here the "running" function doesn't return an error, so only the Terminated state is possible), all collected messages can be read from the `log` field.
+Notice that no further synchronization is necessary in this case... when the service is stopped and a client has observed that via `AwaitTerminated`, any access to `log` is safe.
 
-(This example is adapted from unit tests in basic_service_test.go)
+(This example is adapted from the unit tests in basic_service_test.go)
 
 This may seem like a lot of extra code, and for such a simple usage it probably is.
-Real benefit comes when one starts combining multiple services into a manager, observe them as a group, or let services depend on each other via Await methods.
+The real benefit comes when one starts combining multiple services into a manager, observe them as a group, or let services depend on each other via Await methods.

--- a/services/README.md
+++ b/services/README.md
@@ -54,8 +54,8 @@ The API, states, and semantics are implemented to correspond to the [Service cla
 Multiple services can be managed via a `Manager` (corresponds to the [ServiceManager](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/ServiceManager.html) in Guava library).
 A Manager is initialized with a list of New services.
 It can start the services, and wait until all services are running (= "Healthy" state).
-A Manager can also be stopped – which triggers the stopping of all its services.
-When all services are in their terminal states (Terminated or Final), the manager is said to be Stopped.
+A Manager can also be stopped, which also stops all of its services.
+When all services are in their `Terminated` or `Final` states, the manager is said to be `Stopped`.
 
 ## Implementing custom Service
 

--- a/services/README.md
+++ b/services/README.md
@@ -81,8 +81,8 @@ Example usage is a service that registers some HTTP or gRPC handlers.
 
 ### Using `NewTimerService`
 
-The Timer service runs a supplied function on every tick. If this function returns an error, the service will fail.
-Otherwise the service will continue calling the supplied function until stopped via `StopAsync`.
+The Timer service runs a supplied function on every tick. If this function returns an error, the service fails.
+Otherwise, the service continues calling the supplied function until stopped using `StopAsync`.
 
 ### Using `BasicService` struct
 

--- a/services/README.md
+++ b/services/README.md
@@ -21,7 +21,7 @@ In this state, the service is only instantiated, and ready to be started.
 Start a service by calling its `StartAsync` method. This makes the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.
 Starting is done asynchronously, so that a client can do other work while the service is starting, for example, starting more services.
 
-A Service spends most of its time in the `Running` state, in which it provides it services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
+A service spends most of its time in the `Running` state, in which it provides it services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 
 Clients can stop the service by calling `StopAsync`, which tells the service to stop. `Service` will transition to the `Stopping` state (in which it does the necessary cleanup) and eventually the `Terminated` state.
 If a service fails in its `Starting`, `Running` or `Stopping` state, it will end up in the `Failed` state instead of Terminated.

--- a/services/README.md
+++ b/services/README.md
@@ -74,8 +74,8 @@ Any of the functions can be `nil`, in which case the service simply moves to the
 
 ### Using `NewIdleService`
 
-The Idle service is a service that needs to run custom code during `Starting` or `Stopping` states, but not in the `Running` state.
-The service will remain in the `Running` state until explicitly stopped via `StopAsync`.
+The Idle service needs to run custom code during `Starting` or `Stopping` states, but not in the `Running` state.
+The service remains in the `Running` state until explicitly stopped using `StopAsync`.
 
 Example usage is a service that registers some HTTP or gRPC handlers.
 

--- a/services/README.md
+++ b/services/README.md
@@ -15,7 +15,7 @@ Main benefits of this model are:
 ## Service interface
 
 As the user of the service, here is what you need to know:
-Each service starts in the New state.
+Each service starts in the `New` state.
 In this state, the service is only instantiated, and ready to be started.
 
 Start a service by calling its `StartAsync` method. This makes the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.

--- a/services/README.md
+++ b/services/README.md
@@ -24,7 +24,7 @@ Starting is done asynchronously, so that a client can do other work while the se
 
 A service spends most of its time in the `Running` state, in which it provides its services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 
-Clients can stop the service by calling `StopAsync`, which tells the service to stop. The service transitions to the `Stopping` state (in which it does the necessary cleanup) and eventually to the `Terminated` state.
+Clients can stop the service by calling `StopAsync`, which tells the service to stop. The service transitions to the `Stopping` state to perform necessary cleanup, and then to the `Terminated` state.
 If a service fails in its `Starting`, `Running`, or `Stopping` state, it ends up in the `Failed` state instead of `Terminated`.
 
 Once a service is in a `Terminated` or `Failed` state, it cannot be restarted; these states are terminal.

--- a/services/README.md
+++ b/services/README.md
@@ -18,8 +18,8 @@ As the user of the service, here is what you need to know:
 Each service starts in the New state.
 In this state, the service is only instantiated, and ready to be started.
 
-A Service is started by calling its `StartAsync` method. This will make the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.
-Starting is done asynchronously, so that a client can do other work while the service is starting, for example starting more services.
+Start a service by calling its `StartAsync` method. This makes the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.
+Starting is done asynchronously, so that a client can do other work while the service is starting, for example, starting more services.
 
 A Service spends most of its time in the `Running` state, in which it provides it services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 

--- a/services/README.md
+++ b/services/README.md
@@ -64,7 +64,7 @@ As a developer who wants to implement your own service, there are several possib
 ### Using `NewService`
 
 The easiest possible way to create a service is using the `NewService` function with three functions called `StartingFn`, `RunningFn` and `StoppingFn`.
-The returned service will be in the `New` state.
+The returned service is in the `New` state.
 When it transitions to the `Starting` state (by calling `StartAsync`), `StartingFn` is called.
 When `StartingFn` finishes with no error, the service transitions to the `Running` state and `RunningFn` is called.
 When `RunningFn` finishes, services transition to the `Stopping` state, and `StoppingFn` is called.

--- a/services/README.md
+++ b/services/README.md
@@ -16,7 +16,7 @@ Main benefits of this model are:
 
 As the user of the service, here is what you need to know:
 Each service starts in the New state.
-In this state, the service is not yet doing anything. It is only instantiated, and ready to be started.
+In this state, the service is only instantiated, and ready to be started.
 
 A Service is started by calling its `StartAsync` method. This will make the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.
 Starting is done asynchronously, so that a client can do other work while the service is starting, for example starting more services.

--- a/services/README.md
+++ b/services/README.md
@@ -24,7 +24,7 @@ Starting is done asynchronously, so that a client can do other work while the se
 A service spends most of its time in the `Running` state, in which it provides it services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 
 Clients can stop the service by calling `StopAsync`, which tells the service to stop. The service transitions to the `Stopping` state (in which it does the necessary cleanup) and eventually the `Terminated` state.
-If a service fails in its `Starting`, `Running` or `Stopping` state, it will end up in the `Failed` state instead of Terminated.
+If a service fails in its `Starting`, `Running`, or `Stopping` state, it ends up in the `Failed` state instead of Terminated.
 
 Once a service is in a `Terminated` or `Failed` state, it cannot be restarted, these states are terminal.
 


### PR DESCRIPTION
This PR makes some improvements to the README in `services/`
- adds missing articles
- minor grammar and consistency changes
- updates the state diagram to use `mermaid` instead of plain text so it's easily editable
  - adds a line from running -> failed which was missing from the previous diagram

New flow chart for convenience since the diff view doesn't render it.

```mermaid
flowchart LR
  new[New]
  starting[Starting]
  running[Running]
  stopping[Stopping]
  terminated[Terminated]
  failed[Failed]
  new --> starting --> running --> stopping --> terminated
  new --> terminated
  starting --> failed
  running --> failed
  stopping --> failed
```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `services/README.md` for clarity and maintainability.
> 
> - **Diagram:** Replaces the ASCII state diagram with a `mermaid` flowchart and adds the missing `Running -> Failed` transition
> - **Wording/grammar:** Fixes articles, tense, and consistency; clarifies service states and lifecycle descriptions
> - **Consistency:** Standardizes capitalization and backticks for `Service`, `Manager`, states, and function names; minor comment/example wording tweaks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd9b70582d1ec53047861967e1eb73d873fabdd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->