### PR TITLE
ring: Propagate partition owner deletion from stale memberlist views

### DIFF
--- a/ring/partition_instance_lifecycler.go
+++ b/ring/partition_instance_lifecycler.go
@@ -208,9 +208,11 @@ func (l *PartitionInstanceLifecycler) stopping(_ error) error {
 	level.Info(l.logger).Log("msg", "partition ring lifecycler is shutting down", "ring", l.ringName)
 
 	// Remove the instance from partition owners, if configured to do so.
+	// Use DeleteOwner (OwnerDeleted tombstone) instead of RemoveOwner so deletion
+	// still propagates when the local CAS view is missing the owner entry.
 	if l.RemoveOwnerOnShutdown() {
 		err := l.updateRing(context.Background(), func(ring *PartitionRingDesc) (bool, error) {
-			return ring.RemoveOwner(l.partitionOwnerID()), nil
+			return ring.DeleteOwner(l.partitionOwnerID(), l.cfg.PartitionID, time.Now()), nil
 		})
 
 		if err != nil {

--- a/ring/partition_instance_lifecycler_test.go
+++ b/ring/partition_instance_lifecycler_test.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -339,6 +340,84 @@ func TestPartitionInstanceLifecycler(t *testing.T) {
 			2: {multiPartitionOwnerInstanceID(instanceID1, 2)},
 		}, getPartitionRingFromStore(t, store, ringKey).ownersByPartition())
 	})
