### PR TITLE
fix(server): avoid port collisions in tracing tests

### DIFF
--- a/server/internal/opentracingtest/server_opentracing_test.go
+++ b/server/internal/opentracingtest/server_opentracing_test.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"net/http"
-	"net/url"
-	"strconv"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
@@ -87,22 +84,15 @@ func assertTracingSpans(
 }
 
 func TestHTTPGRPCTracing(t *testing.T) {
-	httpPort := 9099
 	httpAddress := "127.0.0.1"
 
 	httpMethod := http.MethodGet
 
 	helloRouteName := "hello"
 	helloRouteTmpl := "/hello"
-	hostport := net.JoinHostPort(httpAddress, strconv.Itoa(httpPort))
-	helloRouteURLRaw := fmt.Sprintf("http://%s/hello", hostport)
-	helloRouteURL, err := url.Parse(helloRouteURLRaw)
-	require.NoError(t, err)
-
 	helloPathParamRouteTmpl := "/hello/{pathParam}"
-	helloPathParamRouteURLRaw := fmt.Sprintf("http://%s/hello/world", hostport)
-	helloPathParamRouteURL, err := url.Parse(helloPathParamRouteURLRaw)
-	require.NoError(t, err)
+	helloRoutePath := "/hello"
+	helloPathParamRoutePath := "/hello/world"
 
 	// extracted route names or path templates are converted to a Prometheus-compatible label value
 	expectedHelloRouteLabel := middleware.MakeLabelValue(helloRouteName)
@@ -113,14 +103,14 @@ func TestHTTPGRPCTracing(t *testing.T) {
 	expectedOpNameHelloHTTPSpan := "HTTP " + httpMethod + " - " + expectedHelloRouteLabel
 	expectedTagsHelloHTTPSpan := map[string]string{
 		string(ext.Component):  "net/http",
-		string(ext.HTTPUrl):    helloRouteURL.Path,
+		string(ext.HTTPUrl):    helloRoutePath,
 		string(ext.HTTPMethod): httpMethod,
 		"http.route":           helloRouteName,
 	}
 	expectedOpNameHelloPathParamHTTPSpan := "HTTP " + httpMethod + " - " + expectedHelloPathParamRouteLabel
 	expectedTagsHelloPathParamHTTPSpan := map[string]string{
 		string(ext.Component):  "net/http",
-		string(ext.HTTPUrl):    helloPathParamRouteURL.Path,
+		string(ext.HTTPUrl):    helloPathParamRoutePath,
 		string(ext.HTTPMethod): httpMethod,
 		"http.route":           expectedHelloPathParamRouteLabel,
 	}
@@ -130,18 +120,18 @@ func TestHTTPGRPCTracing(t *testing.T) {
 		useOtherGRPC         bool
 		routeName            string // leave blank for unnamed route tests
 		routeTmpl            string
-		reqURL               string
+		reqPath              string
 		expectedTagsByOpName map[string]map[string]string
 	}{
 		"HTTP over gRPC: named route with no params in path template": {
 			useHTTPOverGRPC: true,
 			routeName:       helloRouteName,
 			routeTmpl:       helloRouteTmpl,
-			reqURL:          helloRouteURLRaw,
+			reqPath:         helloRoutePath,
 			expectedTagsByOpName: map[string]map[string]string{
 				"/httpgrpc.HTTP/Handle": {
 					string(ext.Component):  "gRPC",
-					string(ext.HTTPUrl):    helloRouteURL.Path,
+					string(ext.HTTPUrl):    helloRoutePath,
 					string(ext.HTTPMethod): httpMethod,
 					"http.route":           helloRouteName,
 				},
@@ -152,7 +142,7 @@ func TestHTTPGRPCTracing(t *testing.T) {
 			useHTTPOverGRPC: false,
 			routeName:       helloRouteName,
 			routeTmpl:       helloRouteTmpl,
-			reqURL:          helloRouteURLRaw,
+			reqPath:         helloRoutePath,
 			expectedTagsByOpName: map[string]map[string]string{
 				expectedOpNameHelloHTTPSpan: expectedTagsHelloHTTPSpan,
 			},
@@ -161,11 +151,11 @@ func TestHTTPGRPCTracing(t *testing.T) {
 			useHTTPOverGRPC: true,
 			routeName:       "",
 			routeTmpl:       helloPathParamRouteTmpl,
-			reqURL:          helloPathParamRouteURLRaw,
+			reqPath:         helloPathParamRoutePath,
 			expectedTagsByOpName: map[string]map[string]string{
 				"/httpgrpc.HTTP/Handle": {
 					string(ext.Component):  "gRPC",
-					string(ext.HTTPUrl):    helloPathParamRouteURL.Path,
+					string(ext.HTTPUrl):    helloPathParamRoutePath,
 					string(ext.HTTPMethod): httpMethod,
 					"http.route":           expectedHelloPathParamRouteLabel,
 				},
@@ -176,7 +166,7 @@ func TestHTTPGRPCTracing(t *testing.T) {
 			useHTTPOverGRPC: false,
 			routeName:       "",
 			routeTmpl:       helloPathParamRouteTmpl,
-			reqURL:          helloPathParamRouteURLRaw,
+			reqPath:         helloPathParamRoutePath,
 			expectedTagsByOpName: map[string]map[string]string{
 				expectedOpNameHelloPathParamHTTPSpan: expectedTagsHelloPathParamHTTPSpan,
 			},
@@ -207,9 +197,9 @@ func TestHTTPGRPCTracing(t *testing.T) {
 			require.NoError(t, lvl.Set("info"))
 			cfg := server.Config{
 				HTTPListenAddress:        httpAddress,
-				HTTPListenPort:           httpPort,
+				HTTPListenPort:           0,
 				GRPCListenAddress:        httpAddress,
-				GRPCListenPort:           1234,
+				GRPCListenPort:           0,
 				GRPCServerMaxRecvMsgSize: 4 * 1024 * 1024,
 				GRPCServerMaxSendMsgSize: 4 * 1024 * 1024,
 				MetricsNamespace:         "testing_httpgrpc_tracing_" + middleware.MakeLabelValue(testName),
@@ -218,6 +208,7 @@ func TestHTTPGRPCTracing(t *testing.T) {
 			}
 			srv, err := server.New(cfg)
 			require.NoError(t, err)
+			reqURL := fmt.Sprintf("http://%s%s", srv.HTTPListenAddr().String(), test.reqPath)
 
 			grpc_health_v1.RegisterHealthServer(srv.GRPC, health.NewServer())
 
@@ -255,7 +246,7 @@ func TestHTTPGRPCTracing(t *testing.T) {
 				return client.Handle(req.Context(), grpcReq)
 			}
 
-			req, err := http.NewRequest(httpMethod, test.reqURL, bytes.NewReader([]byte{}))
+			req, err := http.NewRequest(httpMethod, reqURL, bytes.NewReader([]byte{}))
 			require.NoError(t, err)
 
 			if test.useHTTPOverGRPC {

--- a/server/internal/oteltest/server_otel_test.go
+++ b/server/internal/oteltest/server_otel_test.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"net/http"
-	"net/url"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -37,22 +34,15 @@ func init() {
 }
 
 func TestOTelTracing(t *testing.T) {
-	httpPort := 9099
 	httpAddress := "127.0.0.1"
 
 	httpMethod := http.MethodGet
 
 	helloRouteName := "hello"
 	helloRouteTmpl := "/hello"
-	hostport := net.JoinHostPort(httpAddress, strconv.Itoa(httpPort))
-	helloRouteURLRaw := fmt.Sprintf("http://%s/hello", hostport)
-	helloRouteURL, err := url.Parse(helloRouteURLRaw)
-	require.NoError(t, err)
-
 	helloPathParamRouteTmpl := "/hello/{pathParam}"
-	helloPathParamRouteURLRaw := fmt.Sprintf("http://%s/hello/world", hostport)
-	helloPathParamRouteURL, err := url.Parse(helloPathParamRouteURLRaw)
-	require.NoError(t, err)
+	helloRoutePath := "/hello"
+	helloPathParamRoutePath := "/hello/world"
 
 	// extracted route names or path templates are converted to a Prometheus-compatible label value
 	expectedHelloRouteLabel := middleware.MakeLabelValue(helloRouteName)
@@ -62,13 +52,13 @@ func TestOTelTracing(t *testing.T) {
 	// regardless of whether the request is routed through the gRPC Handle method first
 	expectedOpNameHelloHTTPSpan := "HTTP " + httpMethod + " - " + expectedHelloRouteLabel
 	expectedAttrsHelloHTTPSpan := []attribute.KeyValue{
-		attribute.String("url.path", helloRouteURL.Path),
+		attribute.String("url.path", helloRoutePath),
 		attribute.String("http.request.method", httpMethod),
 		attribute.String("http.route", helloRouteName),
 	}
 	expectedOpNameHelloPathParamHTTPSpan := "HTTP " + httpMethod + " - " + expectedHelloPathParamRouteLabel
 	expectedAttrsHelloPathParamHTTPSpan := []attribute.KeyValue{
-		attribute.String("url.path", helloPathParamRouteURL.Path),
+		attribute.String("url.path", helloPathParamRoutePath),
 		attribute.String("http.request.method", httpMethod),
 		attribute.String("http.route", expectedHelloPathParamRouteLabel),
 	}
@@ -78,7 +68,7 @@ func TestOTelTracing(t *testing.T) {
 		useOtherGRPC                 bool
 		routeName                    string // leave blank for unnamed route tests
 		routeTmpl                    string
-		reqURL                       string
+		reqPath                      string
 		reqHeaders                   map[string]string
 		expectedAttributesByOpName   map[string][]attribute.KeyValue
 		unexpectedAttributesByOpName map[string][]attribute.Key
@@ -90,7 +80,7 @@ func TestOTelTracing(t *testing.T) {
 			useHTTPOverGRPC: true,
 			routeName:       helloRouteName,
 			routeTmpl:       helloRouteTmpl,
-			reqURL:          helloRouteURLRaw,
+			reqPath:         helloRoutePath,
 			expectedAttributesByOpName: map[string][]attribute.KeyValue{
 				"httpgrpc.HTTP/Handle":      expectedAttrsHelloHTTPSpan,
 				expectedOpNameHelloHTTPSpan: expectedAttrsHelloHTTPSpan,
@@ -100,7 +90,7 @@ func TestOTelTracing(t *testing.T) {
 			useHTTPOverGRPC: false,
 			routeName:       helloRouteName,
 			routeTmpl:       helloRouteTmpl,
-			reqURL:          helloRouteURLRaw,
+			reqPath:         helloRoutePath,
 			expectedAttributesByOpName: map[string][]attribute.KeyValue{
 				expectedOpNameHelloHTTPSpan: expectedAttrsHelloHTTPSpan,
 			},
@@ -109,10 +99,10 @@ func TestOTelTracing(t *testing.T) {
 			useHTTPOverGRPC: true,
 			routeName:       "",
 			routeTmpl:       helloPathParamRouteTmpl,
-			reqURL:          helloPathParamRouteURLRaw,
+			reqPath:         helloPathParamRoutePath,
 			expectedAttributesByOpName: map[string][]attribute.KeyValue{
 				"httpgrpc.HTTP/Handle": {
-					attribute.String("url.path", helloPathParamRouteURL.Path),
+					attribute.String("url.path", helloPathParamRoutePath),
 					attribute.String("http.request.method", httpMethod),
 					attribute.String("http.route", expectedHelloPathParamRouteLabel),
 				},
@@ -123,7 +113,7 @@ func TestOTelTracing(t *testing.T) {
 			useHTTPOverGRPC: false,
 			routeName:       "",
 			routeTmpl:       helloPathParamRouteTmpl,
-			reqURL:          helloPathParamRouteURLRaw,
+			reqPath:         helloPathParamRoutePath,
 			reqHeaders: map[string]string{
 				"X-Unexpected-Header": "42",
 			},
@@ -140,7 +130,7 @@ func TestOTelTracing(t *testing.T) {
 			useHTTPOverGRPC: false,
 			routeName:       "",
 			routeTmpl:       helloPathParamRouteTmpl,
-			reqURL:          helloPathParamRouteURLRaw,
+			reqPath:         helloPathParamRoutePath,
 			reqHeaders: map[string]string{
 				"X-Unexpected-Header": "42",
 				"X-Excluded-Header":   "private",
@@ -184,9 +174,9 @@ func TestOTelTracing(t *testing.T) {
 			require.NoError(t, lvl.Set("info"))
 			cfg := server.Config{
 				HTTPListenAddress:        httpAddress,
-				HTTPListenPort:           httpPort,
+				HTTPListenPort:           0,
 				GRPCListenAddress:        httpAddress,
-				GRPCListenPort:           1234,
+				GRPCListenPort:           0,
 				GRPCServerMaxRecvMsgSize: 4 * 1024 * 1024,
 				GRPCServerMaxSendMsgSize: 4 * 1024 * 1024,
 				MetricsNamespace:         "testing_httpgrpc_tracing_" + middleware.MakeLabelValue(testName),
@@ -198,6 +188,7 @@ func TestOTelTracing(t *testing.T) {
 			}
 			srv, err := server.New(cfg)
 			require.NoError(t, err)
+			reqURL := fmt.Sprintf("http://%s%s", srv.HTTPListenAddr().String(), test.reqPath)
 
 			grpc_health_v1.RegisterHealthServer(srv.GRPC, health.NewServer())
 
@@ -235,7 +226,7 @@ func TestOTelTracing(t *testing.T) {
 				return client.Handle(req.Context(), grpcReq)
 			}
 
-			req, err := http.NewRequest(httpMethod, test.reqURL, bytes.NewReader([]byte{}))
+			req, err := http.NewRequest(httpMethod, reqURL, bytes.NewReader([]byte{}))
 			require.NoError(t, err)
 			for header, value := range test.reqHeaders {
 				req.Header.Set(header, value)


### PR DESCRIPTION
What this PR does

Uses dynamic HTTP and gRPC ports in the OTel and OpenTracing server tests, so they dont fight over `127.0.0.1:9099` and `:1234` when package runs overlap.

Repro

`go test ./server/internal/opentracingtest ./server/internal/oteltest -p 2 -count=20`

Before this it can blow up with `bind: address already in use`, pretty easy to hit.

Which issue(s) this PR fixes

N/A. Related to #381.

Checklist
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to listen configuration and request URL construction; no production server or tracing behavior is modified.
> 
> **Overview**
> The OpenTracing and OTel **server** tracing tests no longer bind HTTP/gRPC to fixed ports (`9099` / `1234`). They set **`HTTPListenPort` and `GRPCListenPort` to `0`**, then build each HTTP request URL from **`srv.HTTPListenAddr()`** after `server.New`, so parallel package runs and high `-count` runs avoid **`address already in use`**.
> 
> Test tables now carry **`reqPath`** (path only) instead of full **`reqURL`** strings, and expected span tags/attributes use those paths directly—dropping unused **`net`**, **`url`**, and **`strconv`** imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad4c16060f4601a8e2b5fe398d5fa0c090bf077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->