### PR TITLE
feat(log): add opt-in sanitization for user-controlled log values

### DIFF
--- a/log/doc.go
+++ b/log/doc.go
@@ -2,15 +2,13 @@
 // used across dskit-based services.
 //
 // It includes constructors for logfmt and JSON loggers (NewGoKit), a
-// Level type wired to a command-line flag, buffered and rate-limited
-// loggers, and a global-logger accessor.
+// Level type integrated with command-line flags, buffered and
+// rate-limited loggers, and a global logger accessor.
 //
-// For values that may originate from user input (HTTP headers, parsed
-// errors, custom Stringers wrapping request data), wrap them at the
-// call site with DropUnsafeChars or EscapeUnsafeChars to neutralise
-// log injection, terminal escape sequences, and trojan-source attacks
-// before they reach the encoder. Only wrapped values are sanitised;
-// an unwrapped Stringer carrying user input still reaches the encoder
-// verbatim, so review call sites that log non-string, non-error values
-// carefully.
+// When logging values that may originate from untrusted sources, use
+// DropUnsafeChars or EscapeUnsafeChars to sanitize control and
+// formatting characters before they reach the encoder. These helpers
+// help prevent log injection, terminal escape sequence injection, and
+// similar attacks while preserving compatibility with both logfmt and
+// JSON logging.
 package log

--- a/log/doc.go
+++ b/log/doc.go
@@ -1,0 +1,16 @@
+// Package log provides building blocks for constructing go-kit loggers
+// used across dskit-based services.
+//
+// It includes constructors for logfmt and JSON loggers (NewGoKit), a
+// Level type wired to a command-line flag, buffered and rate-limited
+// loggers, and a global-logger accessor.
+//
+// For values that may originate from user input (HTTP headers, parsed
+// errors, custom Stringers wrapping request data), wrap them at the
+// call site with DropUnsafeChars or EscapeUnsafeChars to neutralise
+// log injection, terminal escape sequences, and trojan-source attacks
+// before they reach the encoder. Only wrapped values are sanitised;
+// an unwrapped Stringer carrying user input still reaches the encoder
+// verbatim, so review call sites that log non-string, non-error values
+// carefully.
+package log

--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -60,6 +60,16 @@ func (d DroppedUnsafeChars) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
 }
 
+// MarshalText returns the sanitized value in text form. go-kit's logfmt
+// encoder prefers encoding.TextMarshaler over fmt.Stringer.
+//
+// This ensures typed-nil errors are encoded as the unquoted `key=null`
+// form that go-kit produces for the corresponding raw value, rather
+// than passing through the Stringer path.
+func (d DroppedUnsafeChars) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+
 // EscapeUnsafeChars wraps v so that control and formatting characters
 // are replaced with printable escape sequences in its string
 // representation when logged.
@@ -110,6 +120,13 @@ func (e EscapedUnsafeChars) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 	return json.Marshal(e.String())
+}
+
+// MarshalText returns the sanitized form as bytes. See the rationale
+// on DroppedUnsafeChars.MarshalText for why this is needed alongside
+// String for correct logfmt encoding of typed-nil errors.
+func (e EscapedUnsafeChars) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 // render returns the string representation of v, avoiding a

