### PR TITLE
chore: group go.mod updates across all modules in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,12 @@
   "baseBranchPatterns": ["main"],
   "packageRules": [
     {
+      "description": "Group Go module updates across all go.mod files",
+      "matchManagers": ["gomod"],
+      "matchFileNames": ["go.mod", "ring/example/local/go.mod"],
+      "groupName": "go-dependencies"
+    },
+    {
       "description": "Don't update replace directives",
       "matchPackageNames": [
         "github.com/hashicorp/memberlist"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Configure Renovate to update go.mod and ring/example/local/go.mod together in the same PR, keeping dependencies synchronized. This solves the problem of CI failing for Renovate PRs updating go.mod, because ring/example/local/go.mod needs to be updated in lockstep.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures Renovate to batch Go module upgrades across modules.
> 
> - Adds a `packageRules` entry in `renovate.json` to group `gomod` updates for `go.mod` and `ring/example/local/go.mod` under `go-dependencies`, creating single grouped PRs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e4ddb0987e9e0f7870fb9edc38ddcc4c17b836f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->