### PR TITLE
chore: remove URL passwords using Redacted method

### DIFF
--- a/flagext/url.go
+++ b/flagext/url.go
@@ -43,10 +43,6 @@ func (v *URLValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // MarshalYAML implements yaml.Marshaler.
 func (v URLValue) MarshalYAML() (interface{}, error) {
-	if v.URL == nil {
-		return "", nil
-	}
-
 	// Mask out passwords when marshalling URLs back to YAML.
-	return v.URL.Redacted(), nil
+	return v.Redacted(), nil
 }

--- a/flagext/url.go
+++ b/flagext/url.go
@@ -48,12 +48,5 @@ func (v URLValue) MarshalYAML() (interface{}, error) {
 	}
 
 	// Mask out passwords when marshalling URLs back to YAML.
-	u := *v.URL
-	if u.User != nil {
-		if _, set := u.User.Password(); set {
-			u.User = url.UserPassword(u.User.Username(), "********")
-		}
-	}
-
-	return u.String(), nil
+	return v.URL.Redacted(), nil
 }

--- a/flagext/url_test.go
+++ b/flagext/url_test.go
@@ -80,7 +80,7 @@ func TestURLValueYAML(t *testing.T) {
 
 		var testStruct TestStruct
 		require.NoError(t, testStruct.URL.Set("http://username:password@google.com"))
-		expected := []byte(`url: http://username:%2A%2A%2A%2A%2A%2A%2A%2A@google.com
+		expected := []byte(`url: http://username:xxxxx@google.com
 `)
 
 		actual, err := yaml.Marshal(testStruct)

--- a/flagext/url_test.go
+++ b/flagext/url_test.go
@@ -80,8 +80,7 @@ func TestURLValueYAML(t *testing.T) {
 
 		var testStruct TestStruct
 		require.NoError(t, testStruct.URL.Set("http://username:password@google.com")) // trufflehog:ignore
-		expected := []byte(`url: http://username:xxxxx@google.com
-`) // trufflehog:ignore
+		expected := []byte("url: http://username:xxxxx@google.com\n")                 // trufflehog:ignore
 
 		actual, err := yaml.Marshal(testStruct)
 		require.NoError(t, err)

--- a/flagext/url_test.go
+++ b/flagext/url_test.go
@@ -79,9 +79,9 @@ func TestURLValueYAML(t *testing.T) {
 		}
 
 		var testStruct TestStruct
-		require.NoError(t, testStruct.URL.Set("http://username:password@google.com"))
+		require.NoError(t, testStruct.URL.Set("http://username:password@google.com")) // trufflehog:ignore
 		expected := []byte(`url: http://username:xxxxx@google.com
-`)
+`) // trufflehog:ignore
 
 		actual, err := yaml.Marshal(testStruct)
 		require.NoError(t, err)

--- a/runtimeconfig/provider.go
+++ b/runtimeconfig/provider.go
@@ -51,7 +51,7 @@ func newHTTPProvider(rawURL string, client *http.Client, requestDuration *promet
 	if parsed, err := url.Parse(rawURL); err == nil {
 		parsed.RawQuery = ""
 		parsed.Fragment = ""
-		urlForMetrics = parsed.String()
+		urlForMetrics = parsed.Redacted()
 	}
 	return &httpProvider{
 		url:             rawURL,


### PR DESCRIPTION
**What this PR does**:

In runtimeconfig, redact any password before exposing the URL as a metric label.

In flagext, replace our own code with the Go standard library version. This does change the appearance from `********` (url-encoded) to `xxxxx`, but hopefully no-one is relying on this.

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, security-positive changes to how URLs are serialized and labeled; only observable difference is the redaction string format in YAML (`xxxxx` vs `********`).
> 
> **Overview**
> Standardizes URL password masking by delegating to Go’s `url.URL.Redacted()` instead of custom logic.
> 
> In **`flagext`**, `URLValue.MarshalYAML` now returns `v.Redacted()` rather than manually copying the URL and substituting `********` in the userinfo. The YAML test expectation shifts from percent-encoded asterisks to the library’s `xxxxx` placeholder (with trufflehog ignore comments on test literals).
> 
> In **`runtimeconfig`**, the `url` label used for Prometheus histograms is built with `parsed.Redacted()` after stripping query and fragment, so embedded credentials no longer appear in metric labels while real requests still use the full `rawURL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cff08109f02fa30b002899994f577f702539855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->