### PR TITLE
feat(runtimeconfig): disable HTTP keep-alives by default

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -47,7 +47,7 @@ type Config struct {
 	HTTPClientTimeout           time.Duration                       `yaml:"http_client_timeout" category:"advanced"`
 	HTTPClientClusterValidation clusterutil.ClusterValidationConfig `yaml:"http_client_cluster_validation" category:"advanced"`
 	// HTTPClientDisableKeepAlives disables HTTP keep-alives for the runtime config HTTP client.
-	HTTPClientDisableKeepAlives bool `yaml:"http_client_disable_keep_alives" category:"experimental"`
+	HTTPClientDisableKeepAlives bool `yaml:"http_client_disable_keep_alives" category:"advanced"`
 }
 
 // RegisterFlagsWithPrefix registers flags under the specified prefix, which could be empty.

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -46,6 +46,8 @@ type Config struct {
 	// Configurations related to fetching runtime configurations from HTTP URLs rather than local files.
 	HTTPClientTimeout           time.Duration                       `yaml:"http_client_timeout" category:"advanced"`
 	HTTPClientClusterValidation clusterutil.ClusterValidationConfig `yaml:"http_client_cluster_validation" category:"advanced"`
+	// HTTPClientDisableKeepAlives disables HTTP keep-alives for the runtime config HTTP client.
+	HTTPClientDisableKeepAlives bool `yaml:"http_client_disable_keep_alives" category:"experimental"`
 }
 
 // RegisterFlagsWithPrefix registers flags under the specified prefix, which could be empty.
@@ -54,6 +56,7 @@ func (mc *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&mc.LoadPath, prefix+"file", "Comma separated list of yaml files or URLs with the configuration that can be updated at runtime. Runtime config files will be merged from left to right.")
 	f.DurationVar(&mc.ReloadPeriod, prefix+"reload-period", 10*time.Second, "How often to check runtime config files.")
 	f.DurationVar(&mc.HTTPClientTimeout, prefix+"http-client-timeout", 30*time.Second, "HTTP client timeout when fetching runtime config from URLs.")
+	f.BoolVar(&mc.HTTPClientDisableKeepAlives, prefix+"http-client-disable-keep-alives", true, "Disable HTTP keep-alives for the runtime config HTTP client. When enabled, each reload opens a new connection, which prevents long-lived connections from being pinned to a single backend when the runtime config URL is served by multiple replicas behind a connection-level (L4) load balancer, such as a Kubernetes Service.")
 	mc.HTTPClientClusterValidation.RegisterFlagsWithPrefix(prefix+"http-client-cluster-validation.", f)
 }
 
@@ -383,7 +386,10 @@ func (om *Manager) GetConfig() interface{} {
 }
 
 func httpTransport(cfg Config, configName string, registerer prometheus.Registerer, logger log.Logger) http.RoundTripper {
-	rt := http.DefaultTransport
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = cfg.HTTPClientDisableKeepAlives
+
+	var rt http.RoundTripper = transport
 	if cfg.HTTPClientClusterValidation.Label != "" {
 		invalidClusterValidations := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "client_invalid_cluster_validation_label_requests_total",
@@ -397,7 +403,7 @@ func httpTransport(cfg Config, configName string, registerer prometheus.Register
 			level.Warn(logger).Log("msg", msg, "method", method, "cluster_validation_label", cfg.HTTPClientClusterValidation.Label, "component", "runtimeconfig", "load_path", cfg.LoadPath)
 			invalidClusterValidations.WithLabelValues(method).Inc()
 		}
-		rt = middleware.ClusterValidationRoundTripper(cfg.HTTPClientClusterValidation.Label, reporter, http.DefaultTransport)
+		rt = middleware.ClusterValidationRoundTripper(cfg.HTTPClientClusterValidation.Label, reporter, transport)
 	}
 	return rt
 }

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1093,10 +1094,72 @@ func TestConfig_RegisterFlagsWithPrefix(t *testing.T) {
 				tc.prefix + "file",
 				tc.prefix + "reload-period",
 				tc.prefix + "http-client-timeout",
+				tc.prefix + "http-client-disable-keep-alives",
 				tc.prefix + "http-client-cluster-validation.label",
 			} {
 				require.NotNil(t, fs.Lookup(name), "expected flag %q to be registered", name)
 			}
