### PR TITLE
feat(rate-limiter): add method to remove rate limiters that have not been accessed after a specific cutoff time

### DIFF
--- a/limiter/rate_limiter.go
+++ b/limiter/rate_limiter.go
@@ -66,6 +66,21 @@ func (l *RateLimiter) Burst(now time.Time, tenantID string) int {
 	return l.getTenantLimiter(now, tenantID).Burst()
 }
 
+// RemoveStaleEntries removes entries that have not been accessed since
+// the given cutoff time and returns the number of removed entries.
+func (l *RateLimiter) RemoveStaleEntries(cutoff time.Time) int {
+	l.tenantsLock.Lock()
+	defer l.tenantsLock.Unlock()
+	removed := 0
+	for tenantID, entry := range l.tenants {
+		if entry.recheckAt.Before(cutoff) {
+			delete(l.tenants, tenantID)
+			removed++
+		}
+	}
+	return removed
+}
+
 func (l *RateLimiter) getTenantLimiter(now time.Time, tenantID string) *rate.Limiter {
 	recheck := false
 
@@ -108,7 +123,12 @@ func (l *RateLimiter) recheckTenantLimiter(now time.Time, tenantID string) *rate
 	l.tenantsLock.Lock()
 	defer l.tenantsLock.Unlock()
 
-	entry := l.tenants[tenantID]
+	entry, ok := l.tenants[tenantID]
+	if !ok {
+		entry = &tenantLimiter{rate.NewLimiter(limit, burst), now.Add(l.recheckPeriod)}
+		l.tenants[tenantID] = entry
+		return entry.limiter
+	}
 
 	// We check again if the recheck period elapsed, cause it may
 	// have already been rechecked in the meanwhile.

--- a/limiter/rate_limiter_test.go
+++ b/limiter/rate_limiter_test.go
@@ -108,6 +108,39 @@ func TestRateLimiter_WaitN(t *testing.T) {
 	assert.NotNil(t, limiter.WaitN(ctxToCancel, "tenant", 1))
 }
 
+func TestRateLimiter_RemoveStaleEntries(t *testing.T) {
+	strategy := &staticLimitStrategy{tenants: map[string]struct {
+		limit float64
+		burst int
+	}{
+		"tenant-1": {limit: 10, burst: 20},
+		"tenant-2": {limit: 10, burst: 20},
+		"tenant-3": {limit: 10, burst: 20},
+	}}
+
+	recheckPeriod := 10 * time.Second
+	limiter := NewRateLimiter(strategy, recheckPeriod)
+	now := time.Now()
+
+	assert.Equal(t, 0, limiter.RemoveStaleEntries(now.Add(time.Hour)))
+
+	limiter.AllowN(now, "tenant-1", 1)
+	limiter.AllowN(now.Add(5*time.Second), "tenant-2", 1)
+	limiter.AllowN(now.Add(9*time.Second), "tenant-3", 1)
+
+	assert.Equal(t, 0, limiter.RemoveStaleEntries(now))
+	assert.Equal(t, 1, limiter.RemoveStaleEntries(now.Add(12*time.Second)))
+
+	assert.Equal(t, true, limiter.AllowN(now.Add(12*time.Second), "tenant-2", 1))
+	assert.Equal(t, true, limiter.AllowN(now.Add(12*time.Second), "tenant-3", 1))
+
+	limiter.AllowN(now.Add(12*time.Second), "tenant-1", 1)
+
+	assert.Equal(t, 2, limiter.RemoveStaleEntries(now.Add(20*time.Second)))
+	assert.Equal(t, 1, limiter.RemoveStaleEntries(now.Add(time.Hour)))
+	assert.Equal(t, 0, limiter.RemoveStaleEntries(now.Add(2*time.Hour)))
+}
+
 func BenchmarkRateLimiter_CustomMultiTenant(b *testing.B) {
 	strategy := &increasingLimitStrategy{}
 	limiter := NewRateLimiter(strategy, 10*time.Second)


### PR DESCRIPTION
**What this PR does**:

This PR adds `RemoveStaleEntries` to `RateLimiter`, which cleans up per-tenant trackers that have not been accessed after a specified cutoff date.
Callers passing ephemeral tenant IDs can use it to prevent unbounded growth of the rate-limiter's state.

To be used with https://github.com/grafana/mimir/pull/14289.

**Which issue(s) this PR fixes**:

n/a

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared in-memory state and locking in the multi-tenant rate limiter; incorrect cutoff semantics or races could cause unexpected limiter recreation/behavior under load, though the change is small and covered by tests.
> 
> **Overview**
> Adds `RateLimiter.RemoveStaleEntries(cutoff)` to evict per-tenant limiter entries whose `recheckAt` precedes a caller-provided cutoff, preventing unbounded growth when tenant IDs are ephemeral.
> 
> Updates `recheckTenantLimiter` to safely handle tenants removed from the map (recreate the limiter if missing) and adds a unit test covering eviction and subsequent limiter reuse/recreation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9cc4d0b0a0785d87050f93a63613a57dc5afee9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->