### PR TITLE
fix(tracing): respect OTEL_TRACES_SAMPLER env var in NewOTelFromEnv

### DIFF
--- a/tracing/otel.go
+++ b/tracing/otel.go
@@ -66,9 +66,7 @@ func NewOTelFromEnv(serviceName string, logger log.Logger, opts ...OTelOption) (
 	} else if ok {
 		options = append(options, tracesdk.WithSampler(&JaegerDebuggingSampler{jaegerRemoteSampler}))
 	} else {
-		// The default behaviour is to always sample (https://github.com/open-telemetry/opentelemetry-go/blob/2ce0ab20b0c054eb32a3143bc0746961cba88d19/sdk/trace/provider.go#L496),
-		// so we do the same, but wrap it with our sampler that adds support for the jaeger-debug-id HTTP header.
-		options = append(options, tracesdk.WithSampler(&JaegerDebuggingSampler{tracesdk.ParentBased(tracesdk.AlwaysSample())}))
+		options = append(options, tracesdk.WithSampler(&JaegerDebuggingSampler{otelSamplerFromEnv()}))
 	}
 	options = append(options, cfg.tracerProviderOptions...)
 
@@ -181,10 +179,11 @@ func NewResource(serviceName string, customAttributes []attribute.KeyValue) (*re
 //
 // When maybeJaegerRemoteSamplerFromEnv finds a supported Jaeger remote sampler OTEL_TRACES_SAMPLER value, it unsets that environment variable.
 func maybeJaegerRemoteSamplerFromEnv(serviceName string) (tracesdk.Sampler, bool, error) {
-	samplerName, ok := os.LookupEnv("OTEL_TRACES_SAMPLER")
+	samplerName, ok := os.LookupEnv(tracesSamplerKey)
 	if !ok {
 		return nil, false, nil
 	}
+	samplerName = strings.ToLower(strings.TrimSpace(samplerName))
 	parentBased := false
 	switch samplerName {
 	case "jaeger_remote":
@@ -198,9 +197,9 @@ func maybeJaegerRemoteSamplerFromEnv(serviceName string) (tracesdk.Sampler, bool
 
 	// Unset the OTEL_TRACES_SAMPLER environment variable to the SDK's samplerFromEnv()
 	// function complaining about unknown sampler and logging confusing messages.
-	_ = os.Unsetenv("OTEL_TRACES_SAMPLER")
+	_ = os.Unsetenv(tracesSamplerKey)
 
-	args, ok := os.LookupEnv("OTEL_TRACES_SAMPLER_ARG")
+	args, ok := os.LookupEnv(tracesSamplerArgKey)
 	if !ok || args == "" {
 		return nil, false, fmt.Errorf("OTEL_TRACES_SAMPLER_ARG is not set for Jaeger remote sampler %s", samplerName)
 	}
@@ -268,6 +267,70 @@ type closableParentBasedSampler struct {
 }
 
 func (c closableParentBasedSampler) Close() { c.closer.Close() }
+
+// Sampler name constants matching the OpenTelemetry specification.
+// Source: https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/trace/sampler_env.go#L48
+const (
+	tracesSamplerKey    = "OTEL_TRACES_SAMPLER"
+	tracesSamplerArgKey = "OTEL_TRACES_SAMPLER_ARG"
+
+	samplerAlwaysOn                = "always_on"
+	samplerAlwaysOff               = "always_off"
+	samplerTraceIDRatio            = "traceidratio"
+	samplerParentBasedAlwaysOn     = "parentbased_always_on"
+	samplerParentBasedAlwaysOff    = "parentbased_always_off"
+	samplerParentBasedTraceIDRatio = "parentbased_traceidratio"
+)
+
+// otelSamplerFromEnv reads the standard OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG
+// environment variables and returns the corresponding sampler.
+// If OTEL_TRACES_SAMPLER is unset or empty, defaults to ParentBased(AlwaysSample()).
+//
+// Supported values per the OpenTelemetry specification:
+//   - "always_on"                  → AlwaysSample
+//   - "always_off"                 → NeverSample
+//   - "traceidratio"               → TraceIDRatioBased(arg)
+//   - "parentbased_always_on"      → ParentBased(AlwaysSample)
+//   - "parentbased_always_off"     → ParentBased(NeverSample)
+//   - "parentbased_traceidratio"   → ParentBased(TraceIDRatioBased(arg))
+//
+// See https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler
+// Source: https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/trace/sampler_env.go#L48
+func otelSamplerFromEnv() tracesdk.Sampler {
+	samplerName := strings.ToLower(strings.TrimSpace(os.Getenv(tracesSamplerKey)))
+	samplerArg := strings.TrimSpace(os.Getenv(tracesSamplerArgKey))
+
+	switch samplerName {
+	case samplerAlwaysOn:
+		return tracesdk.AlwaysSample()
+	case samplerAlwaysOff:
+		return tracesdk.NeverSample()
+	case samplerTraceIDRatio:
+		return tracesdk.TraceIDRatioBased(parseRatioOrDefault(samplerArg, 1.0))
+	case samplerParentBasedAlwaysOn:
+		return tracesdk.ParentBased(tracesdk.AlwaysSample())
+	case samplerParentBasedAlwaysOff:
+		return tracesdk.ParentBased(tracesdk.NeverSample())
+	case samplerParentBasedTraceIDRatio:
+		return tracesdk.ParentBased(tracesdk.TraceIDRatioBased(parseRatioOrDefault(samplerArg, 1.0)))
+	default:
+		// Matches the upstream default when no sampler is configured.
+		return tracesdk.ParentBased(tracesdk.AlwaysSample())
+	}
+}
+
+// parseRatioOrDefault parses a float64 from s, clamped to [0, defaultVal].
+// Returns defaultVal if s is empty, unparseable, or out of range.
+func parseRatioOrDefault(s string, defaultVal float64) float64 {
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || !(v >= 0 && v <= 1) {
+		return defaultVal
+	}
+	return v
+}
 
 // OTelPropagatorsFromEnv returns a slice of OpenTelemetry TextMapPropagators based on the OTEL_PROPAGATORS environment variable.
 // If the environment variable is not set, it defaults to using TraceContext, Baggage, and Jaeger propagators.

--- a/tracing/otel_test.go
+++ b/tracing/otel_test.go
@@ -295,6 +295,151 @@ func TestOTelPropagatorsFromEnv(t *testing.T) {
 	})
 }
 
+func TestOtelSamplerFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		sampler  string
+		arg      string
+		wantDesc string
+	}{
+		{
+			name:     "unset defaults to ParentBased(AlwaysSample)",
+			sampler:  "",
+			arg:      "",
+			wantDesc: "ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}",
+		},
+		{
+			name:     "always_on",
+			sampler:  "always_on",
+			arg:      "",
+			wantDesc: "AlwaysOnSampler",
+		},
+		{
+			name:     "always_off",
+			sampler:  "always_off",
+			arg:      "",
+			wantDesc: "AlwaysOffSampler",
+		},
+		{
+			name:     "traceidratio with valid arg",
+			sampler:  "traceidratio",
+			arg:      "0.1",
+			wantDesc: "TraceIDRatioBased{0.1}",
+		},
+		{
+			name:     "traceidratio with no arg defaults to 1.0",
+			sampler:  "traceidratio",
+			arg:      "",
+			wantDesc: "AlwaysOnSampler",
+		},
+		{
+			name:     "traceidratio with invalid arg defaults to 1.0",
+			sampler:  "traceidratio",
+			arg:      "not-a-number",
+			wantDesc: "AlwaysOnSampler",
+		},
+		{
+			name:     "traceidratio with out-of-range arg defaults to 1.0",
+			sampler:  "traceidratio",
+			arg:      "2.5",
+			wantDesc: "AlwaysOnSampler",
+		},
+		{
+			name:     "traceidratio with negative arg defaults to 1.0",
+			sampler:  "traceidratio",
+			arg:      "-0.5",
+			wantDesc: "AlwaysOnSampler",
+		},
+		{
+			name:     "parentbased_always_on",
+			sampler:  "parentbased_always_on",
+			arg:      "",
+			wantDesc: "ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}",
+		},
+		{
+			name:     "parentbased_always_off",
+			sampler:  "parentbased_always_off",
+			arg:      "",
+			wantDesc: "ParentBased{root:AlwaysOffSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}",
+		},
+		{
+			name:     "parentbased_traceidratio",
+			sampler:  "parentbased_traceidratio",
+			arg:      "0.5",
+			wantDesc: "ParentBased{root:TraceIDRatioBased{0.5},remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}",
+		},
+		{
+			name:     "unknown sampler defaults to ParentBased(AlwaysSample)",
+			sampler:  "some_unknown_sampler",
+			arg:      "",
+			wantDesc: "ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer saveEnvAndRestoreDeferred("OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG")()
+
+			if tc.sampler == "" {
+				os.Unsetenv("OTEL_TRACES_SAMPLER")
+			} else {
+				os.Setenv("OTEL_TRACES_SAMPLER", tc.sampler)
+			}
+			if tc.arg == "" {
+				os.Unsetenv("OTEL_TRACES_SAMPLER_ARG")
+			} else {
+				os.Setenv("OTEL_TRACES_SAMPLER_ARG", tc.arg)
+			}
+
+			sampler := otelSamplerFromEnv()
+			require.NotNil(t, sampler)
+			assert.Equal(t, tc.wantDesc, sampler.Description())
+		})
+	}
+}
+
+func TestParseRatioOrDefault(t *testing.T) {
+	tests := []struct {
+		input      string
+		defaultVal float64
+		want       float64
+	}{
+		{"0.5", 1.0, 0.5},
+		{"0.0", 1.0, 0.0},
+		{"1.0", 0.5, 1.0},
+		{"", 0.75, 0.75},
+		{"invalid", 0.75, 0.75},
+		{"-0.1", 0.75, 0.75},
+		{"1.1", 0.75, 0.75},
+		{"NaN", 0.75, 0.75},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := parseRatioOrDefault(tc.input, tc.defaultVal)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNewOTelFromEnvRespectsSampler(t *testing.T) {
+	// This test validates the core bug fix: when OTEL_TRACES_SAMPLER=traceidratio
+	// is set with OTEL_TRACES_SAMPLER_ARG=0.1, the sampler should NOT be AlwaysSample.
+	defer saveEnvAndRestoreDeferred("OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG")()
+
+	os.Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
+	os.Setenv("OTEL_TRACES_SAMPLER_ARG", "0.1")
+
+	sampler := otelSamplerFromEnv()
+
+	// Must NOT be AlwaysSample — this is the exact bug we're fixing.
+	alwaysOn := sdktrace.AlwaysSample()
+	assert.NotEqual(t, alwaysOn.Description(), sampler.Description(),
+		"sampler should NOT be AlwaysOnSampler when OTEL_TRACES_SAMPLER=traceidratio")
+
+	assert.Equal(t, "TraceIDRatioBased{0.1}", sampler.Description())
+}
+
 func saveEnvAndRestoreDeferred(vars ...string) func() {
 	originalValues := make(map[string]string)
 	for _, v := range vars {


### PR DESCRIPTION
## Problem

  `NewOTelFromEnv` hardcodes `AlwaysSample()` in its else branch (when no Jaeger
  remote sampler is configured), which overrides any sampler the OTel SDK would
  have configured from the standard `OTEL_TRACES_SAMPLER` environment variable:

      options = append(options, tracesdk.WithSampler(
          &JaegerDebuggingSampler{tracesdk.ParentBased(tracesdk.AlwaysSample())}))

  The comment in `maybeJaegerRemoteSamplerFromEnv` states that the "trace provider
  already configured it through samplerFromEnv()", but the explicit `WithSampler`
  call immediately overrides it. As a result, any dskit-based service setting
  `OTEL_TRACES_SAMPLER=traceidratio` with `OTEL_TRACES_SAMPLER_ARG=0.1` still
  samples 100 % of traces, making it impossible to control trace volume through
  standard OTel environment variables.

  ## Fix

  Replace the hardcoded sampler with `otelSamplerFromEnv()`, a helper that reads
  `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` and returns the correct
  sampler per the [OTel specification][spec]. When the env vars are unset, it
  defaults to `ParentBased(AlwaysSample())`, preserving backward compatibility.

  Supported sampler values:

  | `OTEL_TRACES_SAMPLER`      | Sampler                                 |
  |----------------------------|-----------------------------------------|
  | `always_on`                | `AlwaysSample()`                        |
  | `always_off`               | `NeverSample()`                         |
  | `traceidratio`             | `TraceIDRatioBased(arg)`                |
  | `parentbased_always_on`    | `ParentBased(AlwaysSample())`           |
  | `parentbased_always_off`   | `ParentBased(NeverSample())`            |
  | `parentbased_traceidratio` | `ParentBased(TraceIDRatioBased(arg))`   |

  [spec]: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler

## Unit tests

  - TestOtelSamplerFromEnv — 12 sub-tests covering every sampler type plus
  invalid/missing args and out-of-range ratios
  - TestParseRatioOrDefault — 7 sub-tests for ratio parsing edge cases
  - TestNewOTelFromEnvRespectsSampler — regression test confirming
  traceidratio with 0.1 produces TraceIDRatioBased{0.1}, not
  AlwaysOnSampler

## End-to-end validation with Mimir

The fix can be verified end-to-end by building Mimir against the patched dskit
and checking that OTEL_TRACES_SAMPLER actually controls trace output.

The test stack uses four containers on an internal Docker network:

Prometheus ──scrape + remote write──> Mimir ──OTLP traces──> Alloy ──> Tempo

Prometheus scrapes Mimir metrics and remote-writes them back, which generates
internal Mimir trace activity. Alloy collects the OTLP spans and forwards them
to Tempo.

Directory layout

dskit-931-test/
- docker-compose.yml
- mimir/
    - Dockerfile
    - config.yaml
- alloy/
    - config.alloy
- tempo/
    - tempo.yaml
- prometheus/
    - prometheus.yml

### Files
docker-compose.yml:
```yaml
services:
  mimir:
    build:
      context: ./mimir
      dockerfile: Dockerfile
    container_name: mimir
    volumes:
      - ./mimir/config.yaml:/etc/mimir/config.yaml
    command: ["-config.file=/etc/mimir/config.yaml", "-target=all"]
    environment:
      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
      - OTEL_SERVICE_NAME=mimir
      - OTEL_TRACES_SAMPLER=traceidratio
      - OTEL_TRACES_SAMPLER_ARG=0.5
    networks: [test]
    depends_on: [alloy]

  alloy:
    image: grafana/alloy:v1.13.0
    container_name: alloy
    volumes:
      - ./alloy/config.alloy:/etc/alloy/config.alloy
    command: [run, --server.http.listen-addr=0.0.0.0:12345, /etc/alloy/config.alloy]
    networks: [test]
    depends_on: [tempo]

  tempo:
    image: grafana/tempo:2.10.0
    container_name: tempo
    volumes:
      - ./tempo/tempo.yaml:/etc/tempo.yaml
    command: ["--config.file=/etc/tempo.yaml"]
    networks: [test]

  prometheus:
    image: prom/prometheus:v3.9.1
    container_name: prometheus
    volumes:
      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
    networks: [test]

networks:
  test:
```

mimir/Dockerfile:
```Dockerfile
ARG GO_VERSION=1.25
ARG MIMIR_VERSION=mimir-3.0.2
ARG DSKIT_COMMIT=a4bfa505f5e9

FROM golang:${GO_VERSION}-bookworm AS builder

ARG MIMIR_VERSION
ARG DSKIT_COMMIT

RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*

WORKDIR /src

# Clone upstream dskit at the Mimir-vendored commit, then cherry-pick the fix
# from the PR branch (bubu11e/dskit#fix/otel-sampler-from-env → grafana/dskit#944)
RUN git clone https://github.com/grafana/dskit.git /src/dskit && \
    cd /src/dskit && \
    git checkout ${DSKIT_COMMIT} && \
    git remote add fix https://github.com/bubu11e/dskit.git && \
    git fetch fix fix/otel-sampler-from-env && \
    git cherry-pick --no-commit fix/fix/otel-sampler-from-env

RUN git clone --depth 1 --branch ${MIMIR_VERSION} \
    https://github.com/grafana/mimir.git /src/mimir

WORKDIR /src/mimir
RUN go mod edit -replace github.com/grafana/dskit=/src/dskit && \
    go mod tidy && go mod vendor
RUN CGO_ENABLED=0 go build -o /bin/mimir ./cmd/mimir

# Minimal runtime
FROM gcr.io/distroless/static-debian12:nonroot
COPY --from=builder /bin/mimir /bin/mimir
ENTRYPOINT ["/bin/mimir"]
```

mimir/config.yaml:
```yaml
multitenancy_enabled: false

server:
  http_listen_address: 0.0.0.0
  grpc_listen_port: 9009
  http_listen_port: 8080
  log_format: json
  log_level: warn

distributor:
  ring:
    kvstore:
      store: inmemory

ingester:
  ring:
    kvstore:
      store: inmemory
    replication_factor: 1
```
alloy/config.alloy:
```json
// OTLP receiver — Mimir sends traces here.
otelcol.receiver.otlp "default" {
  grpc { endpoint = "0.0.0.0:4317" }
  http { endpoint = "0.0.0.0:4318" }

  output {
    traces = [otelcol.processor.batch.default.input]
  }
}

otelcol.processor.batch "default" {
  timeout = "1s"

  output {
    traces = [otelcol.exporter.otlp.tempo.input]
  }
}

// Forward traces to Tempo via OTLP gRPC.
otelcol.exporter.otlp "tempo" {
  client {
    endpoint = "tempo:4317"
    tls { insecure = true }
  }
}
```
tempo/tempo.yaml
```yaml
server:
  http_listen_port: 3200

distributor:
  receivers:
    otlp:
      protocols:
        grpc:
          endpoint: 0.0.0.0:4317
        http:
          endpoint: 0.0.0.0:4318

ingester:
  max_block_duration: 5m

compactor:
  compaction:
    block_retention: 1h

storage:
  trace:
    backend: local
    wal:
      path: /var/tempo/wal
    local:
      path: /var/tempo/blocks
```
prometheus/prometheus.yml
```yaml
scrape_configs:
  - job_name: mimir
    static_configs:
      - targets: ['mimir:8080']

remote_write:
  - url: http://mimir:8080/api/v1/push
```


### Running the test
```bash
# Build and start the stack
docker compose up -d --build

# Wait ~30s for Prometheus to start remote-writing and Mimir to generate traces

# Record current span count at the collector
BEFORE=$(docker compose exec prometheus \
  wget -qO- 'http://alloy:12345/metrics' | \
  grep 'otelcol_receiver_accepted_spans_total.*grpc' | grep -oP '\d+$')

sleep 30

AFTER=$(docker compose exec prometheus \
  wget -qO- 'http://alloy:12345/metrics' | \
  grep 'otelcol_receiver_accepted_spans_total.*grpc' | grep -oP '\d+$')

echo "New spans with traceidratio(0.5): $((AFTER - BEFORE))"
# Expected: > 0 (traces are flowing, sampled at 50%)
```

Then switch to always_off to prove the sampler env var is actually respected:
```bash
# Change OTEL_TRACES_SAMPLER=always_off in docker-compose.yml, then:
docker compose up -d mimir

BEFORE=$(docker compose exec prometheus \
  wget -qO- 'http://alloy:12345/metrics' | \
  grep 'otelcol_receiver_accepted_spans_total.*grpc' | grep -oP '\d+$')

sleep 30

AFTER=$(docker compose exec prometheus \
  wget -qO- 'http://alloy:12345/metrics' | \
  grep 'otelcol_receiver_accepted_spans_total.*grpc' | grep -oP '\d+$')

echo "New spans with always_off: $((AFTER - BEFORE))"
# Expected: 0 (no new spans)
# Before this fix: spans keep flowing regardless of OTEL_TRACES_SAMPLER
```

 ### Observed results

| `OTEL_TRACES_SAMPLER` | New spans (30s) | Before fix |
|------------------------|-----------------|------------|
| `traceidratio` (0.5)  | 11 (sampled)    | ~22 (all)  |
| `always_off`           | **0**           | ~22 (all)  |

  ### Clean up
  docker compose down


  Fixes #931

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default trace sampling behavior to honor env-configured samplers, which can materially alter trace volume and operational visibility. Scope is limited to tracing init and is covered by targeted unit/regression tests.
> 
> **Overview**
> `NewOTelFromEnv` no longer hardcodes `ParentBased(AlwaysSample())` when no Jaeger remote sampler is configured; it now derives the sampler from `OTEL_TRACES_SAMPLER`/`OTEL_TRACES_SAMPLER_ARG` (while still wrapping with `JaegerDebuggingSampler`).
> 
> This adds `otelSamplerFromEnv` (plus spec-aligned constants and ratio parsing/clamping) and normalizes Jaeger remote sampler env parsing, with new unit/regression tests covering supported sampler modes and invalid args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f4457cfdda9a8d0e1a98b59a9493cb8ff0f6ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->