### PR TITLE
feat(runtimeconfig): support loading config from HTTP URLs

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -66,11 +66,10 @@ type Manager struct {
 	configLoadSuccess prometheus.Gauge
 	configHash        *prometheus.GaugeVec
 
-	// Maps path to hash. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
+	// Maps provider name to hash. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
 	fileHashes map[string]string
 
-	fileProvider *fileProvider
-	httpProvider *httpProvider // nil if no URL paths are configured
+	providers []provider
 }
 
 // New creates an instance of Manager. Manager is a services.Service, and must be explicitly started to perform any work.
@@ -91,18 +90,24 @@ func New(cfg Config, configName string, registerer prometheus.Registerer, logger
 			Name: "runtime_config_hash",
 			Help: "Hash of the currently active runtime configuration, merged from all configured files.",
 		}, []string{"sha256"}),
-		logger:       logger,
-		fileProvider: &fileProvider{},
+		logger: logger,
 	}
 
+	var httpClient *http.Client
+	var httpDuration *prometheus.HistogramVec
 	for _, p := range cfg.LoadPath {
 		if isURL(p) {
-			timeout := cfg.HTTPClientTimeout
-			if timeout == 0 {
-				timeout = 30 * time.Second
+			if httpClient == nil {
+				timeout := cfg.HTTPClientTimeout
+				if timeout == 0 {
+					timeout = 30 * time.Second
+				}
+				httpClient = &http.Client{Timeout: timeout}
+				httpDuration = newHTTPRequestDuration(registerer)
 			}
-			mgr.httpProvider = newHTTPProvider(&http.Client{Timeout: timeout}, registerer)
-			break
+			mgr.providers = append(mgr.providers, newHTTPProvider(p, httpClient, httpDuration))
+		} else {
+			mgr.providers = append(mgr.providers, newFileProvider(p))
 		}
 	}
 
@@ -172,42 +177,35 @@ func (om *Manager) loop(ctx context.Context) error {
 	}
 }
 
