### PR TITLE
docs(services): add comments, mark terminal states, remove running --> failed transition

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -38,14 +38,24 @@ flowchart LR
   starting[Starting]
   running[Running]
   stopping[Stopping]
-  terminated[Terminated]
+
+  %% Terminal states
+  terminated[Terminated]   
   failed[Failed]
+
+  %% Successful state transition of service:
   new --> starting --> running --> stopping --> terminated
+  
+  %% If service is stopped before starting:
   new --> terminated
+  
+  %% If Starting fails, it goes straight to Failed (skips Stopping):
   starting --> failed
-  running --> failed
+  
+  %% If Running or Stopping fail, service will end up in Failed state.
   stopping --> failed
-	
+  
+  %% There is no direct Running --> Failed transition (goes via Stopping).
 ```
 
 The API, states, and semantics are implemented to correspond to the [Service class](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/Service.html) in the Guava library.


### PR DESCRIPTION
This PR fixes state transition diagram of the service. PR https://github.com/grafana/dskit/pull/868 changed existing ASCII diagram to mermaid, but it introduced a bug -- non-existant `running --> failed` transition. This PR fixes that, and adds comments to help navigate the diagram in raw form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a Mermaid diagram in README; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the **services** Mermaid state diagram in `services/README.md` so it matches real lifecycle behavior after the earlier Mermaid conversion introduced a bogus **`running --> failed`** edge.
> 
> The diagram now groups **terminal** states, documents the happy path and early-stop paths with inline comments, keeps **`starting --> failed`** and **`stopping --> failed`**, and explicitly notes that a running failure must go through **`Stopping`**—not straight to **`Failed`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c630cedee2c96b6193a07537c7c17b91811d11b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->