### PR TITLE
chore(ci): supply-chain hardening for GitHub Actions and protoc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default owners for everything in the repo.
+* @grafana/mimir-maintainers
+
+# Supply-chain-sensitive paths, re-stated for visibility. Owners match the
+# catch-all; a more-specific rule added below would still override.
+/.github/                    @grafana/mimir-maintainers
+/Makefile                    @grafana/mimir-maintainers
+/.scripts/                   @grafana/mimir-maintainers
+/go.mod                      @grafana/mimir-maintainers
+/go.sum                      @grafana/mimir-maintainers
+/ring/example/local/go.mod   @grafana/mimir-maintainers
+/ring/example/local/go.sum   @grafana/mimir-maintainers

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,7 @@
 name: CI
+# This workflow runs on pull_request, which includes PRs from forks. It must
+# remain free of repository secrets and must NOT switch to pull_request_target,
+# otherwise untrusted fork code would gain access to write-capable tokens.
 on:
   push:
     branches:
@@ -40,7 +43,6 @@ jobs:
         run: make test-benchmarks
       - name: Check protos
         run: |
-          apt-get update && apt-get -y install unzip
           go mod vendor
           make check-protos
 

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,7 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 
 GOLANGCI_LINT_VERSION := 2.9.0
 .tools/bin/golangci-lint: .tools
-	@set -o pipefail && \
-	mkdir -p .tools/bin && \
+	@mkdir -p .tools/bin && \
 	OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
 	ARCH=$$(go env GOARCH) && \
 	SLUG=golangci-lint-$(GOLANGCI_LINT_VERSION)-$$OS-$$ARCH && \

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ GOLANGCI_LINT_VERSION := 2.9.0
 	curl -sSfL "$$BASE/$$SLUG.tar.gz" -o ".tools/$$SLUG.tar.gz" && \
 	curl -sSfL "$$BASE/golangci-lint-$(GOLANGCI_LINT_VERSION)-checksums.txt" \
 	  | grep -E "[[:space:]]+$$SLUG\.tar\.gz$$" \
-	  | (cd .tools && shasum -a 256 --check --strict -) && \
+	  | (cd .tools && sha256sum --check --strict -) && \
 	tar -xzf ".tools/$$SLUG.tar.gz" -C .tools/bin --strip-components=1 "$$SLUG/golangci-lint" && \
 	rm ".tools/$$SLUG.tar.gz"
 
@@ -104,7 +104,7 @@ ifeq ("$(wildcard .tools/protoc/bin/protoc)","")
 	mkdir -p .tools/protoc
 	cd .tools/protoc && curl -LO $(PROTO_PATH)$(PROTO_ZIP)
 	# Verify the archive against the pinned SHA256 before unzip.
-	cd .tools/protoc && echo "$(PROTO_ZIP_SHA256)  $(PROTO_ZIP)" | shasum -a 256 --check --strict -
+	cd .tools/protoc && echo "$(PROTO_ZIP_SHA256)  $(PROTO_ZIP)" | sha256sum --check --strict -
 	unzip -n .tools/protoc/$(PROTO_ZIP) -d .tools/protoc/
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,6 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 .tools/bin/faillint: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.15.0
 
-# Download the golangci-lint release tarball directly and verify it
-# against the official checksums file from the same release, instead of
-# piping a fetched install.sh into the shell.
 GOLANGCI_LINT_VERSION := 2.9.0
 .tools/bin/golangci-lint: .tools
 	@set -o pipefail && \

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,23 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 .tools/bin/faillint: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.15.0
 
-GOLANGCI_LINT_VERSION := v2.9.0
+# Download the golangci-lint release tarball directly and verify it
+# against the official checksums file from the same release, instead of
+# piping a fetched install.sh into the shell.
+GOLANGCI_LINT_VERSION := 2.9.0
 .tools/bin/golangci-lint: .tools
-	# Pin install.sh to the release tag, not HEAD.
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b .tools/bin $(GOLANGCI_LINT_VERSION)
+	@set -o pipefail && \
+	mkdir -p .tools/bin && \
+	OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
+	ARCH=$$(go env GOARCH) && \
+	SLUG=golangci-lint-$(GOLANGCI_LINT_VERSION)-$$OS-$$ARCH && \
+	BASE=https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION) && \
+	curl -sSfL "$$BASE/$$SLUG.tar.gz" -o ".tools/$$SLUG.tar.gz" && \
+	curl -sSfL "$$BASE/golangci-lint-$(GOLANGCI_LINT_VERSION)-checksums.txt" \
+	  | grep -E "[[:space:]]+$$SLUG\.tar\.gz$$" \
+	  | (cd .tools && shasum -a 256 --check --strict -) && \
+	tar -xzf ".tools/$$SLUG.tar.gz" -C .tools/bin --strip-components=1 "$$SLUG/golangci-lint" && \
+	rm ".tools/$$SLUG.tar.gz"
 
 .tools/bin/protoc: .tools
 ifeq ("$(wildcard .tools/protoc/bin/protoc)","")

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /usr/bin/env bash
+
 # put tools at the root of the folder
 PATH := $(CURDIR)/.tools/bin:$(PATH)
 # We don't want find to scan inside a bunch of directories
@@ -87,17 +89,18 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 
 GOLANGCI_LINT_VERSION := 2.9.0
 .tools/bin/golangci-lint: .tools
