### PR TITLE
fix(ring): log errors from `Lifecycler.loop()`

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -623,7 +623,8 @@ func (i *Lifecycler) stopping(runningError error) error {
 	if runningError != nil {
 		// previously lifecycler just called os.Exit (from loop method)...
 		// now it stops more gracefully, but also without doing any cleanup
-		return nil
+		level.Error(i.logger).Log("msg", "lifecycler loop() exited with error", "err", runningError)
+		return runningError
 	}
 
 	heartbeatTickerStop, heartbeatTickerChan := newDisableableTicker(i.cfg.HeartbeatPeriod)


### PR DESCRIPTION
**What this PR does**:

This PR fixes an issue where `Lifecycler.loop()` can fail, but the error is not logged anywhere.

Acknowledgement: this issue was originally discovered by @francoposa.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 030dcf8748b7a7aff4c1662bebcc1f1d5e73c06f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->