### PR TITLE
chore: update dskit dependency in ring example project

### DIFF
--- a/ring/example/local/go.mod
+++ b/ring/example/local/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/go-kit/log v0.2.1
-	github.com/grafana/dskit v0.0.0-20260326142830-3dd00ce01fc0
+	github.com/grafana/dskit v0.0.0-20260605182923-6446a4562a3e
 	github.com/prometheus/client_golang v1.23.2
 )
 
@@ -108,6 +108,8 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86
+// Replace memberlist with our fork which includes some fixes that haven't been
+// merged upstream yet.
+replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7
 
 replace github.com/grafana/dskit => ../../../

--- a/ring/example/local/go.sum
+++ b/ring/example/local/go.sum
@@ -87,8 +87,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86 h1:aTwfQuroOmOr//QEn9J1MtC4R4CPR9/IbUd8hZrbWKo=
-github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86/go.mod h1:h60o12SZn/ua/j0B6iKAZezA4eDaGsIuPO70eOaJ6WE=
+github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7 h1:F5hMoc+tCK4AeUKfaL1XFEVEPSg+eKQe712fsSO/JA0=
+github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7/go.mod h1:OSu8+LHxPUHB67c9v5Gfw5NQZxFWOL3EKmn9TgHvyCo=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=

--- a/ring/example/local/local.go
+++ b/ring/example/local/local.go
@@ -177,7 +177,7 @@ func SimpleMemberlistKV(bindaddr string, bindport int, joinmembers []string) *me
 
 	// resolver defines how each peers IP address should be resolved.
 	// We use default resolver comes with Go.
-	resolver := dns.NewProvider(log.With(logger, "component", "dns"), prometheus.NewPedanticRegistry(), dns.GolangResolverType)
+	resolver := dns.NewProvider(dns.GolangResolverType, 0, log.With(logger, "component", "dns"), prometheus.NewPedanticRegistry())
 
 	config.NodeName = bindaddr
 	config.StreamTimeout = 5 * time.Second


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Example-only dependency and API call updates; no production library behavior changes in this diff.
> 
> **Overview**
> Updates the **ring/local example** so it builds against the current **dskit** revision and memberlist fork.
> 
> The example’s **dskit** `require` and local `replace` target a newer pseudo-version, and the **grafana/memberlist** `replace` is bumped with a short comment explaining the fork. **`go.sum`** reflects those dependency changes.
> 
> **`local.go`** adapts to the new **`dns.NewProvider`** signature: resolver type and **`maxIdleConnections`** (`0`) come first, followed by logger and metrics registry—replacing the old argument order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c47d43befc32f7e7036143715850f1f879a1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->