+}
+
+func TestPartitionInstanceLifecycler_RemoveOwnerOnShutdown_WritesTombstoneWhenLocalCASViewIsStale(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	const (
+		partitionID = int32(24)
+		instanceID  = "partition-ingester-a-24"
+	)
+
+	store, closer := consul.NewInMemoryClient(GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	// Converged ring has the owner registered.
+	require.NoError(t, store.CAS(ctx, ringKey, func(interface{}) (interface{}, bool, error) {
+		desc := NewPartitionRingDesc()
+		desc.AddPartition(partitionID, PartitionActive, time.Now())
+		desc.AddOrUpdateOwner(instanceID, OwnerActive, partitionID, time.Now())
+		return desc, true, nil
+	}))
+
+	// Simulate a memberlist node whose local CAS view has not converged and is missing the owner.
+	staleView := NewPartitionRingDesc()
+	staleView.AddPartition(partitionID, PartitionActive, time.Now())
+	staleStore := &stalePartitionRingCASClient{
+		Client:    store,
+		staleView: staleView,
+	}
+
+	cfg := createTestPartitionInstanceLifecyclerConfig(partitionID, instanceID)
+	cfg.PollingInterval = time.Hour
+	lifecycler := NewPartitionInstanceLifecycler(cfg, "test", ringKey, staleStore, logger, nil)
+	lifecycler.SetCreatePartitionOnStartup(false)
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	lifecycler.SetRemoveOwnerOnShutdown(true)
+	staleStore.useStaleView.Store(true)
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler))
+	require.Positive(t, staleStore.staleCASCalls.Load())
+
+	// Lifecycler shutdown uses DeleteOwner, so a tombstone is written even against the
+	// stale view and merges into the converged ring (memberlist gossip equivalent).
+	converged := getPartitionRingFromStore(t, store, ringKey)
+	require.NotNil(t, staleStore.lastWritten)
+	_, err := converged.Merge(staleStore.lastWritten, false)
+	require.NoError(t, err)
+
+	require.Equal(t, OwnerDeleted, converged.Owners[instanceID].State)
+	require.Equal(t, 0, converged.PartitionOwnersCount(partitionID))
+	require.Equal(t, map[int32][]string{}, converged.ownersByPartition())
+}
+
+// stalePartitionRingCASClient simulates a memberlist node whose local CAS view
+// has not converged with the view held by the rest of the cluster.
+type stalePartitionRingCASClient struct {
+	kv.Client
+
+	useStaleView  atomic.Bool
+	staleCASCalls atomic.Int64
+	staleView     *PartitionRingDesc
+	lastWritten   *PartitionRingDesc
+}
+
+func (c *stalePartitionRingCASClient) CAS(ctx context.Context, key string, f func(interface{}) (interface{}, bool, error)) error {
+	if !c.useStaleView.Load() {
+		return c.Client.CAS(ctx, key, f)
+	}
+
+	c.staleCASCalls.Add(1)
+	out, _, err := f(c.staleView.Clone())
+	if err != nil {
+		return err
+	}
+	if out != nil {
+		c.lastWritten = out.(*PartitionRingDesc)
+	}
+	return nil
 }
 
 func assertMapElementsMatch[K cmp.Ordered, V any, S ~[]V](t *testing.T, expected map[K]S, actual map[K]S) {

--- a/ring/partition_instance_lifecycler_test.go
+++ b/ring/partition_instance_lifecycler_test.go
@@ -6,13 +6,13 @@ import (
 	"maps"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/kv/consul"

--- a/ring/partition_ring_editor.go
+++ b/ring/partition_ring_editor.go
@@ -34,7 +34,7 @@ func (l *PartitionRingEditor) ChangePartitionState(ctx context.Context, partitio
 
 func (l *PartitionRingEditor) RemoveMultiPartitionOwner(ctx context.Context, instanceID string, partitionID int32) error {
 	return l.updateRing(ctx, func(ring *PartitionRingDesc) (bool, error) {
-		return ring.RemoveOwner(multiPartitionOwnerInstanceID(instanceID, partitionID)), nil
+		return ring.DeleteOwner(multiPartitionOwnerInstanceID(instanceID, partitionID), partitionID, time.Now()), nil
 	})
 }
 

--- a/ring/partition_ring_model.go
+++ b/ring/partition_ring_model.go
@@ -123,9 +123,13 @@ func (m *PartitionRingDesc) countTokens() map[int32]int64 {
 }
 
 // ownersByPartition returns a map where the key is the partition ID and the value is a list of owner IDs.
+// Deleted owners (tombstones) are excluded.
 func (m *PartitionRingDesc) ownersByPartition() map[int32][]string {
 	out := make(map[int32][]string, len(m.Partitions))
 	for id, o := range m.Owners {
+		if o.State == OwnerDeleted {
+			continue
+		}
 		out[o.OwnedPartition] = append(out[o.OwnedPartition], id)
 	}
 
@@ -290,12 +294,40 @@ func (m *PartitionRingDesc) AddOrUpdateOwner(id string, state OwnerState, ownedP
 }
 
 // RemoveOwner removes a partition owner. Returns true if the ring has been changed.
+//
+// Prefer DeleteOwner when the deletion must propagate via memberlist: RemoveOwner is a
+// no-op if the owner is absent from the local view, so a stale CAS view will not write
+// a tombstone and the owner can remain in the cluster.
 func (m *PartitionRingDesc) RemoveOwner(id string) bool {
 	if _, ok := m.Owners[id]; !ok {
 		return false
 	}
 
 	delete(m.Owners, id)
+	return true
+}
+
+// DeleteOwner marks a partition owner as deleted by writing an OwnerDeleted tombstone.
+// Unlike RemoveOwner, this always updates the ring even if the owner is absent from the
+// local view, which is required for the deletion to propagate under memberlist when the
+// local CAS view is stale.
+//
+// If the owner already exists, its OwnedPartition is preserved. Otherwise ownedPartition
+// is used. Returns true if the ring was changed.
+func (m *PartitionRingDesc) DeleteOwner(id string, ownedPartition int32, now time.Time) bool {
+	prev, ok := m.Owners[id]
+	if ok {
+		if prev.State == OwnerDeleted {
+			return false
+		}
+		ownedPartition = prev.OwnedPartition
+	}
+
+	m.Owners[id] = OwnerDesc{
+		OwnedPartition:   ownedPartition,
+		State:            OwnerDeleted,
+		UpdatedTimestamp: now.Unix(),
+	}
 	return true
 }
 
@@ -306,10 +338,11 @@ func (m *PartitionRingDesc) HasOwner(id string) bool {
 }
 
 // PartitionOwnersCount returns the number of owners for a given partition.
+// Deleted owners (tombstones) are excluded.
 func (m *PartitionRingDesc) PartitionOwnersCount(partitionID int32) int {
 	count := 0
 	for _, o := range m.Owners {
-		if o.OwnedPartition == partitionID {
+		if o.OwnedPartition == partitionID && o.State != OwnerDeleted {
 			count++
 		}
 	}
@@ -318,12 +351,13 @@ func (m *PartitionRingDesc) PartitionOwnersCount(partitionID int32) int {
 
 // PartitionOwnersCountUpdatedBefore returns the number of owners for a given partition,
 // including only owners which have been updated the last time before the input timestamp.
+// Deleted owners (tombstones) are excluded.
 func (m *PartitionRingDesc) PartitionOwnersCountUpdatedBefore(partitionID int32, before time.Time) int {
 	count := 0
 	beforeSeconds := before.Unix()
 
 	for _, o := range m.Owners {
-		if o.OwnedPartition == partitionID && o.GetUpdatedTimestamp() < beforeSeconds {
+		if o.OwnedPartition == partitionID && o.State != OwnerDeleted && o.GetUpdatedTimestamp() < beforeSeconds {
 			count++
 		}
 	}

--- a/ring/partition_ring_model_test.go
+++ b/ring/partition_ring_model_test.go
@@ -183,6 +183,121 @@ func TestPartitionRingDesc_AddOrUpdateOwner(t *testing.T) {
 	})
 }
 
+func TestPartitionRingDesc_DeleteOwner(t *testing.T) {
+	now := time.Now()
+
+	t.Run("should write an OwnerDeleted tombstone when the owner exists", func(t *testing.T) {
+		desc := NewPartitionRingDesc()
+		desc.AddOrUpdateOwner("instance-1", OwnerActive, 1, now)
+
+		require.True(t, desc.DeleteOwner("instance-1", 1, now.Add(time.Second)))
+		assert.Equal(t, OwnerDesc{
+			OwnedPartition:   1,
+			State:            OwnerDeleted,
+			UpdatedTimestamp: now.Add(time.Second).Unix(),
+		}, desc.Owners["instance-1"])
+		assert.Equal(t, 0, desc.PartitionOwnersCount(1))
+		assert.Equal(t, map[int32][]string{}, desc.ownersByPartition())
+	})
+
+	t.Run("should write an OwnerDeleted tombstone when the owner is absent from the local view", func(t *testing.T) {
+		desc := NewPartitionRingDesc()
+
+		require.True(t, desc.DeleteOwner("instance-1", 24, now))
+		assert.Equal(t, OwnerDesc{
+			OwnedPartition:   24,
+			State:            OwnerDeleted,
+			UpdatedTimestamp: now.Unix(),
+		}, desc.Owners["instance-1"])
+		assert.Equal(t, 0, desc.PartitionOwnersCount(24))
+	})
+
+	t.Run("should preserve OwnedPartition from the existing owner entry", func(t *testing.T) {
+		desc := NewPartitionRingDesc()
+		desc.AddOrUpdateOwner("instance-1", OwnerActive, 7, now)
+
+		require.True(t, desc.DeleteOwner("instance-1", 99, now.Add(time.Second)))
+		assert.Equal(t, int32(7), desc.Owners["instance-1"].OwnedPartition)
+	})
+
+	t.Run("should be a no-op if the owner is already deleted", func(t *testing.T) {
+		desc := NewPartitionRingDesc()
+		require.True(t, desc.DeleteOwner("instance-1", 1, now))
+		require.False(t, desc.DeleteOwner("instance-1", 1, now.Add(time.Second)))
+		assert.Equal(t, now.Unix(), desc.Owners["instance-1"].UpdatedTimestamp)
+	})
+}
+
+func TestPartitionRingDesc_PartitionOwnersCount_IgnoresDeleted(t *testing.T) {
+	now := time.Now()
+	desc := NewPartitionRingDesc()
+	desc.AddOrUpdateOwner("owner-active", OwnerActive, 1, now)
+	desc.AddOrUpdateOwner("owner-deleted", OwnerDeleted, 1, now)
+
+	assert.Equal(t, 1, desc.PartitionOwnersCount(1))
+	assert.ElementsMatch(t, []string{"owner-active"}, desc.ownersByPartition()[1])
+}
+
+// TestPartitionRingDesc_StaleLocalCASView_RemoveOwnerVsDeleteOwner compares the two
+// owner-removal strategies when the local CAS view is missing the owner entry
+// (the failure mode that leaves a stale partition owner after prepare_shutdown).
+//
+// RemoveOwner is a no-op against the stale view, so nothing is gossiped and the
+// owner survives in the converged ring. DeleteOwner always writes an OwnerDeleted
+// tombstone, which merges into the converged ring and clears the owner.
+func TestPartitionRingDesc_StaleLocalCASView_RemoveOwnerVsDeleteOwner(t *testing.T) {
+	const (
+		partitionID = int32(24)
+		instanceID  = "partition-ingester-a-24"
+	)
+	now := time.Now()
+
+	newConvergedRing := func() *PartitionRingDesc {
+		desc := NewPartitionRingDesc()
+		desc.AddPartition(partitionID, PartitionActive, now)
+		desc.AddOrUpdateOwner(instanceID, OwnerActive, partitionID, now)
+		return desc
+	}
+
+	newStaleLocalView := func() *PartitionRingDesc {
+		desc := NewPartitionRingDesc()
+		desc.AddPartition(partitionID, PartitionActive, now)
+		return desc
+	}
+
+	t.Run("RemoveOwner leaves the owner in the converged ring", func(t *testing.T) {
+		converged := newConvergedRing()
+		localView := newStaleLocalView()
+
+		changed := localView.RemoveOwner(instanceID)
+		require.False(t, changed, "RemoveOwner must be a no-op when the owner is absent from the local view")
+
+		// Nothing was written, so gossip has no deletion to merge.
+		_, err := converged.Merge(localView, false)
+		require.NoError(t, err)
+
+		require.True(t, converged.HasOwner(instanceID))
+		require.Equal(t, OwnerActive, converged.Owners[instanceID].State)
+		require.Equal(t, 1, converged.PartitionOwnersCount(partitionID))
+	})
+
+	t.Run("DeleteOwner clears the owner from the converged ring", func(t *testing.T) {
+		converged := newConvergedRing()
+		localView := newStaleLocalView()
+
+		changed := localView.DeleteOwner(instanceID, partitionID, now.Add(time.Second))
+		require.True(t, changed, "DeleteOwner must write a tombstone even when the owner is absent from the local view")
+		require.Equal(t, OwnerDeleted, localView.Owners[instanceID].State)
+
+		_, err := converged.Merge(localView, false)
+		require.NoError(t, err)
+
+		require.Equal(t, OwnerDeleted, converged.Owners[instanceID].State)
+		require.Equal(t, 0, converged.PartitionOwnersCount(partitionID))
+		require.Equal(t, map[int32][]string{}, converged.ownersByPartition())
+	})
+}
+
 func TestPartitionRingDesc_Merge_AddPartition(t *testing.T) {
 	tests := map[string]struct {
 		local                *PartitionRingDesc
@@ -1186,6 +1301,7 @@ func TestPartitionRingDesc_PartitionOwnersCountUpdatedBefore(t *testing.T) {
 	desc.AddOrUpdateOwner("owner-1-a", OwnerActive, 1, now)
 	desc.AddOrUpdateOwner("owner-1-b", OwnerActive, 1, now.Add(-1*time.Second))
 	desc.AddOrUpdateOwner("owner-1-c", OwnerActive, 1, now.Add(-2*time.Second))
+	desc.AddOrUpdateOwner("owner-1-deleted", OwnerDeleted, 1, now.Add(-3*time.Second))
 	desc.AddOrUpdateOwner("owner-2-a", OwnerActive, 2, now.Add(-3*time.Second))
 
 	assert.Equal(t, 2, desc.PartitionOwnersCountUpdatedBefore(1, now))


### PR DESCRIPTION
### Summary
Prevent partition owners from remaining in the ring when an instance shuts down while its local memberlist CAS view does not contain its owner entry.

This changes partition-owner shutdown and editor removal to write an explicit `OwnerDeleted` tombstone. Owner-counting and lookup helpers ignore these tombstones while memberlist propagates and eventually removes them.

### Problem
`PartitionInstanceLifecycler` previously removed its owner with `RemoveOwner`. This works when the local CAS view contains the owner, because memberlist converts the missing entry into a deletion tombstone.

If the local view has not converged and does not contain the owner, `RemoveOwner` returns without changing the ring. No tombstone is produced or gossiped, allowing another member’s active owner entry to remain after a clean shutdown.


### Changes
Add `PartitionRingDesc.DeleteOwner`, which writes an explicit `OwnerDeleted` tombstone even when the local view lacks the owner.

Use `DeleteOwner` when:
- `PartitionInstanceLifecycler` removes its owner during shutdown.
- `PartitionRingEditor` removes a multi-partition owner.

Exclude OwnerDeleted entries from:
- `ownersByPartition`
- `PartitionOwnersCount`
- `PartitionOwnersCountUpdatedBefore`

The tombstone remains available for memberlist conflict resolution without being treated as a live partition owner.

### Tests
Added focused coverage for:

- Deleting owners that are present, absent, or already deleted.
- Preserving the known partition ID when deleting an existing owner.
- Excluding tombstones from owner counts.
- Comparing both removal strategies against the same stale local view:
-- `RemoveOwner` produces no update and leaves the active owner in the converged ring.
-- `DeleteOwner` produces a tombstone that wins during merge.
- Verifying lifecycler shutdown writes and propagates the tombstone when its local CAS view lacks the owner.

### Validation
```
 % go test ./ring -race -count=200 -timeout 2m \ 
  -run 'TestPartitionRingDesc_DeleteOwner|TestPartitionRingDesc_StaleLocalCASView|TestPartitionInstanceLifecycler_RemoveOwnerOnShutdown'
ok  	github.com/grafana/dskit/ring	30.830s
```