### PR TITLE
feat: optionally create new traces at the server

### DIFF
--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -36,11 +36,12 @@ type Tracer struct {
 
 	traceHeaders         bool
 	httpHeadersToExclude map[string]bool
+	publicEndpointFn     func(*http.Request) bool
 }
 
 // NewTracer creates a new tracer optionally configuring the tracing of HTTP headers.
 // The configuration for HTTP headers tracing only applies to OpenTelemetry spans.
-func NewTracer(sourceIPs *SourceIPExtractor, traceHeaders bool, excludeHeaders []string) Tracer {
+func NewTracer(sourceIPs *SourceIPExtractor, traceHeaders bool, excludeHeaders []string, publicEndpointFn func(*http.Request) bool) Tracer {
 	httpHeadersToExclude := map[string]bool{}
 	for header := range AlwaysExcludedHeaders {
 		httpHeadersToExclude[header] = true
@@ -54,6 +55,7 @@ func NewTracer(sourceIPs *SourceIPExtractor, traceHeaders bool, excludeHeaders [
 
 		traceHeaders:         traceHeaders,
 		httpHeadersToExclude: httpHeadersToExclude,
+		publicEndpointFn:     publicEndpointFn,
 	}
 }
 
@@ -152,9 +154,15 @@ func (t Tracer) wrapWithOTel(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 
-	return otelhttp.NewHandler(addSpanAttributes, "http.tracing", otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
-		return httpOperationName(r)
-	}))
+	opts := []otelhttp.Option{
+		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+			return httpOperationName(r)
+		}),
+	}
+	if t.publicEndpointFn != nil {
+		opts = append(opts, otelhttp.WithPublicEndpointFn(t.publicEndpointFn))
+	}
+	return otelhttp.NewHandler(addSpanAttributes, "http.tracing", opts...)
 }
 
 // HTTPGRPCTracingInterceptor adds additional information about the encapsulated HTTP request

--- a/server/server.go
+++ b/server/server.go
@@ -172,6 +172,13 @@ type Config struct {
 	Throughput Throughput `yaml:"-"`
 
 	ClusterValidation clusterutil.ServerClusterValidationConfig `yaml:"cluster_validation" category:"experimental"`
+
+	// PublicEndpointFn will create a new trace instead of continuing an
+	// existing trace when the function returns true. A span link will be used
+	// to connect to any existing trace. It only works if using Open-Telemetry
+	// tracing.
+	PublicEndpointFn func(*http.Request) bool `yaml:"-"`
+	CreateNewTraces  bool                     `yaml:"create_new_traces"`
 }
 
 type Throughput struct {
@@ -241,6 +248,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.Throughput.LatencyCutoff, "server.throughput.latency-cutoff", 0, "Requests taking over the cutoff are be observed to measure throughput. Server-Timing header is used with specified unit as the indicator, for example 'Server-Timing: unit;val=8.2'. If set to 0, the throughput is not calculated.")
 	f.StringVar(&cfg.Throughput.Unit, "server.throughput.unit", "samples_processed", "Unit of the server throughput metric, for example 'processed_bytes' or 'samples_processed'. Observed values are gathered from the 'Server-Timing' header with the 'val' key. If set, it is appended to the request_server_throughput metric name.")
 	cfg.ClusterValidation.RegisterFlagsWithPrefix("server.cluster-validation.", f)
+	f.BoolVar(&cfg.CreateNewTraces, "server.create-new-traces", false, "Creates new traces for each call rather than continuing the existing trace. A span link is used to allow navigation to the parent trace. Only works when using Open-Telemetry tracing.")
 }
 
 func (cfg *Config) Validate() error {
@@ -589,11 +597,17 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 	defaultLogMiddleware := middleware.NewLogMiddleware(logger, cfg.LogRequestHeaders, cfg.LogRequestAtInfoLevel, logSourceIPs, strings.Split(cfg.LogRequestExcludeHeadersList, ","))
 	defaultLogMiddleware.DisableRequestSuccessLog = cfg.DisableRequestSuccessLog
 
+	publicEndpointFn := cfg.PublicEndpointFn
+	if publicEndpointFn == nil && cfg.CreateNewTraces {
+		publicEndpointFn = func(*http.Request) bool {
+			return true
+		}
+	}
 	defaultHTTPMiddleware := []middleware.Interface{
 		middleware.RouteInjector{
 			RouteMatcher: router,
 		},
-		middleware.NewTracer(sourceIPs, cfg.TraceRequestHeaders, strings.Split(cfg.TraceRequestExcludeHeadersList, ",")),
+		middleware.NewTracer(sourceIPs, cfg.TraceRequestHeaders, strings.Split(cfg.TraceRequestExcludeHeadersList, ","), publicEndpointFn),
 		defaultLogMiddleware,
 		middleware.Instrument{
 			Duration:          metrics.RequestDuration,


### PR DESCRIPTION
When using a server to serve public facing routes it can be desired to create a new trace id instead of trusting the trace id attached to a public request. Otherwise very large traces can be created which will then be rejected by Tempo.

The parent trace will be referenced using a span link to see the overall context of the request/other services using the public endpoint.

Here is an example of what this will look like in Tempo:
<img width="924" height="298" alt="image" src="https://github.com/user-attachments/assets/5a20b58f-dcee-49be-8c86-5a01bf0d383c" />

Even if the parent trace is not sampled it is possible to find all sampled traces linked to that trace using `{link:traceID = "<trace-id>"}`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP tracing propagation behavior when enabled, which can alter trace continuity and observability expectations for public-facing routes. Risk is limited to OpenTelemetry users and is opt-in via `server.create-new-traces`/`PublicEndpointFn`.
> 
> **Overview**
> Adds support for treating certain HTTP routes as *public endpoints* for OpenTelemetry: when configured, the server starts a **new trace** for matching requests instead of continuing any incoming trace context, and links to the original trace.
> 
> This is wired by extending `middleware.NewTracer` to accept an optional `publicEndpointFn` (passed through to `otelhttp.WithPublicEndpointFn`), and by adding `server.create-new-traces` plus `Config.PublicEndpointFn` to control the behavior when building the default HTTP middleware.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9212984c064e9f0ec6fc70c065f4fdd38aaf3901. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->