### PR TITLE
ring: treat CAS no-change as success during instance registration

### DIFF
--- a/ring/basic_lifecycler.go
+++ b/ring/basic_lifecycler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -353,7 +354,17 @@ func (l *BasicLifecycler) registerInstance(ctx context.Context) error {
 	})
 
 	if err != nil {
-		return err
+		// If the KV store detected no change (the instance's ring entry already matches
+		// what we tried to write), the registration is effectively successful. This can
+		// happen when the stored timestamp is ahead of the current time (e.g., clock
+		// corruption) — the merge function sees no forward progress and returns
+		// "no change detected." Treating this as fatal causes a permanent CrashLoopBackOff
+		// because the same no-change result recurs on every restart (issue grafana/loki#21733).
+		if strings.Contains(err.Error(), "no change detected") {
+			level.Warn(l.logger).Log("msg", "CAS detected no change during registration; instance already registered with identical state", "ring", l.ringName, "instance", l.cfg.ID, "err", err)
+		} else {
+			return err
+		}
 	}
 
 	l.currState.Lock()


### PR DESCRIPTION
When the memberlist KV store returns "no change detected" during instance registration, the ring entry already matches what the lifecycler tried to write. The current code treats this as fatal, causing a permanent CrashLoopBackOff.

This happens when a ring entry has a corrupted `last_heartbeat_at` timestamp far in the future. The merge function compares timestamps and never sees forward progress (`time.Now() < stored_timestamp`), so every CAS retry returns "no change detected." The ruler (or any ring member) then fails to start on every restart with:

```
register instance in the ring: failed to CAS-update key rulers/rulers: no change detected
```

The fix: treat "no change detected" as a warning during registration, not a fatal error. The instance is already registered with the desired state.

Fixes grafana/loki#21733

Note: after this dskit change is merged and released, Loki will need a vendor bump to pick it up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> It changes startup failure semantics for ring registration and relies on substring matching of KV errors, which could mask unrelated "no change detected" failures if that text appears elsewhere.
> 
> **Overview**
> **`BasicLifecycler.registerInstance`** no longer fails startup when the ring KV **CAS** returns **"no change detected"**. That case is treated as successful registration: the code logs a **warning** and continues updating local state and metrics, instead of returning an error.
> 
> This avoids a **restart loop** when memberlist merge sees no forward progress (e.g. a **`last_heartbeat_at`** stored ahead of wall clock) while the instance is already in the desired ring state (grafana/loki#21733). The change adds a **`strings`** import for error substring matching only on this path; other CAS errors still propagate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963b0c8a6ca15747681a507653b9a55bceb55189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->