+
+			// HTTP keep-alives are disabled by default to avoid pinning long-lived
+			// connections to a single backend behind a connection-level load balancer.
+			require.Equal(t, "true", fs.Lookup(tc.prefix+"http-client-disable-keep-alives").DefValue)
+			require.True(t, cfg.HTTPClientDisableKeepAlives)
+		})
+	}
+}
+
+func TestHTTPTransport_DisableKeepAlives(t *testing.T) {
+	t.Run("sets DisableKeepAlives on the transport", func(t *testing.T) {
+		for _, disable := range []bool{true, false} {
+			rt := httpTransport(Config{HTTPClientDisableKeepAlives: disable}, "test", prometheus.NewRegistry(), log.NewNopLogger())
+			tr, ok := rt.(*http.Transport)
+			require.True(t, ok, "expected an *http.Transport when no cluster validation label is set")
+			require.Equal(t, disable, tr.DisableKeepAlives)
+		}
+	})
+
+	t.Run("does not mutate http.DefaultTransport", func(t *testing.T) {
+		_ = httpTransport(Config{HTTPClientDisableKeepAlives: true}, "test", prometheus.NewRegistry(), log.NewNopLogger())
+		require.False(t, http.DefaultTransport.(*http.Transport).DisableKeepAlives, "httpTransport must clone http.DefaultTransport, not mutate it")
+	})
+}
+
+// TestHTTPClient_DisableKeepAlives verifies that, with keep-alives disabled, every
+// fetch opens a fresh connection (so requests get re-balanced across backends), while
+// with keep-alives enabled the connection is reused.
+func TestHTTPClient_DisableKeepAlives(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		disableKeepAlives bool
+		wantNewConns      int64
+	}{
+		{name: "disabled opens a new connection per fetch", disableKeepAlives: true, wantNewConns: 5},
+		{name: "enabled reuses a single connection", disableKeepAlives: false, wantNewConns: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var newConns atomic.Int64
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("value: 1\n"))
+			}))
+			srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+				if state == http.StateNew {
+					newConns.Inc()
+				}
+			}
+			srv.Start()
+			t.Cleanup(srv.Close)
+
+			cfg := Config{HTTPClientDisableKeepAlives: tc.disableKeepAlives}
+			client := &http.Client{Transport: httpTransport(cfg, "test", prometheus.NewRegistry(), log.NewNopLogger())}
+			p := newHTTPProvider(srv.URL+"/config.yaml", client, newHTTPRequestDuration(prometheus.NewRegistry()))
+
+			const fetches = 5
+			for i := 0; i < fetches; i++ {
+				_, err := p.Read(context.Background())
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantNewConns, newConns.Load())
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:

The runtime config HTTP client reuses the shared `http.DefaultTransport`, which keeps connections alive (`IdleConnTimeout` is 90s). With the default 10s reload period the idle connection never expires, so each consumer keeps a single long-lived connection pinned to one backend.

When the runtime config URL is served by multiple replicas behind a connection-level (L4) load balancer — e.g. a Kubernetes ClusterIP Service — the backend is picked once, at connect time, and never changes. Replicas added later (for example by an HPA) receive almost no traffic while the original ones stay saturated, and the imbalance is self-perpetuating because the connections are never recreated.

This adds an experimental `http_client_disable_keep_alives` option, **enabled by default**, so each reload opens a fresh connection and gets re-balanced across all backends. Given the reload interval, the extra connection setup is negligible.

**Which issue(s) this PR fixes**:

n/a

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the runtime-config HTTP client transport; default behavior changes connection reuse but is covered by tests and is opt-out via config.
> 
> **Overview**
> Adds **`http_client_disable_keep_alives`** (CLI: `runtime-config.http-client-disable-keep-alives`), **on by default**, for the runtime config HTTP client used when `LoadPath` entries are URLs.
> 
> **`httpTransport`** now **clones** `http.DefaultTransport`, sets **`DisableKeepAlives`** from that config, and uses the clone for cluster-validation wrapping instead of mutating or sharing the global default transport. With the default reload interval, each periodic fetch can open a **new TCP connection**, which helps **re-balance** requests across replicas behind an **L4** load balancer instead of pinning one long-lived connection to a single backend.
> 
> Tests cover flag defaults, transport behavior (including no mutation of `http.DefaultTransport`), and connection reuse vs. one connection per fetch when keep-alives are enabled vs. disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d84b36c9433958cdc968f9f4911d66339e75db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->