### PR TITLE
feat(ring): lifecycler service flow: propagate context for canceling run func

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -541,7 +541,7 @@ func (i *Lifecycler) Zones() []string {
 func (i *Lifecycler) loop(ctx context.Context) error {
 	// First, see if we exist in the cluster, update our state to match if we do,
 	// and add ourselves (without tokens) if we don't.
-	if err := i.initRing(context.Background()); err != nil {
+	if err := i.initRing(ctx); err != nil {
 		return errors.Wrapf(err, "failed to join the ring %s", i.RingName)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Without this PR, the lifecycler service cannot be stopped while it is blocked in `waitBeforeJoining` for the non-configurable 5-minute `canJoinTimeout`.
When any errors or context cancel/deadlines occur during ingester startup, this allows us to shutdown this service and clean up goroutines without waiting 5 minutes.

See: https://github.com/grafana/mimir/pull/14025

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves lifecycler cancellation by threading `ctx` through core run-loop operations, enabling early shutdown during startup waits.
> 
> - In `Lifecycler.loop`, call `initRing`, `autoJoin`, `verifyTokens`, `changeState`, and `updateConsul` with the run `ctx` instead of `context.Background()`
> - Enables cancellation to interrupt `waitBeforeJoining` and heartbeat updates during service shutdown or startup failures
> - Refactor `TestWaitBeforeJoining` into subtests using `t.Run`; emulate `loop()` by calling `initRing` directly, remove service start/stop, and assert `context.Canceled` when appropriate
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6c5b85bdd71228cda035500601ec45f61ba0945. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->