### PR TITLE
perf(log): avoid reflection in log.isNullValue for string values

### DIFF
--- a/log/sanitize.go
+++ b/log/sanitize.go
@@ -179,6 +179,13 @@ func isNullValue(v any) bool {
 	if v == nil {
 		return true
 	}
+	// Fast path: a string is a value type and cannot be a typed-nil
+	// pointer, so we can return false without using reflection. Strings
+	// are the most common values logged at call sites, making this a
+	// worthwhile optimization.
+	if _, ok := v.(string); ok {
+		return false
+	}
 	rv := reflect.ValueOf(v)
 	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }


### PR DESCRIPTION
**What this PR does**:
This PR introduces a small performance improvement to the change introduced in https://github.com/grafana/dskit/pull/988. Namely, it adds a string short-circuit to `log.isNullValue()` so the hot path in `log.render()` and the `MarshalJSON()` methods of `log.DropUnsafeChars` / `log.EscapeUnsafeChars` skip `reflect.ValueOf` when the wrapped value is a `string`.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral-preserving optimization in null detection; no security or API changes.
> 
> **Overview**
> Adds a **string fast path** in `log.isNullValue` so wrapped `string` values return `false` immediately instead of calling `reflect.ValueOf`.
> 
> That path is hit from `render` and from `MarshalJSON` on `DropUnsafeChars` / `EscapeUnsafeChars`, where strings are the most common logged type. **Nil detection for typed-nil pointers is unchanged** for non-string values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d526a982ff2b05ab694cb2a27eecf188bcba5079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->