### PR TITLE
feat(tenant): use tenant metadata instead of subtenant

### DIFF
--- a/tenant/metadata.go
+++ b/tenant/metadata.go
@@ -1,0 +1,164 @@
+package tenant
+
+import (
+	"fmt"
+	"iter"
+	"maps"
+	"slices"
+	"strings"
+)
+
+const (
+	// metadataSeparator separates the tenant ID from the metadata. The format is
+	// "tenantID:key=value" (e.g. "123456:product=k6"). The colon is not a valid
+	// character in tenant IDs, making it safe to use as a separator.
+	metadataSeparator = ':'
+	// metadataKVSeparator separates individual key value pairs of metadata. The
+	// format is "key=value" (e.g., "source=test"). The equal sign is not a valid
+	// character in tenant IDs, making it safe to use as a separator.
+	metadataKVSeparator = '='
+)
+
+var validMetadataChars [256]bool
+
+func init() {
+	validMetadataChars[metadataSeparator] = true
+	validMetadataChars[metadataKVSeparator] = true
+
+	for c := 'a'; c <= 'z'; c++ {
+		validMetadataChars[c] = true
+	}
+	for c := 'A'; c <= 'Z'; c++ {
+		validMetadataChars[c] = true
+	}
+	for c := '0'; c <= '9'; c++ {
+		validMetadataChars[c] = true
+	}
+	for _, c := range "-_" {
+		validMetadataChars[c] = true
+	}
+}
+
+type errMetadataUnsupportedCharacter struct {
+	pos      int
+	metadata string
+}
+
+func (e *errMetadataUnsupportedCharacter) Error() string {
+	return fmt.Sprintf(
+		"metadata '%s' contains unsupported character '%c'",
+		e.metadata,
+		e.metadata[e.pos],
+	)
+}
+
+type Metadata struct {
+	data map[string]string
+}
+
+func NewMetadata() Metadata {
+	return Metadata{}
+}
+
+// ParseMetadata from string without validating input. ValidMetadata must be used
+// to ensure input contains only allowed characters. The format for metadata is a
+// colon-delimited list of key value pairs.
+// Examples:
+// - key=value
+// - key=value:foo=bar
+func ParseMetadata(input string) (Metadata, error) {
+	if input == "" {
+		return Metadata{}, nil
+	}
+	var (
+		currentPair  string
+		hasMorePairs bool
+		remaining    = input
+		metadata     = NewMetadata()
+	)
+	for {
+		currentPair, remaining, hasMorePairs = stringsCut(remaining, metadataSeparator)
+		key, val, ok := stringsCut(currentPair, metadataKVSeparator)
+		if !ok {
+			return Metadata{}, fmt.Errorf("invalid key value pair %s", currentPair)
+		}
+		metadata.Set(key, val)
+		if !hasMorePairs {
+			break
+		}
+	}
+	return metadata, nil
+}
+
+// ValidMetadata returns an error if the metadata is invalid, nil otherwise.
+// Metadata must contain only lowercase letters, digits, '-', and '='.
+func ValidMetadata(s string) error {
+	for i := 0; i < len(s); i++ {
+		if !validMetadataChars[s[i]] {
+			return &errMetadataUnsupportedCharacter{metadata: s, pos: i}
+		}
+	}
+	if len(s) > MaxMetadataLength {
+		return fmt.Errorf("metadata too long: %d", len(s))
+	}
+	return nil
+}
+
+// Set a key value pair.
+func (m *Metadata) Set(key string, val string) {
+	if m.data == nil {
+		m.data = make(map[string]string)
+	}
+	m.data[key] = val
+}
+
+// Remove the value with key from m.
+func (m Metadata) Remove(key string) {
+	if m.data != nil {
+		delete(m.data, key)
+	}
+}
+
+// Has checks whether a specific metadata key is present.
+func (m Metadata) Has(key string) bool {
+	if m.data == nil {
+		return false
+	}
+	_, ok := m.data[key]
+	return ok
+}
+
+// Get the value set for key.
+func (m Metadata) Get(key string) (string, bool) {
+	if m.data == nil {
+		return "", false
+	}
+	val, ok := m.data[key]
+	return val, ok
+}
+
+// Iter returns a new iterator that yields key/value pairs sorted by keys.
+func (m Metadata) Iter() iter.Seq2[string, string] {
+	return func(yield func(string, string) bool) {
+		keys := slices.Sorted(maps.Keys(m.data))
+		for _, key := range keys {
+			if !yield(key, m.data[key]) {
+				return
+			}
+		}
+	}
+}
+
+// WithTenant encodes the metadata as a tenant-prefixed string.
+// The format is "tenantID:key1=val1:key2=val2" with keys sorted alphabetically.
+func (m Metadata) WithTenant(tenantID string) string {
+	var sb strings.Builder
+	sb.WriteString(tenantID)
+	for key, val := range m.Iter() {
+		sb.WriteRune(metadataSeparator)
+		sb.WriteString(key)
+		sb.WriteRune(metadataKVSeparator)
+		sb.WriteString(val)
+	}
+	return sb.String()
+}

