### PR TITLE
feat: cache: fail client creation on DNS errors

### DIFF
--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -116,10 +116,6 @@ type MemcachedClientConfig struct {
 
 	// TLS to use to connect to the Memcached server.
 	TLS dstls.ClientConfig `yaml:",inline"`
-
-	// DNSIgnoreStartupFailures allows the client to start even if initial DNS resolution fails.
-	// When true, DNS failures are logged but client creation succeeds.
-	DNSIgnoreStartupFailures bool `yaml:"dns_ignore_startup_failures" category:"experimental"`
 }
 
 func (c *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -135,7 +131,6 @@ func (c *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.F
 	f.IntVar(&c.MaxItemSize, prefix+"max-item-size", 1024*1024, "The maximum size of an item stored in memcached, in bytes. Bigger items are not stored. If set to 0, no maximum size is enforced.")
 	f.BoolVar(&c.TLSEnabled, prefix+"tls-enabled", false, "Enable connecting to Memcached with TLS.")
 	c.TLS.RegisterFlagsWithPrefix(prefix, f)
-	f.BoolVar(&c.DNSIgnoreStartupFailures, prefix+"dns-ignore-startup-failures", true, "Allow client creation even if initial DNS resolution fails.")
 }
 
 func (c *MemcachedClientConfig) Validate() error {
@@ -231,7 +226,7 @@ func NewMemcachedClientWithConfig(logger log.Logger, name string, config Memcach
 	go mcClient.resolveAddrsLoop()
 
 	// Do initial DNS resolution
-	if err := mcClient.resolveAddrs(); err != nil && !config.DNSIgnoreStartupFailures {
+	if err = mcClient.resolveAddrs(); err != nil {
 		mcClient.Stop()
 		return nil, err
 	}

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/grafana/gomemcache/memcache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/dskit/flagext"
 )
 
 func TestMemcachedClient_SetAsync(t *testing.T) {
@@ -387,54 +385,6 @@ func BenchmarkMemcachedClient_sortKeysByServer(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		client.sortKeysByServer(keys)
-	}
-}
-
-func TestMemcachedClient_ServerDependency(t *testing.T) {
-	testCases := []struct {
-		name                     string
-		dnsIgnoreStartupFailures bool
-	}{
-		{
-			name:                     "with DNS failures not ignored",
-			dnsIgnoreStartupFailures: false,
-		},
-		{
-			name:                     "with DNS failures ignored",
-			dnsIgnoreStartupFailures: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := &MemcachedClientConfig{}
-			memcachedClientConfigDefaultValues(cfg)
-			cfg.Addresses = flagext.StringSliceCSV{"dns+invalid.:11211"}
-			cfg.DNSIgnoreStartupFailures = tc.dnsIgnoreStartupFailures
-
-			client, err := NewMemcachedClientWithConfig(
-				log.NewNopLogger(),
-				t.Name(),
-				*cfg,
-				prometheus.NewPedanticRegistry(),
-			)
-
-			if !tc.dnsIgnoreStartupFailures {
-				require.Nil(t, client)
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "no memcached server addresses were resolved")
-				return
-			}
-
-			if tc.dnsIgnoreStartupFailures {
-				require.NoError(t, err)
-				require.NotNil(t, client)
-
-				// Verify that the client is still usable, even if initialization failed
-				res := client.GetMulti(context.Background(), []string{"some-key"})
-				require.Empty(t, res)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

This reverts the behavior introduced in #647. Ignoring errors during start up is not a good idea and it has since caused an outage by allowing object storage to be overloaded by badly configured caches/store-gateways.

The problem meant to be solved by the original change (don't block rollouts when memcached or DNS is unavailable) has since been solved in different ways:

* We run 3 replicas of all cache types on Mimir, even metadata caches
* The DNS client used now always uses TCP and retries on errors

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces fail-fast behavior for Memcached client initialization and cleans up deprecated config.
> 
> - On startup, `NewMemcachedClientWithConfig` now returns an error if `resolveAddrs()` fails; the client is stopped and not created
> - Removes `MemcachedClientConfig.DNSIgnoreStartupFailures` and the `--dns-ignore-startup-failures` flag
> - Deletes the `TestMemcachedClient_ServerDependency` test and drops unused `flagext` import in tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3248c0622c8f1b8554d214bfb5d5e8501f8650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->