### PR TITLE
fix(middleware): accept context.Context for goroutine lifecycle in httpConnectionTTLMiddleware

### DIFF
--- a/middleware/http_connection_ttl_middleware_test.go
+++ b/middleware/http_connection_ttl_middleware_test.go
@@ -66,7 +66,7 @@ func TestNewHTTPConnectionTTLMiddleware(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			m, err := NewHTTPConnectionTTLMiddleware(tc.minTTL, tc.maxTTL, tc.idleConnectionCheckFrequency, prometheus.NewRegistry())
+			m, err := NewHTTPConnectionTTLMiddleware(t.Context(), tc.minTTL, tc.maxTTL, tc.idleConnectionCheckFrequency, prometheus.NewRegistry())
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
 				require.NotNil(t, m)
@@ -113,7 +113,7 @@ func TestHTTPConnectionTTLMiddleware_CalculateTTL(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			reg := prometheus.NewRegistry()
-			m, err := NewHTTPConnectionTTLMiddleware(tc.minTTL, tc.maxTTL, time.Second, reg)
+			m, err := NewHTTPConnectionTTLMiddleware(t.Context(), tc.minTTL, tc.maxTTL, time.Second, reg)
 			require.NoError(t, err)
 			require.NotNil(t, m)
 
@@ -182,7 +182,7 @@ func TestHTTPConnectionTTLMiddleware_Wrap(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			reg := prometheus.NewRegistry()
 			// create request per connection limiter middleware
-			m, err := NewHTTPConnectionTTLMiddleware(tc.minTTL, tc.maxTTL, 1*time.Second, reg)
+			m, err := NewHTTPConnectionTTLMiddleware(t.Context(), tc.minTTL, tc.maxTTL, 1*time.Second, reg)
 			require.NoError(t, err)
 
 			// declare default handler
@@ -225,7 +225,7 @@ func TestHTTPConnectionTTLMiddleware_RemoveIdleExpiredConnections(t *testing.T) 
 		closed_connections_with_ttl_total{reason="idle timeout"} 1
 	`
 	reg := prometheus.NewRegistry()
-	m, err := NewHTTPConnectionTTLMiddleware(1*time.Second, 2*time.Second, idleConnectionCheckFrequency, reg)
+	m, err := NewHTTPConnectionTTLMiddleware(t.Context(), 1*time.Second, 2*time.Second, idleConnectionCheckFrequency, reg)
 	require.NoError(t, err)
 
 	// declare default handler
@@ -273,7 +273,7 @@ func TestHTTPConnectionTTLMiddleware_RemoveIdleExpiredConnectionsKeepsActiveConn
 	`
 
 	reg := prometheus.NewRegistry()
-	m, err := NewHTTPConnectionTTLMiddleware(minTTL, maxTTL, idleCheckFrequency, reg)
+	m, err := NewHTTPConnectionTTLMiddleware(t.Context(), minTTL, maxTTL, idleCheckFrequency, reg)
 	require.NoError(t, err)
 
 	rpcMiddleware, ok := m.(*httpConnectionTTLMiddleware)


### PR DESCRIPTION
**What this PR does**:

`NewHTTPConnectionTTLMiddleware` returns `middleware.Interface` (which only has `Wrap()`), but the `Stop()` method for shutting down the background goroutine was only on the unexported concrete type. Callers outside the package could not stop the goroutine without an impossible type assertion.

This replaces the `done` channel and `Stop()` method with a caller-provided `context.Context`. The background goroutine stops when the context is cancelled. This is idiomatic Go and removes the need for a separate cleanup method.

Changes:
- Add `ctx context.Context` as the first parameter of `NewHTTPConnectionTTLMiddleware`
- Remove `done` and `ticker` fields from the struct (ticker is now a local variable in the goroutine)
- The goroutine selects on `ctx.Done()` instead of `m.done`
- Remove the `Stop()` method entirely

**Which issue(s) this PR fixes**:

Fixes #912 and #913

**Checklist**
- [x] Tests updated


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized API change to middleware construction and goroutine shutdown; behavior is otherwise unchanged aside from requiring callers to provide/cancel a context.
> 
> **Overview**
> Updates `NewHTTPConnectionTTLMiddleware` to take a caller-provided `context.Context` and uses `ctx.Done()` to stop the idle-connection cleanup goroutine.
> 
> Removes the internal `ticker`/`done` fields and the concrete-type `Stop()` method (which wasn’t reachable via the exported `middleware.Interface`), and updates tests to pass `t.Context()` when constructing the middleware.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4983d4f5e042999ee23ebfad576d64b170f13e11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->