### PR TITLE
chore(ci): track protoc and golangci-lint versions via Renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,28 @@ ifeq ("$(wildcard .tools/protoc/bin/protoc)","")
 	unzip -n .tools/protoc/$(PROTO_ZIP) -d .tools/protoc/
 endif
 
+# Invoked by Renovate's postUpgradeTasks after it bumps the protoc version in
+# this Makefile. Re-downloads both archives at the new version and rewrites the
+# two PROTO_ZIP_SHA256 lines in place. The first PROTO_ZIP_SHA256 occurrence is
+# Linux, the second is Darwin, matching the structural ordering of the ifeq
+# blocks above; if those blocks are reordered, update this target too.
+.PHONY: update-protoc-sha
+update-protoc-sha: ## Recompute pinned protoc archive SHA256 values from upstream.
+	@set -e; \
+	tmp=$$(mktemp -d); trap 'rm -rf "$$tmp"' EXIT; \
+	base=$$(awk '/^PROTO_PATH := / {print $$3}' Makefile); \
+	linux_zip=$$(awk -F= '/^[[:space:]]+PROTO_ZIP=protoc-.*-linux-x86_64\.zip$$/ {print $$2}' Makefile); \
+	darwin_zip=$$(awk -F= '/^[[:space:]]+PROTO_ZIP=protoc-.*-osx-x86_64\.zip$$/  {print $$2}' Makefile); \
+	curl -sSfL "$$base$$linux_zip"  -o "$$tmp/$$linux_zip"; \
+	curl -sSfL "$$base$$darwin_zip" -o "$$tmp/$$darwin_zip"; \
+	linux_sha=$$(sha256sum "$$tmp/$$linux_zip"  | awk '{print $$1}'); \
+	darwin_sha=$$(sha256sum "$$tmp/$$darwin_zip" | awk '{print $$1}'); \
+	awk -v ls="$$linux_sha" -v ds="$$darwin_sha" ' \
+	  /^[[:space:]]+PROTO_ZIP_SHA256=/ && !linux_done { sub(/=.*/, "=" ls); linux_done=1; print; next } \
+	  /^[[:space:]]+PROTO_ZIP_SHA256=/                { sub(/=.*/, "=" ds);                 print; next } \
+	  { print } \
+	' Makefile > Makefile.new && mv Makefile.new Makefile
+
 .tools/bin/protoc-gen-gogoslick: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,16 @@ PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
 # If you need windows for some reason it's at https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-win32.zip
 UNAME_S := $(shell uname -s)
 PROTO_PATH := https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/
+# Pinned SHA256 hashes maintained by `make update-protoc-sha` (Renovate postUpgradeTasks hook).
+PROTO_ZIP_SHA256_LINUX  := 6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807
+PROTO_ZIP_SHA256_DARWIN := 0decc6ce5beed07f8c20361ddeb5ac7666f09cf34572cca530e16814093f9c0c
 ifeq ($(UNAME_S), Linux)
 	PROTO_ZIP=protoc-3.6.1-linux-x86_64.zip
-	# Bump together with PROTO_ZIP when changing the protobuf version.
-	PROTO_ZIP_SHA256=6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807
+	PROTO_ZIP_SHA256=$(PROTO_ZIP_SHA256_LINUX)
 endif
 ifeq ($(UNAME_S), Darwin)
 	PROTO_ZIP=protoc-3.6.1-osx-x86_64.zip
-	PROTO_ZIP_SHA256=0decc6ce5beed07f8c20361ddeb5ac7666f09cf34572cca530e16814093f9c0c
+	PROTO_ZIP_SHA256=$(PROTO_ZIP_SHA256_DARWIN)
 endif
 GO_MODS=$(shell find . $(DONT_FIND) -type f -name 'go.mod' -print)
 
@@ -113,23 +115,23 @@ endif
 
 # Invoked by Renovate's postUpgradeTasks after it bumps the protoc version in
 # this Makefile. Re-downloads both archives at the new version and rewrites the
-# two PROTO_ZIP_SHA256 lines in place. The first PROTO_ZIP_SHA256 occurrence is
-# Linux, the second is Darwin, matching the structural ordering of the ifeq
-# blocks above; if those blocks are reordered, update this target too.
+# PROTO_ZIP_SHA256_LINUX and PROTO_ZIP_SHA256_DARWIN top-level constants.
 .PHONY: update-protoc-sha
 update-protoc-sha: ## Recompute pinned protoc archive SHA256 values from upstream.
 	@set -e; \
