### PR TITLE
fix(ring): always render read-only state on the ring status page

### DIFF
--- a/ring/ring_http_test.go
+++ b/ring/ring_http_test.go
@@ -78,6 +78,67 @@ func TestRingPageHandler_handle(t *testing.T) {
 		}, `\s*`))), recorder.Body.String())
 	})
 
+	t.Run("always renders the read-only state and keeps the read-only updated timestamp", func(t *testing.T) {
+		readOnlyChange := now.Add(-time.Hour)
+		roRing := fakeRingAccess{
+			desc: &Desc{
+				Ingesters: map[string]InstanceDesc{
+					"read-only": {
+						Zone:                     "zone-a",
+						State:                    ACTIVE,
+						Addr:                     "addr-ro",
+						Timestamp:                now.Unix(),
+						ReadOnly:                 true,
+						ReadOnlyUpdatedTimestamp: readOnlyChange.Unix(),
+					},
+					"read-write-was-read-only": {
+						Zone:                     "zone-b",
+						State:                    ACTIVE,
+						Addr:                     "addr-rw",
+						Timestamp:                now.Unix(),
+						ReadOnly:                 false,
+						ReadOnlyUpdatedTimestamp: readOnlyChange.Unix(),
+					},
+					"never-read-only": {
+						Zone:      "zone-c",
+						State:     ACTIVE,
+						Addr:      "addr-never",
+						Timestamp: now.Unix(),
+						ReadOnly:  false,
+					},
+				},
+			},
+		}
+		roHandler := newRingPageHandler(&roRing, 10*time.Second, StatusPageConfig{})
+
+		recorder := httptest.NewRecorder()
+		roHandler.handle(recorder, httptest.NewRequest(http.MethodGet, "/ring", nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		body := recorder.Body.String()
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "addr-ro", "</td>",
+			"<td>", "</td>",
+			"<td>", "true", "</td>",
+			"<td>", ".+ago.+", "</td>",
+		}, `\s*`))), body)
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "addr-rw", "</td>",
+			"<td>", "</td>",
+			"<td>", "false", "</td>",
+			"<td>", `\d{4}-\d{2}-\d{2}T.+Z`, "</td>",
+		}, `\s*`))), body)
+
+		assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("(?m)%s", strings.Join([]string{
+			"<td>", "addr-never", "</td>",
+			"<td>", "</td>",
+			"<td>", "false", "</td>",
+			"<td>", "</td>",
+		}, `\s*`))), body)
+	})
+
 	t.Run("displays Show Tokens button by default", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		handler.handle(recorder, httptest.NewRequest(http.MethodGet, "/ring", nil))

--- a/ring/ring_status.gohtml
+++ b/ring/ring_status.gohtml
@@ -43,11 +43,10 @@
             <td>{{ .State }}</td>
             <td>{{ .Address }}</td>
             <td>{{ .RegisteredTimestamp | timeOrEmptyString }}</td>
-            {{ if .ReadOnly }}
             <td>{{ .ReadOnly }}</td>
+            {{ if .ReadOnly }}
             <td>{{ .ReadOnlyUpdatedTimestamp | durationSince }} ago ({{ .ReadOnlyUpdatedTimestamp.Format "15:04:05.999" }})</td>
             {{ else }}
-            <td></td>
             <td>{{ .ReadOnlyUpdatedTimestamp | timeOrEmptyString }}</td>
             {{ end }}
             <td>{{ .HeartbeatTimestamp | durationSince }} ago ({{ .HeartbeatTimestamp.Format "15:04:05.999" }})</td>


### PR DESCRIPTION
**What this PR does**:

The ring status page left the "Read-Only" column blank for instances that aren't read-only. Because the "Read-Only Updated" column still rendered the timestamp of the last read-only change, an instance that had switched back to read-write showed a lone timestamp next to a blank cell, which reads as a "stale" state.

This change always renders the boolean in the "Read-Only" column to remove this ambiguity.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to the ring status HTML template plus regression tests; no ring membership or read-only logic changes.
> 
> **Overview**
> Fixes ambiguous ring status UI where **Read-Only** was blank for non-read-only instances while **Read-Only Updated** could still show a timestamp (e.g. after switching back to read-write), which looked like a stale read-only state.
> 
> The **Read-Only** column in `ring_status.gohtml` now always renders the boolean (`true`/`false`) for every instance. **Read-Only Updated** formatting is unchanged: relative “ago” when read-only, formatted time when not read-only but a change timestamp exists, empty when there was never a read-only transition.
> 
> Adds an HTTP handler test covering read-only, formerly read-only, and never-read-only instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c455021c7ee5c0a1a7ae60f38d90ce678d67165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->