### PR TITLE
feat(grpcclient): make client keepalive time and timeout configurable

### DIFF
--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -67,6 +67,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 const defaultInitialWindowSize = 65535 // From https://github.com/grpc/grpc-go/blob/c9d3ea5673252d212c69f3d3c10ce1d7b287a86b/internal/transport/defaults.go#L28
 
+const (
+	defaultKeepaliveTime    = 20 * time.Second
+	defaultKeepaliveTimeout = 10 * time.Second
+)
+
 // RegisterFlagsWithPrefix registers flags with prefix.
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	// Set the default values.
@@ -95,8 +100,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means default gRPC client connect timeout and backoff.")
 	f.DurationVar(&cfg.ConnectBackoffBaseDelay, prefix+".connect-backoff-base-delay", time.Second, "Initial backoff delay after first connection failure. Only relevant if ConnectTimeout > 0.")
 	f.DurationVar(&cfg.ConnectBackoffMaxDelay, prefix+".connect-backoff-max-delay", 5*time.Second, "Maximum backoff delay when establishing a connection. Only relevant if ConnectTimeout > 0.")
-	f.DurationVar(&cfg.KeepaliveTime, prefix+".keepalive-time", 20*time.Second, "After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive. This also determines the socket's TCP_USER_TIMEOUT together with keepalive-timeout.")
-	f.DurationVar(&cfg.KeepaliveTimeout, prefix+".keepalive-timeout", 10*time.Second, "After having pinged for keepalive check, the client waits for a duration of this time and if no activity is seen even after that the connection is closed.")
+	f.DurationVar(&cfg.KeepaliveTime, prefix+".keepalive-time", defaultKeepaliveTime, "After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive. This also determines the socket's TCP_USER_TIMEOUT together with keepalive-timeout.")
+	f.DurationVar(&cfg.KeepaliveTimeout, prefix+".keepalive-timeout", defaultKeepaliveTimeout, "After having pinged for keepalive check, the client waits for a duration of this time and if no activity is seen even after that the connection is closed.")
 
 	cfg.BackoffConfig.RegisterFlagsWithPrefix(prefix, f)
 	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
@@ -192,10 +197,26 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 		grpc.WithDefaultCallOptions(cfg.CallOptions()...),
 		grpcWithChainUnaryInterceptor(unaryClientInterceptors...),
 		grpc.WithChainStreamInterceptor(streamClientInterceptors...),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                cfg.KeepaliveTime,
-			Timeout:             cfg.KeepaliveTimeout,
-			PermitWithoutStream: true,
-		}),
+		grpc.WithKeepaliveParams(cfg.keepaliveParams()),
 	), nil
+}
+
+// keepaliveParams returns the client keepalive parameters, falling back to the
+// defaults when Time or Timeout are unset (e.g. a Config built from YAML that
+// omits these keys, or a struct literal). This avoids accidentally disabling
+// keepalive: grpc-go treats a zero Time as "no keepalive pings".
+func (cfg *Config) keepaliveParams() keepalive.ClientParameters {
+	keepaliveTime := cfg.KeepaliveTime
+	if keepaliveTime <= 0 {
+		keepaliveTime = defaultKeepaliveTime
+	}
+	keepaliveTimeout := cfg.KeepaliveTimeout
+	if keepaliveTimeout <= 0 {
+		keepaliveTimeout = defaultKeepaliveTimeout
+	}
+	return keepalive.ClientParameters{
+		Time:                keepaliveTime,
+		Timeout:             keepaliveTimeout,
+		PermitWithoutStream: true,
+	}
 }

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -45,6 +45,9 @@ type Config struct {
 	ConnectBackoffBaseDelay time.Duration `yaml:"connect_backoff_base_delay" category:"advanced"`
 	ConnectBackoffMaxDelay  time.Duration `yaml:"connect_backoff_max_delay" category:"advanced"`
 
+	KeepaliveTime    time.Duration `yaml:"keepalive_time" category:"advanced"`
+	KeepaliveTimeout time.Duration `yaml:"keepalive_timeout" category:"advanced"`
+
 	Middleware       []grpc.UnaryClientInterceptor  `yaml:"-"`
 	StreamMiddleware []grpc.StreamClientInterceptor `yaml:"-"`
 
@@ -92,6 +95,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means default gRPC client connect timeout and backoff.")
 	f.DurationVar(&cfg.ConnectBackoffBaseDelay, prefix+".connect-backoff-base-delay", time.Second, "Initial backoff delay after first connection failure. Only relevant if ConnectTimeout > 0.")
 	f.DurationVar(&cfg.ConnectBackoffMaxDelay, prefix+".connect-backoff-max-delay", 5*time.Second, "Maximum backoff delay when establishing a connection. Only relevant if ConnectTimeout > 0.")
+	f.DurationVar(&cfg.KeepaliveTime, prefix+".keepalive-time", 20*time.Second, "After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive. This also determines the socket's TCP_USER_TIMEOUT together with keepalive-timeout.")
+	f.DurationVar(&cfg.KeepaliveTimeout, prefix+".keepalive-timeout", 10*time.Second, "After having pinged for keepalive check, the client waits for a duration of this time and if no activity is seen even after that the connection is closed.")
 
 	cfg.BackoffConfig.RegisterFlagsWithPrefix(prefix, f)
 	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
@@ -188,8 +193,8 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 		grpcWithChainUnaryInterceptor(unaryClientInterceptors...),
 		grpc.WithChainStreamInterceptor(streamClientInterceptors...),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                time.Second * 20,
-			Timeout:             time.Second * 10,
+			Time:                cfg.KeepaliveTime,
+			Timeout:             cfg.KeepaliveTimeout,
 			PermitWithoutStream: true,
 		}),
 	), nil

