### PR TITLE
chore: cache: log warnings when `MemcachedClient` operations fail for unexpected reasons

### DIFF
--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -637,6 +637,8 @@ func (c *MemcachedClient) trackError(op string, err error, msg ...interface{}) {
 		c.metrics.failures.WithLabelValues(op, reasonMalformedKey).Inc()
 	case errors.Is(err, memcache.ErrServerError):
 		c.metrics.failures.WithLabelValues(op, reasonServerError).Inc()
+	case errors.Is(err, context.Canceled):
+		c.metrics.failures.WithLabelValues(op, reasonCanceled).Inc()
 	default:
 		c.metrics.failures.WithLabelValues(op, reasonOther).Inc()
 		severity = level.WarnValue() // Log unexpected kinds of errors with higher severity so they're easier to diagnose.

--- a/cache/memcached_client_metrics.go
+++ b/cache/memcached_client_metrics.go
@@ -27,6 +27,7 @@ const (
 	reasonTimeout         = "request-timeout"
 	reasonServerError     = "server-error"
 	reasonNetworkError    = "network-error"
+	reasonCanceled        = "canceled"
 	reasonOther           = "other"
 
 	labelCacheName           = "name"
@@ -88,6 +89,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		cm.failures.WithLabelValues(op, reasonNotStored)
 		cm.failures.WithLabelValues(op, reasonServerError)
 		cm.failures.WithLabelValues(op, reasonNetworkError)
+		cm.failures.WithLabelValues(op, reasonCanceled)
 		cm.failures.WithLabelValues(op, reasonOther)
 	}
 


### PR DESCRIPTION
**What this PR does**:

This PR makes two changes to logging in `MemcachedClient.SetAsync`:

* it logs when an item is not stored in the cache because it is too large
* it increases the log level of log messages emitted when operations fail to warning level if the failure is due to an unexpected reason (the `other` category for the `operation_failures_total` metric)

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to logging and Prometheus failure reason labeling, with no impact to cache semantics beyond emitting additional logs/metrics.
> 
> **Overview**
> Improves `MemcachedClient` observability by centralizing error logging through `trackError`, which now both increments failure metrics and logs with **warn** severity for previously-uncategorized (`other`) errors.
> 
> Adds explicit failure categorization for `context.Canceled` (`reasonCanceled`) and enriches async set skip logs (oversized items and full async buffer) with the affected `key` and size/buffer details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fde9ea1cd96b79703db0e9bc0a03d08f7821d1a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->