### PR TITLE
fix(middleware): reset idleExpired flag on active requests

### DIFF
--- a/middleware/http_connection_ttl_middleware.go
+++ b/middleware/http_connection_ttl_middleware.go
@@ -141,7 +141,8 @@ func (m *httpConnectionTTLMiddleware) removeIdleExpiredConnections() {
 }
 
 // removeExpiredConnection checks if the given connection expired, and in that case removes it from the cache.
-// If the connection is not yet tracked, it creates a new entry. If it exists and is not expired, it updates lastSeen.
+// If the connection is not yet tracked, it creates a new entry. If it exists and is not expired, it updates lastSeen
+// and resets the idleExpired flag (preventing a subsequent idle cleanup pass from deleting the entry).
 // Returns a boolean indicating if the given connection has been removed.
 func (m *httpConnectionTTLMiddleware) removeExpiredConnection(conn string) bool {
 	now := time.Now()
@@ -160,6 +161,7 @@ func (m *httpConnectionTTLMiddleware) removeExpiredConnection(conn string) bool 
 	}
 	if !state.isExpired() {
 		state.lastSeen = now
+		state.idleExpired = false
 		m.connectionsMu.Unlock()
 		return false
 	}

--- a/middleware/http_connection_ttl_middleware_test.go
+++ b/middleware/http_connection_ttl_middleware_test.go
@@ -443,6 +443,50 @@ func TestHTTPConnectionTTLMiddleware_IdleCleanupThenRequest(t *testing.T) {
 
 		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), metricNames...))
 	})
+
+	// Test case: Request arrives before TTL expires, idleExpired should be reset.
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			minTTL = 500 * time.Millisecond
+			maxTTL = 500 * time.Millisecond
+		)
+
+		reg := prometheus.NewRegistry()
+		m, err := NewHTTPConnectionTTLMiddleware(minTTL, maxTTL, 10*time.Second, reg)
+		require.NoError(t, err)
+		t.Cleanup(m.Stop)
+
+		rpcMiddleware := m.(*httpConnectionTTLMiddleware)
+
+		hnd := m.Wrap(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+		}))
+
+		// Send first request to register the connection.
+		w := httptest.NewRecorder()
+		req, err := createRequestWith(t.Context(), http.MethodGet, "/", conn1)
+		require.NoError(t, err)
+		hnd.ServeHTTP(w, req)
+
+		// Directly set idleExpired to simulate a previous cleanup pass.
+		rpcMiddleware.connectionsMu.Lock()
+		state := rpcMiddleware.connections[conn1]
+		require.NotNil(t, state)
+		state.idleExpired = true
+		rpcMiddleware.connectionsMu.Unlock()
+
+		// Send another request - TTL hasn't expired yet.
+		w = httptest.NewRecorder()
+		req, err = createRequestWith(t.Context(), http.MethodGet, "/", conn1)
+		require.NoError(t, err)
+		hnd.ServeHTTP(w, req)
+		require.NotEqual(t, connectionHeaderCloseValue, w.Header().Get(connectionHeaderKey))
+
+		// Verify idleExpired was reset by the request.
+		rpcMiddleware.connectionsMu.Lock()
+		require.False(t, rpcMiddleware.connections[conn1].idleExpired, "idleExpired should be reset after request")
+		rpcMiddleware.connectionsMu.Unlock()
+	})
 }
 
 func checkHTTPConnectionTTL(t *testing.T, m Interface, conn string, shouldConnBeActive bool) bool {


### PR DESCRIPTION
**What this PR does**:

Resets the `idleExpired` flag when a request arrives on a connection whose TTL hasn't expired yet. Without this fix, a connection marked as idle by a cleanup pass would be incorrectly deleted on the next cleanup pass even if requests continued to arrive.

The fix adds `state.idleExpired = false` in `removeExpiredConnection` when updating `lastSeen`, ensuring active connections survive idle cleanup.

**Checklist**
- [x] Tests updated