### PR TITLE
feat(ring): add PartitionRingWatchers and PartitionInstanceRings

### DIFF
--- a/ring/partition_instance_rings.go
+++ b/ring/partition_instance_rings.go
@@ -8,7 +8,7 @@ import (
 // group, each pairing that watcher's partition ring with a shared instance ring. Rings are accessed
 // by the same index used by the underlying PartitionRingWatchers group.
 type PartitionInstanceRings struct {
-	// rings is indexed by position in the group. It always has at least one element.
+	// rings is indexed by position in the group.
 	rings []*PartitionInstanceRing
 }
 

--- a/ring/partition_instance_rings.go
+++ b/ring/partition_instance_rings.go
@@ -1,0 +1,33 @@
+package ring
+
+import (
+	"time"
+)
+
+// PartitionInstanceRings holds one PartitionInstanceRing per watcher in a PartitionRingWatchers
+// group, each pairing that watcher's partition ring with a shared instance ring. Rings are accessed
+// by the same index used by the underlying PartitionRingWatchers group.
+type PartitionInstanceRings struct {
+	// rings is indexed by position in the group. It always has at least one element.
+	rings []*PartitionInstanceRing
+}
+
+// NewPartitionInstanceRings builds one PartitionInstanceRing per watcher in the group, pairing each
+// watcher's partition ring with the shared instance ring.
+func NewPartitionInstanceRings(watchers *PartitionRingWatchers, instanceRing InstanceRingReader, heartbeatTimeout time.Duration) *PartitionInstanceRings {
+	rings := make([]*PartitionInstanceRing, watchers.Count())
+	for i := range rings {
+		rings[i] = NewPartitionInstanceRing(watchers.Watcher(i), instanceRing, heartbeatTimeout)
+	}
+	return &PartitionInstanceRings{rings: rings}
+}
+
+// Count returns the number of rings in the group.
+func (r *PartitionInstanceRings) Count() int {
+	return len(r.rings)
+}
+
+// Get returns the partition-instance ring at the given index.
+func (r *PartitionInstanceRings) Get(idx int) *PartitionInstanceRing {
+	return r.rings[idx]
+}

--- a/ring/partition_instance_rings_test.go
+++ b/ring/partition_instance_rings_test.go
@@ -1,0 +1,94 @@
+package ring
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/kv/consul"
+)
+
+func TestPartitionInstanceRings(t *testing.T) {
+	kvClient, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	// Each ring has a single partition owned by a distinct instance.
+	writePartitionAndOwner(t, kvClient, "ring-0", 0, "instance-0")
+	writePartitionAndOwner(t, kvClient, "ring-1", 0, "instance-1")
+
+	watchers, err := NewPartitionRingWatchers(
+		NewPartitionRingWatcher("ring-0", "ring-0", kvClient, log.NewNopLogger(), nil),
+		NewPartitionRingWatcher("ring-1", "ring-1", kvClient, log.NewNopLogger(), nil),
+	)
+	require.NoError(t, err)
+	startPartitionRingWatchers(t, watchers)
+
+	now := time.Now()
+	instanceRing := staticInstanceRing{instances: map[string]InstanceDesc{
+		"instance-0": {Addr: "addr-0", State: ACTIVE, Timestamp: now.Unix(), Zone: "zone-a"},
+		"instance-1": {Addr: "addr-1", State: ACTIVE, Timestamp: now.Unix(), Zone: "zone-a"},
+	}}
+
+	rings := NewPartitionInstanceRings(watchers, instanceRing, time.Minute)
+	require.Equal(t, 2, rings.Count())
+
+	// Each ring exposes its own partition ring.
+	assert.Equal(t, 1, rings.Get(0).PartitionRing().PartitionsCount())
+	assert.Equal(t, 1, rings.Get(1).PartitionRing().PartitionsCount())
+
+	// Ring 0 resolves only ring 0's partition owner against the shared instance ring; ring 1's
+	// instance is never an owner of ring 0's partitions.
+	readOp := NewOp([]InstanceState{ACTIVE, PENDING}, nil)
+	sets, err := rings.Get(0).GetReplicationSetsForOperation(readOp)
+	require.NoError(t, err)
+	require.Len(t, sets, 1)
+	require.Len(t, sets[0].Instances, 1)
+	assert.Equal(t, "addr-0", sets[0].Instances[0].Addr)
+}
+
+func TestPartitionInstanceRings_SingleRing(t *testing.T) {
+	kvClient, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	writePartitionAndOwner(t, kvClient, "ring", 0, "instance-0")
+
+	watchers, err := NewPartitionRingWatchers(NewPartitionRingWatcher("ring", "ring", kvClient, log.NewNopLogger(), nil))
+	require.NoError(t, err)
+	startPartitionRingWatchers(t, watchers)
+
+	rings := NewPartitionInstanceRings(watchers, staticInstanceRing{}, time.Minute)
+	assert.Equal(t, 1, rings.Count())
+	assert.Same(t, watchers.Watcher(0).PartitionRing(), rings.Get(0).PartitionRing())
+}
+
+// staticInstanceRing is a minimal InstanceRingReader backed by a static map.
+type staticInstanceRing struct {
+	instances map[string]InstanceDesc
+}
+
+func (r staticInstanceRing) GetInstance(id string) (InstanceDesc, error) {
+	inst, ok := r.instances[id]
+	if !ok {
+		return InstanceDesc{}, fmt.Errorf("instance %s not found", id)
+	}
+	return inst, nil
+}
+
+func (r staticInstanceRing) InstancesCount() int { return len(r.instances) }
+
+// writePartitionAndOwner stores a partition ring desc with a single active partition owned by the given instance.
+func writePartitionAndOwner(t *testing.T, kvClient kv.Client, key string, partitionID int32, ownerID string) {
+	t.Helper()
+	require.NoError(t, kvClient.CAS(context.Background(), key, func(interface{}) (interface{}, bool, error) {
+		desc := NewPartitionRingDesc()
+		desc.AddPartition(partitionID, PartitionActive, time.Now())
+		desc.AddOrUpdateOwner(ownerID, OwnerActive, partitionID, time.Now())
+		return desc, true, nil
+	}))
+}