--- a/tenant/metadata_test.go
+++ b/tenant/metadata_test.go
@@ -1,0 +1,116 @@
+package tenant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadata_WithTenant(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *Metadata
+		tenant   string
+		expected string
+	}{
+		{
+			name: "single pair",
+			metadata: &Metadata{data: map[string]string{
+				"key": "value",
+			}},
+			tenant:   "my-tenant",
+			expected: "my-tenant:key=value",
+		},
+		{
+			name: "multiple pairs sorted by key",
+			metadata: &Metadata{data: map[string]string{
+				"product": "k6",
+				"env":     "prod",
+			}},
+			tenant:   "123456",
+			expected: "123456:env=prod:product=k6",
+		},
+		{
+			name:     "empty metadata",
+			metadata: &Metadata{data: map[string]string{}},
+			tenant:   "tenant-a",
+			expected: "tenant-a",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.metadata.WithTenant(tc.tenant))
+		})
+	}
+}
+
+func TestMetadata_Has(t *testing.T) {
+	md := NewMetadata()
+	md.Set("key", "value")
+	assert.True(t, md.Has("key"))
+	assert.False(t, md.Has("missing"))
+}
+
+func TestMetadata_Get(t *testing.T) {
+	var md Metadata
+	md.Set("key", "value")
+	val, ok := md.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "value", val)
+
+	val, ok = md.Get("missing")
+	assert.False(t, ok)
+	assert.Equal(t, "", val)
+}
+
+func Test_ParseMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Metadata
+		errMsg   string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+		},
+		{
+			name:  "single pair",
+			input: "key=value",
+			expected: Metadata{data: map[string]string{
+				"key": "value",
+			}},
+		},
+		{
+			name:  "multiple pairs",
+			input: "product=k6:env=prod",
+			expected: Metadata{data: map[string]string{
+				"product": "k6",
+				"env":     "prod",
+			}},
+		},
+		{
+			name:   "missing equals sign",
+			input:  "noequalssign",
+			errMsg: "invalid key value pair",
+		},
+		{
+			name:   "one valid one invalid pair",
+			input:  "key=value:bad",
+			errMsg: "invalid key value pair",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			md, err := ParseMetadata(tc.input)
+			if tc.errMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, md)
+		})
+	}
+}

