### PR TITLE
fix: start memberlist propagation delay tracker after joining memberlist

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -604,21 +604,6 @@ func (m *KV) starting(ctx context.Context) error {
 	}
 	m.delegateReady.Store(true)
 
-	// Start propagation delay tracker if enabled.
-	if m.cfg.PropagationDelayTracker.Enabled {
-		m.propagationDelayTracker = NewPropagationDelayTracker(
-			m,
-			m.cfg.PropagationDelayTracker,
-			m.memberlist.LocalNode().Name,
-			m.logger,
-			m.registerer,
-		)
-		if err := m.propagationDelayTracker.StartAsync(ctx); err != nil {
-			level.Warn(m.logger).Log("msg", "failed to start propagation delay tracker", "err", err)
-			m.propagationDelayTracker = nil
-		}
-	}
-
 	// Try to fast-join memberlist cluster in Starting state, so that we don't start with empty KV store.
 	if len(m.cfg.JoinMembers) > 0 {
 		if err := m.fastJoinMembersOnStartup(ctx); err != nil {
@@ -649,6 +634,22 @@ func (m *KV) running(ctx context.Context) error {
 	ok := m.joinMembersOnStartup(ctx)
 	if !ok && m.cfg.AbortIfJoinFails {
 		return errFailedToJoinCluster
+	}
+
+	// Start propagation delay tracker after joining the cluster, so that the first
+	// WatchKey callback has the full cluster state and correctly skips pre-existing beacons.
+	if m.cfg.PropagationDelayTracker.Enabled {
+		m.propagationDelayTracker = NewPropagationDelayTracker(
+			m,
+			m.cfg.PropagationDelayTracker,
+			m.memberlist.LocalNode().Name,
+			m.logger,
+			m.registerer,
+		)
+		if err := m.propagationDelayTracker.StartAsync(ctx); err != nil {
+			level.Warn(m.logger).Log("msg", "failed to start propagation delay tracker", "err", err)
+			m.propagationDelayTracker = nil
+		}
 	}
 
 	var tickerChan <-chan time.Time


### PR DESCRIPTION
**What this PR does**:

The propagation delay tracker was starting in `KV.starting()` while the memberlist cluster join was running. This can cause the first `WatchKey` callback to fire with empty or partial state, during rollouts.

In this PR, I'm moving the tracker startup to `KV.running()` after `joinMembersOnStartup()` completes, to increase the chances that the first callback has the full cluster state.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated
