### PR TITLE
fix(kv): wrap and propagate version mismatch error in memberlist kv CAS

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -424,7 +424,6 @@ var (
 	// if merge fails because of CAS version mismatch, this error is returned. CAS operation reacts on it
 	errVersionMismatch     = errors.New("version mismatch")
 	errNoChangeDetected    = errors.New("no change detected")
-	errTooManyRetries      = errors.New("too many retries")
 	emptySnappyEncodedData = snappy.Encode(nil, []byte{})
 )
 
@@ -1302,10 +1301,9 @@ outer:
 
 		return nil
 	}
-
 	if errors.Is(lastError, errVersionMismatch) {
-		// this is more likely error than version mismatch.
-		lastError = errors.Wrap(lastError, errTooManyRetries.Error())
+		// Version mismatch err on CAS would have been retried up to the limit
+		lastError = errors.Wrap(lastError, "too many retries")
 	}
 
 	m.casFailures.Inc()

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -487,7 +487,7 @@ func TestCASFailedBecauseOfVersionChanges(t *testing.T) {
 			return d, true, nil
 		})
 
-		require.EqualError(t, err, "failed to CAS-update key test: too many retries")
+		require.EqualError(t, err, "failed to CAS-update key test: too many retries: version mismatch")
 		require.Equal(t, maxCasRetries, calls)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

We were overwriting/dropping this error and did not know why CAS updates were failing - this propagates the error instead of clobbering.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling change limited to CAS failure messages plus a test update; no behavior change to the CAS retry logic or data path.
> 
> **Overview**
> Fixes CAS failure reporting in memberlist KV by **preserving the underlying `errVersionMismatch` cause** when the retry budget is exhausted, instead of collapsing it into a generic “too many retries” error.
> 
> This switches to `github.com/pkg/errors` for wrapping and updates the relevant unit test to assert the new error message (`too many retries: version mismatch`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 315a85aa7daa7c46af84ddd10d4d5c440f629c80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->