### PR TITLE
chore(logging): remove excessive escaping from a couple of log lines

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -139,9 +139,9 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 			}
 		default:
 			if l.LogRequestHeaders && headers != nil {
-				level.Warn(requestLog).Log("msg", dskit_log.LazySprintf("%s %s (%d) %s Response: %q ws: %v; %s", r.Method, uri, statusCode, time.Since(begin), buf.Bytes(), IsWSHandshakeRequest(r), headers))
+				level.Warn(requestLog).Log("msg", dskit_log.LazySprintf("%s %s (%d) %s Response: %s ws: %v; %s", r.Method, uri, statusCode, time.Since(begin), buf.Bytes(), IsWSHandshakeRequest(r), headers))
 			} else {
-				level.Warn(requestLog).Log("msg", dskit_log.LazySprintf("%s %s (%d) %s Response: %q", r.Method, uri, statusCode, time.Since(begin), buf.Bytes()))
+				level.Warn(requestLog).Log("msg", dskit_log.LazySprintf("%s %s (%d) %s Response: %s", r.Method, uri, statusCode, time.Since(begin), buf.Bytes()))
 			}
 		}
 	})

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -229,7 +229,7 @@ func TestResponseBodyEscapingInLogs(t *testing.T) {
 	output := buf.String()
 	require.Contains(t, output, "level=warn")
 	require.Contains(t, output, "POST /loki/api/v1/push (504)")
-	require.Contains(t, output, `Response: \"{\\\"status\\\":\\\"error\\\",\\\"errorType\\\":\\\"timeout\\\",\\\"error\\\":\\\"rpc error: code = DeadlineExceeded desc = context deadline exceeded\\\"}\\n\"`)
+	require.Contains(t, output, `Response: {\"status\":\"error\",\"errorType\":\"timeout\",\"error\":\"rpc error: code = DeadlineExceeded desc = context deadline exceeded\"}\n`)
 }
 
 type errorWriter struct {

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -211,6 +211,27 @@ func TestLoggingRequestWithExcludedHeaders(t *testing.T) {
 	}
 }
 
+func TestResponseBodyEscapingInLogs(t *testing.T) {
+	responseBody := `{"status":"error","errorType":"timeout","error":"rpc error: code = DeadlineExceeded desc = context deadline exceeded"}` + "\n"
+	buf := bytes.NewBuffer(nil)
+	loggingMiddleware := Log{
+		Log: log.NewGoKitWithWriter(log.LogfmtFormat, buf),
+	}
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGatewayTimeout)
+		_, _ = io.WriteString(w, responseBody)
+	}
+	loggingHandler := loggingMiddleware.Wrap(http.HandlerFunc(handler))
+
+	req := httptest.NewRequest("POST", "/loki/api/v1/push", nil)
+	loggingHandler.ServeHTTP(httptest.NewRecorder(), req)
+
+	output := buf.String()
+	require.Contains(t, output, "level=warn")
+	require.Contains(t, output, "POST /loki/api/v1/push (504)")
+	require.Contains(t, output, `Response: \"{\\\"status\\\":\\\"error\\\",\\\"errorType\\\":\\\"timeout\\\",\\\"error\\\":\\\"rpc error: code = DeadlineExceeded desc = context deadline exceeded\\\"}\\n\"`)
+}
+
 type errorWriter struct {
 	err error
 


### PR DESCRIPTION
Broken into two commits: 
- One pinning the existing behaviour in a unit test
- One changing the behaviour

Change this part of the log line from: 
```
`Response: \"{\\\"status\\\":\\\"error\\\",\\\"errorType\\\":\\\"timeout\\\",\\\"error\\\":\\\"rpc error: code = DeadlineExceeded desc = context deadline exceeded\\\"}\\n\"`
```
To: 
```
Response: {\"status\":\"error\",\"errorType\":\"timeout\",\"error\":\"rpc error: code = DeadlineExceeded desc = context deadline exceeded\"}\n
```
Where the only escaping now is done by logfmt. This makes the log output more readable, especially in cases like this where it contains json. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect log formatting for non-2xx responses and add a unit test to lock in the new output.
> 
> **Overview**
> Makes warn-level request logs print captured response bodies without extra Go string quoting (switches `Response: %q` to `Response: %s`), leaving only logfmt escaping for readability.
> 
> Adds `TestResponseBodyEscapingInLogs` to assert the new output for a 504 response body containing JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d246fcc0d063c2df3befc7b3353defb47cc8386d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->