### PR TITLE
feat(ring/client): add NewRingsServiceDiscovery for multiple rings

### DIFF
--- a/ring/client/ring_service_discovery.go
+++ b/ring/client/ring_service_discovery.go
@@ -23,3 +23,34 @@ func NewRingServiceDiscovery(r ring.ReadRing) PoolServiceDiscovery {
 		return addrs, nil
 	}
 }
+
+// NewRingsServiceDiscovery returns a PoolServiceDiscovery listing the deduplicated addresses
+// of all healthy instances across the given rings.
+func NewRingsServiceDiscovery(rings []ring.ReadRing) PoolServiceDiscovery {
+	discoveries := make([]PoolServiceDiscovery, len(rings))
+	for i, r := range rings {
+		discoveries[i] = NewRingServiceDiscovery(r)
+	}
+
+	return func() ([]string, error) {
+		var addrs []string
+		seen := map[string]struct{}{}
+
+		for _, discovery := range discoveries {
+			ringAddrs, err := discovery()
+			if err != nil {
+				return nil, err
+			}
+
+			for _, addr := range ringAddrs {
+				if _, ok := seen[addr]; ok {
+					continue
+				}
+				seen[addr] = struct{}{}
+				addrs = append(addrs, addr)
+			}
+		}
+
+		return addrs, nil
+	}
+}

--- a/ring/client/ring_service_discovery_test.go
+++ b/ring/client/ring_service_discovery_test.go
@@ -55,6 +55,92 @@ func TestNewRingServiceDiscovery(t *testing.T) {
 	}
 }
 
+func TestNewRingsServiceDiscovery(t *testing.T) {
+	tests := map[string]struct {
+		rings         []*mockReadRing
+		expectedAddrs []string
+		expectedErr   error
+	}{
+		"no rings": {
+			rings:         nil,
+			expectedAddrs: nil,
+		},
+		"single ring with multiple instances": {
+			rings: []*mockReadRing{
+				{mockedReplicationSet: ring.ReplicationSet{Instances: []ring.InstanceDesc{
+					{Addr: "1.1.1.1"},
+					{Addr: "2.2.2.2"},
+				}}},
+			},
+			expectedAddrs: []string{"1.1.1.1", "2.2.2.2"},
+		},
+		"multiple rings with disjoint instances": {
+			rings: []*mockReadRing{
+				{mockedReplicationSet: ring.ReplicationSet{Instances: []ring.InstanceDesc{
+					{Addr: "1.1.1.1"},
+					{Addr: "2.2.2.2"},
+				}}},
+				{mockedReplicationSet: ring.ReplicationSet{Instances: []ring.InstanceDesc{
+					{Addr: "3.3.3.3"},
+				}}},
+			},
+			expectedAddrs: []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+		},
+		"multiple rings with overlapping instances are deduplicated": {
+			rings: []*mockReadRing{
+				{mockedReplicationSet: ring.ReplicationSet{Instances: []ring.InstanceDesc{
+					{Addr: "1.1.1.1"},
+					{Addr: "2.2.2.2"},
+				}}},
+				{mockedReplicationSet: ring.ReplicationSet{Instances: []ring.InstanceDesc{
+					{Addr: "2.2.2.2"},
+					{Addr: "3.3.3.3"},
+				}}},
+			},
+			expectedAddrs: []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+		},
+		"duplicate instances within a single ring are deduplicated": {
+			rings: []*mockReadRing{
+				{mockedReplicationSet: ring.ReplicationSet{Instances: []ring.InstanceDesc{
+					{Addr: "1.1.1.1"},
+					{Addr: "1.1.1.1"},
+				}}},
+			},
+			expectedAddrs: []string{"1.1.1.1"},
+		},
+		"all rings are empty": {
+			rings: []*mockReadRing{
+				{mockedErr: ring.ErrEmptyRing},
+				{mockedErr: ring.ErrEmptyRing},
+			},
+			expectedAddrs: nil,
+		},
+		"one ring fails discovery": {
+			rings: []*mockReadRing{
+				{mockedReplicationSet: ring.ReplicationSet{Instances: []ring.InstanceDesc{
+					{Addr: "1.1.1.1"},
+				}}},
+				{mockedErr: errors.New("mocked error")},
+			},
+			expectedErr: errors.New("mocked error"),
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			rings := make([]ring.ReadRing, len(testData.rings))
+			for i, r := range testData.rings {
+				rings[i] = r
+			}
+
+			d := NewRingsServiceDiscovery(rings)
+			addrs, err := d()
+			assert.Equal(t, testData.expectedErr, err)
+			assert.Equal(t, testData.expectedAddrs, addrs)
+		})
+	}
+}
+
 type mockReadRing struct {
 	ring.ReadRing
 


### PR DESCRIPTION
**What this PR does**:

Adds `NewRingsServiceDiscovery`, the multi-ring counterpart of `NewRingServiceDiscovery`. It returns a `PoolServiceDiscovery` listing the deduplicated addresses of all healthy instances across the given rings, so a single client pool can serve instances spread over several rings.

This logic currently lives in Mimir (see grafana/mimir#15856) but belongs in dskit alongside the existing single-ring helper. The dskit version also deduplicates addresses, which the Mimir implementation does not.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
