### PR TITLE
feat: add command line flags for gRPC server read and write buffer sizes.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -142,6 +142,8 @@ type Config struct {
 	GRPCServerNumWorkers               int           `yaml:"grpc_server_num_workers"`
 	GRPCServerStatsTrackingEnabled     bool          `yaml:"grpc_server_stats_tracking_enabled"`
 	GRPCServerRecvBufferPoolsEnabled   bool          `yaml:"grpc_server_recv_buffer_pools_enabled"`
+	GRPCServerReadBufferSize           int           `yaml:"grpc_server_read_buffer_size"`
+	GRPCServerWriteBufferSize          int           `yaml:"grpc_server_write_buffer_size"`
 
 	LogFormat                    string           `yaml:"log_format"`
 	LogLevel                     log.Level        `yaml:"log_level"`
@@ -230,6 +232,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.GRPCServerStatsTrackingEnabled, "server.grpc.stats-tracking-enabled", true, "If true, the request_message_bytes, response_message_bytes, and inflight_requests metrics will be tracked. Enabling this option prevents the use of memory pools for parsing gRPC request bodies and may lead to more memory allocations.")
 	f.BoolVar(&cfg.GRPCServerRecvBufferPoolsEnabled, "server.grpc.recv-buffer-pools-enabled", false, "Deprecated option, has no effect and will be removed in a future version.")
 	f.IntVar(&cfg.GRPCServerNumWorkers, "server.grpc.num-workers", 0, "If non-zero, configures the amount of GRPC server workers used to serve the requests.")
+	f.IntVar(&cfg.GRPCServerReadBufferSize, "server.grpc.read-buffer-size-bytes", 32*1024, "Size of the read buffer for each gRPC connection (bytes). A smaller buffer may reduce memory usage but may lead to more system calls.")
+	f.IntVar(&cfg.GRPCServerWriteBufferSize, "server.grpc.write-buffer-size-bytes", 32*1024, "Size of the write buffer for each gRPC connection (bytes). A smaller buffer may reduce memory usage but may lead to more system calls.")
 	f.StringVar(&cfg.PathPrefix, "server.path-prefix", "", "Base path to serve all API routes from (e.g. /v1/)")
 	f.StringVar(&cfg.LogFormat, "log.format", log.LogfmtFormat, "Output log messages in the given format. Valid formats: [logfmt, json]")
 	cfg.LogLevel.RegisterFlags(f)
@@ -497,6 +501,8 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		grpc.MaxSendMsgSize(cfg.GRPCServerMaxSendMsgSize),
 		grpc.MaxConcurrentStreams(uint32(cfg.GRPCServerMaxConcurrentStreams)),
 		grpc.NumStreamWorkers(uint32(cfg.GRPCServerNumWorkers)),
+		grpc.ReadBufferSize(cfg.GRPCServerReadBufferSize),
+		grpc.WriteBufferSize(cfg.GRPCServerWriteBufferSize),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds two startup flags:
* `-server.grpc.read-buffer-size-bytes`
* `-server.grpc.write-buffer-size-bytes`

These control the size of the gRPC server's read and write buffers. They use the same default of 32KiB as set by the grpc-go library. This allows gRPC server applications to configure these at will.

**Checklist**
- (n/a) Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 6fad5dd10f43d12df224f3488272473a057136c5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->