### PR TITLE
fix(kv/memberlist): validate propagation delay tracker config

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -277,7 +277,10 @@ func (cfg *KVConfig) Validate() error {
 	if cfg.CompressionAlgorithm != "" && !slices.Contains(supportedCompressionAlgorithms, cfg.CompressionAlgorithm) {
 		return fmt.Errorf("memberlist compression algorithm %q is not supported, valid values: %s", cfg.CompressionAlgorithm, strings.Join(supportedCompressionAlgorithms, ", "))
 	}
-	return cfg.ZoneAwareRouting.Validate()
+	if err := cfg.ZoneAwareRouting.Validate(); err != nil {
+		return err
+	}
+	return cfg.PropagationDelayTracker.Validate()
 }
 
 // GetRejoinSeedNodes returns the seed nodes to use for periodic rejoin.

--- a/kv/memberlist/propagation_tracker.go
+++ b/kv/memberlist/propagation_tracker.go
@@ -46,6 +46,22 @@ func (cfg *PropagationDelayTrackerConfig) RegisterFlagsWithPrefix(f *flag.FlagSe
 	f.DurationVar(&cfg.LogBeaconsLatencyLongerThan, prefix+"log-beacons-latency-longer-than", 0, "Log warning when beacon propagation delay exceeds this threshold. 0 disables logging.")
 }
 
+// Validate validates the propagation delay tracker configuration.
+func (cfg *PropagationDelayTrackerConfig) Validate() error {
+	// Only validate if enabled.
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if cfg.BeaconInterval <= 0 {
+		return fmt.Errorf("propagation delay tracker beacon interval must be greater than 0")
+	}
+	if cfg.BeaconLifetime <= 0 {
+		return fmt.Errorf("propagation delay tracker beacon lifetime must be greater than 0")
+	}
+	return nil
+}
+
 // PropagationDelayTracker is a service that tracks gossip propagation delay across
 // the memberlist cluster by periodically publishing beacons and measuring
 // how long it takes for beacons to propagate.

--- a/kv/memberlist/propagation_tracker_test.go
+++ b/kv/memberlist/propagation_tracker_test.go
@@ -450,3 +450,63 @@ func createPropagationDelayTrackerTestKV(t *testing.T) *KV {
 
 	return mkv
 }
+
+func TestPropagationDelayTrackerConfig_Validate(t *testing.T) {
+	tests := map[string]struct {
+		cfg     PropagationDelayTrackerConfig
+		wantErr string
+	}{
+		"disabled config is always valid": {
+			cfg: PropagationDelayTrackerConfig{
+				Enabled:        false,
+				BeaconInterval: 0,
+				BeaconLifetime: 0,
+			},
+			wantErr: "",
+		},
+		"valid config": {
+			cfg: PropagationDelayTrackerConfig{
+				Enabled:        true,
+				BeaconInterval: 1 * time.Minute,
+				BeaconLifetime: 10 * time.Minute,
+			},
+			wantErr: "",
+		},
+		"invalid - zero beacon interval": {
+			cfg: PropagationDelayTrackerConfig{
+				Enabled:        true,
+				BeaconInterval: 0,
+				BeaconLifetime: 10 * time.Minute,
+			},
+			wantErr: "propagation delay tracker beacon interval must be greater than 0",
+		},
+		"invalid - negative beacon interval": {
+			cfg: PropagationDelayTrackerConfig{
+				Enabled:        true,
+				BeaconInterval: -1 * time.Minute,
+				BeaconLifetime: 10 * time.Minute,
+			},
+			wantErr: "propagation delay tracker beacon interval must be greater than 0",
+		},
+		"invalid - zero beacon lifetime": {
+			cfg: PropagationDelayTrackerConfig{
+				Enabled:        true,
+				BeaconInterval: 1 * time.Minute,
+				BeaconLifetime: 0,
+			},
+			wantErr: "propagation delay tracker beacon lifetime must be greater than 0",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

The memberlist propagation delay tracker uses `rand.Int63n(int64(beaconInterval))` to compute the initial beacon delay. If the beacon interval is configured to 0 or a negative duration, this panics and crashes the process at startup when the tracker is enabled (reported in grafana/mimir#14312).

This adds a `Validate()` method to `PropagationDelayTrackerConfig` (wired into `KVConfig.Validate()`, matching the existing `ZoneAwareRouting` pattern) that rejects a non-positive beacon interval and beacon lifetime when the tracker is enabled.

**Which issue(s) this PR fixes**:

Addresses https://github.com/grafana/mimir/pull/14312#discussion_r2803010048

**Checklist**
- [x] Tests updated
