### PR TITLE
feat(tenant): export TrimMetadata method

### DIFF
--- a/tenant/resolver.go
+++ b/tenant/resolver.go
@@ -28,13 +28,13 @@ func TenantID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	orgID, remaining, hasMoreIDs := stringsCut(orgIDs, tenantIDsSeparator)
-	tenantID := trimMetadata(orgID)
+	tenantID := TrimMetadata(orgID)
 	if err := ValidTenantID(tenantID); err != nil {
 		return "", err
 	}
 	for hasMoreIDs {
 		orgID, remaining, hasMoreIDs = stringsCut(remaining, tenantIDsSeparator)
-		if tenantID != trimMetadata(orgID) {
+		if tenantID != TrimMetadata(orgID) {
 			return "", user.ErrTooManyOrgIDs
 		}
 	}
@@ -67,7 +67,7 @@ func TenantIDs(ctx context.Context) ([]string, error) {
 func parseTenantIDs(orgID string) ([]string, error) {
 	orgIDs := strings.Split(orgID, string(tenantIDsSeparator))
 	for i, part := range orgIDs {
-		tenantId := trimMetadata(part)
+		tenantId := TrimMetadata(part)
 		if err := ValidTenantID(tenantId); err != nil {
 			return nil, err
 		}

--- a/tenant/tenant.go
+++ b/tenant/tenant.go
@@ -124,7 +124,8 @@ func TenantIDsFromOrgID(orgID string) ([]string, error) {
 	return TenantIDs(user.InjectOrgID(context.TODO(), orgID))
 }
 
-func trimMetadata(orgID string) string {
+// TrimMetadata removes metadata from a orgID without validating the input.
+func TrimMetadata(orgID string) string {
 	idx := strings.IndexByte(orgID, metadataSeparator)
 	if idx == -1 {
 		return orgID


### PR DESCRIPTION
**What this PR does**:

Exports `tenant.TrimMetadata` which is used to remove metadata suffix from org IDs. Using this method, callers can avoid parsing metadata (which is expensive) to get the tenant ID.

To be used with https://github.com/grafana/mimir/pull/14289.

**Which issue(s) this PR fixes**:

n/a

**Checklist**
- [n/a] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small visibility change (unexporting -> exporting) plus call-site updates, with no behavioral change expected beyond making the helper available to other packages.
> 
> **Overview**
> Exports `TrimMetadata` (renaming the previously unexported `trimMetadata`) so other packages can strip metadata from org/tenant IDs without full metadata parsing.
> 
> Updates tenant resolution code (`TenantID`/`TenantIDs` parsing) to call the exported helper, keeping existing validation and multi-tenant handling unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fa807ae12574bed712198f02a402ef3b686c318. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->