-func (om *Manager) readPath(ctx context.Context, path string) ([]byte, error) {
-	if isURL(path) {
-		return om.httpProvider.Read(ctx, path)
-	}
-	return om.fileProvider.Read(ctx, path)
-}
-
 // loadConfig loads all configuration files using the loader function then merges the yaml configuration files into one yaml document.
 // and notifies listeners if successful.
 func (om *Manager) loadConfig(ctx context.Context) error {
-	rawData := map[string][]byte{}
+	rawData := make([][]byte, len(om.providers))
 	hashes := map[string]string{}
 
-	for _, f := range om.cfg.LoadPath {
-		buf, err := om.readPath(ctx, f)
+	for i, p := range om.providers {
+		buf, err := p.Read(ctx)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
-			return errors.Wrapf(err, "read %q", f)
+			return errors.Wrapf(err, "read %q", p.Name())
 		}
 
 		if om.cfg.Preprocessor != nil {
 			buf, err = om.cfg.Preprocessor(buf)
 			if err != nil {
 				om.configLoadSuccess.Set(0)
-				return errors.Wrapf(err, "preprocess file %q", f)
+				return errors.Wrapf(err, "preprocess %q", p.Name())
 			}
 		}
 
-		rawData[f] = buf
-		hashes[f] = fmt.Sprintf("%x", sha256.Sum256(buf))
+		rawData[i] = buf
+		hashes[p.Name()] = fmt.Sprintf("%x", sha256.Sum256(buf))
 	}
 
 	// check if new hashes are the same as before
 	sameHashes := true
-	for f, h := range hashes {
-		if om.fileHashes[f] != h {
+	for name, h := range hashes {
+		if om.fileHashes[name] != h {
 			sameHashes = false
 			break
 		}
@@ -220,17 +218,17 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 	}
 
 	mergedConfig := map[string]interface{}{}
-	for i, f := range om.cfg.LoadPath {
-		data := rawData[f]
-		yamlFile, err := om.unmarshalMaybeGzipped(f, data)
+	for i, p := range om.providers {
+		data := rawData[i]
+		yamlFile, err := om.unmarshalMaybeGzipped(p.Name(), data)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
-			return errors.Wrapf(err, "unmarshal file %q", f)
+			return errors.Wrapf(err, "unmarshal %q", p.Name())
 		}
 		mergedConfig, err = mergeConfigMaps(mergedConfig, yamlFile, "")
 		if err != nil {
 			om.configLoadSuccess.Set(0)
-			return errors.Wrapf(err, "can't merge file %q on top of the previous %#v", f, om.cfg.LoadPath[:i])
+			return errors.Wrapf(err, "can't merge %q on top of the previous providers", p.Name())
 		}
 	}
 

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -8,7 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -35,17 +35,19 @@ type Loader func(r io.Reader) (interface{}, error)
 // It holds config related to loading per-tenant config.
 type Config struct {
 	ReloadPeriod time.Duration `yaml:"period" category:"advanced"`
-	// LoadPath contains the path to the runtime config files.
+	// LoadPath contains the path to the runtime config files or HTTP URLs.
 	// Requires a non-empty value
-	LoadPath     flagext.StringSliceCSV `yaml:"file"`
-	Preprocessor Preprocessor           `yaml:"-"`
-	Loader       Loader                 `yaml:"-"`
+	LoadPath          flagext.StringSliceCSV `yaml:"file"`
+	HTTPClientTimeout time.Duration          `yaml:"http_client_timeout" category:"advanced"`
+	Preprocessor      Preprocessor           `yaml:"-"`
+	Loader            Loader                 `yaml:"-"`
 }
 
 // RegisterFlags registers flags.
 func (mc *Config) RegisterFlags(f *flag.FlagSet) {
-	f.Var(&mc.LoadPath, "runtime-config.file", "Comma separated list of yaml files with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
+	f.Var(&mc.LoadPath, "runtime-config.file", "Comma separated list of yaml files or URLs with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
 	f.DurationVar(&mc.ReloadPeriod, "runtime-config.reload-period", 10*time.Second, "How often to check runtime config files.")
+	f.DurationVar(&mc.HTTPClientTimeout, "runtime-config.http-client-timeout", 30*time.Second, "HTTP client timeout when fetching runtime config from URLs.")
 }
 
 // Manager periodically reloads the configuration from specified files, and keeps this
@@ -66,6 +68,9 @@ type Manager struct {
 
 	// Maps path to hash. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
 	fileHashes map[string]string
+
+	fileProvider *fileProvider
+	httpProvider *httpProvider // nil if no URL paths are configured
 }
 
 // New creates an instance of Manager. Manager is a services.Service, and must be explicitly started to perform any work.
@@ -86,19 +91,31 @@ func New(cfg Config, configName string, registerer prometheus.Registerer, logger
 			Name: "runtime_config_hash",
 			Help: "Hash of the currently active runtime configuration, merged from all configured files.",
 		}, []string{"sha256"}),
-		logger: logger,
+		logger:       logger,
+		fileProvider: &fileProvider{},
+	}
+
+	for _, p := range cfg.LoadPath {
+		if isURL(p) {
+			timeout := cfg.HTTPClientTimeout
+			if timeout == 0 {
+				timeout = 30 * time.Second
+			}
+			mgr.httpProvider = newHTTPProvider(&http.Client{Timeout: timeout}, registerer)
+			break
+		}
 	}
 
 	mgr.Service = services.NewBasicService(mgr.starting, mgr.loop, mgr.stopping)
 	return &mgr, nil
 }
 
-func (om *Manager) starting(_ context.Context) error {
+func (om *Manager) starting(ctx context.Context) error {
 	if len(om.cfg.LoadPath) == 0 {
 		return nil
 	}
 
-	return errors.Wrap(om.loadConfig(), "failed to load runtime config")
+	return errors.Wrap(om.loadConfig(ctx), "failed to load runtime config")
 }
 
 // CreateListenerChannel creates new channel that can be used to receive new config values.
@@ -144,7 +161,7 @@ func (om *Manager) loop(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-			err := om.loadConfig()
+			err := om.loadConfig(ctx)
 			if err != nil {
 				// Log but don't stop on error - we don't want to halt all ingesters because of a typo
 				level.Error(om.logger).Log("msg", "failed to load config", "err", err)
@@ -155,17 +172,24 @@ func (om *Manager) loop(ctx context.Context) error {
 	}
 }
 
+func (om *Manager) readPath(ctx context.Context, path string) ([]byte, error) {
+	if isURL(path) {
+		return om.httpProvider.Read(ctx, path)
+	}
+	return om.fileProvider.Read(ctx, path)
+}
+
 // loadConfig loads all configuration files using the loader function then merges the yaml configuration files into one yaml document.
 // and notifies listeners if successful.
-func (om *Manager) loadConfig() error {
+func (om *Manager) loadConfig(ctx context.Context) error {
 	rawData := map[string][]byte{}
 	hashes := map[string]string{}
 
 	for _, f := range om.cfg.LoadPath {
-		buf, err := os.ReadFile(f)
+		buf, err := om.readPath(ctx, f)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
-			return errors.Wrapf(err, "read file %q", f)
+			return errors.Wrapf(err, "read %q", f)
 		}
 
 		if om.cfg.Preprocessor != nil {

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -469,7 +469,7 @@ func TestOverridesManagerFailingPreprocessor(t *testing.T) {
 	require.NoError(t, err)
 	err = services.StartAndAwaitRunning(context.Background(), overridesManager)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "preprocess file")
+	require.Contains(t, err.Error(), "preprocess")
 	require.Contains(t, err.Error(), "some preprocessor error")
 }
 

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -658,20 +659,21 @@ func TestManager_ReloadMetricAfterBadConfigRecovery(t *testing.T) {
 
 	reloadPeriod := 100 * time.Millisecond
 
-	managerConfig := Config{
-		ReloadPeriod: reloadPeriod,
-		LoadPath:     []string{tempFile.Name()},
-		Loader:       testLoadOverrides,
-	}
+	synctest.Test(t, func(t *testing.T) {
+		managerConfig := Config{
+			ReloadPeriod: reloadPeriod,
+			LoadPath:     []string{tempFile.Name()},
+			Loader:       testLoadOverrides,
+		}
 
-	reg := prometheus.NewPedanticRegistry()
+		reg := prometheus.NewPedanticRegistry()
 
-	manager, err := New(managerConfig, "overrides", reg, log.NewNopLogger())
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+		manager, err := New(managerConfig, "overrides", reg, log.NewNopLogger())
+		require.NoError(t, err)
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
 
-	assertHashAndSuccessMetric := func(config []byte, lastSuccessful int) {
-		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+		assertHashAndSuccessMetric := func(config []byte, lastSuccessful int) {
+			assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP runtime_config_hash Hash of the currently active runtime configuration, merged from all configured files.
 					# TYPE runtime_config_hash gauge
 					runtime_config_hash{config="overrides", sha256="%s"} 1
@@ -679,62 +681,70 @@ func TestManager_ReloadMetricAfterBadConfigRecovery(t *testing.T) {
 					# TYPE runtime_config_last_reload_successful gauge
 					runtime_config_last_reload_successful{config="overrides"} %d
 				`, fmt.Sprintf("%x", sha256.Sum256(config)), lastSuccessful))))
+		}
 
-	}
+		// Now success metric should be 1
+		assertHashAndSuccessMetric(validConfig, 1)
 
-	// Now success metric should be 1
-	assertHashAndSuccessMetric(validConfig, 1)
+		// Make config invalid. Now metrics should be 0
+		invalidConfig := []byte("invalid")
+		err = os.WriteFile(tempFile.Name(), invalidConfig, 0600)
+		require.NoError(t, err)
 
-	// Make config invalid. Now metrics should be 0
-	invalidConfig := []byte("invalid")
-	err = os.WriteFile(tempFile.Name(), invalidConfig, 0600)
-	require.NoError(t, err)
+		time.Sleep(2 * reloadPeriod)
+		synctest.Wait()
+		assertHashAndSuccessMetric(validConfig, 0)
 
-	time.Sleep(2 * reloadPeriod)
-	assertHashAndSuccessMetric(validConfig, 0)
+		// Revert config to good state. Make sure it has same hash as before.
+		err = os.WriteFile(tempFile.Name(), validConfig, 0600)
+		require.NoError(t, err)
 
-	// Revert config to good state. Make sure it has same hash as before.
-	err = os.WriteFile(tempFile.Name(), validConfig, 0600)
-	require.NoError(t, err)
+		time.Sleep(2 * reloadPeriod)
+		synctest.Wait()
 
-	time.Sleep(2 * reloadPeriod)
+		// Now success metric should be back to 1.
+		assertHashAndSuccessMetric(validConfig, 1)
 
-	// Now success metric should be back to 1.
-	assertHashAndSuccessMetric(validConfig, 1)
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager))
+	})
 }
 
 func TestManager_UnchangedFileDoesntTriggerReload(t *testing.T) {
-	loadCounter := atomic.NewInt32(0)
+	reloadPeriod := 100 * time.Millisecond
 
-	cfg := newTestOverridesManagerConfig(t, 100*time.Millisecond, func(reader io.Reader) (interface{}, error) {
-		loadCounter.Inc()
-		return valueLoader(reader)
+	cfg := newTestOverridesManagerConfig(t, reloadPeriod, nil)
+
+	synctest.Test(t, func(t *testing.T) {
+		loadCounter := atomic.NewInt32(0)
+		cfg.Loader = func(reader io.Reader) (interface{}, error) {
+			loadCounter.Inc()
+			return valueLoader(reader)
+		}
+
+		overridesManager, err := New(cfg, "overrides", nil, log.NewNopLogger())
+		require.NoError(t, err)
+
+		ch := overridesManager.CreateListenerChannel(10) // must be big enough to hold all modifications.
+
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
+
+		time.Sleep(reloadPeriod + time.Millisecond)
+		synctest.Wait()
+		require.Equal(t, int32(1), loadCounter.Load())
+
+		// Let's make some modifications to the config
+		const mods = 3
+		for i := 0; i < mods; i++ {
+			writeValueToFile(t, cfg.LoadPath[0], value{Value: i})
+			time.Sleep(reloadPeriod + time.Millisecond)
+			synctest.Wait()
+		}
+
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
+
+		assert.Equal(t, mods+1, int(loadCounter.Load())) // + 1 for initial load, before modifications
+		assert.Equal(t, mods+1, len(ch))                 // Loaded values
 	})
-
-	overridesManager, err := New(cfg, "overrides", nil, log.NewNopLogger())
-	require.NoError(t, err)
-
-	ch := overridesManager.CreateListenerChannel(10) // must be big enough to hold all modifications.
-
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
-
-	test.Poll(t, time.Second, 1, func() interface{} {
-		return int(loadCounter.Load())
-	})
-
-	// Let's make some modifications to the config
-	const mods = 3
-	const modDelay = 500 * time.Millisecond
-	for i := 0; i < mods; i++ {
-		writeValueToFile(t, cfg.LoadPath[0], value{Value: i})
-		// wait before next rewrite, but also after last rewrite to give manager a chance to reload the file again
-		time.Sleep(modDelay)
-	}
-
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
-
-	assert.Equal(t, mods+1, int(loadCounter.Load())) // + 1 for initial load, before modifications
-	assert.Equal(t, mods+1, len(ch))                 // Loaded values
 }
 
 func TestManager_GetConfigNilBeforeStarting(t *testing.T) {
@@ -830,17 +840,16 @@ func TestManager_URLPathReloadFailure(t *testing.T) {
 	statusCode = http.StatusInternalServerError
 	mu.Unlock()
 
-	time.Sleep(3 * reloadPeriod)
-
-	// Config should still be the old value.
-	require.Equal(t, value{Value: 42}, manager.GetConfig())
-
-	// The reload success metric should be 0.
-	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+	test.Poll(t, 5*time.Second, nil, func() interface{} {
+		return testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
 		# TYPE runtime_config_last_reload_successful gauge
 		runtime_config_last_reload_successful{config="overrides"} 0
-	`), "runtime_config_last_reload_successful"))
+	`), "runtime_config_last_reload_successful")
+	})
+
+	// Config should still be the old value.
+	require.Equal(t, value{Value: 42}, manager.GetConfig())
 
 	// Switch back to succeeding with a new value.
 	mu.Lock()

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -6,9 +6,12 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -741,4 +744,180 @@ func TestManager_GetConfigNilBeforeStarting(t *testing.T) {
 	// We haven't started the manager yet, so the config should be nil. Which is legal.
 	require.NoError(t, err)
 	require.Nil(t, overridesManager.GetConfig())
+}
+
+func newHTTPConfigServer(t *testing.T, response string) *httptest.Server {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestManager_URLPath(t *testing.T) {
+	srv := newHTTPConfigServer(t, "value: 42\n")
+
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     []string{srv.URL + "/config.yaml"},
+		Loader:       valueLoader,
+	}
+
+	manager, err := New(cfg, "overrides", nil, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager)) })
+
+	require.NotNil(t, manager.GetConfig())
+	require.Equal(t, value{Value: 42}, manager.GetConfig())
+}
+
+func TestManager_URLPathFirstLoadFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     []string{srv.URL + "/config.yaml"},
+		Loader:       valueLoader,
+	}
+
+	manager, err := New(cfg, "overrides", nil, log.NewNopLogger())
+	require.NoError(t, err)
+
+	err = services.StartAndAwaitRunning(context.Background(), manager)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP 500")
+}
+
+func TestManager_URLPathReloadFailure(t *testing.T) {
+	var mu sync.Mutex
+	statusCode := http.StatusOK
+	body := "value: 42\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		sc := statusCode
+		b := body
+		mu.Unlock()
+		w.WriteHeader(sc)
+		if sc == http.StatusOK {
+			_, _ = w.Write([]byte(b))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := prometheus.NewPedanticRegistry()
+	reloadPeriod := 100 * time.Millisecond
+
+	cfg := Config{
+		ReloadPeriod: reloadPeriod,
+		LoadPath:     []string{srv.URL + "/config.yaml"},
+		Loader:       valueLoader,
+	}
+
+	manager, err := New(cfg, "overrides", reg, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager)) })
+
+	require.Equal(t, value{Value: 42}, manager.GetConfig())
+
+	// Switch to failing.
+	mu.Lock()
+	statusCode = http.StatusInternalServerError
+	mu.Unlock()
+
+	time.Sleep(3 * reloadPeriod)
+
+	// Config should still be the old value.
+	require.Equal(t, value{Value: 42}, manager.GetConfig())
+
+	// The reload success metric should be 0.
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP runtime_config_last_reload_successful Whether the last runtime-config reload attempt was successful.
+		# TYPE runtime_config_last_reload_successful gauge
+		runtime_config_last_reload_successful{config="overrides"} 0
+	`), "runtime_config_last_reload_successful"))
+
+	// Switch back to succeeding with a new value.
+	mu.Lock()
+	statusCode = http.StatusOK
+	body = "value: 99\n"
+	mu.Unlock()
+
+	test.Poll(t, 5*time.Second, value{Value: 99}, func() interface{} {
+		return manager.GetConfig()
+	})
+}
+
+func TestManager_MixedPaths(t *testing.T) {
+	// File source.
+	tempFile, err := os.CreateTemp("", "mixed-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(tempFile.Name()) })
+	_, err = tempFile.WriteString("overrides:\n  user1:\n    limit1: 100\n")
+	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
+
+	// HTTP source.
+	srv := newHTTPConfigServer(t, "overrides:\n  user2:\n    limit2: 200\n")
+
+	defaultTestLimits = &TestLimits{Limit1: 0, Limit2: 0}
+
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     []string{tempFile.Name(), srv.URL + "/config.yaml"},
+		Loader:       testLoadOverrides,
+	}
+
+	manager, err := New(cfg, "overrides", nil, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager)) })
+
+	conf := manager.GetConfig().(*testOverrides)
+	require.NotNil(t, conf)
+	require.Equal(t, 100, conf.Overrides["user1"].Limit1)
+	require.Equal(t, 200, conf.Overrides["user2"].Limit2)
+}
+
+func TestManager_URLPathMetrics(t *testing.T) {
+	srv := newHTTPConfigServer(t, "value: 1\n")
+
+	reg := prometheus.NewPedanticRegistry()
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     []string{srv.URL + "/config.yaml"},
+		Loader:       valueLoader,
+	}
+
+	manager, err := New(cfg, "overrides", reg, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager)) })
+
+	metricFamilies, err := reg.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "runtime_config_http_request_duration_seconds" {
+			found = true
+			require.NotEmpty(t, mf.GetMetric())
+			m := mf.GetMetric()[0]
+			require.NotNil(t, m.GetHistogram())
+			assert.Greater(t, m.GetHistogram().GetSampleCount(), uint64(0))
+
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			assert.Equal(t, "200", labels["status_code"])
+			assert.Contains(t, labels["url"], srv.URL)
+		}
+	}
+	assert.True(t, found, "expected runtime_config_http_request_duration_seconds metric")
 }

