### PR TITLE
fix(middleware): make httpConnectionTTLMiddleware Stop safe under concurrent calls

### DIFF
--- a/middleware/http_connection_ttl_middleware.go
+++ b/middleware/http_connection_ttl_middleware.go
@@ -55,6 +55,7 @@ type httpConnectionTTLMiddleware struct {
 
 	connectionsMu sync.Mutex
 	connections   map[string]*connectionState
+	stopOnce      sync.Once
 
 	totalOpenConnections   prometheus.Counter
 	totalClosedConnections *prometheus.CounterVec
@@ -187,12 +188,9 @@ func (m *httpConnectionTTLMiddleware) calculateTTL(conn string) time.Duration {
 // It is safe to call Stop even if the middleware was created with TTL disabled.
 func (m *httpConnectionTTLMiddleware) Stop() {
 	if m.done != nil {
-		select {
-		case <-m.done:
-			// Already closed
-		default:
+		m.stopOnce.Do(func() {
 			close(m.done)
-		}
+		})
 	}
 }
 

--- a/middleware/http_connection_ttl_middleware_test.go
+++ b/middleware/http_connection_ttl_middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -380,6 +381,36 @@ func TestHTTPConnectionTTLMiddleware_ConcurrentRemoveExpiredConnection(t *testin
 		closed_connections_with_ttl_total{reason="limit"} 1
 	`
 	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "closed_connections_with_ttl_total"))
+}
+
+func TestHTTPConnectionTTLMiddleware_StopIsSafeToCallConcurrently(t *testing.T) {
+	const iterations = 1000
+	const goroutines = 32
+
+	prevGOMAXPROCS := runtime.GOMAXPROCS(goroutines)
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(prevGOMAXPROCS)
+	})
+
+	for range iterations {
+		m, err := NewHTTPConnectionTTLMiddleware(time.Second, time.Second, time.Second, prometheus.NewRegistry())
+		require.NoError(t, err)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				<-start
+				m.Stop()
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+	}
 }
 
 func TestHTTPConnectionTTLMiddleware_IdleCleanupThenRequest(t *testing.T) {


### PR DESCRIPTION
What this PR does

`Stop()` currently does a `select` check before `close(m.done)`. If two goroutines call it at the same time, both can hit `default` and one panics with `close of closed channel`.

This switches `Stop()` to `sync.Once` and adds a regression test. Tiny fix, but it makes shutdown less sketchy.

Which issue(s) this PR fixes

Fixes #912

Checklist
- [x] Tests updated

Repro

1. On `main`, run `go test ./middleware -run TestHTTPConnectionTTLMiddleware_StopIsSafeToCallConcurrently -count=1`.
2. It panics with `close of closed channel`.
3. With this patch, the same test passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow shutdown concurrency fix with no change to request handling or TTL logic; risk is limited to ensuring the background goroutine still exits once.
> 
> **Overview**
> **`Stop()` on the HTTP connection TTL middleware** no longer uses a non-atomic `select` before `close(m.done)`, which could let two goroutines both close the channel and panic. Closing **`m.done`** now runs inside **`sync.Once`** via a new **`stopOnce`** field on the middleware struct.
> 
> A regression test **`TestHTTPConnectionTTLMiddleware_StopIsSafeToCallConcurrently`** hammers concurrent **`Stop()`** calls (many iterations × 32 goroutines) to ensure shutdown is idempotent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdaee4fb5bdab3ca5d65a6ce6e4d5f62056fa6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->