--- a/grpcclient/grpcclient_test.go
+++ b/grpcclient/grpcclient_test.go
@@ -54,8 +54,28 @@ func TestConfig(t *testing.T) {
 		fs := flag.NewFlagSet("test", flag.PanicOnError)
 		cfg.RegisterFlagsWithPrefix("test", fs)
 
-		require.Equal(t, 20*time.Second, cfg.KeepaliveTime)
-		require.Equal(t, 10*time.Second, cfg.KeepaliveTimeout)
+		require.Equal(t, defaultKeepaliveTime, cfg.KeepaliveTime)
+		require.Equal(t, defaultKeepaliveTimeout, cfg.KeepaliveTimeout)
+	})
+
+	t.Run("keepalive params", func(t *testing.T) {
+		t.Run("uses configured values", func(t *testing.T) {
+			cfg := Config{KeepaliveTime: 5 * time.Second, KeepaliveTimeout: 2 * time.Second}
+			kp := cfg.keepaliveParams()
+			require.Equal(t, 5*time.Second, kp.Time)
+			require.Equal(t, 2*time.Second, kp.Timeout)
+			require.True(t, kp.PermitWithoutStream)
+		})
+
+		t.Run("falls back to defaults when unset", func(t *testing.T) {
+			// A zero-value Config (e.g. from YAML omitting the keys) must not
+			// disable keepalive: grpc-go treats a zero Time as "no pings".
+			var cfg Config
+			kp := cfg.keepaliveParams()
+			require.Equal(t, defaultKeepaliveTime, kp.Time)
+			require.Equal(t, defaultKeepaliveTimeout, kp.Timeout)
+			require.True(t, kp.PermitWithoutStream)
+		})
 	})
 }
 

--- a/grpcclient/grpcclient_test.go
+++ b/grpcclient/grpcclient_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -46,6 +47,15 @@ func TestConfig(t *testing.T) {
 
 			require.EqualError(t, cfg.Validate(), `unsupported compression type: "invalid"`)
 		})
+	})
+
+	t.Run("keepalive defaults", func(t *testing.T) {
+		var cfg Config
+		fs := flag.NewFlagSet("test", flag.PanicOnError)
+		cfg.RegisterFlagsWithPrefix("test", fs)
+
+		require.Equal(t, 20*time.Second, cfg.KeepaliveTime)
+		require.Equal(t, 10*time.Second, cfg.KeepaliveTimeout)
 	})
 }
 


### PR DESCRIPTION
## What

Exposes the previously hardcoded gRPC client keepalive `Time` and `Timeout` as configuration on `grpcclient.Config`:

- `-<prefix>.keepalive-time` (default `20s`)
- `-<prefix>.keepalive-timeout` (default `10s`)

Defaults match the current hardcoded values, so behavior is unchanged unless overridden. `PermitWithoutStream` remains hardcoded to `true`.

## Why

`grpcclient.Config.DialOption` previously hardcoded the client-side keepalive parameters, so every consumer was fixed at a 20s ping interval / 10s ack timeout. Because grpc-go programs the socket's `TCP_USER_TIMEOUT` from `keepalive.Timeout` (when `Time != infinity`), this also fixed how quickly a client tears down a connection to a peer that has stopped ACKing.

Different clients have different tolerance for detecting a dead or unresponsive peer. A client talking to latency-sensitive backends may want a tighter keepalive / TCP user timeout so a connection to a hung or black-holing peer fails fast, letting request-routing logic retry or fail over rather than stalling until the per-request deadline.

Fixes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)