--- a/runtimeconfig/provider.go
+++ b/runtimeconfig/provider.go
@@ -1,0 +1,93 @@
+package runtimeconfig
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// provider reads raw bytes from a config source.
+type provider interface {
+	Read(ctx context.Context, path string) ([]byte, error)
+}
+
+// fileProvider reads config from the local filesystem.
+type fileProvider struct{}
+
+func (f *fileProvider) Read(_ context.Context, path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// httpProvider fetches config from HTTP/HTTPS URLs with RED metrics.
+type httpProvider struct {
+	client          *http.Client
+	requestDuration *prometheus.HistogramVec
+}
+
+func newHTTPProvider(client *http.Client, registerer prometheus.Registerer) *httpProvider {
+	return &httpProvider{
+		client: client,
+		requestDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "runtime_config_http_request_duration_seconds",
+			Help:    "Time spent fetching runtime config from HTTP URLs.",
+			Buckets: prometheus.DefBuckets,
+			// Use defaults recommended by Prometheus for native histograms.
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"url", "status_code"}),
+	}
+}
+
+func (h *httpProvider) Read(ctx context.Context, url string) ([]byte, error) {
+	start := time.Now()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		h.requestDuration.WithLabelValues(url, "error").Observe(time.Since(start).Seconds())
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	statusCode := strconv.Itoa(resp.StatusCode)
+
+	if resp.StatusCode/100 != 2 {
+		h.requestDuration.WithLabelValues(url, statusCode).Observe(time.Since(start).Seconds())
+		return nil, &httpError{statusCode: resp.StatusCode, url: url}
+	}
+
+	if err != nil {
+		h.requestDuration.WithLabelValues(url, "error").Observe(time.Since(start).Seconds())
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	h.requestDuration.WithLabelValues(url, statusCode).Observe(time.Since(start).Seconds())
+	return body, nil
+}
+
+type httpError struct {
+	statusCode int
+	url        string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d from %s", e.statusCode, e.url)
+}
+
+func isURL(path string) bool {
+	return strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://")
+}

--- a/runtimeconfig/provider.go
+++ b/runtimeconfig/provider.go
@@ -16,48 +16,68 @@ import (
 
 // provider reads raw bytes from a config source.
 type provider interface {
-	Read(ctx context.Context, path string) ([]byte, error)
+	// Name returns the identifier for this provider (file path or URL), used in error messages and hash keys.
+	Name() string
+	// Read returns the contents of the config source.
+	Read(ctx context.Context) ([]byte, error)
 }
 
 // fileProvider reads config from the local filesystem.
-type fileProvider struct{}
-
-func (f *fileProvider) Read(_ context.Context, path string) ([]byte, error) {
-	return os.ReadFile(path)
+type fileProvider struct {
+	path string
 }
 
-// httpProvider fetches config from HTTP/HTTPS URLs with RED metrics.
+func newFileProvider(path string) *fileProvider {
+	return &fileProvider{path: path}
+}
+
+func (f *fileProvider) Name() string { return f.path }
+
+func (f *fileProvider) Read(_ context.Context) ([]byte, error) {
+	return os.ReadFile(f.path)
+}
+
+// httpProvider fetches config from an HTTP/HTTPS URL with RED metrics.
 type httpProvider struct {
+	url             string
 	client          *http.Client
 	requestDuration *prometheus.HistogramVec
 }
 
-func newHTTPProvider(client *http.Client, registerer prometheus.Registerer) *httpProvider {
+func newHTTPProvider(url string, client *http.Client, requestDuration *prometheus.HistogramVec) *httpProvider {
 	return &httpProvider{
-		client: client,
-		requestDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "runtime_config_http_request_duration_seconds",
-			Help:    "Time spent fetching runtime config from HTTP URLs.",
-			Buckets: prometheus.DefBuckets,
-			// Use defaults recommended by Prometheus for native histograms.
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"url", "status_code"}),
+		url:             url,
+		client:          client,
+		requestDuration: requestDuration,
 	}
 }
 
-func (h *httpProvider) Read(ctx context.Context, url string) ([]byte, error) {
+// newHTTPRequestDuration creates the shared histogram for all httpProvider instances.
+func newHTTPRequestDuration(registerer prometheus.Registerer) *prometheus.HistogramVec {
+	return promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "runtime_config_http_request_duration_seconds",
+		Help:    "Time spent fetching runtime config from HTTP URLs.",
+		Buckets: prometheus.DefBuckets,
+		// Use defaults recommended by Prometheus for native histograms.
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
+	}, []string{"url", "status_code"})
+}
+
+func (h *httpProvider) Name() string { return h.url }
+
+func (h *httpProvider) Read(ctx context.Context) ([]byte, error) {
 	start := time.Now()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		h.requestDuration.WithLabelValues(url, "error").Observe(time.Since(start).Seconds())
+		h.requestDuration.WithLabelValues(h.url, "error").Observe(time.Since(start).Seconds())
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -66,16 +86,16 @@ func (h *httpProvider) Read(ctx context.Context, url string) ([]byte, error) {
 	statusCode := strconv.Itoa(resp.StatusCode)
 
 	if resp.StatusCode/100 != 2 {
-		h.requestDuration.WithLabelValues(url, statusCode).Observe(time.Since(start).Seconds())
-		return nil, &httpError{statusCode: resp.StatusCode, url: url}
+		h.requestDuration.WithLabelValues(h.url, statusCode).Observe(time.Since(start).Seconds())
+		return nil, &httpError{statusCode: resp.StatusCode, url: h.url}
 	}
 
 	if err != nil {
-		h.requestDuration.WithLabelValues(url, "error").Observe(time.Since(start).Seconds())
+		h.requestDuration.WithLabelValues(h.url, "error").Observe(time.Since(start).Seconds())
 		return nil, fmt.Errorf("read response body: %w", err)
 	}
 
-	h.requestDuration.WithLabelValues(url, statusCode).Observe(time.Since(start).Seconds())
+	h.requestDuration.WithLabelValues(h.url, statusCode).Observe(time.Since(start).Seconds())
 	return body, nil
 }
 

--- a/runtimeconfig/provider.go
+++ b/runtimeconfig/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -40,13 +41,21 @@ func (f *fileProvider) Read(_ context.Context) ([]byte, error) {
 // httpProvider fetches config from an HTTP/HTTPS URL with RED metrics.
 type httpProvider struct {
 	url             string
+	urlForMetrics   string // scheme+host+path only, no query/fragment
 	client          *http.Client
 	requestDuration *prometheus.HistogramVec
 }
 
-func newHTTPProvider(url string, client *http.Client, requestDuration *prometheus.HistogramVec) *httpProvider {
+func newHTTPProvider(rawURL string, client *http.Client, requestDuration *prometheus.HistogramVec) *httpProvider {
+	urlForMetrics := rawURL
+	if parsed, err := url.Parse(rawURL); err == nil {
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		urlForMetrics = parsed.String()
+	}
 	return &httpProvider{
-		url:             url,
+		url:             rawURL,
+		urlForMetrics:   urlForMetrics,
 		client:          client,
 		requestDuration: requestDuration,
 	}
@@ -77,7 +86,7 @@ func (h *httpProvider) Read(ctx context.Context) ([]byte, error) {
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		h.requestDuration.WithLabelValues(h.url, "error").Observe(time.Since(start).Seconds())
+		h.requestDuration.WithLabelValues(h.urlForMetrics, "error").Observe(time.Since(start).Seconds())
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -87,17 +96,17 @@ func (h *httpProvider) Read(ctx context.Context) ([]byte, error) {
 	if resp.StatusCode/100 != 2 {
 		// Drain body to allow connection reuse.
 		_, _ = io.Copy(io.Discard, resp.Body)
-		h.requestDuration.WithLabelValues(h.url, statusCode).Observe(time.Since(start).Seconds())
+		h.requestDuration.WithLabelValues(h.urlForMetrics, statusCode).Observe(time.Since(start).Seconds())
 		return nil, &httpError{statusCode: resp.StatusCode, url: h.url}
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		h.requestDuration.WithLabelValues(h.url, "error").Observe(time.Since(start).Seconds())
+		h.requestDuration.WithLabelValues(h.urlForMetrics, "error").Observe(time.Since(start).Seconds())
 		return nil, fmt.Errorf("read response body: %w", err)
 	}
 
-	h.requestDuration.WithLabelValues(h.url, statusCode).Observe(time.Since(start).Seconds())
+	h.requestDuration.WithLabelValues(h.urlForMetrics, statusCode).Observe(time.Since(start).Seconds())
 	return body, nil
 }
 

--- a/runtimeconfig/provider.go
+++ b/runtimeconfig/provider.go
@@ -83,6 +83,7 @@ func (h *httpProvider) Read(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
+	req.Header.Set("User-Agent", "dskit-runtimeconfig")
 
 	resp, err := h.client.Do(req)
 	if err != nil {

--- a/runtimeconfig/provider.go
+++ b/runtimeconfig/provider.go
@@ -82,14 +82,16 @@ func (h *httpProvider) Read(ctx context.Context) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
 	statusCode := strconv.Itoa(resp.StatusCode)
 
 	if resp.StatusCode/100 != 2 {
+		// Drain body to allow connection reuse.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		h.requestDuration.WithLabelValues(h.url, statusCode).Observe(time.Since(start).Seconds())
 		return nil, &httpError{statusCode: resp.StatusCode, url: h.url}
 	}
 
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		h.requestDuration.WithLabelValues(h.url, "error").Observe(time.Since(start).Seconds())
 		return nil, fmt.Errorf("read response body: %w", err)

--- a/runtimeconfig/provider_test.go
+++ b/runtimeconfig/provider_test.go
@@ -33,6 +33,12 @@ func TestIsURL(t *testing.T) {
 	}
 }
 
+func newTestHTTPProvider(t *testing.T, url string, client *http.Client) (*httpProvider, *prometheus.Registry) {
+	reg := prometheus.NewPedanticRegistry()
+	dur := newHTTPRequestDuration(reg)
+	return newHTTPProvider(url, client, dur), reg
+}
+
 func TestHTTPProvider_Success(t *testing.T) {
 	body := "overrides:\n  user1:\n    limit1: 100\n"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -40,12 +46,12 @@ func TestHTTPProvider_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	reg := prometheus.NewPedanticRegistry()
-	p := newHTTPProvider(&http.Client{}, reg)
+	p, _ := newTestHTTPProvider(t, srv.URL+"/config.yaml", &http.Client{})
 
-	data, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	data, err := p.Read(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, body, string(data))
+	assert.Equal(t, srv.URL+"/config.yaml", p.Name())
 
 	assert.Equal(t, 1, testutil.CollectAndCount(p.requestDuration))
 }
@@ -56,10 +62,9 @@ func TestHTTPProvider_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	reg := prometheus.NewPedanticRegistry()
-	p := newHTTPProvider(&http.Client{}, reg)
+	p, _ := newTestHTTPProvider(t, srv.URL+"/config.yaml", &http.Client{})
 
-	_, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	_, err := p.Read(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 500")
 
@@ -76,10 +81,9 @@ func TestHTTPProvider_NonOKStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	reg := prometheus.NewPedanticRegistry()
-	p := newHTTPProvider(&http.Client{}, reg)
+	p, _ := newTestHTTPProvider(t, srv.URL+"/config.yaml", &http.Client{})
 
-	_, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	_, err := p.Read(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 403")
 
@@ -97,10 +101,9 @@ func TestHTTPProvider_Timeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	reg := prometheus.NewPedanticRegistry()
-	p := newHTTPProvider(&http.Client{Timeout: 50 * time.Millisecond}, reg)
+	p, _ := newTestHTTPProvider(t, srv.URL+"/config.yaml", &http.Client{Timeout: 50 * time.Millisecond})
 
-	_, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	_, err := p.Read(context.Background())
 	require.Error(t, err)
 
 	assert.Equal(t, 1, testutil.CollectAndCount(p.requestDuration))
@@ -115,12 +118,11 @@ func TestHTTPProvider_ContextCanceled(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	reg := prometheus.NewPedanticRegistry()
-	p := newHTTPProvider(&http.Client{}, reg)
+	p, _ := newTestHTTPProvider(t, srv.URL+"/config.yaml", &http.Client{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := p.Read(ctx, srv.URL+"/config.yaml")
+	_, err := p.Read(ctx)
 	require.Error(t, err)
 }

--- a/runtimeconfig/provider_test.go
+++ b/runtimeconfig/provider_test.go
@@ -1,0 +1,126 @@
+package runtimeconfig
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"http://example.com/config.yaml", true},
+		{"https://example.com/config.yaml", true},
+		{"HTTP://EXAMPLE.COM/config.yaml", false}, // case-sensitive
+		{"/etc/config.yaml", false},
+		{"config.yaml", false},
+		{"", false},
+		{"ftp://example.com/config.yaml", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, isURL(tt.path))
+		})
+	}
+}
+
+func TestHTTPProvider_Success(t *testing.T) {
+	body := "overrides:\n  user1:\n    limit1: 100\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	reg := prometheus.NewPedanticRegistry()
+	p := newHTTPProvider(&http.Client{}, reg)
+
+	data, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, body, string(data))
+
+	assert.Equal(t, 1, testutil.CollectAndCount(p.requestDuration))
+}
+
+func TestHTTPProvider_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	reg := prometheus.NewPedanticRegistry()
+	p := newHTTPProvider(&http.Client{}, reg)
+
+	_, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 500")
+
+	var httpErr *httpError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, 500, httpErr.statusCode)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(p.requestDuration))
+}
+
+func TestHTTPProvider_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	reg := prometheus.NewPedanticRegistry()
+	p := newHTTPProvider(&http.Client{}, reg)
+
+	_, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 403")
+
+	var httpErr *httpError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, 403, httpErr.statusCode)
+}
+
+func TestHTTPProvider_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(10 * time.Second):
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	reg := prometheus.NewPedanticRegistry()
+	p := newHTTPProvider(&http.Client{Timeout: 50 * time.Millisecond}, reg)
+
+	_, err := p.Read(context.Background(), srv.URL+"/config.yaml")
+	require.Error(t, err)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(p.requestDuration))
+}
+
+func TestHTTPProvider_ContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(10 * time.Second):
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	reg := prometheus.NewPedanticRegistry()
+	p := newHTTPProvider(&http.Client{}, reg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := p.Read(ctx, srv.URL+"/config.yaml")
+	require.Error(t, err)
+}

