### PR TITLE
ring: clamp far-future heartbeat timestamps to prevent permanently stuck instances

### DIFF
--- a/ring/merge_test.go
+++ b/ring/merge_test.go
@@ -480,6 +480,155 @@ func TestMergeMissingIntoLeft(t *testing.T) {
 	}
 }
 
+func TestMergeFarFutureTimestamp_IncomingClamped(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+	farFuture := time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
+	// Local ring has instance with current timestamp.
+	local := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: nowUnix, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+		},
+	}
+
+	// Incoming ring has same instance with a corrupted far-future timestamp.
+	incoming := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: farFuture, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+		},
+	}
+
+	change, err := local.mergeWithTime(incoming, false, now)
+	assert.NoError(t, err)
+
+	// The incoming far-future timestamp should be clamped to now.
+	// Since clamped incoming (now) == local (now), no change from the incoming side.
+	// But the timestamps are equal so no update from the merge loop.
+	ing := local.Ingesters["Ing 1"]
+	assert.Equal(t, nowUnix, ing.Timestamp, "local timestamp should remain current")
+	assert.Nil(t, change, "no change expected when clamped incoming equals local")
+}
+
+func TestMergeFarFutureTimestamp_LocalClamped(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+	farFuture := time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
+	// Local ring has instance with corrupted far-future timestamp.
+	local := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: farFuture, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+		},
+	}
+
+	// Incoming ring has same instance with a current timestamp (slightly newer).
+	incoming := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: nowUnix + 5, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+		},
+	}
+
+	change, err := local.mergeWithTime(incoming, false, now)
+	assert.NoError(t, err)
+	assert.NotNil(t, change, "change expected: local was clamped and incoming wins")
+
+	// Local entry should now have the incoming's timestamp (which is nowUnix+5, after clamping local to nowUnix).
+	ing := local.Ingesters["Ing 1"]
+	assert.Equal(t, nowUnix+5, ing.Timestamp, "incoming should win after local is clamped")
+}
+
+func TestMergeFarFutureTimestamp_LocalClampedSelfHealing(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+	farFuture := time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
+	// Local ring has instance with corrupted far-future timestamp.
+	local := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: farFuture, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+		},
+	}
+
+	// Incoming ring has a DIFFERENT instance only (no mention of Ing 1).
+	incoming := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 2": {Addr: "addr2", Timestamp: nowUnix, State: ACTIVE, Tokens: []uint32{100, 200}},
+		},
+	}
+
+	change, err := local.mergeWithTime(incoming, false, now)
+	assert.NoError(t, err)
+	assert.NotNil(t, change, "change expected: Ing 1 was clamped, Ing 2 is new")
+
+	// Ing 1's corrupted timestamp should be clamped to now.
+	ing1 := local.Ingesters["Ing 1"]
+	assert.Equal(t, nowUnix, ing1.Timestamp, "corrupted local timestamp should be clamped to now")
+
+	// The change should include both the clamped Ing 1 and the new Ing 2.
+	changeDesc := change.(*Desc)
+	assert.Contains(t, changeDesc.Ingesters, "Ing 1", "clamped entry should be in change for gossip propagation")
+	assert.Contains(t, changeDesc.Ingesters, "Ing 2", "new entry should be in change")
+}
+
+func TestMergeFarFutureTimestamp_LocalCASMarkLeft(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+	farFuture := time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
+	// Local ring has instance with corrupted far-future timestamp.
+	local := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: farFuture, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+			"Ing 2": {Addr: "addr2", Timestamp: nowUnix, State: ACTIVE, Tokens: []uint32{100, 200}},
+		},
+	}
+
+	// Incoming ring does NOT have Ing 1 (it's gone), localCAS should mark it LEFT.
+	incoming := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 2": {Addr: "addr2", Timestamp: nowUnix, State: ACTIVE, Tokens: []uint32{100, 200}},
+		},
+	}
+
+	change, err := local.mergeWithTime(incoming, true, now)
+	assert.NoError(t, err)
+	assert.NotNil(t, change)
+
+	// Ing 1 should be marked LEFT with a current timestamp (not the far-future one).
+	ing1 := local.Ingesters["Ing 1"]
+	assert.Equal(t, LEFT, ing1.State, "missing instance should be marked LEFT via localCAS")
+	assert.Equal(t, nowUnix, ing1.Timestamp, "timestamp should be current, not far-future")
+	assert.Nil(t, ing1.Tokens, "LEFT instance should have no tokens")
+}
+
+func TestMergeFarFutureTimestamp_LegitimateClockSkew(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+
+	// Timestamp 30 minutes in the future (within allowed drift) should NOT be clamped.
+	slightlyFuture := nowUnix + 1800
+
+	local := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: nowUnix, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+		},
+	}
+
+	incoming := &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"Ing 1": {Addr: "addr1", Timestamp: slightlyFuture, State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+		},
+	}
+
+	change, err := local.mergeWithTime(incoming, false, now)
+	assert.NoError(t, err)
+	assert.NotNil(t, change, "incoming with slightly future timestamp should win")
+
+	ing := local.Ingesters["Ing 1"]
+	assert.Equal(t, slightlyFuture, ing.Timestamp, "legitimate clock skew should be accepted without clamping")
+}
+
 func mergeLocalCAS(ring1, ring2 *Desc, nowUnixTime int64) (*Desc, *Desc) {
 	change, err := ring1.mergeWithTime(ring2, true, time.Unix(nowUnixTime, 0))
 	if err != nil {

--- a/ring/model.go
+++ b/ring/model.go
@@ -14,6 +14,26 @@ import (
 	"github.com/grafana/dskit/loser"
 )
 
+const (
+	// maxAllowedClockDrift is the maximum allowed clock drift for ring instance
+	// heartbeat timestamps. Timestamps further in the future than now + maxAllowedClockDrift
+	// are considered corrupted and clamped to the current time. This prevents a
+	// corrupted far-future timestamp from permanently blocking ring state updates
+	// via the gossip merge protocol.
+	maxAllowedClockDrift = 1 * time.Hour
+)
+
+// clampTimestamp returns the given unix timestamp unchanged if it is within the
+// allowed clock drift from now. If it exceeds now + maxAllowedClockDrift, it
+// returns now's unix timestamp instead. This prevents corrupted far-future
+// timestamps from permanently winning ring state merges.
+func clampTimestamp(ts int64, now time.Time) int64 {
+	if ts > now.Add(maxAllowedClockDrift).Unix() {
+		return now.Unix()
+	}
+	return ts
+}
+
 // ByAddr is a sortable list of InstanceDesc.
 type ByAddr []InstanceDesc
 
@@ -180,9 +200,14 @@ func (i *InstanceDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration, n
 }
 
 // IsHeartbeatHealthy returns whether the heartbeat timestamp for the ingester is within the
-// specified timeout period.
+// specified timeout period. Timestamps more than maxAllowedClockDrift in the future are
+// treated as unhealthy, since they indicate a corrupted timestamp.
 func (i *InstanceDesc) IsHeartbeatHealthy(heartbeatTimeout time.Duration, now time.Time) bool {
-	return now.Sub(time.Unix(i.Timestamp, 0)) <= heartbeatTimeout
+	heartbeatTime := time.Unix(i.Timestamp, 0)
+	if heartbeatTime.After(now.Add(maxAllowedClockDrift)) {
+		return false
+	}
+	return now.Sub(heartbeatTime) <= heartbeatTimeout
 }
 
 // IsReady returns no error if the instance is ACTIVE and healthy.
@@ -245,8 +270,24 @@ func (d *Desc) mergeWithTime(mergeable memberlist.Mergeable, localCAS bool, now 
 	var updated []string
 	tokensChanged := false
 
+	// Clamp any local entries with corrupted far-future timestamps.
+	// This self-heals corruption by bringing timestamps back to the present,
+	// allowing normal heartbeat/merge semantics to resume.
+	for name, ting := range thisIngesterMap {
+		clamped := clampTimestamp(ting.Timestamp, now)
+		if clamped != ting.Timestamp {
+			ting.Timestamp = clamped
+			thisIngesterMap[name] = ting
+			updated = append(updated, name)
+		}
+	}
+
 	for name, oing := range otherIngesterMap {
 		ting := thisIngesterMap[name]
+
+		// Clamp incoming far-future timestamps before comparison.
+		oing.Timestamp = clampTimestamp(oing.Timestamp, now)
+
 		// ting.Timestamp will be 0, if there was no such ingester in our version
 		if oing.Timestamp > ting.Timestamp {
 			if !tokensEqual(ting.Tokens, oing.Tokens) {

--- a/ring/model_test.go
+++ b/ring/model_test.go
@@ -123,6 +123,90 @@ func TestInstanceDesc_GetLastHeartbeatAt(t *testing.T) {
 	}
 }
 
+func TestClampTimestamp(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+
+	tests := map[string]struct {
+		ts       int64
+		expected int64
+	}{
+		"timestamp in the past": {
+			ts:       nowUnix - 3600,
+			expected: nowUnix - 3600,
+		},
+		"timestamp at current time": {
+			ts:       nowUnix,
+			expected: nowUnix,
+		},
+		"timestamp slightly in the future (within drift)": {
+			ts:       nowUnix + 1800, // 30 minutes
+			expected: nowUnix + 1800,
+		},
+		"timestamp at exactly max drift boundary": {
+			ts:       now.Add(maxAllowedClockDrift).Unix(),
+			expected: now.Add(maxAllowedClockDrift).Unix(),
+		},
+		"timestamp beyond max drift": {
+			ts:       nowUnix + 7200, // 2 hours
+			expected: nowUnix,
+		},
+		"timestamp far in the future (year 2034)": {
+			ts:       time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
+			expected: nowUnix,
+		},
+		"zero timestamp": {
+			ts:       0,
+			expected: 0,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := clampTimestamp(testData.ts, now)
+			assert.Equal(t, testData.expected, result)
+		})
+	}
+}
+
+func TestIsHeartbeatHealthy_FarFutureTimestamp(t *testing.T) {
+	now := time.Now()
+	timeout := time.Minute
+
+	tests := map[string]struct {
+		timestamp int64
+		expected  bool
+	}{
+		"recent heartbeat": {
+			timestamp: now.Add(-30 * time.Second).Unix(),
+			expected:  true,
+		},
+		"expired heartbeat": {
+			timestamp: now.Add(-90 * time.Second).Unix(),
+			expected:  false,
+		},
+		"heartbeat slightly in the future (within drift)": {
+			timestamp: now.Add(30 * time.Minute).Unix(),
+			expected:  true,
+		},
+		"heartbeat far in the future (beyond drift)": {
+			timestamp: now.Add(2 * time.Hour).Unix(),
+			expected:  false,
+		},
+		"heartbeat in year 2034": {
+			timestamp: time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
+			expected:  false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ing := &InstanceDesc{Timestamp: testData.timestamp}
+			assert.Equal(t, testData.expected, ing.IsHeartbeatHealthy(timeout, now))
+		})
+	}
+}
+
 func normalizedSource() *Desc {
 	r := NewDesc()
 	r.Ingesters["first"] = InstanceDesc{


### PR DESCRIPTION
**What this PR does**:
A crash can corrupt a ring instance's heartbeat timestamp to a
far-future value (e.g. year 2034). When this happens, the instance
becomes permanently stuck in the gossip ring because:

- The merge logic uses "highest timestamp wins", so no legitimate heartbeat (using time.Now()) can ever override the corrupted entry
- The localCAS path marks missing instances as LEFT with the current time, but other nodes reject this via gossip since their copy has the higher corrupted timestamp
- IsHeartbeatHealthy treats future timestamps as healthy (the time difference is negative, always within the timeout), so the instance can never be considered unhealthy or evicted

Fix by clamping timestamps that exceed now + 1 hour (maxAllowedClockDrift)
to the current time in both the merge function and IsHeartbeatHealthy.
The merge fix is self-healing: each node independently clamps corrupted
entries and gossips the correction, allowing normal operations to resume
on the next heartbeat cycle.


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/mimir/issues/13810

That issue is the same issue we encountered on our cluster: we had an 
instance with a heartbeat timestamp in 2034 in UP status, the only way
we could fix it was by having a fake member join, emit a DOWN status for
the broken instance with a timestamp into the future (to beat out the 2034
year).

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ring gossip merge and heartbeat health semantics by clamping future timestamps; mistakes could cause instances to be marked unhealthy or allow stale state to win, but the change is bounded by a 1h drift window and covered by targeted tests.
> 
> **Overview**
> Prevents corrupted far-future heartbeat timestamps from permanently winning ring gossip merges by introducing `maxAllowedClockDrift` (1h) and clamping any timestamp beyond `now + drift` back to `now`.
> 
> `mergeWithTime` now *self-heals* local corrupted entries (and gossips the correction via the returned change set) and clamps incoming entries before doing the "highest timestamp wins" comparison; `IsHeartbeatHealthy` now treats far-future heartbeats as unhealthy instead of always healthy.
> 
> Adds unit tests covering clamping behavior, merge outcomes (including `localCAS` marking missing instances `LEFT`), and acceptance of small legitimate clock skew.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec87a4cf52f6bc179ffe9a418ab9045220dd0797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->