-	@mkdir -p .tools/bin && \
-	OS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
-	ARCH=$$(go env GOARCH) && \
-	SLUG=golangci-lint-$(GOLANGCI_LINT_VERSION)-$$OS-$$ARCH && \
-	BASE=https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION) && \
-	curl -sSfL "$$BASE/$$SLUG.tar.gz" -o ".tools/$$SLUG.tar.gz" && \
-	curl -sSfL "$$BASE/golangci-lint-$(GOLANGCI_LINT_VERSION)-checksums.txt" \
-	  | grep -E "[[:space:]]+$$SLUG\.tar\.gz$$" \
-	  | (cd .tools && sha256sum --check --strict -) && \
-	tar -xzf ".tools/$$SLUG.tar.gz" -C .tools/bin --strip-components=1 "$$SLUG/golangci-lint" && \
-	rm ".tools/$$SLUG.tar.gz"
+	@set -e; \
+	mkdir -p .tools/bin; \
+	OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+	ARCH=$$(go env GOARCH); \
+	SLUG=golangci-lint-$(GOLANGCI_LINT_VERSION)-$$OS-$$ARCH; \
+	BASE=https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION); \
+	curl -sSfL "$$BASE/$$SLUG.tar.gz" -o ".tools/$$SLUG.tar.gz"; \
+	curl -sSfL "$$BASE/golangci-lint-$(GOLANGCI_LINT_VERSION)-checksums.txt" -o ".tools/golangci-lint-checksums.txt"; \
+	grep -E "[[:space:]]+$$SLUG\.tar\.gz$$" ".tools/golangci-lint-checksums.txt" > ".tools/$$SLUG.sha256"; \
+	(cd .tools && sha256sum --check --strict "$$SLUG.sha256"); \
+	tar -xzf ".tools/$$SLUG.tar.gz" -C .tools/bin --strip-components=1 "$$SLUG/golangci-lint"; \
+	rm ".tools/$$SLUG.tar.gz" ".tools/golangci-lint-checksums.txt" ".tools/$$SLUG.sha256"
 
 .tools/bin/protoc: .tools
 ifeq ("$(wildcard .tools/protoc/bin/protoc)","")

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ UNAME_S := $(shell uname -s)
 PROTO_PATH := https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/
 ifeq ($(UNAME_S), Linux)
 	PROTO_ZIP=protoc-3.6.1-linux-x86_64.zip
+	# Bump together with PROTO_ZIP when changing the protobuf version.
+	PROTO_ZIP_SHA256=6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807
 endif
 ifeq ($(UNAME_S), Darwin)
 	PROTO_ZIP=protoc-3.6.1-osx-x86_64.zip
+	PROTO_ZIP_SHA256=0decc6ce5beed07f8c20361ddeb5ac7666f09cf34572cca530e16814093f9c0c
 endif
 GO_MODS=$(shell find . $(DONT_FIND) -type f -name 'go.mod' -print)
 
@@ -82,13 +85,17 @@ check-protos: clean-protos protos ## Re-generates protos and git diffs them
 .tools/bin/faillint: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.15.0
 
+GOLANGCI_LINT_VERSION := v2.9.0
 .tools/bin/golangci-lint: .tools
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b .tools/bin v2.9.0
+	# Pin install.sh to the release tag, not HEAD.
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b .tools/bin $(GOLANGCI_LINT_VERSION)
 
 .tools/bin/protoc: .tools
 ifeq ("$(wildcard .tools/protoc/bin/protoc)","")
 	mkdir -p .tools/protoc
 	cd .tools/protoc && curl -LO $(PROTO_PATH)$(PROTO_ZIP)
+	# Verify the archive against the pinned SHA256 before unzip.
+	cd .tools/protoc && echo "$(PROTO_ZIP_SHA256)  $(PROTO_ZIP)" | shasum -a 256 --check --strict -
 	unzip -n .tools/protoc/$(PROTO_ZIP) -d .tools/protoc/
 endif
 


### PR DESCRIPTION
**What this PR does**:

This PR addresses items arising from a general github actions supply-chain risk audit.

The items addressed in this PR include;

* adding a CODEOWNERS file. @grafana/mimir-maintainers was chosen as a default owner, but reviewers please advise if there is a better owner group for this repo
* removed a specific install of `unzip` - this is provided in the base image and not required
* added known SHA versions for strict comparison on downloaded tooling binaries 

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to ownership metadata, CI comments/cleanup, and verified downloads for dev/CI tooling—no runtime product logic.
> 
> **Overview**
> Adds **CODEOWNERS** with `@grafana/mimir-maintainers` as the default owner and explicit rules for supply-chain-sensitive paths (`.github/`, `Makefile`, `.scripts/`, `go.mod`/`go.sum`, and local ring example modules).
> 
> Documents that the **CI** workflow must stay on `pull_request` (not `pull_request_target`) and avoid secrets when fork PRs run. Drops the redundant `apt-get install unzip` step before `check-protos`.
> 
> **Makefile** supply-chain tightening: sets `SHELL` to bash; pins **SHA256** checks for downloaded `protoc` archives (Linux/macOS) before unzip; replaces the golangci-lint remote `install.sh` with a versioned release tarball verified against the published checksums file, then extracts `golangci-lint` into `.tools/bin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a5b92a5d8b511af6c6712fb33b7c7eba03db512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->