### PR TITLE
feat(runtimeconfig): support cluster validation label for HTTP loader

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -21,7 +21,9 @@ import (
 	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
 )
 
@@ -37,17 +39,27 @@ type Config struct {
 	ReloadPeriod time.Duration `yaml:"period" category:"advanced"`
 	// LoadPath contains the path to the runtime config files or HTTP URLs.
 	// Requires a non-empty value
-	LoadPath          flagext.StringSliceCSV `yaml:"file"`
-	HTTPClientTimeout time.Duration          `yaml:"http_client_timeout" category:"advanced"`
-	Preprocessor      Preprocessor           `yaml:"-"`
-	Loader            Loader                 `yaml:"-"`
+	LoadPath     flagext.StringSliceCSV `yaml:"file"`
+	Preprocessor Preprocessor           `yaml:"-"`
+	Loader       Loader                 `yaml:"-"`
+
+	// Configurations related to fetching runtime configurations from HTTP URLs rather than local files.
+	HTTPClientTimeout           time.Duration                       `yaml:"http_client_timeout" category:"advanced"`
+	HTTPClientClusterValidation clusterutil.ClusterValidationConfig `yaml:"http_client_cluster_validation" category:"advanced"`
+}
+
+// RegisterFlagsWithPrefix registers flags under the specified prefix, which could be empty.
+// If a non-empty prefix is provided, it's expected to end with a dot.
+func (mc *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.Var(&mc.LoadPath, prefix+"file", "Comma separated list of yaml files or URLs with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
+	f.DurationVar(&mc.ReloadPeriod, prefix+"reload-period", 10*time.Second, "How often to check runtime config files.")
+	f.DurationVar(&mc.HTTPClientTimeout, prefix+"http-client-timeout", 30*time.Second, "HTTP client timeout when fetching runtime config from URLs.")
+	mc.HTTPClientClusterValidation.RegisterFlagsWithPrefix(prefix+"http-client-cluster-validation.", f)
 }
 
 // RegisterFlags registers flags.
 func (mc *Config) RegisterFlags(f *flag.FlagSet) {
-	f.Var(&mc.LoadPath, "runtime-config.file", "Comma separated list of yaml files or URLs with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
-	f.DurationVar(&mc.ReloadPeriod, "runtime-config.reload-period", 10*time.Second, "How often to check runtime config files.")
-	f.DurationVar(&mc.HTTPClientTimeout, "runtime-config.http-client-timeout", 30*time.Second, "HTTP client timeout when fetching runtime config from URLs.")
+	mc.RegisterFlagsWithPrefix("runtime-config.", f)
 }
 
 // Manager periodically reloads the configuration from specified files, and keeps this
@@ -102,7 +114,7 @@ func New(cfg Config, configName string, registerer prometheus.Registerer, logger
 				if timeout == 0 {
 					timeout = 30 * time.Second
 				}
-				httpClient = &http.Client{Timeout: timeout}
+				httpClient = &http.Client{Timeout: timeout, Transport: httpTransport(cfg, registerer, logger)}
 				httpDuration = newHTTPRequestDuration(registerer)
 			}
 			mgr.providers = append(mgr.providers, newHTTPProvider(p, httpClient, httpDuration))
@@ -362,4 +374,24 @@ func (om *Manager) GetConfig() interface{} {
 		return *p
 	}
 	return nil
+}
+
+func httpTransport(cfg Config, registerer prometheus.Registerer, logger log.Logger) http.RoundTripper {
+	rt := http.DefaultTransport
+	if cfg.HTTPClientClusterValidation.Label != "" {
+		invalidClusterValidations := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Name: "client_invalid_cluster_validation_label_requests_total",
+			Help: "Number of requests with invalid cluster validation label.",
+			ConstLabels: map[string]string{
+				"client":   "runtime-config",
+				"protocol": "http",
+			},
+		}, []string{"method"})
+		reporter := func(msg string, method string) {
+			level.Warn(logger).Log("msg", msg, "method", method, "cluster_validation_label", cfg.HTTPClientClusterValidation.Label, "component", "runtimeconfig", "load_path", cfg.LoadPath)
+			invalidClusterValidations.WithLabelValues(method).Inc()
+		}
+		rt = middleware.ClusterValidationRoundTripper(cfg.HTTPClientClusterValidation.Label, reporter, http.DefaultTransport)
+	}
+	return rt
 }

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -4,6 +4,8 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +27,7 @@ import (
 	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
@@ -929,4 +932,125 @@ func TestManager_URLPathMetrics(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected runtime_config_http_request_duration_seconds metric")
+}
+
+func TestManager_URLPath_ClusterValidationLabel(t *testing.T) {
+	var receivedCluster atomic.String
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCluster.Store(r.Header.Get(clusterutil.ClusterValidationLabelHeader))
+		_, _ = w.Write([]byte("value: 42\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     []string{srv.URL + "/config.yaml"},
+		Loader:       valueLoader,
+		HTTPClientClusterValidation: clusterutil.ClusterValidationConfig{
+			Label: "my-cluster",
+		},
+	}
+
+	manager, err := New(cfg, "overrides", nil, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager)) })
+
+	require.Equal(t, value{Value: 42}, manager.GetConfig())
+	require.Equal(t, "my-cluster", receivedCluster.Load())
+}
+
+func TestManager_URLPath_ClusterValidationLabel_RejectedByServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body, err := json.Marshal(map[string]string{
+			"cluster_validation_error_message": "wrong cluster",
+			"route":                            "GET",
+		})
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNetworkAuthenticationRequired)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := prometheus.NewPedanticRegistry()
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     []string{srv.URL + "/config.yaml"},
+		Loader:       valueLoader,
+		HTTPClientClusterValidation: clusterutil.ClusterValidationConfig{
+			Label: "client-cluster",
+		},
+	}
+
+	manager, err := New(cfg, "overrides", reg, log.NewNopLogger())
+	require.NoError(t, err)
+
+	err = services.StartAndAwaitRunning(context.Background(), manager)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "request rejected by the server: wrong cluster")
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP client_invalid_cluster_validation_label_requests_total Number of requests with invalid cluster validation label.
+		# TYPE client_invalid_cluster_validation_label_requests_total counter
+		client_invalid_cluster_validation_label_requests_total{client="runtime-config",config="overrides",method="GET",protocol="http"} 1
+	`), "client_invalid_cluster_validation_label_requests_total"))
+}
+
+func TestManager_URLPath_NoClusterValidationLabelByDefault(t *testing.T) {
+	var receivedCluster atomic.String
+	receivedCluster.Store("<unset>")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v, ok := r.Header[clusterutil.ClusterValidationLabelHeader]; ok {
+			receivedCluster.Store(strings.Join(v, ","))
+		} else {
+			receivedCluster.Store("")
+		}
+		_, _ = w.Write([]byte("value: 7\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     []string{srv.URL + "/config.yaml"},
+		Loader:       valueLoader,
+	}
+
+	manager, err := New(cfg, "overrides", nil, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager)) })
+
+	require.Equal(t, value{Value: 7}, manager.GetConfig())
+	require.Equal(t, "", receivedCluster.Load())
+}
+
+func TestConfig_RegisterFlagsWithPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		prefix string
+	}{
+		{name: "default prefix via RegisterFlags", prefix: "runtime-config."},
+		{name: "custom prefix", prefix: "my-runtime-config."},
+		{name: "empty prefix", prefix: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.PanicOnError)
+			var cfg Config
+			if tc.prefix == "runtime-config." {
+				cfg.RegisterFlags(fs)
+			} else {
+				cfg.RegisterFlagsWithPrefix(tc.prefix, fs)
+			}
+
+			for _, name := range []string{
+				tc.prefix + "file",
+				tc.prefix + "reload-period",
+				tc.prefix + "http-client-timeout",
+				tc.prefix + "http-client-cluster-validation.label",
+			} {
+				require.NotNil(t, fs.Lookup(name), "expected flag %q to be registered", name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does**:

Adds an optional cluster validation label to the HTTP runtime config loader. When `runtime-config.http-client-cluster-validation.label` is set, the loader's HTTP client wraps its transport with `middleware.ClusterValidationRoundTripper`, sending the `X-Cluster` header on every request and surfacing server-side rejections together with a `client_invalid_cluster_validation_label_requests_total` counter.

This protects services that load runtime config over HTTP from accidentally fetching it from the wrong cluster — e.g. when a config server URL is reused across environments.

The `Config.RegisterFlagsWithPrefix` helper is also exposed so callers can mount the runtime config flags under a custom prefix.

This is a second take on https://github.com/grafana/dskit/pull/964

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optional HTTP transport middleware and new config/flags for cluster validation, which can change startup/reload behavior for URL-based runtime config when enabled. Default behavior remains unchanged when the label is unset.
> 
> **Overview**
> **Runtime config loaded via HTTP can now include an optional cluster validation label.** When `runtime-config.http-client-cluster-validation.label` is set, the HTTP client wraps its transport with `middleware.ClusterValidationRoundTripper`, sending the cluster header and recording a new `client_invalid_cluster_validation_label_requests_total` metric when requests are rejected.
> 
> **Config flag registration was refactored** to add `Config.RegisterFlagsWithPrefix`, letting callers mount all runtime-config flags (including the new cluster validation flags) under a custom prefix; `RegisterFlags` now delegates to this helper.
> 
> Tests were added to verify header behavior (set/unset), server-side rejection handling/metrics, and prefixed flag registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda4c820d468fc1ac9260fbb8e3fdfa7131bacc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->