--- a/runtimeconfig/provider_test.go
+++ b/runtimeconfig/provider_test.go
@@ -41,7 +41,8 @@ func newTestHTTPProvider(t *testing.T, url string, client *http.Client) (*httpPr
 
 func TestHTTPProvider_Success(t *testing.T) {
 	body := "overrides:\n  user1:\n    limit1: 100\n"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "dskit-runtimeconfig", r.Header.Get("User-Agent"))
 		_, _ = w.Write([]byte(body))
 	}))
 	defer srv.Close()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	gokit_log "github.com/go-kit/log"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	gokit_log "github.com/go-kit/log"


### PR DESCRIPTION
## Summary

The runtimeconfig Manager can now fetch config from HTTP/HTTPS URLs in addition to local filesystem paths. This enables centralized config distribution without requiring shared filesystems.

When a `LoadPath` entry starts with `http://` or `https://`, it is fetched via HTTP GET instead of `os.ReadFile`. A `provider` abstraction cleanly separates the two read mechanisms.

HTTP fetches are instrumented with a native histogram (`runtime_config_http_request_duration_seconds`) with `url` and `status_code` labels. On reload failure the previous config is retained; on first load failure the Manager fails to start.

New flag: `--runtime-config.http-client-timeout` (default 30s).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds network-based config loading with a new HTTP client, timeout setting, and request metrics; failures now depend on remote availability and HTTP semantics, which can affect startup/reload behavior.
> 
> **Overview**
> The runtime config `Manager` can now load and merge config from **either local files or `http(s)` URLs** in `LoadPath`, using a new `provider` abstraction (`fileProvider`/`httpProvider`).
> 
> This introduces a configurable HTTP client timeout (`--runtime-config.http-client-timeout`) and a new Prometheus histogram (`runtime_config_http_request_duration_seconds{url,status_code}`) to track fetch latency/outcomes, while updating hashing/error messages to key off provider names instead of file paths.
> 
> Tests are expanded to cover URL loading, mixed file+URL merges, first-load vs reload failure behavior (retaining prior config on reload failure), and HTTP provider edge cases (non-2xx, timeout, canceled context), plus some timing-related test stabilization via `synctest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd169a74c5de4f78acaebdd589cabd11e8f616c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->