### PR TITLE
fix(ring): clear ReadOnlyUpdatedTimestamp when disabling read-only

### DIFF
--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -559,7 +559,11 @@ func (l *BasicLifecycler) changeReadOnlyState(ctx context.Context, readOnly bool
 		}
 
 		i.ReadOnly = readOnly
-		i.ReadOnlyUpdatedTimestamp = time.Now().Unix()
+		if readOnly {
+			i.ReadOnlyUpdatedTimestamp = time.Now().Unix()
+		} else {
+			i.ReadOnlyUpdatedTimestamp = 0
+		}
 		return true
 	})
 

--- a/ring/basic_lifecycler_test.go
+++ b/ring/basic_lifecycler_test.go
@@ -521,15 +521,8 @@ func TestBasicLifecycler_ChangeReadOnlyState(t *testing.T) {
 		require.InDelta(t, readOnlySince.Sub(readOnlyChange), 0, float64(time.Second))
 	}
 
-	// Let the clock advance a little bit.
-	// Read only timestamp has seconds precision.
-	time.Sleep(time.Second + 500*time.Millisecond)
-
 	// Change the read-only state to false.
 	{
-		_, prevReadOnlySince := lifecycler.GetReadOnlyState()
-		require.NotZero(t, prevReadOnlySince)
-
 		err := lifecycler.ChangeReadOnlyState(context.Background(), false)
 		require.NoError(t, err)
 		assert.Equal(t, float64(0), testutil.ToFloat64(lifecycler.metrics.readOnly))
@@ -539,9 +532,34 @@ func TestBasicLifecycler_ChangeReadOnlyState(t *testing.T) {
 		assert.True(t, ok)
 		readOnly, readOnlySince := desc.GetReadOnlyState()
 		require.False(t, readOnly)
-		// Since this has seconds precision we can forget about monotonic clocks and just assert that new timestamp is higher.
-		require.True(t, readOnlySince.After(prevReadOnlySince))
+		require.Zero(t, readOnlySince)
 	}
+}
+
+func TestBasicLifecycler_ChangeReadOnlyState_ClearsTimestampWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	lifecycler, _, store, err := prepareBasicLifecycler(t, cfg)
+	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+
+	// Enable read-only; timestamp must be set.
+	require.NoError(t, lifecycler.ChangeReadOnlyState(ctx, true))
+	desc, ok := getInstanceFromStore(t, store, testInstanceID)
+	require.True(t, ok)
+	readOnly, readOnlySince := desc.GetReadOnlyState()
+	require.True(t, readOnly)
+	require.NotZero(t, readOnlySince)
+
+	// Disable read-only; timestamp must be zeroed.
+	require.NoError(t, lifecycler.ChangeReadOnlyState(ctx, false))
+	desc, ok = getInstanceFromStore(t, store, testInstanceID)
+	require.True(t, ok)
+	readOnly, readOnlySince = desc.GetReadOnlyState()
+	require.False(t, readOnly)
+	require.Zero(t, readOnlySince)
+	require.Zero(t, desc.ReadOnlyUpdatedTimestamp)
 }
 
 func TestBasicLifecycler_TokensObservePeriod(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

During HPA downscale in Mimir's usage-tracker, instances that had `ReadOnly` toggled back to false kept showing the stale timestamp on

This change zeroes `ReadOnlyUpdatedTimestamp` on the `readOnly=false` transition so the persisted ring entry matches what `GetReadOnlyState` already returns from its in-memory view.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in ring lifecycler persistence with targeted tests; no auth or broad API changes.
> 
> **Overview**
> **`BasicLifecycler.changeReadOnlyState`** no longer bumps **`ReadOnlyUpdatedTimestamp`** on every toggle: it sets the field to **`time.Now().Unix()`** only when entering read-only, and sets it to **`0`** when leaving read-only so persisted ring entries match **`InstanceDesc.GetReadOnlyState`** (no stale “since” time after HPA/downscale clears read-only).
> 
> Tests now expect a **zero** read-only-since time after disabling read-only, and a dedicated test asserts the stored timestamp is cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a97c9f4f5feb4a09845a5bfe0dffe9ceac64bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->