### PR TITLE
fix: cache: Allow additional discovery configuration for pooling, period

### DIFF
--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -75,6 +75,14 @@ type MemcachedClientConfig struct {
 	// resolved with the DNS provider.
 	Addresses flagext.StringSliceCSV `yaml:"addresses"`
 
+	// AddressesLookupPeriod specifies how often addresses are resolved with the
+	// DNS provider.
+	AddressesLookupPeriod time.Duration `yaml:"addresses_lookup_period" category:"advanced"`
+
+	// AddressesLookupPoolSize specifies how many idle connections to the DNS provider
+	// are kept open. Use 0 to disable keeping any idle connections open.
+	AddressesLookupPoolSize uint `yaml:"addresses_lookup_pool_size" category:"advanced"`
+
 	// Timeout specifies the socket read/write timeout.
 	Timeout time.Duration `yaml:"timeout"`
 
@@ -120,6 +128,8 @@ type MemcachedClientConfig struct {
 
 func (c *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&c.Addresses, prefix+"addresses", "Comma-separated list of memcached addresses. Each address can be an IP address, hostname, or an entry specified in the DNS Service Discovery format.")
+	f.DurationVar(&c.AddressesLookupPeriod, prefix+"addresses-lookup-period", dnsProviderUpdateInterval, "How often each address is resolved to an IP address or list of host names.")
+	f.UintVar(&c.AddressesLookupPoolSize, prefix+"addresses-lookup-pool-size", 0, "How many idle connections to the DNS resolver are kept open. 0 disables keeping any idle connections open.")
 	f.DurationVar(&c.Timeout, prefix+"timeout", 200*time.Millisecond, "The socket read/write timeout.")
 	f.DurationVar(&c.ConnectTimeout, prefix+"connect-timeout", 200*time.Millisecond, "The connection timeout.")
 	f.Float64Var(&c.MinIdleConnectionsHeadroomPercentage, prefix+"min-idle-connections-headroom-percentage", -1, "The minimum number of idle connections to keep open as a percentage (0-100) of the number of recently used idle connections. If negative, idle connections are kept open indefinitely.")
@@ -245,7 +255,7 @@ func newMemcachedClient(
 	reg = prometheus.WrapRegistererWith(
 		prometheus.Labels{labelCacheBackend: backendValueMemcached},
 		prometheus.WrapRegistererWithPrefix(cacheMetricNamePrefix, reg))
-	addressProvider := dns.NewProvider(logger, reg, dns.MiekgdnsResolverType)
+	addressProvider := dns.NewProvider(dns.MiekgdnsResolverType, config.AddressesLookupPoolSize, logger, reg)
 	metrics := newClientMetrics(reg)
 
 	c := &MemcachedClient{
@@ -825,7 +835,7 @@ func (c *MemcachedClient) sortKeysByServer(keys []string) []string {
 }
 
 func (c *MemcachedClient) resolveAddrsLoop() {
-	ticker := time.NewTicker(dnsProviderUpdateInterval)
+	ticker := time.NewTicker(c.config.AddressesLookupPeriod)
 	defer ticker.Stop()
 
 	for {

--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -36,6 +36,7 @@ const (
 var (
 	ErrNoMemcachedAddresses                    = errors.New("no memcached addresses provided")
 	ErrMemcachedMaxAsyncConcurrencyNotPositive = errors.New("max async concurrency must be positive")
+	ErrMemcachedAddressLookupPeriodNotPositive = errors.New("address lookup period must be greater than 0")
 
 	_ Cache = (*MemcachedClient)(nil)
 )
@@ -151,6 +152,10 @@ func (c *MemcachedClientConfig) Validate() error {
 	// Set async only available when MaxAsyncConcurrency > 0.
 	if c.MaxAsyncConcurrency <= 0 {
 		return ErrMemcachedMaxAsyncConcurrencyNotPositive
+	}
+
+	if c.AddressesLookupPeriod <= 0 {
+		return ErrMemcachedAddressLookupPeriodNotPositive
 	}
 
 	return nil

--- a/dns/miekgdns/resolver.go
+++ b/dns/miekgdns/resolver.go
@@ -61,8 +61,8 @@ type Resolver struct {
 
 // NewResolver creates a new Resolver that uses the provided resolv.conf configuration
 // to perform DNS queries. Configuration from resolv.conf will be periodically reloaded.
-func NewResolver(resolvConf string, logger log.Logger) *Resolver {
-	return NewResolverWithClient(resolvConf, logger, defaultResolvConfReload, NewPoolingClient(defaultMaxConnsPerHost))
+func NewResolver(resolvConf string, maxIdle uint, logger log.Logger) *Resolver {
+	return NewResolverWithClient(resolvConf, logger, defaultResolvConfReload, NewPoolingClient(maxIdle))
 }
 
 // NewResolverWithClient creates a new Resolver that uses the provided resolv.conf configuration,
@@ -290,14 +290,14 @@ func defaultClientConfig() *dns.ClientConfig {
 // PoolingClient is a DNS client that pools TCP connections to each nameserver.
 type PoolingClient struct {
 	network string
-	maxOpen int
+	maxOpen uint
 
 	mtx   sync.Mutex
 	pools map[string]*Pool
 }
 
 // NewPoolingClient creates a new PoolingClient instance that keeps up to maxOpen connections to each nameserver.
-func NewPoolingClient(maxOpen int) *PoolingClient {
+func NewPoolingClient(maxOpen uint) *PoolingClient {
 	return &PoolingClient{
 		network: "tcp",
 		maxOpen: maxOpen,
@@ -370,7 +370,7 @@ type Pool struct {
 }
 
 // NewPool creates a new DNS connection Pool, keeping up to maxConns open.
-func NewPool(maxConns int) *Pool {
+func NewPool(maxConns uint) *Pool {
 	return &Pool{
 		conns: make(chan *dns.Conn, maxConns),
 	}

--- a/dns/miekgdns/resolver_test.go
+++ b/dns/miekgdns/resolver_test.go
@@ -321,31 +321,36 @@ func TestPoolingClient(t *testing.T) {
 
 func TestPool(t *testing.T) {
 	// NOTE: This test talks to the local DNS server over the network
-
 	conf := getClientConfig(t)
 	server := net.JoinHostPort(conf.Servers[0], conf.Port)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
 
-	pool := NewPool(defaultMaxConnsPerHost)
-	var conn *dns.Conn
-	var err error
+	for name, numConns := range map[string]uint{"pooling disabled": 0, "pooling enabled": 1} {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
 
-	t.Run("get connection", func(t *testing.T) {
-		conn, err = pool.Get(ctx, "tcp", server)
-		require.NoError(t, err)
-		require.NotNil(t, conn)
-	})
+			pool := NewPool(numConns)
+			var conn *dns.Conn
+			var err error
 
-	t.Run("put connection", func(t *testing.T) {
-		require.NoError(t, pool.Put(conn))
-	})
+			t.Run("get connection", func(t *testing.T) {
+				conn, err = pool.Get(ctx, "tcp", server)
+				require.NoError(t, err)
+				require.NotNil(t, conn)
+			})
 
-	t.Run("close", func(t *testing.T) {
-		pool.Close()
-		_, err = pool.Get(ctx, "tcp", server)
-		require.Error(t, err)
-	})
+			t.Run("put connection", func(t *testing.T) {
+				require.NoError(t, pool.Put(conn))
+				require.Len(t, pool.conns, int(numConns))
+			})
+
+			t.Run("close", func(t *testing.T) {
+				pool.Close()
+				_, err = pool.Get(ctx, "tcp", server)
+				require.Error(t, err)
+			})
+		})
+	}
 }
 
 type mockClient struct {

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -55,25 +55,22 @@ func (t *ResolverType) Set(v string) error {
 	}
 }
 
-func (t ResolverType) toResolver(logger log.Logger) ipLookupResolver {
-	var r ipLookupResolver
-	switch t {
-	case GolangResolverType:
-		r = &godns.Resolver{Resolver: net.DefaultResolver}
-	case MiekgdnsResolverType:
-		r = miekgdns.NewResolver(miekgdns.DefaultResolvConfPath, logger)
-	default:
-		level.Warn(logger).Log("msg", "no such resolver type, defaulting to golang", "type", t)
-		r = &godns.Resolver{Resolver: net.DefaultResolver}
-	}
-	return r
-}
-
 // NewProvider returns a new empty provider with a given resolver type.
 // If empty resolver type is net.DefaultResolver.
-func NewProvider(logger log.Logger, reg prometheus.Registerer, resolverType ResolverType) *Provider {
+func NewProvider(resolverType ResolverType, maxIdleConnections uint, logger log.Logger, reg prometheus.Registerer) *Provider {
+	var backend ipLookupResolver
+	switch resolverType {
+	case GolangResolverType:
+		backend = &godns.Resolver{Resolver: net.DefaultResolver}
+	case MiekgdnsResolverType:
+		backend = miekgdns.NewResolver(miekgdns.DefaultResolvConfPath, maxIdleConnections, logger)
+	default:
+		level.Warn(logger).Log("msg", "no such resolver type, defaulting to golang", "type", resolverType)
+		backend = &godns.Resolver{Resolver: net.DefaultResolver}
+	}
+
 	p := &Provider{
-		resolver: NewResolver(resolverType.toResolver(logger), logger),
+		resolver: NewResolver(backend, logger),
 		resolved: make(map[string][]string),
 		logger:   logger,
 		resolverAddrsDesc: prometheus.NewDesc(

--- a/dns/provider_test.go
+++ b/dns/provider_test.go
@@ -24,7 +24,7 @@ func TestProvider(t *testing.T) {
 		"127.0.0.5:19095",
 	}
 
-	prv := NewProvider(log.NewNopLogger(), nil, "")
+	prv := NewProvider("", 0, log.NewNopLogger(), nil)
 	prv.resolver = &mockResolver{
 		res: map[string][]string{
 			"a": ips[:2],


### PR DESCRIPTION
**What this PR does**:

Allow how often new cache servers are discovered to be configured and allow pooling of connections to the DNS servers used for discovery to be disabled.

This fixes an issue where systemd-resolved aggressively closes idle TCP connections after 10s. The combination of pooling and only doing discovery every 30s meant that this would always fail after startup unless retries were also configured.

**Which issue(s) this PR fixes**:

Fixes #991

Required for https://github.com/grafana/mimir/issues/15565

**Checklist**
- [X] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default memcached DNS resolver pooling (now off) and breaks the `dns.NewProvider` call signature for downstream importers; mis-tuned lookup period could affect cache node discovery timing.
> 
> **Overview**
> Adds **Memcached** discovery knobs so operators can tune how often cache server addresses are re-resolved and whether the miekgdns resolver keeps idle TCP connections to upstream DNS.
> 
> **`addresses_lookup_period`** (default still 30s) drives the background refresh loop instead of a fixed constant, with validation that it must be positive. **`addresses_lookup_pool_size`** (default **0**) is passed into `dns.NewProvider` and the miekgdns pooling client so idle DNS connections can be disabled—addressing failures when resolvers (e.g. systemd-resolved) close idle TCP before the next 30s lookup.
> 
> `dns.NewProvider` is refactored to take resolver type and max idle connections up front; miekgdns pool sizes are **`uint`**, and tests cover pooling disabled vs enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46c4e385f4623db4759038d55ec2c5afb23a28b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->