### PR TITLE
chore: speed up TestSpreadMinimizingTokenGenerator_VerifyInstanceOwnershipSpreadByZone

### DIFF
--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -318,7 +318,7 @@ func TestSpreadMinimizingTokenGenerator_VerifyInstanceOwnershipSpreadByZone(t *t
 	t.Parallel()
 
 	tokensPerInstance := 512
-	instancesPerZone := 10000
+	instancesPerZone := 1000
 	instanceByToken, tokensByZone := createTokensForAllInstancesAndZones(t, instancesPerZone, tokensPerInstance)
 	ownershipByInstanceByZone := registeredOwnershipByZone(instancesPerZone, instanceByToken, tokensByZone)
 	for _, ownershipByInstance := range ownershipByInstanceByZone {


### PR DESCRIPTION
**What this PR does**:

Reduce `instancesPerZone` in `TestSpreadMinimizingTokenGenerator_VerifyInstanceOwnershipSpreadByZone` from 10,000 to 1,000, to speed up the test execution with `-race`.

The ownership spread property being tested is deterministic (not statistical), so 1,000 instances is sufficient to validate that ownership is spread across instances and zones. The existing spread threshold (0.2%) still passes without relaxation.

Based on local runs:

| | Time |
|---|---|
| Before | 91.05s |
| After | 8.54s |
| Speedup | **10.7x** |

Actual impact in CI: `github.com/grafana/dskit/ring` time reduced from `731.743s` to `650.800s` (-81s).

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
