### PR TITLE
fix(ring): recover ring entries with a corrupted future heartbeat timestamp

### DIFF
--- a/ring/basic_lifecycler_future_timestamp_test.go
+++ b/ring/basic_lifecycler_future_timestamp_test.go
@@ -1,0 +1,95 @@
+package ring
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv/codec"
+	"github.com/grafana/dskit/kv/memberlist"
+	"github.com/grafana/dskit/services"
+)
+
+type noopDNSProvider struct{}
+
+func (noopDNSProvider) Resolve(context.Context, []string) error { return nil }
+func (noopDNSProvider) Addresses() []string                     { return nil }
+
+// TestBasicLifecycler_RegisterRecoversFromFutureHeartbeat exercises the full registration flow
+// against a real memberlist KV (the backend where the bug reproduces; the in-memory consul mock
+// does not run the ring merge). It seeds the instance's own ring entry with a heartbeat timestamp
+// far in the future, then starts the lifecycler and asserts that:
+//   - registration succeeds (before the fix the memberlist merge returned "no change detected" on
+//     every retry, so the lifecycler failed to start and the process CrashLoopBackOff-ed), and
+//   - the entry stored in the KV is healed back to ~now (re-read from the store, not from the
+//     lifecycler's local copy).
+//
+// See grafana/loki#21733.
+func TestBasicLifecycler_RegisterRecoversFromFutureHeartbeat(t *testing.T) {
+	ctx := context.Background()
+
+	var mlCfg memberlist.KVConfig
+	flagext.DefaultValues(&mlCfg)
+	mlCfg.TCPTransport = memberlist.TCPTransportConfig{BindAddrs: []string{"127.0.0.1"}, BindPort: 0}
+	mlCfg.Codecs = []codec.Codec{GetCodec()}
+
+	mkv := memberlist.NewKV(mlCfg, log.NewNopLogger(), noopDNSProvider{}, prometheus.NewPedanticRegistry())
+	require.NoError(t, services.StartAndAwaitRunning(ctx, mkv))
+	t.Cleanup(func() { _ = services.StopAndAwaitTerminated(context.Background(), mkv) })
+
+	store, err := memberlist.NewClient(mkv, GetCodec())
+	require.NoError(t, err)
+
+	// Seed the instance's own ring entry with a corrupted heartbeat timestamp ~100 years ahead.
+	futureTS := time.Now().Add(100 * 365 * 24 * time.Hour).Unix()
+	require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (interface{}, bool, error) {
+		desc := GetOrCreateRingDesc(in)
+		desc.Ingesters[testInstanceID] = InstanceDesc{
+			Addr:                "127.0.0.1:12345",
+			Zone:                zone(1),
+			State:               ACTIVE,
+			Tokens:              []uint32{1, 2, 3, 4, 5},
+			Timestamp:           futureTS,
+			RegisteredTimestamp: time.Now().Add(-time.Hour).Unix(),
+		}
+		return desc, true, nil
+	}))
+
+	// Sanity check: the corrupted entry is actually stored.
+	require.Equal(t, futureTS, ringDescFromStore(t, store).Ingesters[testInstanceID].Timestamp)
+
+	cfg := prepareBasicLifecyclerConfig()
+	delegate := &mockDelegate{
+		onRegister: func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ InstanceDesc) (InstanceState, Tokens) {
+			return ACTIVE, Tokens{1, 2, 3, 4, 5}
+		},
+	}
+	lifecycler, err := NewBasicLifecycler(cfg, testRingName, testRingKey, store, delegate, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	// Before the fix this fails: registration never makes forward progress and returns
+	// "no change detected", so the service does not reach Running.
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	t.Cleanup(func() { _ = services.StopAndAwaitTerminated(context.Background(), lifecycler) })
+
+	// The stored entry must be healed to ~now, not left at the corrupted future timestamp.
+	healed := ringDescFromStore(t, store).Ingesters[testInstanceID].Timestamp
+	assert.Less(t, healed, futureTS, "heartbeat timestamp was not healed; still in the future")
+	assert.InDelta(t, time.Now().Unix(), healed, 60, "healed timestamp should be around now")
+}
+
+func ringDescFromStore(t *testing.T, store interface {
+	Get(context.Context, string) (interface{}, error)
+}) *Desc {
+	t.Helper()
+	val, err := store.Get(context.Background(), testRingKey)
+	require.NoError(t, err)
+	require.NotNil(t, val)
+	return val.(*Desc)
+}