--- a/ring/partition_ring_watchers.go
+++ b/ring/partition_ring_watchers.go
@@ -1,0 +1,89 @@
+package ring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/dskit/services"
+)
+
+// PartitionRingWatchers groups one or more PartitionRingWatcher and exposes them through a single
+// service, indexed by their position in the group. It runs the watchers as subservices, so starting
+// or stopping the group starts or stops all of them, and a failure in any watcher surfaces as a
+// failure of the group.
+//
+// It is useful when a process watches several partition rings at once (for example one ring per
+// shard, tenant group, or logical partition set) and wants to manage their lifecycle together.
+type PartitionRingWatchers struct {
+	services.Service
+
+	// watchers is indexed by position in the group. It always has at least one element.
+	watchers []*PartitionRingWatcher
+
+	subservices        *services.Manager
+	subservicesWatcher *services.FailureWatcher
+}
+
+// NewPartitionRingWatchers groups the given watchers into a single service. At least one watcher
+// must be provided. The watchers are indexed by the order in which they are passed and must not be
+// started by the caller: the returned service starts and stops them.
+func NewPartitionRingWatchers(watchers ...*PartitionRingWatcher) (*PartitionRingWatchers, error) {
+	if len(watchers) == 0 {
+		return nil, fmt.Errorf("at least one partition ring watcher must be provided")
+	}
+
+	subservices := make([]services.Service, len(watchers))
+	for i, w := range watchers {
+		subservices[i] = w
+	}
+	manager, err := services.NewManager(subservices...)
+	if err != nil {
+		return nil, fmt.Errorf("creating partition ring watchers service manager: %w", err)
+	}
+
+	w := &PartitionRingWatchers{
+		watchers:           watchers,
+		subservices:        manager,
+		subservicesWatcher: services.NewFailureWatcher(),
+	}
+	w.Service = services.NewBasicService(w.starting, w.running, w.stopping).WithName("partition-ring-watchers")
+	return w, nil
+}
+
+// Count returns the number of watchers in the group.
+func (w *PartitionRingWatchers) Count() int {
+	return len(w.watchers)
+}
+
+// Watcher returns the watcher at the given index.
+func (w *PartitionRingWatchers) Watcher(idx int) *PartitionRingWatcher {
+	return w.watchers[idx]
+}
+
+// PartitionRing returns the partition ring of the watcher at the given index.
+func (w *PartitionRingWatchers) PartitionRing(idx int) *PartitionRing {
+	return w.watchers[idx].PartitionRing()
+}
+
+// All returns the watchers indexed by position in the group. The returned slice must not be modified.
+func (w *PartitionRingWatchers) All() []*PartitionRingWatcher {
+	return w.watchers
+}
+
+func (w *PartitionRingWatchers) starting(ctx context.Context) error {
+	w.subservicesWatcher.WatchManager(w.subservices)
+	return services.StartManagerAndAwaitHealthy(ctx, w.subservices)
+}
+
+func (w *PartitionRingWatchers) running(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-w.subservicesWatcher.Chan():
+		return fmt.Errorf("partition ring watcher subservice failed: %w", err)
+	}
+}
+
+func (w *PartitionRingWatchers) stopping(_ error) error {
+	return services.StopManagerAndAwaitStopped(context.Background(), w.subservices)
+}