-	tmp=$$(mktemp -d); trap 'rm -rf "$$tmp"' EXIT; \
+	tmp=$$(mktemp -d); trap 'rm -rf "$$tmp" Makefile.new' EXIT; \
 	base=$$(awk '/^PROTO_PATH := / {print $$3}' Makefile); \
 	linux_zip=$$(awk -F= '/^[[:space:]]+PROTO_ZIP=protoc-.*-linux-x86_64\.zip$$/ {print $$2}' Makefile); \
 	darwin_zip=$$(awk -F= '/^[[:space:]]+PROTO_ZIP=protoc-.*-osx-x86_64\.zip$$/  {print $$2}' Makefile); \
+	[ -n "$$base" ] && [ -n "$$linux_zip" ] && [ -n "$$darwin_zip" ] \
+	  || { echo "update-protoc-sha: failed to extract PROTO_PATH or PROTO_ZIP values from Makefile" >&2; exit 1; }; \
 	curl -sSfL "$$base$$linux_zip"  -o "$$tmp/$$linux_zip"; \
 	curl -sSfL "$$base$$darwin_zip" -o "$$tmp/$$darwin_zip"; \
 	linux_sha=$$(sha256sum "$$tmp/$$linux_zip"  | awk '{print $$1}'); \
 	darwin_sha=$$(sha256sum "$$tmp/$$darwin_zip" | awk '{print $$1}'); \
 	awk -v ls="$$linux_sha" -v ds="$$darwin_sha" ' \
-	  /^[[:space:]]+PROTO_ZIP_SHA256=/ && !linux_done { sub(/=.*/, "=" ls); linux_done=1; print; next } \
-	  /^[[:space:]]+PROTO_ZIP_SHA256=/                { sub(/=.*/, "=" ds);                 print; next } \
+	  /^PROTO_ZIP_SHA256_LINUX[[:space:]]*:=/  { sub(/:=.*/, ":= " ls); print; next } \
+	  /^PROTO_ZIP_SHA256_DARWIN[[:space:]]*:=/ { sub(/:=.*/, ":= " ds); print; next } \
 	  { print } \
 	' Makefile > Makefile.new && mv Makefile.new Makefile
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,12 +5,47 @@
     "schedule:daily"
   ],
   "baseBranchPatterns": ["main"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": [
+        "protobuf/releases/download/v(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)/",
+        "protoc-(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)-linux",
+        "protoc-(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)-osx",
+        "protoc-(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)-win32"
+      ],
+      "depNameTemplate": "protocolbuffers/protobuf",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": [
+        "GOLANGCI_LINT_VERSION\\s*:=\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ],
   "packageRules": [
     {
       "description": "Group Go module updates across all go.mod files",
       "matchManagers": ["gomod"],
       "matchFileNames": ["go.mod", "ring/example/local/go.mod"],
       "groupName": "go-dependencies"
+    },
+    {
+      "description": "Recompute pinned protoc archive SHA256 values after a version bump. Requires 'make update-protoc-sha' on the Renovate runner allowedPostUpgradeCommands allowlist; if not allowed, CI sha256sum --check will fail until a human refreshes the hashes.",
+      "matchPackageNames": ["protocolbuffers/protobuf"],
+      "postUpgradeTasks": {
+        "commands": ["make update-protoc-sha"],
+        "fileFilters": ["Makefile"],
+        "executionMode": "update"
+      }
     },
     {
       "description": "Don't update replace directives",


### PR DESCRIPTION
**What this PR does**:

Track protoc and golangci-lint versions via Renovate.

Also adds a new `postUpgradeTasks` make file target to update PROTO_ZIP_SHA256 entries after a bump.

The new make target has been confirmed to run locally and a renovate dry-run indicates the custom matchers have the correct regexes.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and dependency-automation only; no runtime application logic changes, though protoc bumps could affect generated code if Renovate merges without hash refresh.
> 
> **Overview**
> Wires **Renovate** to bump **protoc** (`protocolbuffers/protobuf`) and **golangci-lint** versions declared in the `Makefile`, instead of leaving those pins manual.
> 
> The `Makefile` now keeps Linux and Darwin **protoc** zip SHA256s as shared top-level constants and adds **`make update-protoc-sha`**, which re-downloads both archives and rewrites those hashes—intended to run automatically via Renovate **`postUpgradeTasks`** after a protoc version bump. If that command is not on the Renovate allowlist, CI’s existing `sha256sum --check` on protoc download will fail until someone refreshes the hashes manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220be0dc6c7618840752fadc5353bfb3ae068131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->