### PR TITLE
fix(middleware): resolve TOCTOU race in httpConnectionTTLMiddleware

### DIFF
--- a/middleware/http_connection_ttl_middleware_test.go
+++ b/middleware/http_connection_ttl_middleware_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -330,6 +332,47 @@ func TestHTTPConnectionTTLMiddleware_RemoveIdleExpiredConnectionsKeepsActiveConn
 	}, 2*maxTTL, idleCheckFrequency)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), metricNames...))
+}
+
+func TestHTTPConnectionTTLMiddleware_ConcurrentRemoveExpiredConnection(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewHTTPConnectionTTLMiddleware(1*time.Millisecond, 1*time.Millisecond, 1*time.Second, reg)
+	require.NoError(t, err)
+
+	rpcMiddleware, ok := m.(*httpConnectionTTLMiddleware)
+	require.True(t, ok)
+
+	// Seed the connection so it gets tracked.
+	removed := rpcMiddleware.removeExpiredConnection(conn1)
+	require.False(t, removed)
+
+	// Wait for the connection to expire.
+	time.Sleep(10 * time.Millisecond)
+
+	// Concurrently call removeExpiredConnection; exactly one should report removal.
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	var removedCount atomic.Int64
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			if rpcMiddleware.removeExpiredConnection(conn1) {
+				removedCount.Inc()
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(1), removedCount.Load(), "expected exactly 1 goroutine to report the connection as removed")
+
+	// Exactly 1 close should be recorded, regardless of concurrency.
+	expectedMetrics := `
+		# HELP closed_connections_with_ttl_total Number of connections that connection with TTL middleware closed or stopped tracking
+		# TYPE closed_connections_with_ttl_total counter
+		closed_connections_with_ttl_total{reason="limit"} 1
+	`
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "closed_connections_with_ttl_total"))
 }
 
 func checkHTTPConnectionTTL(t *testing.T, m Interface, conn string, shouldConnBeActive bool) bool {


### PR DESCRIPTION
**What this PR does**:

`removeExpiredConnection` had a time-of-check-time-of-use race: `connectionState()` acquired and released the lock, then `isExpired()` was checked without the lock held, and the lock was re-acquired to `delete()`. This gap allowed:

- **Metric double-counting**: Two concurrent requests from the same expired connection both see `isExpired() == true`, both delete, both increment the counter.
- **Phantom re-creation**: Background idle cleanup deletes an entry, then `connectionState()` re-creates it with a fresh TTL, causing the connection to escape TTL enforcement.

The fix inlines the `connectionState` logic into `removeExpiredConnection` so that lookup, expiry check, and delete all happen under a single lock hold. The now-unused `connectionState` method is removed.

**Which issue(s) this PR fixes**:

Fixes #906

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized locking/metrics change plus a new test; behavior should be safer under concurrency, with low chance of unintended side effects outside TTL tracking.
> 
> **Overview**
> Fixes a TOCTOU race in `httpConnectionTTLMiddleware.removeExpiredConnection` by performing connection creation, last-seen updates, expiry checks, and deletion under a single mutex hold, preventing double-deletes/metric double-counting and avoiding re-creating entries after eviction.
> 
> Removes the now-redundant `connectionState` helper and adds `TestHTTPConnectionTTLMiddleware_ConcurrentRemoveExpiredConnection` to assert only one concurrent caller reports removal and the `closed_connections_with_ttl_total{reason="limit"}` metric increments once.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38e6a34c5bc3eda9d9172ecf1562c2ca84f2dcfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->