### PR TITLE
ci: build nested submodules to catch breaks the root ./... misses

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,6 +37,8 @@ jobs:
           go-version: '1.26.x'
       - name: Go mod check
         run: make mod-check
+      - name: Build submodules
+        run: make build-submodules
       - name: Lint
         run: make lint
       - name: Test benchmarks

--- a/.scripts/build-submodules.sh
+++ b/.scripts/build-submodules.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Vet each Go module passed as an argument. Nested modules are separate
+# from the root module, so the root `go build ./...` / `go test ./...` / lint
+# never compile them; `go vet` type-checks both package and test files here,
+# catching API breaks in them that would otherwise pass CI.
+for path in "$@"; do
+  dir=$(dirname "$path")
+  echo "Vetting module ${dir}"
+  ( cd "${dir}" && go vet -tags netgo ./... )
+done

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ ifeq ($(UNAME_S), Darwin)
 	PROTO_ZIP_SHA256=$(PROTO_ZIP_SHA256_DARWIN)
 endif
 GO_MODS=$(shell find . $(DONT_FIND) -type f -name 'go.mod' -print)
+SUBMODULE_GO_MODS=$(filter-out ./go.mod,$(GO_MODS))
 
 .DEFAULT_GOAL := help
 
@@ -45,6 +46,10 @@ test: ## Runs Go tests
 .PHONY: test-benchmarks
 test-benchmarks: ## Runs Go benchmarks with 1 iteration to make sure they still make sense
 	go test -tags netgo -run=NONE -bench=. -benchtime=1x -timeout 30m ./...
+
+.PHONY: build-submodules
+build-submodules: ## Vets each nested module (separate go.mod) not covered by the root ./...
+	@./.scripts/build-submodules.sh $(SUBMODULE_GO_MODS)
 
 .PHONY: lint
 lint: .tools/bin/misspell .tools/bin/faillint .tools/bin/golangci-lint ## Runs misspell, golangci-lint, and faillint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

ring/example/local is a separate Go module, so the root build/test/lint steps never compile it and API breaks there pass CI. Add a `build-submodules` `make` target (run in the check job) that runs `go vet` on each nested module, which type-checks both package and test files so API breaks in them fail CI.

**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Checklist**
- [ ] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no runtime or production code paths affected; risk is limited to possible new vet failures on nested modules.
> 
> **Overview**
> Nested Go modules (e.g. `ring/example/local`) are outside the root module, so root **`./...`** build, test, and lint never type-check them and API breaks there can slip through CI.
> 
> This PR adds **`make build-submodules`**, which discovers every **`go.mod`** except the root and runs **`go vet -tags netgo ./...`** in each module directory via **`.scripts/build-submodules.sh`**, covering package and test code. The CI **Check** job runs this step after **`mod-check`** and before lint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ff3a643d2d06deaeef1231a0bb887bbb702c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->