--- a/ring/merge_future_timestamp_test.go
+++ b/ring/merge_future_timestamp_test.go
@@ -1,0 +1,187 @@
+package ring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeWithTime_FutureTimestampGuard verifies that a ring entry whose heartbeat timestamp is
+// implausibly far in the future (e.g. after clock corruption, grafana/loki#21733) can be reclaimed
+// by a normal now-dated write, and can never win a merge itself.
+func TestMergeWithTime_FutureTimestampGuard(t *testing.T) {
+	const now = int64(1_700_000_000) // fixed reference time
+	skew := int64(acceptableClockSkew / time.Second)
+
+	corrupt := now + skew + 3600 // well beyond the acceptable skew: corrupted
+	nearBoundary := now + skew   // exactly at the boundary: still acceptable
+	justOver := now + skew + 1   // just past the boundary: corrupted
+
+	entry := func(ts int64, tokens ...uint32) InstanceDesc {
+		return InstanceDesc{Addr: "addr", State: ACTIVE, Timestamp: ts, Tokens: tokens}
+	}
+
+	tests := map[string]struct {
+		stored   *InstanceDesc // nil => instance missing from the local ring
+		incoming InstanceDesc
+		wantTS   int64 // expected timestamp of the merged entry
+	}{
+		"reclaim: a now write beats a corrupted future entry even though it is older": {
+			stored:   ptr(entry(corrupt, 1, 2, 3)),
+			incoming: entry(now, 1, 2, 3),
+			wantTS:   now,
+		},
+		"reject: a corrupted future entry cannot beat a valid stored entry": {
+			stored:   ptr(entry(now, 1, 2, 3)),
+			incoming: entry(corrupt, 1, 2, 3),
+			wantTS:   now,
+		},
+		"both acceptable: newer incoming wins (unchanged behaviour)": {
+			stored:   ptr(entry(now-10, 1, 2, 3)),
+			incoming: entry(now, 1, 2, 3),
+			wantTS:   now,
+		},
+		"both acceptable: older incoming loses (unchanged behaviour)": {
+			stored:   ptr(entry(now, 1, 2, 3)),
+			incoming: entry(now-10, 1, 2, 3),
+			wantTS:   now,
+		},
+		"both corrupted: higher timestamp wins (documented, deterministic)": {
+			stored:   ptr(entry(corrupt, 1, 2, 3)),
+			incoming: entry(corrupt+10, 1, 2, 3),
+			wantTS:   corrupt + 10,
+		},
+		"missing slot: a corrupted future entry is still admitted (keeps merge commutative)": {
+			// A future-corrupt entry into an absent slot is admitted, matching the pre-existing
+			// "newer than the zero value wins" behaviour, so non-CAS merges stay commutative. It is
+			// healed once the owner writes a plausible timestamp (see the reclaim case above).
+			stored:   nil,
+			incoming: entry(corrupt, 1, 2, 3),
+			wantTS:   corrupt,
+		},
+		"missing slot: a valid entry is admitted (unchanged behaviour)": {
+			stored:   nil,
+			incoming: entry(now, 1, 2, 3),
+			wantTS:   now,
+		},
+		"boundary: an entry exactly at now+skew is still acceptable": {
+			stored:   ptr(entry(corrupt, 1, 2, 3)),
+			incoming: entry(nearBoundary, 1, 2, 3),
+			wantTS:   nearBoundary,
+		},
+		"boundary: an entry one second past the boundary is corrupted": {
+			stored:   ptr(entry(now, 1, 2, 3)),
+			incoming: entry(justOver, 1, 2, 3),
+			wantTS:   now, // justOver rejected
+		},
+		"reclaim heals even when the tokens are identical": {
+			stored:   ptr(entry(corrupt, 1, 2, 3)),
+			incoming: entry(now, 1, 2, 3),
+			wantTS:   now,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			stored := &Desc{Ingesters: map[string]InstanceDesc{}}
+			if tc.stored != nil {
+				stored.Ingesters["instance"] = *tc.stored
+			}
+			incoming := &Desc{Ingesters: map[string]InstanceDesc{"instance": tc.incoming}}
+
+			_, err := stored.mergeWithTime(incoming, false, time.Unix(now, 0))
+			assert.NoError(t, err)
+
+			got, ok := stored.Ingesters["instance"]
+			require.True(t, ok)
+			assert.Equal(t, tc.wantTS, got.Timestamp)
+		})
+	}
+}
+
+// TestMergeWithTime_FutureTimestampGuard_Converges verifies that merging in either order converges
+// to the healed (valid) timestamp, so the guard does not break gossip convergence.
+func TestMergeWithTime_FutureTimestampGuard_Converges(t *testing.T) {
+	const now = int64(1_700_000_000)
+	corrupt := now + int64(acceptableClockSkew/time.Second) + 3600
+
+	corruptRing := func() *Desc {
+		return &Desc{Ingesters: map[string]InstanceDesc{
+			"instance": {Addr: "addr", State: ACTIVE, Timestamp: corrupt, Tokens: []uint32{1, 2, 3}},
+		}}
+	}
+	healedRing := func() *Desc {
+		return &Desc{Ingesters: map[string]InstanceDesc{
+			"instance": {Addr: "addr", State: ACTIVE, Timestamp: now, Tokens: []uint32{1, 2, 3}},
+		}}
+	}
+
+	// A node holding the corrupted entry receives the healed one: it must adopt the healed value.
+	{
+		d := corruptRing()
+		_, err := d.mergeWithTime(healedRing(), false, time.Unix(now, 0))
+		assert.NoError(t, err)
+		assert.Equal(t, now, d.Ingesters["instance"].Timestamp)
+	}
+
+	// A node holding the healed entry receives the corrupted one: it must keep the healed value,
+	// so the corrupted timestamp can never re-propagate.
+	{
+		d := healedRing()
+		_, err := d.mergeWithTime(corruptRing(), false, time.Unix(now, 0))
+		assert.NoError(t, err)
+		assert.Equal(t, now, d.Ingesters["instance"].Timestamp)
+	}
+}
+
+// TestMergeWithTime_LeftExceptionPreserved verifies the "accept LEFT even if the timestamp did not
+// change" behaviour is unaffected by the future-timestamp guard.
+func TestMergeWithTime_LeftExceptionPreserved(t *testing.T) {
+	const now = int64(1_700_000_000)
+
+	stored := &Desc{Ingesters: map[string]InstanceDesc{
+		"instance": {Addr: "addr", State: ACTIVE, Timestamp: now, Tokens: []uint32{1, 2, 3}},
+	}}
+	incoming := &Desc{Ingesters: map[string]InstanceDesc{
+		"instance": {Addr: "addr", State: LEFT, Timestamp: now},
+	}}
+
+	_, err := stored.mergeWithTime(incoming, false, time.Unix(now, 0))
+	assert.NoError(t, err)
+	assert.Equal(t, LEFT, stored.Ingesters["instance"].State)
+}
+
+// TestMergeWithTime_GuardIsTimeRelative documents that the future-timestamp guard is evaluated
+// against the current time: a timestamp that is implausibly far ahead now is compared normally again
+// once the wall clock has advanced past it. This is intentional — a value that is no longer
+// distinguishable from a legitimate heartbeat must be treated like one — and it is why a genuinely
+// corrupted (years-ahead) timestamp is healed and propagated long before it could ever be re-accepted,
+// while any re-acceptance of a value only just beyond the window is bounded by acceptableClockSkew.
+func TestMergeWithTime_GuardIsTimeRelative(t *testing.T) {
+	const now = int64(1_700_000_000)
+	skew := int64(acceptableClockSkew / time.Second)
+	future := now + skew + 3600 // one hour beyond the acceptable window at `now`
+
+	ring := func(ts int64) *Desc {
+		return &Desc{Ingesters: map[string]InstanceDesc{
+			"instance": {Addr: "addr", State: ACTIVE, Timestamp: ts, Tokens: []uint32{1, 2, 3}},
+		}}
+	}
+
+	// At `now` the future timestamp is implausible, so a now-dated write reclaims the entry.
+	stored := ring(future)
+	_, err := stored.mergeWithTime(ring(now), false, time.Unix(now, 0))
+	assert.NoError(t, err)
+	assert.Equal(t, now, stored.Ingesters["instance"].Timestamp)
+
+	// Once the wall clock has advanced past it, the same timestamp is within the acceptable window
+	// again and is compared normally, so a lingering copy can win on merit.
+	stored = ring(now)
+	_, err = stored.mergeWithTime(ring(future), false, time.Unix(future, 0))
+	assert.NoError(t, err)
+	assert.Equal(t, future, stored.Ingesters["instance"].Timestamp)
+}
+
+func ptr(d InstanceDesc) *InstanceDesc { return &d }

