### PR TITLE
feat(runtimeconfig): propagate tracing on HTTP config fetches

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v3"
 
@@ -405,5 +406,8 @@ func httpTransport(cfg Config, configName string, registerer prometheus.Register
 		}
 		rt = middleware.ClusterValidationRoundTripper(cfg.HTTPClientClusterValidation.Label, reporter, transport)
 	}
-	return rt
+
+	return otelhttp.NewTransport(rt, otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+		return "RuntimeConfig " + r.Method
+	}))
 }

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v3"
 
@@ -1109,12 +1110,13 @@ func TestConfig_RegisterFlagsWithPrefix(t *testing.T) {
 }
 
 func TestHTTPTransport_DisableKeepAlives(t *testing.T) {
-	t.Run("sets DisableKeepAlives on the transport", func(t *testing.T) {
+	t.Run("returns a transport wrapped for tracing", func(t *testing.T) {
 		for _, disable := range []bool{true, false} {
 			rt := httpTransport(Config{HTTPClientDisableKeepAlives: disable}, "test", prometheus.NewRegistry(), log.NewNopLogger())
-			tr, ok := rt.(*http.Transport)
-			require.True(t, ok, "expected an *http.Transport when no cluster validation label is set")
-			require.Equal(t, disable, tr.DisableKeepAlives)
+			_, ok := rt.(*otelhttp.Transport)
+			require.True(t, ok, "expected an *otelhttp.Transport when no cluster validation label is set")
+			// DisableKeepAlives is set on the underlying *http.Transport, which otelhttp.Transport
+			// doesn't expose; TestHTTPClient_DisableKeepAlives verifies the resulting behaviour end-to-end.
 		}
 	})
 


### PR DESCRIPTION
Wraps the runtime-config HTTP transport with `otelhttp.NewTransport` so config reloads fetched over HTTP get a client span and propagate W3C trace-context headers, matching how the rest of the codebase instruments HTTP/gRPC clients (`middleware/http_tracing.go`, `otelgrpc.NewClientHandler`).