### PR TITLE
fix(loser): calling Push could result in seeing the same element twice

### DIFF
--- a/loser/loser.go
+++ b/loser/loser.go
@@ -138,8 +138,13 @@ func (t *Tree[E]) playGame(a, b int) (loser, winner int) {
 
 func parent(i int) int { return i / 2 }
 
-// Add a new list to the merge set
+// Push adds a new list to the merge set. The previous winner is lost,
+// and users must call Next() before calling Winner() again.
 func (t *Tree[E]) Push(list []E) {
+	// Advance the current winner, if any, so it is not returned again.
+	if len(t.nodes) > 0 && t.nodes[0].index != -1 && t.nodes[t.nodes[0].index].index != -1 {
+		t.moveNext(t.nodes[0].index)
+	}
 	// First, see if we can replace one that was previously finished.
 	for newPos := len(t.nodes) / 2; newPos < len(t.nodes); newPos++ {
 		if t.nodes[newPos].index == -1 {

--- a/loser/loser_test.go
+++ b/loser/loser_test.go
@@ -146,3 +146,18 @@ func TestPush(t *testing.T) {
 		})
 	}
 }
+
+func TestPushDuringIteration(t *testing.T) {
+	// Start with {1, 2} then push {5, 6}, {3}, {4}, interleaved with some Next() calls.
+	lt := loser.New([][]uint64{{1, 2}}, math.MaxUint64)
+
+	require.True(t, lt.Next())
+	require.Equal(t, uint64(1), lt.Winner())
+	lt.Push([]uint64{5, 6})
+	require.True(t, lt.Next())
+	require.Equal(t, uint64(2), lt.Winner())
+
+	lt.Push([]uint64{3})
+	lt.Push([]uint64{4})
+	checkTreeEqual(t, lt, []uint64{3, 4, 5, 6})
+}


### PR DESCRIPTION
**What this PR does**:

Based on part of https://github.com/grafana/loki/pull/23295 from @jnewbigin

`loser.Tree.Push` flagged a full re-initialize on the next `Next()`, without advancing the previous winner.
A push after iteration had started therefore caused the current winner's already-returned value to be emitted a second time. 

**Checklist**
- [x] Tests updated
