### PR TITLE
fix(ring): log errors from `Lifecycler` loop

### DIFF
--- a/ring/lifecycler.go
+++ b/ring/lifecycler.go
@@ -623,7 +623,8 @@ func (i *Lifecycler) stopping(runningError error) error {
 	if runningError != nil {
 		// previously lifecycler just called os.Exit (from loop method)...
 		// now it stops more gracefully, but also without doing any cleanup
-		return nil
+		level.Error(i.logger).Log("msg", "lifecycler loop() exited with error", "err", runningError)
+		return runningError
 	}
 
 	heartbeatTickerStop, heartbeatTickerChan := newDisableableTicker(i.cfg.HeartbeatPeriod)


### PR DESCRIPTION

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error handling in `ring/lifecycler.go` shutdown path.
> 
> - In `stopping()`, if `runningError` is non-nil, log the error and return it (previously returned `nil` silently), altering service shutdown semantics to propagate failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8663c1f260d23668f988df98282b707a50ba07db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->