### PR TITLE
feat(tenant): bring back metadata Get and Has

### DIFF
--- a/tenant/metadata.go
+++ b/tenant/metadata.go
@@ -206,6 +206,22 @@ func (m Metadata) With(key string, val string) Metadata {
 	return m
 }
 
+// Has checks whether a specific metadata key is present.
+func (m Metadata) Has(key string) bool {
+	_, ok := m.Get(key)
+	return ok
+}
+
+// Get the value set for key.
+func (m Metadata) Get(key string) (string, bool) {
+	for k, v := range m.Iter() {
+		if k == key {
+			return v, true
+		}
+	}
+	return "", false
+}
+
 // WithTenant encodes the metadata as a tenant-prefixed string.
 // The format is "tenantID:key1=val1:key2=val2" with keys sorted alphabetically.
 func (m Metadata) WithTenant(tenantID string) string {

--- a/tenant/metadata_test.go
+++ b/tenant/metadata_test.go
@@ -69,6 +69,25 @@ func TestMetadata_IsEmpty(t *testing.T) {
 	}
 }
 
+func TestMetadata_Has(t *testing.T) {
+	var md Metadata
+	md.Set("key", "value")
+	assert.True(t, md.Has("key"))
+	assert.False(t, md.Has("missing"))
+}
+
+func TestMetadata_Get(t *testing.T) {
+	var md Metadata
+	md.Set("key", "value")
+	val, ok := md.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "value", val)
+
+	val, ok = md.Get("missing")
+	assert.False(t, ok)
+	assert.Equal(t, "", val)
+}
+
 func TestMetadata_DivideIter(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION


**What this PR does**:

Adds back methods Get and Has that were removed in #938.

Although they hide O(n) complexity, we expect n to be always small enough in practical scenarios.

**Which issue(s) this PR fixes**:

—

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds convenience accessors over existing metadata iteration without changing encoding/validation behavior; main concern is minor O(n) lookups on small metadata sets.
> 
> **Overview**
> Restores `Metadata.Get` and `Metadata.Has` to allow callers to check for a key and retrieve its value without manually iterating.
> 
> Adds unit coverage for both methods, including presence/absence behavior and return values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c234e7565a462b8bec2085a873e36e1d9f615a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->