### PR TITLE
chore(ci): use github-release-attachments datasource for protoc SHAs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,26 @@ DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o 
 PROTO_DEFS := $(shell find . $(DONT_FIND) -type f -name '*.proto' -print)
 PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
 # Download the proper protoc version for Darwin (osx) and Linux.
-# If you need windows for some reason it's at https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-win32.zip
+# If you need windows for some reason it's at https://github.com/protocolbuffers/protobuf/releases/download/$(PROTO_VERSION)/protoc-$(PROTO_VERSION:v%=%)-win32.zip
 UNAME_S := $(shell uname -s)
-PROTO_PATH := https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/
-# Pinned SHA256 hashes maintained by `make update-protoc-sha` (Renovate postUpgradeTasks hook).
+# renovate: datasource=github-release-attachments depName=protocolbuffers/protobuf
+PROTO_VERSION := v3.6.1
+# Pinned SHA256 hashes for the protoc archives. Maintained by Renovate via the
+# github-release-attachments datasource: the digestVersion= marker pins each
+# digest to its release tag, and Renovate identifies which release asset each
+# SHA fingerprints (linux-x86_64 vs osx-x86_64) by hashing the assets, so a
+# version bump rewrites the marker and both SHAs in lockstep.
+# renovate: datasource=github-release-attachments depName=protocolbuffers/protobuf digestVersion=v3.6.1
 PROTO_ZIP_SHA256_LINUX  := 6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807
+# renovate: datasource=github-release-attachments depName=protocolbuffers/protobuf digestVersion=v3.6.1
 PROTO_ZIP_SHA256_DARWIN := 0decc6ce5beed07f8c20361ddeb5ac7666f09cf34572cca530e16814093f9c0c
+PROTO_PATH := https://github.com/protocolbuffers/protobuf/releases/download/$(PROTO_VERSION)/
 ifeq ($(UNAME_S), Linux)
-	PROTO_ZIP=protoc-3.6.1-linux-x86_64.zip
+	PROTO_ZIP=protoc-$(PROTO_VERSION:v%=%)-linux-x86_64.zip
 	PROTO_ZIP_SHA256=$(PROTO_ZIP_SHA256_LINUX)
 endif
 ifeq ($(UNAME_S), Darwin)
-	PROTO_ZIP=protoc-3.6.1-osx-x86_64.zip
+	PROTO_ZIP=protoc-$(PROTO_VERSION:v%=%)-osx-x86_64.zip
 	PROTO_ZIP_SHA256=$(PROTO_ZIP_SHA256_DARWIN)
 endif
 GO_MODS=$(shell find . $(DONT_FIND) -type f -name 'go.mod' -print)
@@ -112,28 +120,6 @@ ifeq ("$(wildcard .tools/protoc/bin/protoc)","")
 	cd .tools/protoc && echo "$(PROTO_ZIP_SHA256)  $(PROTO_ZIP)" | sha256sum --check --strict -
 	unzip -n .tools/protoc/$(PROTO_ZIP) -d .tools/protoc/
 endif
-
-# Invoked by Renovate's postUpgradeTasks after it bumps the protoc version in
-# this Makefile. Re-downloads both archives at the new version and rewrites the
-# PROTO_ZIP_SHA256_LINUX and PROTO_ZIP_SHA256_DARWIN top-level constants.
-.PHONY: update-protoc-sha
-update-protoc-sha: ## Recompute pinned protoc archive SHA256 values from upstream.
-	@set -e; \
-	tmp=$$(mktemp -d); trap 'rm -rf "$$tmp" Makefile.new' EXIT; \
-	base=$$(awk '/^PROTO_PATH := / {print $$3}' Makefile); \
-	linux_zip=$$(awk -F= '/^[[:space:]]+PROTO_ZIP=protoc-.*-linux-x86_64\.zip$$/ {print $$2}' Makefile); \
-	darwin_zip=$$(awk -F= '/^[[:space:]]+PROTO_ZIP=protoc-.*-osx-x86_64\.zip$$/  {print $$2}' Makefile); \
-	[ -n "$$base" ] && [ -n "$$linux_zip" ] && [ -n "$$darwin_zip" ] \
-	  || { echo "update-protoc-sha: failed to extract PROTO_PATH or PROTO_ZIP values from Makefile" >&2; exit 1; }; \
-	curl -sSfL "$$base$$linux_zip"  -o "$$tmp/$$linux_zip"; \
-	curl -sSfL "$$base$$darwin_zip" -o "$$tmp/$$darwin_zip"; \
-	linux_sha=$$(sha256sum "$$tmp/$$linux_zip"  | awk '{print $$1}'); \
-	darwin_sha=$$(sha256sum "$$tmp/$$darwin_zip" | awk '{print $$1}'); \
-	awk -v ls="$$linux_sha" -v ds="$$darwin_sha" ' \
-	  /^PROTO_ZIP_SHA256_LINUX[[:space:]]*:=/  { sub(/:=.*/, ":= " ls); print; next } \
-	  /^PROTO_ZIP_SHA256_DARWIN[[:space:]]*:=/ { sub(/:=.*/, ":= " ds); print; next } \
-	  { print } \
-	' Makefile > Makefile.new && mv Makefile.new Makefile
 
 .tools/bin/protoc-gen-gogoslick: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0

