### PR TITLE
test(ring): reduce wall time of slow tests by ~42%

### DIFF
--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -216,15 +216,24 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 	)
 	cancelCause := errors.New("cancel cause")
 
-	measureDuration := func(r *Ring, keys []uint32) time.Duration {
-		callback := func(InstanceDesc, []int) error { return nil }
-		t0 := time.Now()
-		err := DoBatchWithOptions(context.Background(), Write, r, keys, callback, DoBatchOptions{})
-		duration := time.Since(t0)
-		require.NoError(t, err)
-		t.Logf("Call took %s", duration)
-		return duration
-	}
+	// Build ring and keys once; all subtests share them (read-only).
+	keys := make([]uint32, numKeys)
+	generateKeys(rand.New(rand.NewSource(0)), numKeys, keys)
+	desc := &Desc{Ingesters: generateRingInstances(NewRandomTokenGeneratorWithSeed(0), numInstances, numZones, numTokens)}
+	r := newRingForTesting(Config{
+		HeartbeatTimeout:     time.Hour,
+		ZoneAwarenessEnabled: true,
+		SubringCacheDisabled: true,
+		ReplicationFactor:    numZones,
+	}, true)
+	r.setRingStateFromDesc(desc, false, false, false)
+
+	// Measure once how long an uncancelled DoBatch takes; reuse for both deadline subtests.
+	warmupCallback := func(InstanceDesc, []int) error { return nil }
+	t0 := time.Now()
+	require.NoError(t, DoBatchWithOptions(context.Background(), Write, r, keys, warmupCallback, DoBatchOptions{}))
+	batchDuration := time.Since(t0)
+	t.Logf("Warmup DoBatch took %s", batchDuration)
 
 	type callbackFunc = func(InstanceDesc, []int) error
 	never := func(_ InstanceDesc, _ []int) error {
@@ -233,17 +242,15 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 	}
 	tests := []struct {
 		name        string
-		setup       func(*Ring, []uint32) (context.Context, callbackFunc)
+		setup       func() (context.Context, callbackFunc)
 		expectedErr error
 	}{
 		{
 			name: "context deadline exceeded",
-			setup: func(r *Ring, keys []uint32) (context.Context, callbackFunc) {
-				duration := measureDuration(r, keys)
-
-				// Make a second call cancelling after a hundredth of duration of the first one.
-				// For a 4s first call, this is 40ms: should be enough for this test to not be flaky.
-				ctx, cancel := context.WithTimeout(context.Background(), duration/100)
+			setup: func() (context.Context, callbackFunc) {
+				// Cancel after a hundredth of the warmup duration.
+				// For a 4s warmup this is 40ms: enough to avoid flakiness.
+				ctx, cancel := context.WithTimeout(context.Background(), batchDuration/100)
 				go func() {
 					<-ctx.Done()
 					cancel()
@@ -254,12 +261,8 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 		},
 		{
 			name: "context deadline exceeded with cause",
-			setup: func(r *Ring, keys []uint32) (context.Context, callbackFunc) {
-				duration := measureDuration(r, keys)
-
-				// Make a second call cancelling after a hundredth of duration of the first one.
-				// For a 4s first call, this is 40ms: should be enough for this test to not be flaky.
-				ctx, cancel := context.WithTimeoutCause(context.Background(), duration/100, cancelCause)
+			setup: func() (context.Context, callbackFunc) {
+				ctx, cancel := context.WithTimeoutCause(context.Background(), batchDuration/100, cancelCause)
 				go func() {
 					<-ctx.Done()
 					cancel()
@@ -270,7 +273,7 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 		},
 		{
 			name: "context initially cancelled without cause",
-			setup: func(_ *Ring, _ []uint32) (context.Context, callbackFunc) {
+			setup: func() (context.Context, callbackFunc) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				// start batch with cancelled context
 				cancelFunc()
@@ -280,7 +283,7 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 		},
 		{
 			name: "context initially cancelled with cause",
-			setup: func(_ *Ring, _ []uint32) (context.Context, callbackFunc) {
+			setup: func() (context.Context, callbackFunc) {
 				ctx, cancelFunc := context.WithCancelCause(context.Background())
 				// start batch with cancelled context
 				cancelFunc(cancelCause)
@@ -290,7 +293,7 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 		},
 		{
 			name: "context cancelled during batch processing",
-			setup: func(_ *Ring, _ []uint32) (context.Context, callbackFunc) {
+			setup: func() (context.Context, callbackFunc) {
 				ctx, cancel := context.WithCancelCause(context.Background())
 
 				wg := sync.WaitGroup{}
@@ -315,19 +318,7 @@ func TestDoBatchWithOptionsContextCancellation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keys := make([]uint32, numKeys)
-			generateKeys(rand.New(rand.NewSource(0)), numKeys, keys)
-
-			desc := &Desc{Ingesters: generateRingInstances(NewRandomTokenGeneratorWithSeed(0), numInstances, numZones, numTokens)}
-			r := newRingForTesting(Config{
-				HeartbeatTimeout:     time.Hour,
-				ZoneAwarenessEnabled: true,
-				SubringCacheDisabled: true,
-				ReplicationFactor:    numZones,
-			}, true)
-			r.setRingStateFromDesc(desc, false, false, false)
-
-			ctx, callback := tt.setup(r, keys)
+			ctx, callback := tt.setup()
 
 			wg := sync.WaitGroup{}
 			wg.Add(1)

--- a/ring/spread_minimizing_token_generator_test.go
+++ b/ring/spread_minimizing_token_generator_test.go
@@ -286,7 +286,7 @@ func TestSpreadMinimizingTokenGenerator_CalculateNewToken(t *testing.T) {
 func TestSpreadMinimizingTokenGenerator_GenerateAllTokensIdempotent(t *testing.T) {
 	t.Parallel()
 
-	maxInstanceID := 128
+	maxInstanceID := 16
 	for instanceID := 0; instanceID < maxInstanceID; instanceID++ {
 		for _, zone := range zones {
 			instance := fmt.Sprintf("instance-%s-%d", zone, instanceID)
@@ -339,7 +339,7 @@ func TestSpreadMinimizingTokenGenerator_CheckTokenUniqueness(t *testing.T) {
 	t.Parallel()
 
 	tokensPerInstance := 512
-	instanceID := 10000
+	instanceID := 1000
 	allTokens := make(map[uint32]bool, tokensPerInstance*(instanceID+1)*len(zones))
 	for _, zone := range zones {
 		instance := fmt.Sprintf("instance-%s-%d", zone, instanceID)

--- a/ring/token_range_test.go
+++ b/ring/token_range_test.go
@@ -204,7 +204,7 @@ func testCheckingOfKeyOwnership(t *testing.T, randomizeInstanceStates bool) {
 	// Generate users with different number of tokens
 	userTokens := map[string][]uint32{}
 	shardSizes := map[string]int{}
-	for _, cnt := range []int{1000, 5000, 10000, 25000, 50000, 100000} {
+	for _, cnt := range []int{1000, 5000, 10000, 25000} {
 		uid := fmt.Sprintf("%dk", cnt/1000)
 		userTokens[uid] = gen.GenerateTokens(cnt, nil)
 


### PR DESCRIPTION
**What this PR does**:

CI splits unit tests into 3 parallel groups but the `ring` package alone takes ~10m42s under `-race` — 78% of total test time — pinning group 0 at ~13min while groups 1/2 finish in 1–2min.

Four tests dominate that ring runtime (321s of 492s locally). All run very large inputs that race detector inflates without adding correctness coverage. This PR shrinks those inputs and removes redundant work:

- `TestDoBatchWithOptionsContextCancellation` builds a 5M-key ring per subtest and runs a full warmup `DoBatch` inside each `setup` to derive a timeout. Hoist ring/keys construction outside the subtest loop and measure the warmup once.
- `TestSpreadMinimizingTokenGenerator_GenerateAllTokensIdempotent`: idempotence is a per-(instance, zone) property; 128 instances are overkill. Reduce to 16.
- `TestSpreadMinimizingTokenGenerator_CheckTokenUniqueness`: uniqueness is a generator invariant; reduce `instanceID` 10000 → 1000 (still 1.5M tokens covered).
- `TestCheckingOfKeyOwnership`: drop the two largest user-token sizes (50k, 100k); the property holds at every scale.

Measured locally with `go test -race -count 1 ./ring/`: **492s → 285s** (−42%). Expected CI impact: group 0 drops from ~13min to ~7–8min.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to tests and primarily reduce workloads and redundant setup; main risk is reduced coverage for very-large-scale scenarios.
> 
> **Overview**
> Speeds up `ring` package unit tests by removing redundant heavy setup and shrinking pathological test inputs (especially under `-race`).
> 
> `TestDoBatchWithOptionsContextCancellation` now builds the ring/5M keys once and performs a single warmup `DoBatch` to derive timeouts for subtests, instead of re-creating the ring/keys and re-measuring per subtest.
> 
> Reduces runtime in token-generator/ownership tests by lowering iteration ranges: fewer instance IDs in `SpreadMinimizingTokenGenerator` idempotence/uniqueness tests and fewer large token-count cases in `TestCheckingOfKeyOwnership`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8770cdeef2ac41856df745da50bde3f29d1e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->