### PR TITLE
fix(cache): fix issue where events emitted by `SpanlessTracingCache` backed by Memcached have empty `name` attribute

### DIFF
--- a/cache/memcached_client.go
+++ b/cache/memcached_client.go
@@ -272,6 +272,7 @@ func newMemcachedClient(
 		selector:        selector,
 		addressProvider: addressProvider,
 		stop:            make(chan struct{}, 1),
+		name:            name,
 		getMultiGate: gate.New(
 			prometheus.WrapRegistererWithPrefix(getMultiMetricNamePrefix, reg),
 			config.MaxGetMultiConcurrency,

--- a/cache/memcached_client_test.go
+++ b/cache/memcached_client_test.go
@@ -344,6 +344,12 @@ func TestMemcachedClient_Delete(t *testing.T) {
 	require.Empty(t, afterDeletionResult)
 }
 
+func TestMemcachedClient_Name(t *testing.T) {
+	client, _, err := setupDefaultMemcachedClient()
+	require.NoError(t, err)
+	require.Equal(t, "test", client.Name())
+}
+
 func BenchmarkMemcachedClient_sortKeysByServer(b *testing.B) {
 	mockSelector := &mockServerSelector{
 		servers: []mockServer{


### PR DESCRIPTION
**What this PR does**:

This PR fixes an issue where events emitted by `SpanlessTracingCache` have an empty `name` attribute if the underlying cache is a Memcached client.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
