### PR TITLE
feat: add -memberlist.abort-if-fast-join-fails-min-nodes

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -155,14 +155,15 @@ type KVConfig struct {
 	ClusterLabelVerificationDisabled bool   `yaml:"cluster_label_verification_disabled" category:"advanced"`
 
 	// List of members to join
-	JoinMembers          flagext.StringSliceCSVMulti `yaml:"join_members"`
-	MinJoinBackoff       time.Duration               `yaml:"min_join_backoff" category:"advanced"`
-	MaxJoinBackoff       time.Duration               `yaml:"max_join_backoff" category:"advanced"`
-	MaxJoinRetries       int                         `yaml:"max_join_retries" category:"advanced"`
-	AbortIfFastJoinFails bool                        `yaml:"abort_if_cluster_fast_join_fails" category:"advanced"`
-	AbortIfJoinFails     bool                        `yaml:"abort_if_cluster_join_fails"`
-	RejoinInterval       time.Duration               `yaml:"rejoin_interval" category:"advanced"`
-	RejoinSeedNodes      flagext.StringSliceCSVMulti `yaml:"rejoin_seed_nodes" category:"experimental"`
+	JoinMembers                  flagext.StringSliceCSVMulti `yaml:"join_members"`
+	MinJoinBackoff               time.Duration               `yaml:"min_join_backoff" category:"advanced"`
+	MaxJoinBackoff               time.Duration               `yaml:"max_join_backoff" category:"advanced"`
+	MaxJoinRetries               int                         `yaml:"max_join_retries" category:"advanced"`
+	AbortIfFastJoinFails         bool                        `yaml:"abort_if_cluster_fast_join_fails" category:"advanced"`
+	AbortIfFastJoinFailsMinNodes int                         `yaml:"abort_if_cluster_fast_join_fails_min_nodes" category:"advanced"`
+	AbortIfJoinFails             bool                        `yaml:"abort_if_cluster_join_fails"`
+	RejoinInterval               time.Duration               `yaml:"rejoin_interval" category:"advanced"`
+	RejoinSeedNodes              flagext.StringSliceCSVMulti `yaml:"rejoin_seed_nodes" category:"experimental"`
 
 	// Remove LEFT ingesters from ring after this timeout.
 	LeftIngestersTimeout   time.Duration `yaml:"left_ingesters_timeout" category:"advanced"`
@@ -210,6 +211,7 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.MaxJoinBackoff, prefix+"memberlist.max-join-backoff", 1*time.Minute, "Max backoff duration to join other cluster members.")
 	f.IntVar(&cfg.MaxJoinRetries, prefix+"memberlist.max-join-retries", 10, "Max number of retries to join other cluster members.")
 	f.BoolVar(&cfg.AbortIfFastJoinFails, prefix+"memberlist.abort-if-fast-join-fails", false, "Abort if this node fails the fast memberlist cluster joining procedure at startup. When enabled, it's guaranteed that other services, depending on memberlist, have an updated view over the cluster state when they're started.")
+	f.IntVar(&cfg.AbortIfFastJoinFailsMinNodes, prefix+"memberlist.abort-if-fast-join-fails-min-nodes", 1, "Minimum number of seed nodes that must be successfully joined during fast-join for it to succeed. Only applies when -memberlist.abort-if-fast-join-fails is enabled.")
 	f.BoolVar(&cfg.AbortIfJoinFails, prefix+"memberlist.abort-if-join-fails", cfg.AbortIfJoinFails, "Abort if this node fails to join memberlist cluster at startup. When enabled, it's not guaranteed that other services are started only after the cluster state has been successfully updated; use 'abort-if-fast-join-fails' instead.")
 	f.DurationVar(&cfg.RejoinInterval, prefix+"memberlist.rejoin-interval", 0, "If not 0, how often to rejoin the cluster. Occasional rejoin can help to fix the cluster split issue, and is harmless otherwise. For example when using only few components as a seed nodes (via -memberlist.join), then it's recommended to use rejoin. If -memberlist.join points to dynamic service that resolves to all gossiping nodes (eg. Kubernetes headless service), then rejoin is not needed.")
 	f.Var(&cfg.RejoinSeedNodes, prefix+"memberlist.rejoin-seed-nodes", "Seed nodes to use for periodic rejoin. Takes precedence over -memberlist.join for rejoining. If not specified, -memberlist.join is used. Can be specified multiple times or as a comma-separated list. Supports IP, hostname, or DNS Service Discovery format.")
@@ -718,9 +720,9 @@ func (m *KV) fastJoinMembersOnStartup(ctx context.Context) error {
 		nodes = nodes[1:]
 	}
 
-	if totalJoined == 0 {
-		level.Warn(m.logger).Log("msg", "memberlist fast-join failed because no node has been successfully reached", "elapsed_time", time.Since(startTime))
-		return fmt.Errorf("no memberlist node reached during fast-join procedure")
+	if totalJoined < m.cfg.AbortIfFastJoinFailsMinNodes {
+		level.Warn(m.logger).Log("msg", "memberlist fast-join failed to reach minimum required seed nodes", "joined_nodes", totalJoined, "required_nodes", m.cfg.AbortIfFastJoinFailsMinNodes, "elapsed_time", time.Since(startTime))
+		return fmt.Errorf("fast-join failed to reach minimum required seed nodes: joined %d, required %d", totalJoined, m.cfg.AbortIfFastJoinFailsMinNodes)
 	}
 
 	level.Info(m.logger).Log("msg", "memberlist fast-join finished", "joined_nodes", totalJoined, "elapsed_time", time.Since(startTime))


### PR DESCRIPTION
**What this PR does**:

In this PR I'm adding the config option `-memberlist.abort-if-fast-join-fails-min-nodes` that allows to configure the min number of seed nodes to join during the fast join at startup. The default value is 1, which is how it was behaving before this PR, so the default behaviour is unchanged.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