--- a/tenant/resolver.go
+++ b/tenant/resolver.go
@@ -12,11 +12,11 @@ import (
 // tenant ID. It returns an error user.ErrNoOrgID if there is no tenant ID
 // supplied or user.ErrTooManyOrgIDs if there are multiple tenant IDs present.
 //
-// If the orgID contains a subtenant (format "tenantID:subtenantID"), this function
-// strips the subtenant part and returns only the tenant ID. This ensures backward
-// compatibility with existing code that is not subtenant-aware.
+// If the orgID contains metadata (format "tenantID:key=value"), this function
+// strips the metadata part and returns only the tenant ID. This ensures backward
+// compatibility with existing code that is not metadata-aware.
 //
-// The SubtenantID is not validated.
+// The metadata is not validated.
 //
 // ignore stutter warning
 //
@@ -28,13 +28,13 @@ func TenantID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	orgID, remaining, hasMoreIDs := stringsCut(orgIDs, tenantIDsSeparator)
-	tenantID := trimSubtenantID(orgID)
+	tenantID := trimMetadata(orgID)
 	if err := ValidTenantID(tenantID); err != nil {
 		return "", err
 	}
 	for hasMoreIDs {
 		orgID, remaining, hasMoreIDs = stringsCut(remaining, tenantIDsSeparator)
-		if tenantID != trimSubtenantID(orgID) {
+		if tenantID != trimMetadata(orgID) {
 			return "", user.ErrTooManyOrgIDs
 		}
 	}
@@ -45,12 +45,12 @@ func TenantID(ctx context.Context) (string, error) {
 // normalized list of ordered and distinct tenant IDs (as produced by
 // NormalizeTenantIDs).
 //
-// If the orgID contains subtenants (format "tenantID:subtenantID" or
-// "tenant1:sub1|tenant2:sub2"), this function strips the subtenant parts
+// If the orgID contains metadata (format "tenantID:key=value" or
+// "tenant1:k=v1|tenant2:k=v2"), this function strips the metadata parts
 // and returns only the tenant IDs. This ensures backward compatibility
-// with existing code that is not subtenant-aware.
+// with existing code that is not metadata-aware.
 //
-// SubtenantIDs are not validated.
+// Metadata is not validated.
 //
 // ignore stutter warning
 //
@@ -67,7 +67,7 @@ func TenantIDs(ctx context.Context) ([]string, error) {
 func parseTenantIDs(orgID string) ([]string, error) {
 	orgIDs := strings.Split(orgID, string(tenantIDsSeparator))
 	for i, part := range orgIDs {
-		tenantId := trimSubtenantID(part)
+		tenantId := trimMetadata(part)
 		if err := ValidTenantID(tenantId); err != nil {
 			return nil, err
 		}
@@ -76,69 +76,51 @@ func parseTenantIDs(orgID string) ([]string, error) {
 	return NormalizeTenantIDs(orgIDs), nil
 }
 
-// SubtenantID returns the subtenant ID from the context, or an empty string if
-// no subtenant is present. The orgID format is "tenantID:subtenantID" (e.g., "123456:k6").
+// ExtractWithMetadata returns the tenant ID and optional metadata from the context,
+// or nil metadata if no metadata is present. The orgID format is "tenantID:metadata"
+// (e.g., "123456:test=yes").
 //
 //nolint:revive
-func SubtenantID(ctx context.Context) (tenantID string, subtenantID string, _ error) {
+func ExtractWithMetadata(ctx context.Context) (tenantID string, m Metadata, err error) {
 	//lint:ignore faillint wrapper around upstream method
 	orgIDs, err := user.ExtractOrgID(ctx)
 	if err != nil {
-		return "", "", err
+		return "", Metadata{}, err
 	}
+	return ParseWithMetadata(orgIDs)
+}
 
+// ParseWithMetadata returns the tenant ID and optional metadata from orgID(s).
+// Metadata is nil if no metadata is present. The orgID format is
+// "tenantID:key=value" or "tenantID:k1=v1:k2=v2".
+//
+// Examples:
+//   - 123456              (tenantID=123456, metadata=nil)
+//   - 123456:a=b          (tenantID=123456, metadata={a: b})
+//   - 123456:a=b:c=d      (tenantID=123456, metadata={a: b, c: d})
+func ParseWithMetadata(orgIDs string) (tenantID string, m Metadata, err error) {
 	orgID, remaining, hasMoreIDs := stringsCut(orgIDs, tenantIDsSeparator)
-	tenantID, subtenantID = splitTenantAndSubtenant(orgID)
+	tenantID, metadataString := splitTenantAndMetadata(orgID)
 	if err := ValidTenantID(tenantID); err != nil {
-		return "", "", err
+		return "", Metadata{}, err
 	}
-	if err := ValidSubtenantID(subtenantID); err != nil {
-		return "", "", err
+	if err := ValidMetadata(metadataString); err != nil {
+		return "", Metadata{}, err
 	}
 	var nextOrgID string
 	for hasMoreIDs {
 		nextOrgID, remaining, hasMoreIDs = stringsCut(remaining, tenantIDsSeparator)
-		// We can compare the entire orgID, no need to split into tenant/subtenant.
+		// We can compare the entire orgID, no need to split into tenant/metadata.
 		// The orgID is already guaranteed to be valid.
 		if orgID != nextOrgID {
-			return "", "", user.ErrTooManyOrgIDs
+			return "", Metadata{}, user.ErrTooManyOrgIDs
 		}
 	}
-	return tenantID, subtenantID, nil
-}
-
-// SubtenantIDs returns a normalized list of all subtenant IDs from the context
-// (as produced by NormalizeTenantIDs). Empty subtenants are omitted from the
-// result.
-//
-// ignore stutter warning
-//
-//nolint:revive
-func SubtenantIDs(ctx context.Context) ([]string, error) {
-	//lint:ignore faillint wrapper around upstream method
-	orgID, err := user.ExtractOrgID(ctx)
+	m, err = ParseMetadata(metadataString)
 	if err != nil {
-		return nil, err
+		return "", Metadata{}, err
 	}
-	return parseSubtenantIDs(orgID)
-}
-
-func parseSubtenantIDs(orgID string) ([]string, error) {
-	parts := strings.Split(orgID, string(tenantIDsSeparator))
-	var subtenantIDs []string
-	for _, part := range parts {
-		tenantID, subtenantID := splitTenantAndSubtenant(part)
-		if err := ValidTenantID(tenantID); err != nil {
-			return nil, err
-		}
-		if subtenantID != "" {
-			if err := ValidSubtenantID(subtenantID); err != nil {
-				return nil, err
-			}
-			subtenantIDs = append(subtenantIDs, subtenantID)
-		}
-	}
-	return NormalizeTenantIDs(subtenantIDs), nil
+	return tenantID, m, nil
 }
 
 type Resolver interface {
@@ -152,15 +134,6 @@ type Resolver interface {
 	// normalized list of ordered and distinct tenant IDs (as produced by
 	// NormalizeTenantIDs).
 	TenantIDs(context.Context) ([]string, error)
-
-	// SubtenantID returns the tenant ID and subtenant ID from the context.
-	// Returns empty subtenant if no subtenant is present.
-	// The orgID format is "tenantID:subtenantID".
-	SubtenantID(context.Context) (string, string, error)
-
-	// SubtenantIDs returns all subtenant IDs from the context. It should return
-	// a normalized list of ordered and distinct subtenant IDs.
-	SubtenantIDs(context.Context) ([]string, error)
 }
 
 type MultiResolver struct{}
@@ -181,12 +154,4 @@ func (t *MultiResolver) TenantID(ctx context.Context) (string, error) {
 
 func (t *MultiResolver) TenantIDs(ctx context.Context) ([]string, error) {
 	return TenantIDs(ctx)
-}
-
-func (t *MultiResolver) SubtenantID(ctx context.Context) (string, string, error) {
-	return SubtenantID(ctx)
-}
-
-func (t *MultiResolver) SubtenantIDs(ctx context.Context) ([]string, error) {
-	return SubtenantIDs(ctx)
 }

--- a/tenant/resolver_test.go
+++ b/tenant/resolver_test.go
@@ -15,222 +15,205 @@ func strptr(s string) *string {
 }
 
 type resolverTestCase struct {
-	name            string
-	headerValue     *string
-	errTenantID     error
-	errTenantIDs    error
-	errSubtenantID  error
-	errSubtenantIDs error
-	tenantID        string
-	tenantIDs       []string
-	subtenantID     string
-	subtenantIDs    []string
+	name               string
+	headerValue        *string
+	errTenantID        error
+	errTenantIDs       error
+	errMetadata        error
+	errMetadataContain string // for checking error message contains this string
+	tenantID           string
+	tenantIDs          []string
+	metadata           Metadata
 }
 
 func TestTenantIDs(t *testing.T) {
 	for _, tc := range []resolverTestCase{
 		{
-			name:            "no-header",
-			errTenantID:     user.ErrNoOrgID,
-			errTenantIDs:    user.ErrNoOrgID,
-			errSubtenantID:  user.ErrNoOrgID,
-			errSubtenantIDs: user.ErrNoOrgID,
+			name:         "no-header",
+			errTenantID:  user.ErrNoOrgID,
+			errTenantIDs: user.ErrNoOrgID,
+			errMetadata:  user.ErrNoOrgID,
 		},
 		{
 			name:        "empty",
 			headerValue: strptr(""),
 			tenantIDs:   []string{""},
-			subtenantID: "",
 		},
 		{
 			name:        "single-tenant",
 			headerValue: strptr("tenant-a"),
 			tenantID:    "tenant-a",
 			tenantIDs:   []string{"tenant-a"},
-			subtenantID: "",
 		},
 		{
-			name:            "parent-dir",
-			headerValue:     strptr(".."),
-			errTenantID:     errUnsafeTenantID,
-			errTenantIDs:    errUnsafeTenantID,
-			errSubtenantID:  errUnsafeTenantID,
-			errSubtenantIDs: errUnsafeTenantID,
+			name:         "parent-dir",
+			headerValue:  strptr(".."),
+			errTenantID:  errUnsafeTenantID,
+			errTenantIDs: errUnsafeTenantID,
+			errMetadata:  errUnsafeTenantID,
 		},
 		{
-			name:            "current-dir",
-			headerValue:     strptr("."),
-			errTenantID:     errUnsafeTenantID,
-			errTenantIDs:    errUnsafeTenantID,
-			errSubtenantID:  errUnsafeTenantID,
-			errSubtenantIDs: errUnsafeTenantID,
+			name:         "current-dir",
+			headerValue:  strptr("."),
+			errTenantID:  errUnsafeTenantID,
+			errTenantIDs: errUnsafeTenantID,
+			errMetadata:  errUnsafeTenantID,
 		},
 		{
-			name:           "multi-tenant",
-			headerValue:    strptr("tenant-a|tenant-b"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"tenant-a", "tenant-b"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
+			name:        "multi-tenant",
+			headerValue: strptr("tenant-a|tenant-b"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 		{
-			name:           "multi-tenant-wrong-order",
-			headerValue:    strptr("tenant-b|tenant-a"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"tenant-a", "tenant-b"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
+			name:        "multi-tenant-wrong-order",
+			headerValue: strptr("tenant-b|tenant-a"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 		{
-			name:           "multi-tenant-duplicate-order",
-			headerValue:    strptr("tenant-b|tenant-b|tenant-a"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"tenant-a", "tenant-b"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
+			name:        "multi-tenant-duplicate-order",
+			headerValue: strptr("tenant-b|tenant-b|tenant-a"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 		{
 			// Duplicated single tenant should return that tenant (backward compatible)
-			name:         "multi-tenant-same-tenant-duplicated",
-			headerValue:  strptr("tenant-a|tenant-a"),
-			tenantID:     "tenant-a",
-			tenantIDs:    []string{"tenant-a"},
-			subtenantID:  "",
-			subtenantIDs: nil,
+			name:        "multi-tenant-same-tenant-duplicated",
+			headerValue: strptr("tenant-a|tenant-a"),
+			tenantID:    "tenant-a",
+			tenantIDs:   []string{"tenant-a"},
 		},
 		{
-			// Duplicated single tenant with subtenant
-			name:         "multi-tenant-same-tenant-with-subtenant-duplicated",
-			headerValue:  strptr("tenant-a:k6|tenant-a:k6"),
-			tenantID:     "tenant-a",
-			tenantIDs:    []string{"tenant-a"},
-			subtenantID:  "k6",
-			subtenantIDs: []string{"k6"},
+			// Duplicated single tenant with metadata
+			name:        "multi-tenant-same-tenant-with-metadata-duplicated",
+			headerValue: strptr("tenant-a:key=value|tenant-a:key=value"),
+			tenantID:    "tenant-a",
+			tenantIDs:   []string{"tenant-a"},
+			metadata:    Metadata{data: map[string]string{"key": "value"}},
 		},
 		{
-			// TenantID/SubtenantID return early when different tenants found, before validating all
-			name:            "multi-tenant-with-relative-path",
-			headerValue:     strptr("tenant-a|tenant-b|.."),
-			errTenantID:     user.ErrTooManyOrgIDs,
-			errTenantIDs:    errUnsafeTenantID,
-			errSubtenantID:  user.ErrTooManyOrgIDs,
-			errSubtenantIDs: errUnsafeTenantID,
+			// TenantID/ExtractWithMetadata return early when different tenants found, before validating all
+			name:         "multi-tenant-with-relative-path",
+			headerValue:  strptr("tenant-a|tenant-b|.."),
+			errTenantID:  user.ErrTooManyOrgIDs,
+			errTenantIDs: errUnsafeTenantID,
+			errMetadata:  user.ErrTooManyOrgIDs,
 		},
 		{
-			name:            "containing-forward-slash",
-			headerValue:     strptr("forward/slash"),
-			errTenantID:     &errTenantIDUnsupportedCharacter{pos: 7, tenantID: "forward/slash"},
-			errTenantIDs:    &errTenantIDUnsupportedCharacter{pos: 7, tenantID: "forward/slash"},
-			errSubtenantID:  &errTenantIDUnsupportedCharacter{pos: 7, tenantID: "forward/slash"},
-			errSubtenantIDs: &errTenantIDUnsupportedCharacter{pos: 7, tenantID: "forward/slash"},
+			name:         "containing-forward-slash",
+			headerValue:  strptr("forward/slash"),
+			errTenantID:  &errTenantIDUnsupportedCharacter{pos: 7, tenantID: "forward/slash"},
+			errTenantIDs: &errTenantIDUnsupportedCharacter{pos: 7, tenantID: "forward/slash"},
+			errMetadata:  &errTenantIDUnsupportedCharacter{pos: 7, tenantID: "forward/slash"},
 		},
 		{
-			name:            "containing-backward-slash",
-			headerValue:     strptr(`backward\slash`),
-			errTenantID:     &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
-			errTenantIDs:    &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
-			errSubtenantID:  &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
-			errSubtenantIDs: &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
+			name:         "containing-backward-slash",
+			headerValue:  strptr(`backward\slash`),
+			errTenantID:  &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
+			errTenantIDs: &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
+			errMetadata:  &errTenantIDUnsupportedCharacter{pos: 8, tenantID: "backward\\slash"},
 		},
 		{
-			name:            "too-long",
-			headerValue:     strptr(strings.Repeat("123", MaxTenantIDLength)),
-			errTenantID:     errTenantIDTooLong,
-			errTenantIDs:    errTenantIDTooLong,
-			errSubtenantID:  errTenantIDTooLong,
-			errSubtenantIDs: errTenantIDTooLong,
+			name:         "too-long",
+			headerValue:  strptr(strings.Repeat("123", MaxTenantIDLength)),
+			errTenantID:  errTenantIDTooLong,
+			errTenantIDs: errTenantIDTooLong,
+			errMetadata:  errTenantIDTooLong,
 		},
-		// Subtenant test cases
+		// Metadata test cases
 		{
-			name:         "tenant-with-subtenant",
-			headerValue:  strptr("123456:k6"),
-			tenantID:     "123456",
-			tenantIDs:    []string{"123456"},
-			subtenantID:  "k6",
-			subtenantIDs: []string{"k6"},
+			name:        "tenant-with-metadata",
+			headerValue: strptr("123456:key=value"),
+			tenantID:    "123456",
+			tenantIDs:   []string{"123456"},
+			metadata:    Metadata{data: map[string]string{"key": "value"}},
 		},
 		{
-			name:         "tenant-with-subtenant-complex",
-			headerValue:  strptr("my-tenant-id:my-subtenant"),
-			tenantID:     "my-tenant-id",
-			tenantIDs:    []string{"my-tenant-id"},
-			subtenantID:  "my-subtenant",
-			subtenantIDs: []string{"my-subtenant"},
+			name:        "tenant-with-metadata-complex",
+			headerValue: strptr("my-tenant-id:product=k6"),
+			tenantID:    "my-tenant-id",
+			tenantIDs:   []string{"my-tenant-id"},
+			metadata:    Metadata{data: map[string]string{"product": "k6"}},
 		},
 		{
-			name:        "tenant-with-empty-subtenant",
+			name:        "tenant-with-empty-metadata",
 			headerValue: strptr("tenant-a:"),
 			tenantID:    "tenant-a",
 			tenantIDs:   []string{"tenant-a"},
-			subtenantID: "",
 		},
 		{
-			// TenantID/TenantIDs don't validate subtenant, only SubtenantID/SubtenantIDs do
-			name:            "invalid-subtenant-with-slash",
-			headerValue:     strptr("tenant-a:sub/tenant"),
-			tenantID:        "tenant-a",
-			tenantIDs:       []string{"tenant-a"},
-			errSubtenantID:  &errTenantIDUnsupportedCharacter{pos: 3, tenantID: "sub/tenant"},
-			errSubtenantIDs: &errTenantIDUnsupportedCharacter{pos: 3, tenantID: "sub/tenant"},
+			// TenantID/TenantIDs don't validate metadata, only ExtractWithMetadata does
+			name:        "invalid-metadata-with-slash",
+			headerValue: strptr("tenant-a:key/value"),
+			tenantID:    "tenant-a",
+			tenantIDs:   []string{"tenant-a"},
+			errMetadata: &errMetadataUnsupportedCharacter{pos: 3, metadata: "key/value"},
 		},
 		{
-			// TenantID/TenantIDs don't validate subtenant, only SubtenantID/SubtenantIDs do
-			name:            "invalid-subtenant-too-long",
-			headerValue:     strptr("tenant-a:" + strings.Repeat("x", MaxTenantIDLength+1)),
-			tenantID:        "tenant-a",
-			tenantIDs:       []string{"tenant-a"},
-			errSubtenantID:  errTenantIDTooLong,
-			errSubtenantIDs: errTenantIDTooLong,
+			// TenantID/TenantIDs don't validate metadata, only ExtractWithMetadata does
+			name:               "invalid-metadata-too-long",
+			headerValue:        strptr("tenant-a:" + strings.Repeat("x", MaxMetadataLength+1)),
+			tenantID:           "tenant-a",
+			tenantIDs:          []string{"tenant-a"},
+			errMetadataContain: "metadata too long",
 		},
 		{
-			// TenantID/TenantIDs don't validate subtenant, only SubtenantID/SubtenantIDs do
-			name:            "invalid-subtenant-parent-dir",
-			headerValue:     strptr("tenant-a:.."),
-			tenantID:        "tenant-a",
-			tenantIDs:       []string{"tenant-a"},
-			errSubtenantID:  errUnsafeTenantID,
-			errSubtenantIDs: errUnsafeTenantID,
+			// Metadata missing = separator
+			name:               "invalid-metadata-no-equals",
+			headerValue:        strptr("tenant-a:keyvalue"),
+			tenantID:           "tenant-a",
+			tenantIDs:          []string{"tenant-a"},
+			errMetadataContain: "invalid key value pair",
 		},
 		{
-			name:           "multi-tenant-with-subtenant",
-			headerValue:    strptr("tenant-a|tenant-b:k6"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"tenant-a", "tenant-b"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
-			subtenantIDs:   []string{"k6"},
+			name:        "multi-tenant-with-metadata",
+			headerValue: strptr("tenant-a|tenant-b:key=value"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 		{
-			// Multiple tenants with the same subtenant is supported.
-			name:           "multi-tenant-with-same-subtenant",
-			headerValue:    strptr("123123:k6|1234515:k6"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"123123", "1234515"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
-			subtenantIDs:   []string{"k6"},
+			// Multiple tenants with the same metadata is supported.
+			name:        "multi-tenant-with-same-metadata",
+			headerValue: strptr("123123:key=k6|1234515:key=k6"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"123123", "1234515"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 		{
-			// Multiple tenants with different subtenants.
-			name:           "multi-tenant-with-different-subtenants",
-			headerValue:    strptr("123123:k6|1234515:k7"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"123123", "1234515"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
-			subtenantIDs:   []string{"k6", "k7"},
+			// Multiple tenants with different metadata.
+			name:        "multi-tenant-with-different-metadata",
+			headerValue: strptr("123123:key=k6|1234515:key=k7"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"123123", "1234515"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 		{
-			// Mixed: some tenants with subtenant, some without.
-			name:           "multi-tenant-mixed-subtenant",
-			headerValue:    strptr("tenant-a|tenant-b:k6"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"tenant-a", "tenant-b"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
-			subtenantIDs:   []string{"k6"},
+			// Mixed: some tenants with metadata, some without.
+			name:        "multi-tenant-mixed-metadata",
+			headerValue: strptr("tenant-a|tenant-b:key=value"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 		{
-			// Each tenant has its own subtenant declaration but they're the same.
-			name:           "multi-tenant-each-with-same-subtenant",
-			headerValue:    strptr("tenant-a:k6|tenant-b:k6|tenant-c:k6"),
-			errTenantID:    user.ErrTooManyOrgIDs,
-			tenantIDs:      []string{"tenant-a", "tenant-b", "tenant-c"},
-			errSubtenantID: user.ErrTooManyOrgIDs,
-			subtenantIDs:   []string{"k6"},
+			name:        "tenant-with-multiple-metadata-pairs",
+			headerValue: strptr("tenant-a:env=prod:product=k6"),
+			tenantID:    "tenant-a",
+			tenantIDs:   []string{"tenant-a"},
+			metadata:    Metadata{data: map[string]string{"env": "prod", "product": "k6"}},
+		},
+		{
+			// Each tenant has its own metadata declaration but they're the same.
+			name:        "multi-tenant-each-with-same-metadata",
+			headerValue: strptr("tenant-a:key=k6|tenant-b:key=k6|tenant-c:key=k6"),
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b", "tenant-c"},
+			errMetadata: user.ErrTooManyOrgIDs,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -255,21 +238,16 @@ func TestTenantIDs(t *testing.T) {
 				assert.Equal(t, tc.tenantIDs, tenantIDs)
 			}
 
-			tenantIDFromSub, subtenantID, err := SubtenantID(ctx)
-			if tc.errSubtenantID != nil {
-				assert.Equal(t, tc.errSubtenantID, err)
+			tenantIDFromMeta, metadata, err := ExtractWithMetadata(ctx)
+			if tc.errMetadata != nil {
+				assert.Equal(t, tc.errMetadata, err)
+			} else if tc.errMetadataContain != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMetadataContain)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tc.tenantID, tenantIDFromSub)
-				assert.Equal(t, tc.subtenantID, subtenantID)
-			}
-
-			subtenantIDs, err := SubtenantIDs(ctx)
-			if tc.errSubtenantIDs != nil {
-				assert.Equal(t, tc.errSubtenantIDs, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.subtenantIDs, subtenantIDs)
+				assert.Equal(t, tc.tenantID, tenantIDFromMeta)
+				assert.Equal(t, tc.metadata, metadata)
 			}
 		})
 	}

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -14,13 +14,9 @@ import (
 const (
 	// MaxTenantIDLength is the max length of single tenant ID in bytes
 	MaxTenantIDLength = 150
+	MaxMetadataLength = 64
 
 	tenantIDsSeparator = '|'
-
-	// subtenantIDSeparator separates the tenant ID from the subtenant ID.
-	// The format is "tenantID:subtenantID" (e.g., "123456:k6").
-	// The colon is not a valid character in tenant IDs, making it safe to use as a separator.
-	subtenantIDSeparator = ':'
 )
 
 var (
@@ -98,12 +94,6 @@ func ValidTenantID(s string) error {
 	return nil
 }
 
-// ValidSubtenantID returns an error if the subtenant ID is invalid, nil otherwise.
-// Subtenant IDs follow the same rules as tenant IDs.
-func ValidSubtenantID(s string) error {
-	return ValidTenantID(s)
-}
-
 // JoinTenantIDs returns all tenant IDs concatenated with the separator character `|`
 func JoinTenantIDs(tenantIDs []string) string {
 	return strings.Join(tenantIDs, string(tenantIDsSeparator))
@@ -134,19 +124,19 @@ func TenantIDsFromOrgID(orgID string) ([]string, error) {
 	return TenantIDs(user.InjectOrgID(context.TODO(), orgID))
 }
 
-func trimSubtenantID(orgID string) string {
-	idx := strings.IndexByte(orgID, subtenantIDSeparator)
+func trimMetadata(orgID string) string {
+	idx := strings.IndexByte(orgID, metadataSeparator)
 	if idx == -1 {
 		return orgID
 	}
 	return orgID[:idx]
 }
 
-// splitTenantAndSubtenant splits an orgID into tenant ID and subtenant ID.
-// If the orgID contains no subtenant separator, the subtenant will be empty.
-// The format is "tenantID:subtenantID" (e.g., "123456:k6").
-func splitTenantAndSubtenant(orgID string) (tenantID, subtenantID string) {
-	idx := strings.IndexByte(orgID, subtenantIDSeparator)
+// splitTenantAndMetadata splits an orgID into tenant ID and metadata.
+// If the orgID contains no metadata separator, the metadata string will be empty.
+// The format is "tenantID:key=value" (e.g., "123456:product=k6").
+func splitTenantAndMetadata(orgID string) (tenantID, metadata string) {
+	idx := strings.IndexByte(orgID, metadataSeparator)
 	if idx == -1 {
 		return orgID, ""
 	}

--- a/tenant/tenant_test.go
+++ b/tenant/tenant_test.go
@@ -72,29 +72,29 @@ func BenchmarkTenantID(b *testing.B) {
 	})
 }
 
-func BenchmarkSubtenantID(b *testing.B) {
+func BenchmarkExtractWithMetadata(b *testing.B) {
 	singleCtx := context.Background()
-	singleCtx = user.InjectOrgID(singleCtx, "tenant-a:k6")
-	singleNoSubCtx := context.Background()
-	singleNoSubCtx = user.InjectOrgID(singleNoSubCtx, "tenant-a")
+	singleCtx = user.InjectOrgID(singleCtx, "tenant-a:key=value")
+	singleNoMetaCtx := context.Background()
+	singleNoMetaCtx = user.InjectOrgID(singleNoMetaCtx, "tenant-a")
 	multiCtx := context.Background()
-	multiCtx = user.InjectOrgID(multiCtx, "tenant-a:k6|tenant-a:k6")
+	multiCtx = user.InjectOrgID(multiCtx, "tenant-a:key=value|tenant-a:key=value")
 
 	b.ResetTimer()
 	b.ReportAllocs()
-	b.Run("single-with-subtenant", func(b *testing.B) {
+	b.Run("single-with-metadata", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _, _ = SubtenantID(singleCtx)
+			_, _, _ = ExtractWithMetadata(singleCtx)
 		}
 	})
-	b.Run("single-no-subtenant", func(b *testing.B) {
+	b.Run("single-no-metadata", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _, _ = SubtenantID(singleNoSubCtx)
+			_, _, _ = ExtractWithMetadata(singleNoMetaCtx)
 		}
 	})
 	b.Run("multi-same-tenant", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _, _ = SubtenantID(multiCtx)
+			_, _, _ = ExtractWithMetadata(multiCtx)
 		}
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core tenant identification/parsing logic and removes the prior subtenant API surface, which could affect callers and request routing if any edge cases or integrations relied on the old format.
> 
> **Overview**
> Adds a new `Metadata` type with parsing/validation utilities (including length limits and deterministic encoding via `WithTenant`) to support `tenantID:key=value(:k=v...)` identifiers.
> 
> Updates tenant resolution to **strip metadata for backward-compatible `TenantID`/`TenantIDs`**, and replaces subtenant APIs with `ExtractWithMetadata`/`ParseWithMetadata` that validate and parse metadata while enforcing single-orgID consistency. Tests and benchmarks are updated accordingly, and subtenant-related constants/helpers/interfaces are removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 426308fc9c8e5f1d5feff6373750ccd21b120415. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->