### PR TITLE
fix(runtimeconfig): make cluster-validation counter compatible with shared registries

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -90,6 +90,12 @@ func New(cfg Config, configName string, registerer prometheus.Registerer, logger
 		return nil, errors.New("LoadPath is empty")
 	}
 
+	// The cluster-validation counter shares its name with similarly-named counters from other
+	// client-side cluster-validation reporters in the calling application (e.g. gRPC clients), so
+	// its label set must match theirs: {client, protocol, method}, with no per-manager "config"
+	// label. We therefore pass an un-wrapped registerer to httpTransport and disambiguate per
+	// manager via the "client" label value (set to "runtime-config/<configName>").
+	clusterValidationRegisterer := registerer
 	registerer = prometheus.WrapRegistererWith(prometheus.Labels{"config": configName}, registerer)
 
 	mgr := Manager{
@@ -114,7 +120,7 @@ func New(cfg Config, configName string, registerer prometheus.Registerer, logger
 				if timeout == 0 {
 					timeout = 30 * time.Second
 				}
-				httpClient = &http.Client{Timeout: timeout, Transport: httpTransport(cfg, registerer, logger)}
+				httpClient = &http.Client{Timeout: timeout, Transport: httpTransport(cfg, configName, clusterValidationRegisterer, logger)}
 				httpDuration = newHTTPRequestDuration(registerer)
 			}
 			mgr.providers = append(mgr.providers, newHTTPProvider(p, httpClient, httpDuration))
@@ -376,14 +382,14 @@ func (om *Manager) GetConfig() interface{} {
 	return nil
 }
 
-func httpTransport(cfg Config, registerer prometheus.Registerer, logger log.Logger) http.RoundTripper {
+func httpTransport(cfg Config, configName string, registerer prometheus.Registerer, logger log.Logger) http.RoundTripper {
 	rt := http.DefaultTransport
 	if cfg.HTTPClientClusterValidation.Label != "" {
 		invalidClusterValidations := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "client_invalid_cluster_validation_label_requests_total",
 			Help: "Number of requests with invalid cluster validation label.",
 			ConstLabels: map[string]string{
-				"client":   "runtime-config",
+				"client":   "runtime-config/" + configName,
 				"protocol": "http",
 			},
 		}, []string{"method"})

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -993,8 +994,53 @@ func TestManager_URLPath_ClusterValidationLabel_RejectedByServer(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP client_invalid_cluster_validation_label_requests_total Number of requests with invalid cluster validation label.
 		# TYPE client_invalid_cluster_validation_label_requests_total counter
-		client_invalid_cluster_validation_label_requests_total{client="runtime-config",config="overrides",method="GET",protocol="http"} 1
+		client_invalid_cluster_validation_label_requests_total{client="runtime-config/overrides",method="GET",protocol="http"} 1
 	`), "client_invalid_cluster_validation_label_requests_total"))
+}
+
+// TestManager_URLPath_ClusterValidationLabel_SharedRegistry verifies that the
+// cluster-validation counter is registered with a label set ({client, protocol,
+// method}) that matches the convention used by other client-side cluster-
+// validation counters in the calling application (e.g. gRPC clients). Per-
+// manager disambiguation is done via the "client" label value. A regression
+// here would cause a MustRegister panic on startup in deployments that run
+// multiple Managers (or a Manager alongside cluster-validated gRPC clients) on
+// the same registry.
+func TestManager_URLPath_ClusterValidationLabel_SharedRegistry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	reg := prometheus.NewPedanticRegistry()
+
+	// Pre-register a counter mimicking what a gRPC client of the calling application would
+	// register: same name, same label set ({client, protocol, method}), no "config" label.
+	_ = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "client_invalid_cluster_validation_label_requests_total",
+		Help: "Number of requests with invalid cluster validation label.",
+		ConstLabels: map[string]string{
+			"client":   "some-grpc-client",
+			"protocol": "grpc",
+		},
+	}, []string{"method"})
+
+	mk := func(name string) *Manager {
+		cfg := Config{
+			ReloadPeriod: time.Second,
+			LoadPath:     []string{srv.URL + "/" + name + ".yaml"},
+			Loader:       valueLoader,
+			HTTPClientClusterValidation: clusterutil.ClusterValidationConfig{
+				Label: "shared-cluster",
+			},
+		}
+		mgr, err := New(cfg, name, reg, log.NewNopLogger())
+		require.NoError(t, err)
+		return mgr
+	}
+
+	require.NotPanics(t, func() {
+		_ = mk("first")
+		_ = mk("second")
+	})
 }
 
 func TestManager_URLPath_NoClusterValidationLabelByDefault(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Follow-up fix for #966.

The cluster-validation counter (`client_invalid_cluster_validation_label_requests_total`) was registered through the per-manager `{config=<name>}` wrapper applied at the top of `New`, giving it the label set `{config, client, protocol, method}`.

Callers commonly register a similarly-named counter for their own client-side cluster-validation reporters (e.g. gRPC clients) with the conventional label set `{client, protocol, method}` — see how Mimir does it in [`pkg/util/metrics.go`](https://github.com/grafana/mimir/blob/41b25ff0b71b33397a4972414e1c3c79144f726d/pkg/util/metrics.go#L13-L31). On a shared root registry (e.g. Mimir monolithic mode), the dimensional mismatch trips the Prometheus client's consistency check and panics on startup whenever the runtime-config HTTP cluster validation label is non-empty.

This PR registers the counter on the un-wrapped registerer (no `config` label) and disambiguates per `Manager` via the `client` label value, set to `runtime-config-<configName>`. The label set now matches the convention used by other client-side cluster-validation counters and can coexist with them on the same registry.

A new test (`TestManager_URLPath_ClusterValidationLabel_SharedRegistry`) pre-registers a counter mimicking a gRPC client's own reporter on the same registry and verifies that constructing `Manager` instances afterwards does not panic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Prometheus metric registration/labeling for the HTTP cluster-validation counter plus added tests, with no impact to runtime config loading behavior beyond metric dimensions.
> 
> **Overview**
> Fixes the HTTP cluster-validation metric to **avoid label-set conflicts on shared Prometheus registries** by registering `client_invalid_cluster_validation_label_requests_total` *without* the per-manager `config` label and instead disambiguating Managers via the `client` const label (`runtime-config/<configName>`).
> 
> Updates the existing cluster-validation rejection test expectations and adds a new regression test ensuring multiple `Manager` instances (and pre-existing client reporters) can coexist on the same registry without `MustRegister` panics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a38b4578abbbbef814d260ec99e6edb81674f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->