### PR TITLE
feat: cache: Record the number of servers touched for get-multi

### DIFF
--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -810,6 +810,12 @@ func (c *MemcachedClient) sortKeysByServer(keys []string) []string {
 		bucketed[addrString] = append(bucketed[addrString], key)
 	}
 
+	// Record the number of servers we've bucketed keys into. Note that this is only
+	// done in the "batching" code path because sorting keys by server doesn't help
+	// when there's only a single batch being used. This is fine since we expect the
+	// number of servers touched to be higher for requests with more keys.
+	c.metrics.serversTouched.WithLabelValues(opGetMulti).Observe(float64(len(bucketed)))
+
 	out := make([]string, 0, len(keys))
 	for srv := range bucketed {
 		out = append(out, bucketed[srv]...)

--- a/cache/memcached_client_metrics.go
+++ b/cache/memcached_client_metrics.go
@@ -47,6 +47,7 @@ type clientMetrics struct {
 	duration        *prometheus.HistogramVec
 	dataSize        *prometheus.HistogramVec
 	skippedDataSize *prometheus.HistogramVec
+	serversTouched  *prometheus.HistogramVec
 }
 
 // newClientMetrics creates a new bundle of metrics about an instance of a cache client. Note
@@ -150,6 +151,18 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 	cm.skippedDataSize.WithLabelValues(opAdd)
 	cm.skippedDataSize.WithLabelValues(opSet)
 	cm.skippedDataSize.WithLabelValues(opCompareAndSwap)
+
+	cm.serversTouched = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name: "operation_servers_touched",
+		Help: "The number of servers requests were made to during a batched operation.",
+		Buckets: []float64{
+			1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024,
+		},
+		NativeHistogramBucketFactor: 1.1,
+	},
+		[]string{"operation"},
+	)
+	cm.serversTouched.WithLabelValues(opGetMulti)
 
 	return cm
 }


### PR DESCRIPTION
**What this PR does**:

Record the number of servers that requests were made to to help estimate the number of connections required at any one time.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Prometheus histogram and a single observation in the `getmulti` batching path, without changing cache behavior or request flow.
> 
> **Overview**
> Adds a new Prometheus histogram metric, `cache_operation_servers_touched{operation="getmulti"}`, to record how many distinct memcached servers are contacted during a batched `GetMulti`.
> 
> The metric is observed when keys are bucketed by server in `sortKeysByServer`, enabling visibility into fan-out/connection pressure for large multi-get requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37a578ae6910fc6b3315a0c0cd85417edb4c4385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->