--- a/ring/model.go
+++ b/ring/model.go
@@ -14,6 +14,15 @@ import (
 	"github.com/grafana/dskit/loser"
 )
 
+// acceptableClockSkew is how far in the future a ring entry's heartbeat timestamp is allowed to be,
+// relative to the local clock, before it is treated as corrupted rather than a real heartbeat.
+// It is deliberately generous, well above any realistic inter-node clock skew (the ring already
+// assumes clocks are synchronised within the heartbeat timeout, which defaults to one minute), so a
+// legitimately clock-skewed instance is never rejected; and far below the timestamps produced by
+// corruption (e.g. a serialization error yielding a timestamp years in the future), so those can be
+// detected and reclaimed. See mergeWithTime and grafana/loki#21733.
+const acceptableClockSkew = time.Hour
+
 // ByAddr is a sortable list of InstanceDesc.
 type ByAddr []InstanceDesc
 
@@ -245,10 +254,41 @@ func (d *Desc) mergeWithTime(mergeable memberlist.Mergeable, localCAS bool, now 
 	var updated []string
 	tokensChanged := false
 
+	// A heartbeat timestamp more than acceptableClockSkew ahead of the local clock cannot come from a
+	// real heartbeat and is treated as corrupted (e.g. a clock error when the entry was written, see
+	// grafana/loki#21733). While a stored entry looks corrupted, an entry with a plausible timestamp
+	// wins the merge even though it is numerically older, so the owning instance can reclaim its entry
+	// with an ordinary now-dated write instead of being stuck (which otherwise CrashLoopBackOff-s the
+	// instance on registration). This test is relative to the current time, so it only holds while the
+	// timestamp is still implausibly far ahead: once the wall clock advances past it, the value is no
+	// longer distinguishable from a legitimate heartbeat and is compared normally again. In practice a
+	// genuinely corrupted timestamp is years ahead, so the healed value has long since propagated
+	// before that could happen; for a value only just beyond the skew window any such re-acceptance is
+	// bounded by acceptableClockSkew and self-heals as the owner keeps heartbeating.
+	maxAcceptableTimestamp := now.Add(acceptableClockSkew).Unix()
+
 	for name, oing := range otherIngesterMap {
-		ting := thisIngesterMap[name]
-		// ting.Timestamp will be 0, if there was no such ingester in our version
-		if oing.Timestamp > ting.Timestamp {
+		ting, tingExists := thisIngesterMap[name]
+		// ting.Timestamp will be 0, if there was no such ingester in our version.
+
+		// Normally the entry with the newer timestamp wins. The guard only changes the outcome when we
+		// already have an entry to compare against: a plausible timestamp beats an implausibly-future
+		// (corrupted) one even when it is numerically older, and a corrupted timestamp cannot overwrite
+		// a plausible one. When the instance is absent locally we keep the plain "newer wins" admission
+		// (which also admits a corrupted entry) so that non-CAS merges stay commutative and nodes do not
+		// diverge on whether the entry exists; a corrupted entry admitted this way is healed by the rule
+		// above once the owner writes a plausible timestamp.
+		accept := false
+		switch {
+		case !tingExists:
+			accept = oing.Timestamp > ting.Timestamp // ting.Timestamp is 0 here
+		case oing.Timestamp <= maxAcceptableTimestamp && ting.Timestamp > maxAcceptableTimestamp:
+			accept = true
+		case (oing.Timestamp <= maxAcceptableTimestamp) == (ting.Timestamp <= maxAcceptableTimestamp) && oing.Timestamp > ting.Timestamp:
+			accept = true
+		}
+
+		if accept {
 			if !tokensEqual(ting.Tokens, oing.Tokens) {
 				tokensChanged = true
 			}


### PR DESCRIPTION
**What this PR does**:

A ring entry whose heartbeat timestamp is corrupted to a value far in the future can never be reclaimed. The memberlist merge keeps whichever entry has the higher timestamp, so an instance's own now-dated registration and heartbeat writes always compare older and lose, registration fails with `no change detected` on every retry, and the instance CrashLoopBackOffs permanently while the entry is treated as healthy indefinitely. Forgetting it does not help because gossip re-propagates the corrupted entry.

The merge now treats a heartbeat timestamp more than `acceptableClockSkew` (1h) ahead of the local clock as corrupted rather than genuinely newer: while a stored entry looks corrupted, an entry with a plausible timestamp wins even when it is numerically older, so an instance reclaims its own entry with an ordinary heartbeat, and a corrupted timestamp cannot overwrite a plausible one. Behaviour is unchanged for entries with plausible timestamps, and entries are still admitted into an absent slot as before so non-CAS merges stay commutative.

**Which issue(s) this PR fixes**:

Fixes grafana/loki#21733

**Checklist**
- [x] Tests updated