--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -124,7 +124,40 @@ func isUnsafe(r rune) bool {
 
 // needsSanitization reports whether s contains any character the
 // sanitizers would alter.
+//
+// Most log data is plain ASCII, so we optimize for that common case by
+// scanning bytes first:
+//
+//   - printable ASCII characters (0x20-0x7E) and tab are considered safe
+//   - all other ASCII control characters, including DEL, are unsafe
+//   - non-ASCII bytes trigger a fallback to rune-level validation
+//
+// The rune-level path checks for Unicode control, formatting, line, and
+// paragraph separator characters (for example U+2028 and U+2029) that
+// could be used to manipulate log output.
+//
+// This avoids decoding every rune in ordinary ASCII strings while still
+// correctly handling dangerous Unicode characters.
 func needsSanitization(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\t':
+			// Safe (matches the exception in isUnsafe).
+		case c >= 0x20 && c < 0x7f:
+			// Printable ASCII — safe.
+		case c < 0x80:
+			// ASCII C0 control or DEL — unsafe.
+			return true
+		default:
+			// Non-ASCII: defer to rune-level check from here.
+			return needsSanitizationRuneLevel(s[i:])
+		}
+	}
+	return false
+}
+
+func needsSanitizationRuneLevel(s string) bool {
 	for _, r := range s {
 		if isUnsafe(r) {
 			return true

--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -7,29 +7,29 @@ import (
 	"unicode"
 )
 
-// DropUnsafeChars wraps v so that control and formatting characters
-// (newlines, ANSI escape codes, bidi overrides, etc.) are stripped
-// from its string representation when logged. Use it for values that
-// may carry user input to defend against log injection and terminal-
-// escape attacks.
+// DropUnsafeChars wraps v so that control and formatting characters are
+// removed from its string representation when logged. This helps prevent
+// log injection, terminal escape sequence injection, and other attacks
+// that rely on special characters in untrusted input.
 //
-// Usage:
+// Use it when logging values that may originate from users or other
+// untrusted sources.
 //
 //	level.Info(logger).Log("user_agent", log.DropUnsafeChars(r.UserAgent()))
 func DropUnsafeChars(v any) DroppedUnsafeChars {
 	return DroppedUnsafeChars{v: v}
 }
 
-// DroppedUnsafeChars is the value type returned by DropUnsafeChars. It
-// implements fmt.Stringer and json.Marshaler so it works correctly with
+// DroppedUnsafeChars is the value returned by DropUnsafeChars. It
+// implements fmt.Stringer and json.Marshaler for compatibility with
 // both logfmt and JSON go-kit encoders.
 type DroppedUnsafeChars struct {
 	v any
 }
 
-// String renders v with unsafe characters removed. Tab is preserved.
-// Returns the rendered string unchanged when it contains nothing
-// dangerous.
+// String returns the string representation of v with unsafe characters
+// removed. Tab is preserved. If no unsafe characters are present, the
+// original string is returned unchanged.
 func (d DroppedUnsafeChars) String() string {
 	s := render(d.v)
 	if !needsSanitization(s) {
@@ -46,35 +46,37 @@ func (d DroppedUnsafeChars) String() string {
 	return b.String()
 }
 
-// MarshalJSON serialises the sanitized form as a JSON string. Without
-// this, json.Marshal would emit "{}" for the unexported field.
+// MarshalJSON encodes the sanitized value as a JSON string. Without this
+// method, json.Marshal would encode the wrapper as an empty object
+// because its fields are unexported.
 func (d DroppedUnsafeChars) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
 }
 
 // EscapeUnsafeChars wraps v so that control and formatting characters
-// (newlines, ANSI escape codes, bidi overrides, etc.) are replaced
-// with printable \xNN, \uNNNN, or \UNNNNNNNN sequences in its string
-// representation when logged. Use it for values that may carry user
-// input to defend against log injection and terminal-escape attacks
-// while keeping a readable record of what was sanitized.
+// are replaced with printable escape sequences in its string
+// representation when logged.
 //
-// Usage:
+// Use it for values that may originate from untrusted sources to help
+// prevent log injection and terminal escape sequence injection while
+// preserving a readable representation of the original value.
 //
 //	level.Info(logger).Log("user_agent", log.EscapeUnsafeChars(r.UserAgent()))
 func EscapeUnsafeChars(v any) EscapedUnsafeChars {
 	return EscapedUnsafeChars{v: v}
 }
 
-// EscapedUnsafeChars is the value type returned by EscapeUnsafeChars.
-// It implements fmt.Stringer and json.Marshaler.
+// EscapedUnsafeChars is the value returned by EscapeUnsafeChars. It
+// implements fmt.Stringer and json.Marshaler for compatibility with
+// both logfmt and JSON go-kit encoders.
 type EscapedUnsafeChars struct {
 	v any
 }
 
-// String renders v with unsafe characters replaced by their printable
-// escape form. Tab is preserved. Returns the rendered string unchanged
-// when it contains nothing dangerous.
+// String returns the string representation of v with unsafe characters
+// replaced by printable escape sequences. Tab is preserved. If no
+// unsafe characters are present, the original string is returned
+// unchanged.
 func (e EscapedUnsafeChars) String() string {
 	s := render(e.v)
 	if !needsSanitization(s) {
@@ -97,8 +99,8 @@ func (e EscapedUnsafeChars) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.String())
 }
 
-// render returns v's string form, avoiding a fmt.Sprint allocation
-// when v is already a string or an error.
+// render returns the string representation of v, avoiding a
+// fmt.Sprint allocation when v is already a string or an error.
 func render(v any) string {
 	switch t := v.(type) {
 	case string:
@@ -109,12 +111,14 @@ func render(v any) string {
 	return fmt.Sprint(v)
 }
 
-// isUnsafe reports whether r is a control or formatting character that
-// should be sanitized. Covers Unicode categories Cc (ASCII C0 + DEL +
-// C1), Cf (formatting incl. bidi overrides), Zl (line separator U+2028),
-// and Zp (paragraph separator U+2029). Tab is treated as safe because
-// it has legitimate uses (stack traces, tabular output) and is already
-// escaped by logfmt and JSON encoders.
+// isUnsafe reports whether r should be sanitized. It matches Unicode
+// categories Cc (control characters), Cf (formatting characters,
+// including bidi overrides), Zl (line separators), and Zp (paragraph
+// separators).
+//
+// Tab is treated as safe because it has legitimate uses (for example,
+// stack traces and tabular output) and is already escaped by logfmt and
+// JSON encoders.
 func isUnsafe(r rune) bool {
 	if r == '\t' {
 		return false
@@ -166,8 +170,8 @@ func needsSanitizationRuneLevel(s string) bool {
 	return false
 }
 
-// writeEscape appends r's printable escape sequence to b, choosing
-// \xNN, \uNNNN, or \UNNNNNNNN according to the rune's width.
+// writeEscape appends a printable escape sequence for r to b, using
+// \xNN, \uNNNN, or \UNNNNNNNN depending on the rune's value.
 func writeEscape(b *strings.Builder, r rune) {
 	switch {
 	case r < 0x100:

--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // DropUnsafeChars wraps v so that control and formatting characters are
@@ -38,11 +39,22 @@ func (d DroppedUnsafeChars) String() string {
 	}
 	var b strings.Builder
 	b.Grow(len(s))
-	for _, r := range s {
-		if isUnsafe(r) {
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		// An invalid UTF-8 byte (e.g. a lone C1 continuation byte such
+		// as 0x85) decodes to RuneError with size 1. Drop it so that
+		// malformed bytes cannot smuggle control characters past the
+		// sanitiser.
+		if r == utf8.RuneError && size == 1 {
+			i++
 			continue
 		}
-		b.WriteRune(r)
+		if isUnsafe(r) {
+			i += size
+			continue
+		}
+		b.WriteString(s[i : i+size])
+		i += size
 	}
 	return b.String()
 }
@@ -101,12 +113,23 @@ func (e EscapedUnsafeChars) String() string {
 	}
 	var b strings.Builder
 	b.Grow(len(s))
-	for _, r := range s {
-		if isUnsafe(r) {
-			writeEscape(&b, r)
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		// An invalid UTF-8 byte (e.g. a lone C1 continuation byte such
+		// as 0x85) decodes to RuneError with size 1. Emit \xNN for the
+		// raw byte so its value survives sanitisation for forensic use.
+		if r == utf8.RuneError && size == 1 {
+			writeEscape(&b, rune(s[i]))
+			i++
 			continue
 		}
-		b.WriteRune(r)
+		if isUnsafe(r) {
+			writeEscape(&b, r)
+			i += size
+			continue
+		}
+		b.WriteString(s[i : i+size])
+		i += size
 	}
 	return b.String()
 }
@@ -201,16 +224,11 @@ func needsSanitization(s string) bool {
 			return true
 		default:
 			// Non-ASCII: defer to rune-level check from here.
-			return needsSanitizationRuneLevel(s[i:])
-		}
-	}
-	return false
-}
-
-func needsSanitizationRuneLevel(s string) bool {
-	for _, r := range s {
-		if isUnsafe(r) {
-			return true
+			remainder := s[i:]
+			if !utf8.ValidString(remainder) {
+				return true
+			}
+			return strings.ContainsFunc(remainder, isUnsafe)
 		}
 	}
 	return false

--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -3,6 +3,7 @@ package log
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"unicode"
 )
@@ -49,7 +50,13 @@ func (d DroppedUnsafeChars) String() string {
 // MarshalJSON encodes the sanitized value as a JSON string. Without this
 // method, json.Marshal would encode the wrapper as an empty object
 // because its fields are unexported.
+//
+// A typed-nil error is encoded as the JSON null literal so the output
+// matches the behavior of the underlying go-kit logger.
 func (d DroppedUnsafeChars) MarshalJSON() ([]byte, error) {
+	if e, ok := d.v.(error); ok && isNilPointer(e) {
+		return []byte("null"), nil
+	}
 	return json.Marshal(d.String())
 }
 
@@ -95,20 +102,42 @@ func (e EscapedUnsafeChars) String() string {
 }
 
 // MarshalJSON serialises the sanitized form as a JSON string.
+//
+// A typed-nil error is encoded as the JSON null literal so the output
+// matches what go-kit would produce for the same value.
 func (e EscapedUnsafeChars) MarshalJSON() ([]byte, error) {
+	if err, ok := e.v.(error); ok && isNilPointer(err) {
+		return []byte("null"), nil
+	}
 	return json.Marshal(e.String())
 }
 
 // render returns the string representation of v, avoiding a
 // fmt.Sprint allocation when v is already a string or an error.
+//
+// For errors, it handles the typed-nil case (a non-nil error interface
+// wrapping a nil concrete pointer). Calling Error() on such a value may
+// panic, so render returns "null" to match the behavior of go-kit's
+// logfmt encoder.
 func render(v any) string {
 	switch t := v.(type) {
 	case string:
 		return t
 	case error:
+		if isNilPointer(t) {
+			return "null"
+		}
 		return t.Error()
 	}
 	return fmt.Sprint(v)
+}
+
+// isNilPointer reports whether v is an interface whose dynamic value is
+// a nil pointer. The interface itself is non-nil, but the value it contains
+// is nil.
+func isNilPointer(v any) bool {
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }
 
 // isUnsafe reports whether r should be sanitized. It matches Unicode

--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -1,0 +1,147 @@
+package log
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// DropUnsafeChars wraps v so that control and formatting characters
+// (newlines, ANSI escape codes, bidi overrides, etc.) are stripped
+// from its string representation when logged. Use it for values that
+// may carry user input to defend against log injection and terminal-
+// escape attacks.
+//
+// Usage:
+//
+//	level.Info(logger).Log("user_agent", log.DropUnsafeChars(r.UserAgent()))
+func DropUnsafeChars(v any) DroppedUnsafeChars {
+	return DroppedUnsafeChars{v: v}
+}
+
+// DroppedUnsafeChars is the value type returned by DropUnsafeChars. It
+// implements fmt.Stringer and json.Marshaler so it works correctly with
+// both logfmt and JSON go-kit encoders.
+type DroppedUnsafeChars struct {
+	v any
+}
+
+// String renders v with unsafe characters removed. Tab is preserved.
+// Returns the rendered string unchanged when it contains nothing
+// dangerous.
+func (d DroppedUnsafeChars) String() string {
+	s := render(d.v)
+	if !needsSanitization(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isUnsafe(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// MarshalJSON serialises the sanitized form as a JSON string. Without
+// this, json.Marshal would emit "{}" for the unexported field.
+func (d DroppedUnsafeChars) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// EscapeUnsafeChars wraps v so that control and formatting characters
+// (newlines, ANSI escape codes, bidi overrides, etc.) are replaced
+// with printable \xNN, \uNNNN, or \UNNNNNNNN sequences in its string
+// representation when logged. Use it for values that may carry user
+// input to defend against log injection and terminal-escape attacks
+// while keeping a readable record of what was sanitized.
+//
+// Usage:
+//
+//	level.Info(logger).Log("user_agent", log.EscapeUnsafeChars(r.UserAgent()))
+func EscapeUnsafeChars(v any) EscapedUnsafeChars {
+	return EscapedUnsafeChars{v: v}
+}
+
+// EscapedUnsafeChars is the value type returned by EscapeUnsafeChars.
+// It implements fmt.Stringer and json.Marshaler.
+type EscapedUnsafeChars struct {
+	v any
+}
+
+// String renders v with unsafe characters replaced by their printable
+// escape form. Tab is preserved. Returns the rendered string unchanged
+// when it contains nothing dangerous.
+func (e EscapedUnsafeChars) String() string {
+	s := render(e.v)
+	if !needsSanitization(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isUnsafe(r) {
+			writeEscape(&b, r)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// MarshalJSON serialises the sanitized form as a JSON string.
+func (e EscapedUnsafeChars) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.String())
+}
+
+// render returns v's string form, avoiding a fmt.Sprint allocation
+// when v is already a string or an error.
+func render(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case error:
+		return t.Error()
+	}
+	return fmt.Sprint(v)
+}
+
+// isUnsafe reports whether r is a control or formatting character that
+// should be sanitized. Covers Unicode categories Cc (ASCII C0 + DEL +
+// C1), Cf (formatting incl. bidi overrides), Zl (line separator U+2028),
+// and Zp (paragraph separator U+2029). Tab is treated as safe because
+// it has legitimate uses (stack traces, tabular output) and is already
+// escaped by logfmt and JSON encoders.
+func isUnsafe(r rune) bool {
+	if r == '\t' {
+		return false
+	}
+	return unicode.In(r, unicode.Cc, unicode.Cf, unicode.Zl, unicode.Zp)
+}
+
+// needsSanitization reports whether s contains any character the
+// sanitizers would alter.
+func needsSanitization(s string) bool {
+	for _, r := range s {
+		if isUnsafe(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeEscape appends r's printable escape sequence to b, choosing
+// \xNN, \uNNNN, or \UNNNNNNNN according to the rune's width.
+func writeEscape(b *strings.Builder, r rune) {
+	switch {
+	case r < 0x100:
+		fmt.Fprintf(b, `\x%02x`, r)
+	case r < 0x10000:
+		fmt.Fprintf(b, `\u%04x`, r)
+	default:
+		fmt.Fprintf(b, `\U%08x`, r)
+	}
+}

--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -63,10 +63,10 @@ func (d DroppedUnsafeChars) String() string {
 // method, json.Marshal would encode the wrapper as an empty object
 // because its fields are unexported.
 //
-// A typed-nil error is encoded as the JSON null literal so the output
-// matches the behavior of the underlying go-kit logger.
+// A nil value (a nil interface or a typed-nil pointer) is encoded as
+// the JSON null literal so the output matches go-kit's behaviour.
 func (d DroppedUnsafeChars) MarshalJSON() ([]byte, error) {
-	if e, ok := d.v.(error); ok && isNilPointer(e) {
+	if isNullValue(d.v) {
 		return []byte("null"), nil
 	}
 	return json.Marshal(d.String())
@@ -136,10 +136,10 @@ func (e EscapedUnsafeChars) String() string {
 
 // MarshalJSON serialises the sanitized form as a JSON string.
 //
-// A typed-nil error is encoded as the JSON null literal so the output
-// matches what go-kit would produce for the same value.
+// A nil value (a nil interface or a typed-nil pointer) is encoded as
+// the JSON null literal so the output matches go-kit's behaviour.
 func (e EscapedUnsafeChars) MarshalJSON() ([]byte, error) {
-	if err, ok := e.v.(error); ok && isNilPointer(err) {
+	if isNullValue(e.v) {
 		return []byte("null"), nil
 	}
 	return json.Marshal(e.String())
@@ -155,27 +155,30 @@ func (e EscapedUnsafeChars) MarshalText() ([]byte, error) {
 // render returns the string representation of v, avoiding a
 // fmt.Sprint allocation when v is already a string or an error.
 //
-// For errors, it handles the typed-nil case (a non-nil error interface
-// wrapping a nil concrete pointer). Calling Error() on such a value may
-// panic, so render returns "null" to match the behavior of go-kit's
-// logfmt encoder.
+// Nil values (a nil interface or a non-nil interface wrapping a nil
+// concrete pointer) render as "null" to match what go-kit's encoders
+// produce for the same input and to avoid calling Error() on a nil
+// receiver.
 func render(v any) string {
+	if isNullValue(v) {
+		return "null"
+	}
 	switch t := v.(type) {
 	case string:
 		return t
 	case error:
-		if isNilPointer(t) {
-			return "null"
-		}
 		return t.Error()
 	}
 	return fmt.Sprint(v)
 }
 
-// isNilPointer reports whether v is an interface whose dynamic value is
-// a nil pointer. The interface itself is non-nil, but the value it contains
-// is nil.
-func isNilPointer(v any) bool {
+// isNullValue reports whether v should be encoded as a null literal —
+// either a nil interface (the dynamic type and value are both nil) or
+// a non-nil interface wrapping a nil concrete pointer.
+func isNullValue(v any) bool {
+	if v == nil {
+		return true
+	}
 	rv := reflect.ValueOf(v)
 	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }

--- a/log/sanitize_test.go
+++ b/log/sanitize_test.go
@@ -16,6 +16,13 @@ type testUnsafeUserInputStringer struct{ s string }
 
 func (u testUnsafeUserInputStringer) String() string { return u.s }
 
+// testNilSafeError is an error type with a pointer receiver. A typed-nil
+// pointer of this type stored in an error interface would panic if
+// Error() were called, allowing the typed-nil guard to be tested.
+type testNilSafeError struct{ msg string }
+
+func (e *testNilSafeError) Error() string { return e.msg }
+
 // TestDropVsEscapeUnsafeChars compares the output of
 // DroppedUnsafeChars and EscapedUnsafeChars side-by-side. For each
 // input, the same row shows the result of calling String() on both
@@ -99,6 +106,11 @@ func TestDropVsEscapeUnsafeChars(t *testing.T) {
 			wantDrop:   "42",
 			wantEscape: "42",
 		},
+		"typed-nil error renders as \"null\" without panicking": {
+			input:      (*testNilSafeError)(nil),
+			wantDrop:   "null",
+			wantEscape: "null",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -128,6 +140,25 @@ func TestEscapedUnsafeChars_MarshalJSON(t *testing.T) {
 	got, err := json.Marshal(EscapeUnsafeChars("Mozilla\nlevel=info msg=fake\x1b[31m!"))
 	require.NoError(t, err)
 	require.JSONEq(t, `"Mozilla\\x0alevel=info msg=fake\\x1b[31m!"`, string(got))
+}
+
+// TestUnsafeChars_TypedNilError_MarshalJSON verifies that wrapping a
+// typed-nil error encodes to the JSON null literal (not the string
+// "null"), matching what go-kit's JSON encoder writes for an unwrapped
+// typed-nil error.
+func TestUnsafeChars_TypedNilError_MarshalJSON(t *testing.T) {
+	var typed *testNilSafeError
+
+	for name, marshaler := range map[string]json.Marshaler{
+		"DroppedUnsafeChars": DropUnsafeChars(typed),
+		"EscapedUnsafeChars": EscapeUnsafeChars(typed),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := json.Marshal(marshaler)
+			require.NoError(t, err)
+			require.Equal(t, "null", string(got))
+		})
+	}
 }
 
 // benchSink prevents benchmark results from being optimized away by the
@@ -250,6 +281,13 @@ func TestEndToEnd_logfmt(t *testing.T) {
 				"escape": "user_agent=\"path=/foo\\\\x0aFAKE\"\n",
 			},
 		},
+		"typed-nil error renders as null, matching go-kit raw output": {
+			value: (*testNilSafeError)(nil),
+			wantOnWire: map[string]string{
+				"drop":   "user_agent=null\n",
+				"escape": "user_agent=null\n",
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -297,6 +335,13 @@ func TestEndToEnd_json(t *testing.T) {
 			wantOnWire: map[string]string{
 				"drop":   `{"user_agent":"path=/fooFAKE"}`,
 				"escape": `{"user_agent":"path=/foo\\x0aFAKE"}`,
+			},
+		},
+		"typed-nil error renders as JSON null, matching go-kit raw output": {
+			value: (*testNilSafeError)(nil),
+			wantOnWire: map[string]string{
+				"drop":   `{"user_agent":null}`,
+				"escape": `{"user_agent":null}`,
 			},
 		},
 	}

--- a/log/sanitize_test.go
+++ b/log/sanitize_test.go
@@ -10,16 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testUnsafeUserInputStringer is a stand-in for a custom type that wraps
-// attacker-influenced text behind fmt.Stringer.
+// testUnsafeUserInputStringer is a stand-in for a custom fmt.Stringer
+// that exposes attacker-controlled input.
 type testUnsafeUserInputStringer struct{ s string }
 
 func (u testUnsafeUserInputStringer) String() string { return u.s }
 
-// TestDropVsEscapeUnsafeChars compares the two wrappers side-by-side:
-// for every input, the same row shows what DroppedUnsafeChars and
-// EscapedUnsafeChars each render via String(). The any-typed input
-// exercises both string and Stringer paths through fmt.Sprint.
+// TestDropVsEscapeUnsafeChars compares the output of
+// DroppedUnsafeChars and EscapedUnsafeChars side-by-side. For each
+// input, the same row shows the result of calling String() on both
+// wrappers.
+//
+// The any-typed input exercises both string and fmt.Stringer code
+// paths.
 func TestDropVsEscapeUnsafeChars(t *testing.T) {
 	testCases := map[string]struct {
 		input      any
@@ -106,35 +109,37 @@ func TestDropVsEscapeUnsafeChars(t *testing.T) {
 	}
 }
 
-// TestDroppedUnsafeChars_MarshalJSON verifies that json.Marshal on a
-// DroppedUnsafeChars returns a JSON string containing the inner value
-// with unsafe characters dropped.
+// TestDroppedUnsafeChars_MarshalJSON verifies that json.Marshal
+// encodes a DroppedUnsafeChars as a JSON string containing the
+// sanitized value.
 func TestDroppedUnsafeChars_MarshalJSON(t *testing.T) {
 	got, err := json.Marshal(DropUnsafeChars("Mozilla\nlevel=info msg=fake\x1b[31m!"))
 	require.NoError(t, err)
 	require.JSONEq(t, `"Mozillalevel=info msg=fake[31m!"`, string(got))
 }
 
-// TestEscapedUnsafeChars_MarshalJSON verifies that json.Marshal on an
-// EscapedUnsafeChars returns a JSON string containing the inner value
-// with unsafe characters replaced by their printable escape sequences.
-// Note that JSON's own backslash escaping doubles ours: the on-wire
-// bytes show `\\x0a` for a sanitized string containing `\x0a` (a
-// single backslash followed by x0a).
+// TestEscapedUnsafeChars_MarshalJSON verifies that json.Marshal
+// encodes an EscapedUnsafeChars as a JSON string with unsafe
+// characters replaced by printable escape sequences.
+//
+// JSON escaping is applied on top of the sanitization, so the encoded
+// output contains `\\x0a` for a sanitized string containing `\x0a`.
 func TestEscapedUnsafeChars_MarshalJSON(t *testing.T) {
 	got, err := json.Marshal(EscapeUnsafeChars("Mozilla\nlevel=info msg=fake\x1b[31m!"))
 	require.NoError(t, err)
 	require.JSONEq(t, `"Mozilla\\x0alevel=info msg=fake\\x1b[31m!"`, string(got))
 }
 
-// benchSink prevents the compiler from optimising away benchmark calls.
+// benchSink prevents benchmark results from being optimized away by the
+// compiler.
 var benchSink string
 
-// Sample values shared by the benchmarks and the allocation test.
-// These represent a single field value a caller would wrap at a log
-// call site (a user-agent header is the canonical case): "clean" is a
-// well-formed value; "dirty" mixes in an ANSI escape and a newline so
-// the strings.Builder path is exercised.
+// Sample values shared by the benchmarks and allocation test.
+//
+// Each value represents a single log field that would be wrapped at a
+// logging call site. "clean" is a typical user-agent string, while
+// "dirty" includes an ANSI escape sequence and a newline to exercise
+// the sanitization path.
 var (
 	benchClean = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 	benchDirty = "Mozilla\x1b[31mFAKE\x1b[0m\nlevel=info msg=hacked"
@@ -171,9 +176,9 @@ func BenchmarkEscapeUnsafeChars(b *testing.B) {
 }
 
 // BenchmarkRawSprint measures fmt.Sprint(v) on the same inputs. This
-// is the work the underlying logger performs per value when no wrapper
-// is used; the delta against BenchmarkDropUnsafeChars and
-// BenchmarkEscapeUnsafeChars approximates the wrapper's added cost.
+// represents the baseline cost of logging an unwrapped value; the
+// difference from BenchmarkDropUnsafeChars and
+// BenchmarkEscapeUnsafeChars approximates the cost of sanitization.
 func BenchmarkRawSprint(b *testing.B) {
 	b.Run("clean", func(b *testing.B) {
 		b.ReportAllocs()
@@ -189,11 +194,10 @@ func BenchmarkRawSprint(b *testing.B) {
 	})
 }
 
-// TestZeroAllocsOnCleanStringPath is a regression guard: wrapping a
-// clean string and calling String() must not allocate. The wrapper is
-// constructed outside the closure so the measurement captures only
-// String()'s allocation behaviour, not any string-to-any boxing at the
-// call site.
+// TestZeroAllocsOnCleanStringPath is a regression test that verifies
+// String() does not allocate for a clean string input. The wrapper is
+// constructed outside the measurement so only String()'s allocation
+// behavior is counted.
 func TestZeroAllocsOnCleanStringPath(t *testing.T) {
 	dropped := DropUnsafeChars(benchClean)
 	escaped := EscapeUnsafeChars(benchClean)
@@ -207,9 +211,9 @@ func TestZeroAllocsOnCleanStringPath(t *testing.T) {
 	}), "EscapedUnsafeChars.String must not allocate on a clean string input")
 }
 
-// TestEndToEnd_logfmt verifies that values wrapped with DropUnsafeChars
-// or EscapeUnsafeChars produce the expected bytes on the wire when
-// logged through go-kit's logfmt encoder.
+// TestEndToEnd_logfmt verifies that values wrapped with
+// DropUnsafeChars or EscapeUnsafeChars are encoded as expected by
+// go-kit's logfmt logger.
 func TestEndToEnd_logfmt(t *testing.T) {
 	testCases := map[string]struct {
 		value      any
@@ -225,24 +229,24 @@ func TestEndToEnd_logfmt(t *testing.T) {
 		"embedded newline is sanitized before reaching the encoder": {
 			value: "Mozilla\nFAKE",
 			wantOnWire: map[string]string{
-				// Drop yields "MozillaFAKE" — no whitespace, so logfmt
-				// emits it unquoted.
+				// Drop yields "MozillaFAKE". Because the result contains no whitespace,
+				// logfmt emits it without quotes.
 				"drop": "user_agent=MozillaFAKE\n",
-				// Escape yields "Mozilla\x0aFAKE" (literal backslash);
-				// logfmt does not quote on backslash alone, so it
-				// reaches the wire as-is.
+				// Escape yields "Mozilla\x0aFAKE" (with a literal backslash). Because
+				// the result contains no whitespace, logfmt does not quote it and it
+				// reaches the output unchanged.
 				"escape": "user_agent=Mozilla\\x0aFAKE\n",
 			},
 		},
 		"custom Stringer rendering user-controlled text is sanitized": {
 			value: testUnsafeUserInputStringer{"path=/foo\nFAKE"},
 			wantOnWire: map[string]string{
-				// Drop yields "path=/fooFAKE"; the embedded '=' forces
-				// logfmt to quote the whole value.
+				// Drop yields "path=/fooFAKE". Because the value contains '=',
+				// logfmt quotes it in the output.
 				"drop": "user_agent=\"path=/fooFAKE\"\n",
-				// Escape yields "path=/foo\x0aFAKE"; '=' still forces
-				// quoting, and inside the quote logfmt doubles the
-				// backslash to keep the output unambiguously parseable.
+				// Escape yields "path=/foo\x0aFAKE". The embedded '=' causes logfmt to
+				// quote the value, and the backslash in `\x0a` is escaped within the
+				// quoted string.
 				"escape": "user_agent=\"path=/foo\\\\x0aFAKE\"\n",
 			},
 		},
@@ -266,9 +270,9 @@ func TestEndToEnd_logfmt(t *testing.T) {
 	}
 }
 
-// TestEndToEnd_json verifies that values wrapped with DropUnsafeChars
-// or EscapeUnsafeChars produce the expected bytes on the wire when
-// logged through go-kit's JSON encoder.
+// TestEndToEnd_json verifies the final JSON output produced by go-kit
+// when logging values wrapped with DropUnsafeChars or
+// EscapeUnsafeChars.
 func TestEndToEnd_json(t *testing.T) {
 	testCases := map[string]struct {
 		value      any

--- a/log/sanitize_test.go
+++ b/log/sanitize_test.go
@@ -71,6 +71,24 @@ func TestDropVsEscapeUnsafeChars(t *testing.T) {
 			wantDrop:   "abcdef",
 			wantEscape: "abc\\x85def",
 		},
+		"lone 0x85 byte (invalid UTF-8, would be U+0085 NEL in valid encoding)": {
+			// Without the fix, this byte would survive untouched
+			// because for/range decodes it as utf8.RuneError which
+			// isUnsafe does not flag.
+			input:      "abc\x85def",
+			wantDrop:   "abcdef",
+			wantEscape: "abc\\x85def",
+		},
+		"lone C1 continuation byte unrelated to NEL (0x82)": {
+			input:      "abc\x82def",
+			wantDrop:   "abcdef",
+			wantEscape: "abc\\x82def",
+		},
+		"truncated U+2028 prefix (0xe2 0x80 with no continuation byte)": {
+			input:      "first\xe2\x80second",
+			wantDrop:   "firstsecond",
+			wantEscape: "first\\xe2\\x80second",
+		},
 		"Unicode LINE SEPARATOR (U+2028)": {
 			input:      "first\u2028second",
 			wantDrop:   "firstsecond",

--- a/log/sanitize_test.go
+++ b/log/sanitize_test.go
@@ -129,6 +129,20 @@ func TestDropVsEscapeUnsafeChars(t *testing.T) {
 			wantDrop:   "null",
 			wantEscape: "null",
 		},
+		"nil any renders as \"null\" (matches go-kit's encoding of nil)": {
+			input:      nil,
+			wantDrop:   "null",
+			wantEscape: "null",
+		},
+		"nil error interface renders as \"null\"": {
+			// `var err error` becomes a nil interface when boxed into
+			// any; the case error: branch of render does not match,
+			// so without the isNullValue guard at the top this would
+			// fall through to fmt.Sprint(nil) → "<nil>".
+			input:      error(nil),
+			wantDrop:   "null",
+			wantEscape: "null",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -160,22 +174,31 @@ func TestEscapedUnsafeChars_MarshalJSON(t *testing.T) {
 	require.JSONEq(t, `"Mozilla\\x0alevel=info msg=fake\\x1b[31m!"`, string(got))
 }
 
-// TestUnsafeChars_TypedNilError_MarshalJSON verifies that wrapping a
-// typed-nil error encodes to the JSON null literal (not the string
-// "null"), matching what go-kit's JSON encoder writes for an unwrapped
-// typed-nil error.
-func TestUnsafeChars_TypedNilError_MarshalJSON(t *testing.T) {
-	var typed *testNilSafeError
+// TestUnsafeChars_NullValue_MarshalJSON verifies that wrapping any
+// nil-like value (nil any, nil interface error, typed-nil pointer)
+// encodes to the JSON null literal — not the string "null" or "<nil>" —
+// matching what go-kit's JSON encoder writes for the same input.
+func TestUnsafeChars_NullValue_MarshalJSON(t *testing.T) {
+	var typedNil *testNilSafeError
+	var nilIface error
 
-	for name, marshaler := range map[string]json.Marshaler{
-		"DroppedUnsafeChars": DropUnsafeChars(typed),
-		"EscapedUnsafeChars": EscapeUnsafeChars(typed),
-	} {
-		t.Run(name, func(t *testing.T) {
-			got, err := json.Marshal(marshaler)
-			require.NoError(t, err)
-			require.Equal(t, "null", string(got))
-		})
+	inputs := map[string]any{
+		"nil any":             nil,
+		"nil error interface": nilIface,
+		"typed-nil error ptr": typedNil,
+	}
+
+	for inputName, in := range inputs {
+		for wrapperName, marshaler := range map[string]json.Marshaler{
+			"DroppedUnsafeChars": DropUnsafeChars(in),
+			"EscapedUnsafeChars": EscapeUnsafeChars(in),
+		} {
+			t.Run(inputName+"/"+wrapperName, func(t *testing.T) {
+				got, err := json.Marshal(marshaler)
+				require.NoError(t, err)
+				require.Equal(t, "null", string(got))
+			})
+		}
 	}
 }
 
@@ -306,6 +329,13 @@ func TestEndToEnd_logfmt(t *testing.T) {
 				"escape": "user_agent=null\n",
 			},
 		},
+		"nil any renders as null, matching go-kit raw output": {
+			value: nil,
+			wantOnWire: map[string]string{
+				"drop":   "user_agent=null\n",
+				"escape": "user_agent=null\n",
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -357,6 +387,13 @@ func TestEndToEnd_json(t *testing.T) {
 		},
 		"typed-nil error renders as JSON null, matching go-kit raw output": {
 			value: (*testNilSafeError)(nil),
+			wantOnWire: map[string]string{
+				"drop":   `{"user_agent":null}`,
+				"escape": `{"user_agent":null}`,
+			},
+		},
+		"nil any renders as JSON null, matching go-kit raw output": {
+			value: nil,
 			wantOnWire: map[string]string{
 				"drop":   `{"user_agent":null}`,
 				"escape": `{"user_agent":null}`,

--- a/log/sanitize_test.go
+++ b/log/sanitize_test.go
@@ -1,0 +1,316 @@
+package log
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+// testUnsafeUserInputStringer is a stand-in for a custom type that wraps
+// attacker-influenced text behind fmt.Stringer.
+type testUnsafeUserInputStringer struct{ s string }
+
+func (u testUnsafeUserInputStringer) String() string { return u.s }
+
+// TestDropVsEscapeUnsafeChars compares the two wrappers side-by-side:
+// for every input, the same row shows what DroppedUnsafeChars and
+// EscapedUnsafeChars each render via String(). The any-typed input
+// exercises both string and Stringer paths through fmt.Sprint.
+func TestDropVsEscapeUnsafeChars(t *testing.T) {
+	testCases := map[string]struct {
+		input      any
+		wantDrop   string
+		wantEscape string
+	}{
+		"plain ascii passes through unchanged": {
+			input:      "hello world",
+			wantDrop:   "hello world",
+			wantEscape: "hello world",
+		},
+		"tab is preserved in both modes": {
+			input:      "col1\tcol2",
+			wantDrop:   "col1\tcol2",
+			wantEscape: "col1\tcol2",
+		},
+		"log injection via newline": {
+			input:      "first line\nlevel=info msg=fake",
+			wantDrop:   "first linelevel=info msg=fake",
+			wantEscape: "first line\\x0alevel=info msg=fake",
+		},
+		"ANSI color escape (terminal injection)": {
+			input:      "\x1b[31mFAKE ERROR\x1b[0m",
+			wantDrop:   "[31mFAKE ERROR[0m",
+			wantEscape: "\\x1b[31mFAKE ERROR\\x1b[0m",
+		},
+		"NUL byte": {
+			input:      "abc\x00def",
+			wantDrop:   "abcdef",
+			wantEscape: "abc\\x00def",
+		},
+		"DEL (0x7F)": {
+			input:      "abc\x7fdef",
+			wantDrop:   "abcdef",
+			wantEscape: "abc\\x7fdef",
+		},
+		"C1 control NEL (U+0085)": {
+			input:      "abc\u0085def",
+			wantDrop:   "abcdef",
+			wantEscape: "abc\\x85def",
+		},
+		"Unicode LINE SEPARATOR (U+2028)": {
+			input:      "first\u2028second",
+			wantDrop:   "firstsecond",
+			wantEscape: "first\\u2028second",
+		},
+		"bidi override (trojan source attack)": {
+			input:      "if (admin)\u202e true \u202d{ deleteAll() }",
+			wantDrop:   "if (admin) true { deleteAll() }",
+			wantEscape: "if (admin)\\u202e true \\u202d{ deleteAll() }",
+		},
+		"non-control multi-byte unicode passes through": {
+			input:      "héllo 世界",
+			wantDrop:   "héllo 世界",
+			wantEscape: "héllo 世界",
+		},
+		"empty string": {
+			input:      "",
+			wantDrop:   "",
+			wantEscape: "",
+		},
+		"custom Stringer with embedded newline is sanitized": {
+			input:      testUnsafeUserInputStringer{"path=/foo\nFAKE"},
+			wantDrop:   "path=/fooFAKE",
+			wantEscape: "path=/foo\\x0aFAKE",
+		},
+		"non-Stringer struct: default formatting then sanitize": {
+			input:      struct{ X string }{"ab\nc"},
+			wantDrop:   "{abc}",
+			wantEscape: "{ab\\x0ac}",
+		},
+		"int passes through (Sprint formats numerically)": {
+			input:      42,
+			wantDrop:   "42",
+			wantEscape: "42",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wantDrop, DropUnsafeChars(tc.input).String(), "DroppedUnsafeChars.String()")
+			require.Equal(t, tc.wantEscape, EscapeUnsafeChars(tc.input).String(), "EscapedUnsafeChars.String()")
+		})
+	}
+}
+
+// TestDroppedUnsafeChars_MarshalJSON verifies that json.Marshal on a
+// DroppedUnsafeChars returns a JSON string containing the inner value
+// with unsafe characters dropped.
+func TestDroppedUnsafeChars_MarshalJSON(t *testing.T) {
+	got, err := json.Marshal(DropUnsafeChars("Mozilla\nlevel=info msg=fake\x1b[31m!"))
+	require.NoError(t, err)
+	require.JSONEq(t, `"Mozillalevel=info msg=fake[31m!"`, string(got))
+}
+
+// TestEscapedUnsafeChars_MarshalJSON verifies that json.Marshal on an
+// EscapedUnsafeChars returns a JSON string containing the inner value
+// with unsafe characters replaced by their printable escape sequences.
+// Note that JSON's own backslash escaping doubles ours: the on-wire
+// bytes show `\\x0a` for a sanitized string containing `\x0a` (a
+// single backslash followed by x0a).
+func TestEscapedUnsafeChars_MarshalJSON(t *testing.T) {
+	got, err := json.Marshal(EscapeUnsafeChars("Mozilla\nlevel=info msg=fake\x1b[31m!"))
+	require.NoError(t, err)
+	require.JSONEq(t, `"Mozilla\\x0alevel=info msg=fake\\x1b[31m!"`, string(got))
+}
+
+// benchSink prevents the compiler from optimising away benchmark calls.
+var benchSink string
+
+// Sample values shared by the benchmarks and the allocation test.
+// These represent a single field value a caller would wrap at a log
+// call site (a user-agent header is the canonical case): "clean" is a
+// well-formed value; "dirty" mixes in an ANSI escape and a newline so
+// the strings.Builder path is exercised.
+var (
+	benchClean = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+	benchDirty = "Mozilla\x1b[31mFAKE\x1b[0m\nlevel=info msg=hacked"
+)
+
+func BenchmarkDropUnsafeChars(b *testing.B) {
+	b.Run("clean", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchSink = DropUnsafeChars(benchClean).String()
+		}
+	})
+	b.Run("dirty", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchSink = DropUnsafeChars(benchDirty).String()
+		}
+	})
+}
+
+func BenchmarkEscapeUnsafeChars(b *testing.B) {
+	b.Run("clean", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchSink = EscapeUnsafeChars(benchClean).String()
+		}
+	})
+	b.Run("dirty", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchSink = EscapeUnsafeChars(benchDirty).String()
+		}
+	})
+}
+
+// BenchmarkRawSprint measures fmt.Sprint(v) on the same inputs. This
+// is the work the underlying logger performs per value when no wrapper
+// is used; the delta against BenchmarkDropUnsafeChars and
+// BenchmarkEscapeUnsafeChars approximates the wrapper's added cost.
+func BenchmarkRawSprint(b *testing.B) {
+	b.Run("clean", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchSink = fmt.Sprint(benchClean)
+		}
+	})
+	b.Run("dirty", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchSink = fmt.Sprint(benchDirty)
+		}
+	})
+}
+
+// TestZeroAllocsOnCleanStringPath is a regression guard: wrapping a
+// clean string and calling String() must not allocate. The wrapper is
+// constructed outside the closure so the measurement captures only
+// String()'s allocation behaviour, not any string-to-any boxing at the
+// call site.
+func TestZeroAllocsOnCleanStringPath(t *testing.T) {
+	dropped := DropUnsafeChars(benchClean)
+	escaped := EscapeUnsafeChars(benchClean)
+
+	require.Zero(t, testing.AllocsPerRun(100, func() {
+		benchSink = dropped.String()
+	}), "DroppedUnsafeChars.String must not allocate on a clean string input")
+
+	require.Zero(t, testing.AllocsPerRun(100, func() {
+		benchSink = escaped.String()
+	}), "EscapedUnsafeChars.String must not allocate on a clean string input")
+}
+
+// TestEndToEnd_logfmt verifies that values wrapped with DropUnsafeChars
+// or EscapeUnsafeChars produce the expected bytes on the wire when
+// logged through go-kit's logfmt encoder.
+func TestEndToEnd_logfmt(t *testing.T) {
+	testCases := map[string]struct {
+		value      any
+		wantOnWire map[string]string // logger name -> expected bytes
+	}{
+		"clean string passes through both wrappers unchanged": {
+			value: "Mozilla/5.0",
+			wantOnWire: map[string]string{
+				"drop":   "user_agent=Mozilla/5.0\n",
+				"escape": "user_agent=Mozilla/5.0\n",
+			},
+		},
+		"embedded newline is sanitized before reaching the encoder": {
+			value: "Mozilla\nFAKE",
+			wantOnWire: map[string]string{
+				// Drop yields "MozillaFAKE" — no whitespace, so logfmt
+				// emits it unquoted.
+				"drop": "user_agent=MozillaFAKE\n",
+				// Escape yields "Mozilla\x0aFAKE" (literal backslash);
+				// logfmt does not quote on backslash alone, so it
+				// reaches the wire as-is.
+				"escape": "user_agent=Mozilla\\x0aFAKE\n",
+			},
+		},
+		"custom Stringer rendering user-controlled text is sanitized": {
+			value: testUnsafeUserInputStringer{"path=/foo\nFAKE"},
+			wantOnWire: map[string]string{
+				// Drop yields "path=/fooFAKE"; the embedded '=' forces
+				// logfmt to quote the whole value.
+				"drop": "user_agent=\"path=/fooFAKE\"\n",
+				// Escape yields "path=/foo\x0aFAKE"; '=' still forces
+				// quoting, and inside the quote logfmt doubles the
+				// backslash to keep the output unambiguously parseable.
+				"escape": "user_agent=\"path=/foo\\\\x0aFAKE\"\n",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Run("drop", func(t *testing.T) {
+				buf := &bytes.Buffer{}
+				logger := log.NewLogfmtLogger(buf)
+				require.NoError(t, logger.Log("user_agent", DropUnsafeChars(tc.value)))
+				require.Equal(t, tc.wantOnWire["drop"], buf.String())
+			})
+			t.Run("escape", func(t *testing.T) {
+				buf := &bytes.Buffer{}
+				logger := log.NewLogfmtLogger(buf)
+				require.NoError(t, logger.Log("user_agent", EscapeUnsafeChars(tc.value)))
+				require.Equal(t, tc.wantOnWire["escape"], buf.String())
+			})
+		})
+	}
+}
+
+// TestEndToEnd_json verifies that values wrapped with DropUnsafeChars
+// or EscapeUnsafeChars produce the expected bytes on the wire when
+// logged through go-kit's JSON encoder.
+func TestEndToEnd_json(t *testing.T) {
+	testCases := map[string]struct {
+		value      any
+		wantOnWire map[string]string
+	}{
+		"clean string passes through both wrappers unchanged": {
+			value: "Mozilla/5.0",
+			wantOnWire: map[string]string{
+				"drop":   `{"user_agent":"Mozilla/5.0"}`,
+				"escape": `{"user_agent":"Mozilla/5.0"}`,
+			},
+		},
+		"embedded newline is sanitized before reaching the encoder": {
+			value: "Mozilla\nFAKE",
+			wantOnWire: map[string]string{
+				"drop":   `{"user_agent":"MozillaFAKE"}`,
+				"escape": `{"user_agent":"Mozilla\\x0aFAKE"}`,
+			},
+		},
+		"custom Stringer rendering user-controlled text is sanitized": {
+			value: testUnsafeUserInputStringer{"path=/foo\nFAKE"},
+			wantOnWire: map[string]string{
+				"drop":   `{"user_agent":"path=/fooFAKE"}`,
+				"escape": `{"user_agent":"path=/foo\\x0aFAKE"}`,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Run("drop", func(t *testing.T) {
+				buf := &bytes.Buffer{}
+				logger := log.NewJSONLogger(buf)
+				require.NoError(t, logger.Log("user_agent", DropUnsafeChars(tc.value)))
+				require.JSONEq(t, tc.wantOnWire["drop"], buf.String())
+			})
+			t.Run("escape", func(t *testing.T) {
+				buf := &bytes.Buffer{}
+				logger := log.NewJSONLogger(buf)
+				require.NoError(t, logger.Log("user_agent", EscapeUnsafeChars(tc.value)))
+				require.JSONEq(t, tc.wantOnWire["escape"], buf.String())
+			})
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

This PR introduces two opt-in helpers for safely logging user-controlled values:

- `DropUnsafeChars(v any)` removes control and formatting characters from the value's string representation.
- `EscapeUnsafeChars(v any)` replaces them with printable escape sequences (`\xNN`, `\uNNNN`, etc.).

Both helpers return types implementing `fmt.Stringer` and `json.Marshaler`, allowing them to work transparently with go-kit's logfmt and JSON encoders.

The sanitization targets characters that can affect log integrity, including:

- embedded newlines and other control characters (log injection / log forging)
- ANSI escape sequences (terminal injection)
- Unicode line separators (`U+2028`, `U+2029`, `NEL`)
- bidirectional formatting characters used in Trojan Source-style attacks

The wrappers are intentionally opt-in. Callers explicitly mark values that may originate from untrusted sources, allowing existing logging behavior to remain unchanged.

### Usage

```go
level.Info(logger).Log("user_agent", log.DropUnsafeChars(r.UserAgent()))
```

or

```go
level.Info(logger).Log("user_agent", log.EscapeUnsafeChars(r.UserAgent()))
```

## Benchmarks

Per-call cost on a typical user-agent string, using raw `fmt.Sprint(v)` (the work performed by the encoder for an unwrapped value) as the baseline.

"Clean" means the input contains no unsafe characters (the common case). "Dirty" means sanitization is required.

| Scenario     | This PR          | Baseline (`fmt.Sprint`) |
|--------------|------------------|-------------------------|
| Clean (drop) | 27 ns, 1 alloc   | 34 ns, 2 allocs         |
| Clean (esc)  | 28 ns, 1 alloc   | 34 ns, 2 allocs         |
| Dirty (drop) | 540 ns, 2 allocs | 31 ns, 2 allocs         |
| Dirty (esc)  | 690 ns, 4 allocs | 31 ns, 2 allocs         |

The common ("clean") path is faster than the baseline because the wrappers avoid `fmt.Sprint` for common input types (`string` and `error`) and perform a lightweight ASCII scan before falling back to Unicode-aware validation.

Additional allocations and processing occur only when sanitization is actually required.
**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, opt-in logging helpers with no change to default log behavior; security-sensitive only where callers adopt the wrappers.
> 
> **Overview**
> Adds **opt-in** helpers so callers can wrap untrusted log field values before they hit go-kit encoders: `DropUnsafeChars` strips control/format/line-separator runes (tabs kept), and `EscapeUnsafeChars` turns them into `\xNN` / `\uNNNN` / `\UNNNNNNNN` sequences.
> 
> Wrappers implement `String`, `json.Marshaler`, and `encoding.TextMarshaler` so logfmt and JSON output stay aligned with raw go-kit behavior (including JSON/logfmt `null` for nil and typed-nil pointers, without panicking on typed-nil errors). Sanitization uses a fast ASCII scan on the common path, handles invalid UTF-8 bytes, and is documented in new `log/doc.go`.
> 
> Tests cover injection-style inputs, marshaling, zero allocations on clean strings, benchmarks, and end-to-end logfmt/JSON logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d593a0b21ddd149cbcaf6b494aad0ee9d8a5f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->