--- a/renovate.json
+++ b/renovate.json
@@ -10,8 +10,8 @@
       "customType": "regex",
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+PROTO_VERSION\\s*:=\\s*(?<currentValue>v\\d+\\.\\d+(?:\\.\\d+)?)",
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) digestVersion=(?<currentValue>v\\d+\\.\\d+(?:\\.\\d+)?)\\s+PROTO_ZIP_SHA256_(?:LINUX|DARWIN)\\s*:=\\s*(?<currentDigest>[a-f0-9]{64})"
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+[A-Za-z0-9_]+\\s*:=\\s*(?<currentValue>[^\\s]+)",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) digestVersion=(?<currentValue>[^\\s]+)\\s+[A-Za-z0-9_]+\\s*:=\\s*(?<currentDigest>[a-f0-9]{64})"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -10,15 +10,9 @@
       "customType": "regex",
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
-        "protobuf/releases/download/v(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)/",
-        "protoc-(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)-linux",
-        "protoc-(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)-osx",
-        "protoc-(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)-win32"
-      ],
-      "depNameTemplate": "protocolbuffers/protobuf",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$",
-      "versioningTemplate": "loose"
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+PROTO_VERSION\\s*:=\\s*(?<currentValue>v\\d+\\.\\d+(?:\\.\\d+)?)",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) digestVersion=(?<currentValue>v\\d+\\.\\d+(?:\\.\\d+)?)\\s+PROTO_ZIP_SHA256_(?:LINUX|DARWIN)\\s*:=\\s*(?<currentDigest>[a-f0-9]{64})"
+      ]
     },
     {
       "customType": "regex",
@@ -37,15 +31,6 @@
       "matchManagers": ["gomod"],
       "matchFileNames": ["go.mod", "ring/example/local/go.mod"],
       "groupName": "go-dependencies"
-    },
-    {
-      "description": "Recompute pinned protoc archive SHA256 values after a version bump. Requires 'make update-protoc-sha' on the Renovate runner allowedPostUpgradeCommands allowlist; if not allowed, CI sha256sum --check will fail until a human refreshes the hashes.",
-      "matchPackageNames": ["protocolbuffers/protobuf"],
-      "postUpgradeTasks": {
-        "commands": ["make update-protoc-sha"],
-        "fileFilters": ["Makefile"],
-        "executionMode": "update"
-      }
     },
     {
       "description": "Don't update replace directives",


### PR DESCRIPTION
Use `github-release-attachments` to maintain protoc - removing the need for the callback make file target to update the SHAs.

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/tooling-only change; protoc download still uses pinned SHA256 checks, with less custom Renovate runner command allowlisting.
> 
> **Overview**
> Renovate now drives **protoc** version and archive SHA256 pins from **Makefile** comments instead of a custom regex on download URLs plus a post-upgrade shell step.
> 
> The Makefile adds **`PROTO_VERSION`** and **`# renovate:`** markers for `github-release-attachments` (including **`digestVersion`** on the Linux and Darwin SHA constants), derives download URLs and zip names from **`PROTO_VERSION`**, and **removes** the **`update-protoc-sha`** target that re-downloaded archives and rewrote hashes. **`renovate.json`** replaces the old protoc URL/version regex manager and the **`protocolbuffers/protobuf`** **`postUpgradeTasks`** rule with generic regex managers that read those Makefile comment lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb6edd26e440e6194f9fc6ec100af5eec12d447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->