### PR TITLE
docs(cache): correct WrapWithLRUCache expiry behavior in godoc

### DIFF
--- a/cache/lru.go
+++ b/cache/lru.go
@@ -36,7 +36,7 @@ type Item struct {
 // WrapWithLRUCache wraps a given `Cache` c with a LRU cache. The LRU cache will always store items in both caches.
 // However it will only fetch items from the underlying cache if the LRU cache doesn't have the item.
 // Items fetched from the underlying cache will be stored in the LRU cache with a default TTL.
-// The LRU cache will also remove items from the underlying cache if they are expired.
+// Items that have expired in the LRU cache are evicted from it on read and re-fetched from the underlying cache.
 // The LRU cache is limited in number of items using `lruSize`. This means this cache is not tailored for large items or items that have a big
 // variation in size.
 func WrapWithLRUCache(c Cache, name string, reg prometheus.Registerer, lruSize int, defaultTTL time.Duration, logger log.Logger) (*LRUCache, error) {

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -164,3 +164,25 @@ func TestLRUCache_GetMultiWithError_PropagatesError(t *testing.T) {
 	require.Empty(t, result)
 	require.ErrorIs(t, err, backendErr)
 }
+
+func TestLRUCache_ExpiredItemsAreEvictedNotDeletedFromUnderlying(t *testing.T) {
+	var (
+		mock = NewInstrumentedMockCache()
+		ctx  = context.Background()
+	)
+
+	reg := prometheus.NewPedanticRegistry()
+	lru, err := WrapWithLRUCache(mock, "test", reg, 10000, 2*time.Hour, log.NewNopLogger())
+	require.NoError(t, err)
+
+	// The entry is still live in the underlying cache but already expired in the LRU.
+	mock.SetAsync("key", []byte("value"), time.Hour)
+	lru.lru.Add("key", &Item{Data: []byte("value"), ExpiresAt: time.Now().Add(-time.Minute)})
+
+	// Reading the key evicts the expired entry from the LRU and re-fetches it from the underlying cache.
+	result := lru.GetMulti(ctx, []string{"key"})
+	require.Equal(t, map[string][]byte{"key": []byte("value")}, result)
+
+	// The underlying cache is never asked to delete the expired entry.
+	require.Zero(t, mock.CountDeleteCalls())
+}


### PR DESCRIPTION
**What this PR does**:

The godoc for `WrapWithLRUCache` says:

> The LRU cache will also remove items from the underlying cache if they are expired.

That isn't what the code does. When an entry is expired in the LRU, `GetMultiWithError` only evicts it from the in-memory LRU and re-fetches it from the underlying cache:

```go
if item.ExpiresAt.After(now) {
    found[k] = item.Data
    continue
}
l.lru.Remove(k)
miss = append(miss, k)
```

The only place the underlying cache is deleted from is the explicit `Delete` method. The expiry path never calls `l.c.Delete`, so the underlying cache is never touched on expiry. The sentence has been inaccurate since the package was added.

This reworks the sentence to describe the actual behavior and adds a test that asserts the underlying cache is never asked to delete an expired entry (using `InstrumentedMockCache.CountDeleteCalls`).

**Which issue(s) this PR fixes**:

None.

**Checklist**
- [x] Tests updated