--- a/ring/partition_ring_watchers_test.go
+++ b/ring/partition_ring_watchers_test.go
@@ -1,0 +1,118 @@
+package ring
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/services"
+)
+
+func TestPartitionRingWatchers_SingleWatcher(t *testing.T) {
+	kvClient, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	writePartitions(t, kvClient, "ring", 0, 1, 2)
+
+	w, err := NewPartitionRingWatchers(NewPartitionRingWatcher("ring", "ring", kvClient, log.NewNopLogger(), nil))
+	require.NoError(t, err)
+	startPartitionRingWatchers(t, w)
+
+	assert.Equal(t, 1, w.Count())
+	assert.Equal(t, 3, w.PartitionRing(0).PartitionsCount())
+	assert.Same(t, w.Watcher(0), w.All()[0])
+	assert.Same(t, w.Watcher(0).PartitionRing(), w.PartitionRing(0))
+}
+
+func TestPartitionRingWatchers_MultipleWatchers(t *testing.T) {
+	kvClient, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	// Each watcher has its own key with a distinct number of partitions.
+	writePartitions(t, kvClient, "ring-0", 0)
+	writePartitions(t, kvClient, "ring-1", 0, 1)
+	writePartitions(t, kvClient, "ring-2", 0, 1, 2)
+
+	w, err := NewPartitionRingWatchers(
+		NewPartitionRingWatcher("ring-0", "ring-0", kvClient, log.NewNopLogger(), nil),
+		NewPartitionRingWatcher("ring-1", "ring-1", kvClient, log.NewNopLogger(), nil),
+		NewPartitionRingWatcher("ring-2", "ring-2", kvClient, log.NewNopLogger(), nil),
+	)
+	require.NoError(t, err)
+	startPartitionRingWatchers(t, w)
+
+	require.Equal(t, 3, w.Count())
+	assert.Len(t, w.All(), 3)
+
+	// Each accessor returns the ring at its own index.
+	assert.Equal(t, 1, w.PartitionRing(0).PartitionsCount())
+	assert.Equal(t, 2, w.PartitionRing(1).PartitionsCount())
+	assert.Equal(t, 3, w.PartitionRing(2).PartitionsCount())
+
+	assert.Same(t, w.Watcher(1).PartitionRing(), w.PartitionRing(1))
+}
+
+func TestPartitionRingWatchers_DoesNotPanicWithRealRegistererAndDistinctlyNamedWatchers(t *testing.T) {
+	kvClient, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	// A real registerer panics on duplicate metric registration if the per-watcher ring metrics
+	// aren't disambiguated by their (distinct) names.
+	reg := prometheus.NewPedanticRegistry()
+	var w *PartitionRingWatchers
+	require.NotPanics(t, func() {
+		var err error
+		w, err = NewPartitionRingWatchers(
+			NewPartitionRingWatcher("ring-0", "ring-0", kvClient, log.NewNopLogger(), reg),
+			NewPartitionRingWatcher("ring-1", "ring-1", kvClient, log.NewNopLogger(), reg),
+			NewPartitionRingWatcher("ring-2", "ring-2", kvClient, log.NewNopLogger(), reg),
+			NewPartitionRingWatcher("ring-3", "ring-3", kvClient, log.NewNopLogger(), reg),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 4, w.Count())
+	})
+
+	// Start and stop so the watcher subservices don't leak goroutines.
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), w))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), w))
+}
+
+func TestPartitionRingWatchers_ReturnsErrorWhenNoWatchersProvided(t *testing.T) {
+	w, err := NewPartitionRingWatchers()
+	assert.Error(t, err)
+	assert.Nil(t, w)
+}
+
+// writePartitions stores a partition ring desc with the given partition IDs under the given key.
+func writePartitions(t *testing.T, kvClient kv.Client, key string, partitionIDs ...int32) {
+	t.Helper()
+
+	require.NoError(t, kvClient.CAS(context.Background(), key, func(interface{}) (interface{}, bool, error) {
+		desc := NewPartitionRingDesc()
+		for _, id := range partitionIDs {
+			desc.AddPartition(id, PartitionActive, time.Now())
+		}
+		return desc, true, nil
+	}))
+}
+
+func startPartitionRingWatchers(t *testing.T, w *PartitionRingWatchers) {
+	t.Helper()
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), w))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), w))
+	})
+
+	// Give the watchers a moment to load the initial ring state from the KV store.
+	require.Eventually(t, func() bool {
+		return w.PartitionRing(0).PartitionsCount() > 0
+	}, time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
**What this PR does**:

Adds two general-purpose helpers to the `ring` package:

- `PartitionRingWatchers` groups one or more `PartitionRingWatcher` and manages their lifecycle as a single service, exposing them by index. This is useful when a process watches several partition rings at once (e.g. one ring per shard, tenant group, or logical partition set) and wants to start, stop, and monitor them together.
- `PartitionInstanceRings` builds one `PartitionInstanceRing` per watcher in such a group, each pairing that watcher's partition ring with a shared instance ring.

These were originally written in Mimir and are generic enough to live in dskit, so other dskit consumers can reuse them. The dskit versions are decoupled from any application-specific ring naming: callers build the individual watchers (choosing their own names and KV keys) and pass them in.

**Which issue(s) this PR fixes**:

(none)

**Checklist**
- [x] Tests updated
