### PR TITLE
feat: expose ReserveN on RateLimiter for cancellable multi-limiter reservations

### DIFF
--- a/limiter/rate_limiter.go
+++ b/limiter/rate_limiter.go
@@ -48,6 +48,14 @@ func (l *RateLimiter) AllowN(now time.Time, tenantID string, n int) bool {
 	return l.getTenantLimiter(now, tenantID).AllowN(now, n)
 }
 
+// ReserveN returns a Reservation that indicates how long the caller must wait
+// before n tokens may be consumed at time now for the given tenant. The caller
+// may Cancel the reservation to return the reserved tokens, which is useful when
+// making an all-or-nothing decision across multiple limiters.
+func (l *RateLimiter) ReserveN(now time.Time, tenantID string, n int) *rate.Reservation {
+	return l.getTenantLimiter(now, tenantID).ReserveN(now, n)
+}
+
 // WaitN blocks until n events are allowed to happen.
 // It returns an error if n exceeds the Limiter's burst size, the Context is
 // canceled, or the expected wait time exceeds the Context's Deadline.

--- a/limiter/rate_limiter_test.go
+++ b/limiter/rate_limiter_test.go
@@ -66,6 +66,79 @@ func TestRateLimiter_AllowN(t *testing.T) {
 	assert.Equal(t, true, limiter.AllowN(now.Add(time.Second), "tenant-2", 2))
 }
 
+func TestRateLimiter_ReserveN(t *testing.T) {
+	strategy := &staticLimitStrategy{tenants: map[string]struct {
+		limit float64
+		burst int
+	}{
+		"tenant-1": {limit: 10, burst: 20},
+	}}
+
+	limiter := NewRateLimiter(strategy, 10*time.Second)
+	now := time.Now()
+
+	// A reservation within the burst is OK and requires no wait.
+	r := limiter.ReserveN(now, "tenant-1", 5)
+	assert.True(t, r.OK())
+	assert.Equal(t, time.Duration(0), r.DelayFrom(now))
+
+	// Exhaust the remaining burst.
+	r = limiter.ReserveN(now, "tenant-1", 15)
+	assert.True(t, r.OK())
+	assert.Equal(t, time.Duration(0), r.DelayFrom(now))
+
+	// Once the burst is exhausted, a further reservation is OK but must wait.
+	r = limiter.ReserveN(now, "tenant-1", 5)
+	assert.True(t, r.OK())
+	assert.Greater(t, r.DelayFrom(now), time.Duration(0))
+}
+
+func TestRateLimiter_ReserveN_Cancel(t *testing.T) {
+	strategy := &staticLimitStrategy{tenants: map[string]struct {
+		limit float64
+		burst int
+	}{
+		"tenant-1": {limit: 10, burst: 20},
+	}}
+
+	limiter := NewRateLimiter(strategy, 10*time.Second)
+	now := time.Now()
+
+	// Reserve the whole burst.
+	r := limiter.ReserveN(now, "tenant-1", 20)
+	assert.True(t, r.OK())
+	assert.Equal(t, time.Duration(0), r.DelayFrom(now))
+
+	// With the bucket exhausted, a full-burst request can't be served immediately.
+	assert.False(t, limiter.AllowN(now, "tenant-1", 20))
+
+	// Cancelling the reservation should return the tokens to the bucket. We use
+	// CancelAt(now) rather than Cancel() to keep the test deterministic: Cancel()
+	// uses time.Now() internally, which would have advanced past the fixed now and
+	// turned the cancellation into a no-op.
+	r.CancelAt(now)
+
+	// Now the same amount can be consumed again at the same instant, proving
+	// that cancellation restored the tokens.
+	assert.True(t, limiter.AllowN(now, "tenant-1", 20))
+}
+
+func TestRateLimiter_ReserveN_ExceedsBurst(t *testing.T) {
+	strategy := &staticLimitStrategy{tenants: map[string]struct {
+		limit float64
+		burst int
+	}{
+		"tenant-1": {limit: 10, burst: 20},
+	}}
+
+	limiter := NewRateLimiter(strategy, 10*time.Second)
+	now := time.Now()
+
+	// A reservation larger than the burst can never be satisfied.
+	r := limiter.ReserveN(now, "tenant-1", 21)
+	assert.False(t, r.OK())
+}
+
 func TestRateLimiter_WaitN(t *testing.T) {
 	strategy := &staticLimitStrategy{tenants: map[string]struct {
 		limit float64


### PR DESCRIPTION
**What this PR does**:

Adds a `ReserveN` method to the multi-tenant `limiter.RateLimiter`, exposing the cancellation-capable reservation API from `golang.org/x/time/rate`.

`RateLimiter` currently only exposes `AllowN` and `WaitN`. Neither supports rollback: `AllowN` consumes tokens immediately on success, and `WaitN` blocks. There is no way to make an **all-or-nothing decision across several per-tenant limiters** — tentatively take tokens from multiple buckets and, if any one of them can't proceed, return the tokens already taken from the others.

The underlying `*rate.Limiter` already supports this via `ReserveN`, which returns a `*rate.Reservation` exposing `OK()`, `Delay()/DelayFrom()`, and `Cancel()/CancelAt()`. This PR simply surfaces it on the per-tenant wrapper, mirroring the existing `AllowN`:

```go
func (l *RateLimiter) ReserveN(now time.Time, tenantID string, n int) *rate.Reservation {
	return l.getTenantLimiter(now, tenantID).ReserveN(now, n)
}
```

**Which issue(s) this PR fixes**:

re https://github.com/grafana/loki/pull/22435 -- To preserve the all-or-nothing push contract, the distributor wants to reserve from every relevant bucket and cancel all reservations if any bucket is over budget, so tokens aren't consumed for a request that ultimately gets rejected (which otherwise lets one over-limit policy slowly drain unrelated buckets across client retries).



**Special notes for your reviewer**:

The added test for cancellation uses `Reservation.CancelAt(now)` rather than `Cancel()`. `Cancel()` delegates to `CancelAt(time.Now())`; with the deterministic fixed `now` used throughout the limiter tests, the reservation's act time is already in the past relative to wall-clock, so `Cancel()` short-circuits to a no-op and the test would be flaky. `CancelAt(now)` is the time-pinned equivalent and keeps the test deterministic. The production `Cancel()` path is unchanged.

**Checklist**
- [x] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API on the limiter wrapper with unit tests only; no changes to existing AllowN/WaitN behavior.
> 
> **Overview**
> Adds **`RateLimiter.ReserveN`**, delegating to each tenant’s underlying `golang.org/x/time/rate.Limiter` so callers get a `*rate.Reservation` with **`OK`**, **delay**, and **cancel** semantics—same pattern as existing **`AllowN`**.
> 
> This enables **all-or-nothing checks across multiple per-tenant buckets**: reserve tokens tentatively and **`Cancel`** if any limiter would reject the request, instead of **`AllowN`** consuming tokens immediately with no rollback.
> 
> Tests cover in-burst reservations, post-burst wait delays, **`CancelAt(now)`** restoring tokens (deterministic vs flaky **`Cancel()`**), and requests larger than burst returning **`!OK()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8985d0f800b1d4d6a4b1e9c359f711d633e38462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->