### PR TITLE
feat(spanprofiler): emit trace_id pprof label

### DIFF
--- a/spanprofiler/spanprofiler.go
+++ b/spanprofiler/spanprofiler.go
@@ -2,6 +2,7 @@ package spanprofiler
 
 import (
 	"context"
+	"fmt"
 	"runtime/pprof"
 
 	"github.com/opentracing/opentracing-go"
@@ -12,8 +13,9 @@ import (
 // any Span found within `ctx` as a ChildOfRef. If no such parent could be
 // found, StartSpanFromContext creates a root (parentless) Span.
 //
-// The call sets `operationName` as `span_name` pprof label, and the new span
-// identifier as `span_id` pprof label, if the trace is sampled.
+// The call sets `operationName` as `span_name` pprof label, the new span
+// identifier as `span_id` pprof label, and the trace identifier as `trace_id`
+// pprof label, if the trace is sampled.
 //
 // The second return value is a context.Context object built around the
 // returned Span.
@@ -34,8 +36,9 @@ func StartSpanFromContext(ctx context.Context, operationName string, opts ...ope
 // it creates a root span. It also returns a context.Context object built
 // around the returned span.
 //
-// The call sets `operationName` as `span_name` pprof label, and the new span
-// identifier as `span_id` pprof label, if the trace is sampled.
+// The call sets `operationName` as `span_name` pprof label, the new span
+// identifier as `span_id` pprof label, and the trace identifier as `trace_id`
+// pprof label, if the trace is sampled.
 //
 // It's behavior is identical to StartSpanFromContext except that it takes an explicit
 // tracer as opposed to using the global tracer.
@@ -43,7 +46,7 @@ func StartSpanFromContextWithTracer(ctx context.Context, tracer opentracing.Trac
 	span, ctx := opentracing.StartSpanFromContextWithTracer(ctx, tracer, operationName, opts...)
 	spanCtx, ok := span.Context().(jaeger.SpanContext)
 	if ok {
-		span = wrapJaegerSpanWithGoroutineLabels(ctx, span, operationName, sampledSpanID(spanCtx))
+		span = wrapJaegerSpanWithGoroutineLabels(ctx, span, operationName, sampledSpanID(spanCtx), sampledTraceID(spanCtx))
 	}
 	return span, ctx
 }
@@ -53,6 +56,7 @@ func wrapJaegerSpanWithGoroutineLabels(
 	span opentracing.Span,
 	operationName string,
 	spanID string,
+	traceID string,
 ) *spanWrapper {
 	// Note that pprof labels are propagated through the goroutine's local
 	// storage and are always copied to child goroutines. This way, stack
@@ -62,7 +66,8 @@ func wrapJaegerSpanWithGoroutineLabels(
 	if spanID != "" {
 		ctx = pprof.WithLabels(parentCtx, pprof.Labels(
 			spanNameLabelName, operationName,
-			spanIDLabelName, spanID))
+			spanIDLabelName, spanID,
+			traceIDLabelName, traceID))
 	} else {
 		// Even if the trace has not been sampled, we still need to keep track
 		// of samples that belong to the span (all spans with the given name).
@@ -104,4 +109,15 @@ func sampledSpanID(spanCtx jaeger.SpanContext) string {
 		return spanCtx.SpanID().String()
 	}
 	return ""
+}
+
+// sampledTraceID returns the trace ID as a 32-character W3C hex string, if the
+// span is sampled, otherwise an empty string is returned. Unlike
+// jaeger.TraceID.String, it always zero-pads to 32 characters.
+func sampledTraceID(spanCtx jaeger.SpanContext) string {
+	if !spanCtx.IsSampled() {
+		return ""
+	}
+	t := spanCtx.TraceID()
+	return fmt.Sprintf("%016x%016x", t.High, t.Low)
 }

--- a/spanprofiler/spanprofiler_test.go
+++ b/spanprofiler/spanprofiler_test.go
@@ -8,6 +8,39 @@ import (
 	"github.com/uber/jaeger-client-go"
 )
 
+func TestSampledTraceID(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		traceID jaeger.TraceID
+		sampled bool
+		want    string
+	}{
+		{
+			name:    "64-bit trace ID is zero-padded to 32 characters",
+			traceID: jaeger.TraceID{High: 0, Low: 0x1},
+			sampled: true,
+			want:    "00000000000000000000000000000001",
+		},
+		{
+			name:    "128-bit trace ID",
+			traceID: jaeger.TraceID{High: 0xabc, Low: 0xdef},
+			sampled: true,
+			want:    "0000000000000abc0000000000000def",
+		},
+		{
+			name:    "unsampled trace returns empty string",
+			traceID: jaeger.TraceID{High: 0xabc, Low: 0xdef},
+			sampled: false,
+			want:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spanCtx := jaeger.NewSpanContext(tc.traceID, jaeger.SpanID(1), jaeger.SpanID(0), tc.sampled, nil)
+			require.Equal(t, tc.want, sampledTraceID(spanCtx))
+		})
+	}
+}
+
 func TestSpanProfiler_pprof_labels_propagation(t *testing.T) {
 	tt := initTestTracer(t, 1)
 	defer func() { require.NoError(t, tt.Close()) }()

--- a/spanprofiler/tracer.go
+++ b/spanprofiler/tracer.go
@@ -13,6 +13,7 @@ const (
 
 	spanIDLabelName   = "span_id"
 	spanNameLabelName = "span_name"
+	traceIDLabelName  = "trace_id"
 )
 
 type tracer struct{ opentracing.Tracer }
@@ -53,7 +54,7 @@ func (t *tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOp
 	// concept: this makes it impossible to save an existing pprof context and
 	// all the original pprof labels associated with the goroutine.
 	ctx := context.Background()
-	return wrapJaegerSpanWithGoroutineLabels(ctx, span, operationName, sampledSpanID(spanCtx))
+	return wrapJaegerSpanWithGoroutineLabels(ctx, span, operationName, sampledSpanID(spanCtx), sampledTraceID(spanCtx))
 }
 
 // isRootSpan reports whether the span is a root span.

--- a/spanprofiler/tracer_test.go
+++ b/spanprofiler/tracer_test.go
@@ -25,6 +25,12 @@ func TestTracer_pprof_labels_propagation(t *testing.T) {
 		require.Equal(t, pprofLabels["span_name"], "RootSpan")
 		_, err := jaeger.SpanIDFromString(pprofLabels["span_id"])
 		require.NoError(t, err)
+		// trace_id is the 32-character W3C form of the span's trace ID.
+		traceID := pprofLabels["trace_id"]
+		require.Len(t, traceID, 32)
+		parsed, err := jaeger.TraceIDFromString(traceID)
+		require.NoError(t, err)
+		require.Equal(t, rootSpan.Context().(jaeger.SpanContext).TraceID(), parsed)
 		// Make sure the root span has "pyroscope.profile.id" attribute,
 		// and it matches the corresponding pprof label.
 		require.Equal(t, pprofLabels["span_id"], spanTags(rootSpan)["pyroscope.profile.id"])


### PR DESCRIPTION
Adds a `trace_id` pprof label (32-char zero-padded W3C hex) alongside `span_id` on sampled root spans, mirroring otel-profiling-go for the Jaeger/OpenTracing path. Enables traces↔profiles correlation by trace ID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive profiling labels and formatting helper with tests; no auth, data, or sampling-behavior changes beyond an extra label when already sampled.
> 
> **Overview**
> Sampled Jaeger/OpenTracing spans now attach a **`trace_id`** pprof label in addition to **`span_name`** and **`span_id`**, so CPU profiles can be correlated with traces by trace ID (aligned with otel-profiling-go).
> 
> **`sampledTraceID`** formats the Jaeger trace ID as a **32-character zero-padded W3C hex** string when the span is sampled; unsampled traces still only get **`span_name`**. **`wrapJaegerSpanWithGoroutineLabels`** and both **`StartSpanFromContextWithTracer`** and **`NewTracer`** root-span wiring pass the new label through unchanged sampling rules.
> 
> Tests cover **`sampledTraceID`** padding/parsing and assert the root-span **`trace_id`** label matches the span’s trace context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919334660b0704e7e725fbe01caf630d4c645279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->