### PR TITLE
feat: cache: emit metric for size of items not stored in cache due to breaching size limit

### DIFF
--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -304,9 +304,7 @@ func (c *MemcachedClient) SetMultiAsync(data map[string][]byte, ttl time.Duratio
 }
 
 func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) {
-	if c.config.MaxItemSize > 0 && len(value) > c.config.MaxItemSize {
-		c.metrics.skipped.WithLabelValues(opSet, reasonMaxItemSize).Inc()
-		level.Debug(c.logger).Log("msg", "failed to store item to cache because it is too large", "key", key, "size", len(value), "max_item_size", c.config.MaxItemSize)
+	if !c.itemSizeIsAcceptable(key, value, opSet) {
 		return
 	}
 
@@ -323,6 +321,17 @@ func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 		c.metrics.skipped.WithLabelValues(opSet, reasonAsyncBufferFull).Inc()
 		level.Debug(c.logger).Log("msg", "failed to store item to cache because the async buffer is full", "key", key, "err", err, "buffer_size", c.config.MaxAsyncBufferSize)
 	}
+}
+
+func (c *MemcachedClient) itemSizeIsAcceptable(key string, value []byte, op string) bool {
+	if c.config.MaxItemSize > 0 && len(value) > c.config.MaxItemSize {
+		c.metrics.skipped.WithLabelValues(op, reasonMaxItemSize).Inc()
+		c.metrics.skippedDataSize.WithLabelValues(op).Observe(float64(len(value)))
+		level.Debug(c.logger).Log("msg", "failed to store item to cache because it is too large", "key", key, "size", len(value), "max_item_size", c.config.MaxItemSize, "op", op)
+		return false
+	}
+
+	return true
 }
 
 func (c *MemcachedClient) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
@@ -574,8 +583,7 @@ func (c *MemcachedClient) FlushAll(ctx context.Context) error {
 }
 
 func (c *MemcachedClient) storeOperation(ctx context.Context, key string, value []byte, ttl time.Duration, operation string, f func(ctx context.Context, key string, value []byte, ttl time.Duration) error) error {
-	if c.config.MaxItemSize > 0 && len(value) > c.config.MaxItemSize {
-		c.metrics.skipped.WithLabelValues(operation, reasonMaxItemSize).Inc()
+	if !c.itemSizeIsAcceptable(key, value, operation) {
 		return nil
 	}
 

--- a/cache/memcached_client_metrics.go
+++ b/cache/memcached_client_metrics.go
@@ -39,13 +39,14 @@ const (
 )
 
 type clientMetrics struct {
-	requests   prometheus.Counter
-	hits       prometheus.Counter
-	operations *prometheus.CounterVec
-	failures   *prometheus.CounterVec
-	skipped    *prometheus.CounterVec
-	duration   *prometheus.HistogramVec
-	dataSize   *prometheus.HistogramVec
+	requests        prometheus.Counter
+	hits            prometheus.Counter
+	operations      *prometheus.CounterVec
+	failures        *prometheus.CounterVec
+	skipped         *prometheus.CounterVec
+	duration        *prometheus.HistogramVec
+	dataSize        *prometheus.HistogramVec
+	skippedDataSize *prometheus.HistogramVec
 }
 
 // newClientMetrics creates a new bundle of metrics about an instance of a cache client. Note
@@ -127,6 +128,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Buckets: []float64{
 			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
 		},
+		NativeHistogramBucketFactor: 1.1,
 	},
 		[]string{"operation"},
 	)
@@ -134,6 +136,20 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 	cm.dataSize.WithLabelValues(opAdd)
 	cm.dataSize.WithLabelValues(opSet)
 	cm.dataSize.WithLabelValues(opCompareAndSwap)
+
+	cm.skippedDataSize = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name: "operation_skipped_data_size_bytes",
+		Help: "Tracks the size of data not stored in the cache because it exceeds the maximum size limit.",
+		Buckets: []float64{
+			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
+		},
+		NativeHistogramBucketFactor: 1.1,
+	},
+		[]string{"operation"},
+	)
+	cm.skippedDataSize.WithLabelValues(opAdd)
+	cm.skippedDataSize.WithLabelValues(opSet)
+	cm.skippedDataSize.WithLabelValues(opCompareAndSwap)
 
 	return cm
 }


### PR DESCRIPTION
**What this PR does**:

This PR:

* fixes an issue where the `failed to store item to cache because it is too large` message introduced in https://github.com/grafana/dskit/pull/934 is not logged if a method other than `SetAsync` is used
* makes the `operation_data_size_bytes` metric available as a native histogram
* introduces a `operation_skipped_data_size_bytes` metric to track the size of items not stored in the cache because they are too large

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [n/a] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to cache skip logging/metrics and do not affect cache read/write semantics beyond earlier returns for oversize items (which were already skipped). Main risk is metric cardinality/volume changes and dashboards/alerts needing updates for the new histogram.
> 
> **Overview**
> Centralizes max-item-size enforcement into `itemSizeIsAcceptable()` and reuses it from both `SetAsync` and the shared `storeOperation()`, ensuring oversize writes consistently log the skip and increment skip counters across operations.
> 
> Adds a new Prometheus histogram `operation_skipped_data_size_bytes` (labeled by operation) to record the byte size of items skipped due to `max_item_size`, and enables native-histogram configuration for `operation_data_size_bytes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17490f6337ef41c6a18569727f20148c3756bde9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->