### PR TITLE
chore: fix TestRejoin flakyness

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -196,6 +196,9 @@ type KVConfig struct {
 	// This useful to override it in tests.
 	discoverMembersBackoff backoff.Config `yaml:"-"`
 
+	// probeInterval overrides the default probe interval when non-zero. This is useful for testing.
+	probeInterval time.Duration `yaml:"-"`
+
 	// Hooks used for testing.
 	beforeJoinMembersOnStartupHook func(_ context.Context)
 }
@@ -510,8 +513,13 @@ func (m *KV) buildMemberlistConfig() (*memberlist.Config, error) {
 	// For our use cases, we don't need a very fast detection of dead nodes. Since we use a TCP transport
 	// and we open a new TCP connection for each packet, we prefer to reduce the probe frequency and increase
 	// the timeout compared to defaults.
-	mlCfg.ProbeInterval = 5 * time.Second // Probe a random node every this interval. This setting is also the total timeout for the direct + indirect probes.
-	mlCfg.ProbeTimeout = 2 * time.Second  // Timeout for the direct probe.
+	if m.cfg.probeInterval > 0 {
+		mlCfg.ProbeInterval = m.cfg.probeInterval
+		mlCfg.ProbeTimeout = m.cfg.probeInterval / 2
+	} else {
+		mlCfg.ProbeInterval = 5 * time.Second // Probe a random node every this interval. This setting is also the total timeout for the direct + indirect probes.
+		mlCfg.ProbeTimeout = 2 * time.Second  // Timeout for the direct probe.
+	}
 
 	// Since we use a custom transport based on TCP, having TCP-based fallbacks doesn't give us any benefit.
 	// On the contrary, if we keep TCP pings enabled, each node will effectively run 2x pings against a dead

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -1503,6 +1503,7 @@ func TestRejoin(t *testing.T) {
 	cfg1.RandomizeNodeName = true
 	cfg1.Codecs = []codec.Codec{dataCodec{}}
 	cfg1.AbortIfJoinFails = false
+	cfg1.probeInterval = 500 * time.Millisecond
 
 	cfg2 := cfg1
 	cfg2.TCPTransport.BindPort = ports[1]


### PR DESCRIPTION
**What this PR does**:

Fix flaky `TestRejoin` by reducing probe interval.

The test waited 10s for node departure detection, but if the graceful leave broadcast wasn't delivered before shutdown, memberlist falls back to failure detection via probing. With the default ProbeInterval=5s and SuspicionMult=4, this takes ~22s for a 2-node cluster, exceeding the timeout.

Added an unexported `probeInterval` override to `KVConfig` (following the existing pattern for test-only config) and set it to 500ms in the test, reducing worst-case detection to ~2.2s.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
