### PR TITLE
feat(runtimeconfig): unmarshal with JSON if possible; add MapLoader

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -5,10 +5,12 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +35,9 @@ type Preprocessor func(b []byte) ([]byte, error)
 // Loader loads the configuration from files.
 type Loader func(r io.Reader) (interface{}, error)
 
+// MapLoader loads the configuration from a map.
+type MapLoader func(m map[string]interface{}) (interface{}, error)
+
 // Config holds the config for an Manager instance.
 // It holds config related to loading per-tenant config.
 type Config struct {
@@ -42,6 +47,9 @@ type Config struct {
 	LoadPath     flagext.StringSliceCSV `yaml:"file"`
 	Preprocessor Preprocessor           `yaml:"-"`
 	Loader       Loader                 `yaml:"-"`
+	// MapLoader, if set, is used instead of Loader and receives the merged
+	// configuration as a map[string]any directly.
+	MapLoader MapLoader `yaml:"-"`
 
 	// Configurations related to fetching runtime configurations from HTTP URLs rather than local files.
 	HTTPClientTimeout           time.Duration                       `yaml:"http_client_timeout" category:"advanced"`
@@ -253,17 +261,31 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 		}
 	}
 
-	buf, err := yaml.Marshal(mergedConfig)
-	if err != nil {
-		om.configLoadSuccess.Set(0)
-		return errors.Wrap(err, "marshal file")
-	}
+	var (
+		cfg  interface{}
+		hash [sha256.Size]byte
+		err  error
+	)
+	if om.cfg.MapLoader != nil {
+		hash = combinedFilesHash(hashes)
+		cfg, err = om.cfg.MapLoader(mergedConfig)
+		if err != nil {
+			om.configLoadSuccess.Set(0)
+			return errors.Wrap(err, "load file")
+		}
+	} else {
+		buf, err := yaml.Marshal(mergedConfig)
+		if err != nil {
+			om.configLoadSuccess.Set(0)
+			return errors.Wrap(err, "marshal file")
+		}
 
-	hash := sha256.Sum256(buf)
-	cfg, err := om.cfg.Loader(bytes.NewReader(buf))
-	if err != nil {
-		om.configLoadSuccess.Set(0)
-		return errors.Wrap(err, "load file")
+		hash = sha256.Sum256(buf)
+		cfg, err = om.cfg.Loader(bytes.NewReader(buf))
+		if err != nil {
+			om.configLoadSuccess.Set(0)
+			return errors.Wrap(err, "load file")
+		}
 	}
 	om.configLoadSuccess.Set(1)
 
@@ -279,9 +301,28 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 	return nil
 }
 
+func combinedFilesHash(hashes map[string]string) [sha256.Size]byte {
+	names := make([]string, 0, len(hashes))
+	for name := range hashes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	h := sha256.New()
+	for _, name := range names {
+		_, _ = io.WriteString(h, name)
+		_, _ = io.WriteString(h, "=")
+		_, _ = io.WriteString(h, hashes[name])
+		_, _ = io.WriteString(h, ";")
+	}
+	var out [sha256.Size]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
 func (om *Manager) unmarshalMaybeGzipped(filename string, data []byte) (map[string]any, error) {
-	yamlFile := map[string]any{}
 	if strings.HasSuffix(filename, ".gz") {
+		yamlFile := map[string]any{}
 		r, err := gzip.NewReader(bytes.NewReader(data))
 		if err != nil {
 			return nil, errors.Wrap(err, "read gzipped file")
@@ -291,14 +332,38 @@ func (om *Manager) unmarshalMaybeGzipped(filename string, data []byte) (map[stri
 		return yamlFile, errors.Wrap(err, "uncompress/unmarshal gzipped file")
 	}
 
-	if err := yaml.Unmarshal(data, &yamlFile); err != nil {
+	m, err := unmarshalJSONOrYAML(data)
+	if err != nil {
 		// Give a hint if we think that file is gzipped.
 		if isGzip(data) {
 			return nil, errors.Wrap(err, "file looks gzipped but doesn't have a .gz extension")
 		}
 		return nil, err
 	}
-	return yamlFile, nil
+	return m, nil
+}
+
+// unmarshalJSONOrYAML decodes data into a map. If the data appears to be a JSON
+// object (its first non-whitespace byte is '{'), it is decoded with
+// encoding/json, which is faster. YAML is used as a fallback
+func unmarshalJSONOrYAML(data []byte) (map[string]any, error) {
+	if looksLikeJSONObject(data) {
+		m := map[string]any{}
+		if err := json.Unmarshal(data, &m); err == nil {
+			return m, nil
+		}
+	}
+
+	m := map[string]any{}
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func looksLikeJSONObject(data []byte) bool {
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	return len(trimmed) > 0 && trimmed[0] == '{'
 }
 
 func isGzip(data []byte) bool {

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -5,12 +5,13 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -37,6 +38,11 @@ type Loader func(r io.Reader) (interface{}, error)
 
 // MapLoader loads the configuration from a map.
 type MapLoader func(m map[string]interface{}) (interface{}, error)
+
+type providerHash struct {
+	name   string
+	digest [sha256.Size]byte
+}
 
 // Config holds the config for an Manager instance.
 // It holds config related to loading per-tenant config.
@@ -89,8 +95,8 @@ type Manager struct {
 	configLoadSuccess prometheus.Gauge
 	configHash        *prometheus.GaugeVec
 
-	// Maps provider name to hash. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
-	fileHashes map[string]string
+	// Provider hashes in LoadPath order. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
+	fileHashes []providerHash
 
 	providers []provider
 }
@@ -210,7 +216,7 @@ func (om *Manager) loop(ctx context.Context) error {
 // and notifies listeners if successful.
 func (om *Manager) loadConfig(ctx context.Context) error {
 	rawData := make([][]byte, len(om.providers))
-	hashes := map[string]string{}
+	hashes := make([]providerHash, len(om.providers))
 
 	for i, p := range om.providers {
 		buf, err := p.Read(ctx)
@@ -228,19 +234,13 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 		}
 
 		rawData[i] = buf
-		hashes[p.Name()] = fmt.Sprintf("%x", sha256.Sum256(buf))
-	}
-
-	// check if new hashes are the same as before
-	sameHashes := true
-	for name, h := range hashes {
-		if om.fileHashes[name] != h {
-			sameHashes = false
-			break
+		hashes[i] = providerHash{
+			name:   p.Name(),
+			digest: sha256.Sum256(buf),
 		}
 	}
 
-	if sameHashes {
+	if slices.Equal(om.fileHashes, hashes) {
 		// No need to rebuild runtime config.
 		om.configLoadSuccess.Set(1)
 		return nil
@@ -301,19 +301,14 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 	return nil
 }
 
-func combinedFilesHash(hashes map[string]string) [sha256.Size]byte {
-	names := make([]string, 0, len(hashes))
-	for name := range hashes {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
+func combinedFilesHash(hashes []providerHash) [sha256.Size]byte {
 	h := sha256.New()
-	for _, name := range names {
-		_, _ = io.WriteString(h, name)
-		_, _ = io.WriteString(h, "=")
-		_, _ = io.WriteString(h, hashes[name])
-		_, _ = io.WriteString(h, ";")
+	var nameLength [8]byte
+	for _, providerHash := range hashes {
+		binary.BigEndian.PutUint64(nameLength[:], uint64(len(providerHash.name)))
+		_, _ = h.Write(nameLength[:])
+		_, _ = io.WriteString(h, providerHash.name)
+		_, _ = h.Write(providerHash.digest[:])
 	}
 	var out [sha256.Size]byte
 	copy(out[:], h.Sum(nil))

--- a/runtimeconfig/manager_bench_test.go
+++ b/runtimeconfig/manager_bench_test.go
@@ -1,0 +1,94 @@
+package runtimeconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func BenchmarkManagerLoadConfig(b *testing.B) {
+	dir := b.TempDir()
+
+	yamlData, err := yaml.Marshal(generateOverrides(1000))
+	require.NoError(b, err)
+	jsonData, err := json.Marshal(generateOverrides(15000))
+	require.NoError(b, err)
+
+	yamlPath := filepath.Join(dir, "small.yaml")
+	jsonPath := filepath.Join(dir, "big.json")
+	require.NoError(b, os.WriteFile(yamlPath, yamlData, 0600))
+	require.NoError(b, os.WriteFile(jsonPath, jsonData, 0600))
+
+	cfg := Config{
+		LoadPath: []string{yamlPath, jsonPath},
+		Loader:   benchLoader,
+	}
+	m, err := New(cfg, "bench", prometheus.NewPedanticRegistry(), log.NewNopLogger())
+	require.NoError(b, err)
+
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		// Reset the per-file hash cache so every iteration performs a full
+		// reload instead of short-circuiting on unchanged hashes.
+		m.fileHashes = nil
+		require.NoError(b, m.loadConfig(ctx))
+	}
+}
+
+type benchConfig struct {
+	IngestionRate      float64           `yaml:"ingestion_rate" json:"ingestion_rate"`
+	IngestionBurstSize int               `yaml:"ingestion_burst_size" json:"ingestion_burst_size"`
+	MaxGlobalSeries    int               `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
+	MaxLabelNames      int               `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
+	Enabled            bool              `yaml:"enabled" json:"enabled"`
+	DisplayName        string            `yaml:"display_name" json:"display_name"`
+	Labels             map[string]string `yaml:"labels" json:"labels"`
+}
+
+type benchOverrides struct {
+	Overrides map[string]benchConfig `yaml:"overrides" json:"overrides"`
+}
+
+func newBenchConfig(i int) benchConfig {
+	return benchConfig{
+		IngestionRate:      float64(10000 + i),
+		IngestionBurstSize: 200000 + i,
+		MaxGlobalSeries:    1500000 + i,
+		MaxLabelNames:      30 + (i % 10),
+		Enabled:            i%2 == 0,
+		DisplayName:        fmt.Sprintf("Tenant number %08d with a reasonably long display name", i),
+		Labels: map[string]string{
+			"team":        fmt.Sprintf("team-%04d", i%128),
+			"environment": []string{"dev", "staging", "prod"}[i%3],
+			"region":      []string{"us-east-1", "us-west-2", "eu-west-1"}[i%3],
+			"cost_center": fmt.Sprintf("cc-%06d", i),
+		},
+	}
+}
+
+func generateOverrides(numTenants int) benchOverrides {
+	o := benchOverrides{Overrides: make(map[string]benchConfig, numTenants)}
+	for i := 0; i < numTenants; i++ {
+		o.Overrides[fmt.Sprintf("tenant-%08d", i)] = newBenchConfig(i)
+	}
+	return o
+}
+
+func benchLoader(r io.Reader) (interface{}, error) {
+	o := &benchOverrides{}
+	if err := yaml.NewDecoder(r).Decode(o); err != nil {
+		return nil, err
+	}
+	return o, nil
+}

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -329,6 +329,61 @@ func TestOverridesManagerMultipleFilesWithOverrides(t *testing.T) {
 	require.Equal(t, 1234, conf.Overrides["user1"].Limit1)
 }
 
+func TestOverridesManagerMapLoader(t *testing.T) {
+	tempFiles, err := generateRuntimeFiles(t,
+		[]string{`overrides:
+  user1:
+    limit1: 101`,
+			`overrides:
+  user2:
+    limit2: 204`})
+	require.NoError(t, err)
+
+	reg := prometheus.NewPedanticRegistry()
+	cfg := Config{
+		ReloadPeriod: time.Second,
+		LoadPath:     generateLoadPath(tempFiles),
+		Loader: func(io.Reader) (interface{}, error) {
+			return nil, errors.New("Loader should not be called when MapLoader is set")
+		},
+		MapLoader: func(m map[string]interface{}) (interface{}, error) {
+			js, err := json.Marshal(m)
+			require.NoError(t, err)
+			var o testOverrides
+			err = json.Unmarshal(js, &o)
+			require.NoError(t, err)
+			return &o, nil
+		},
+	}
+
+	overridesManager, err := New(cfg, "overrides", reg, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager)) })
+
+	conf := overridesManager.GetConfig().(*testOverrides)
+	require.Equal(t, 101, conf.Overrides["user1"].Limit1)
+	require.Equal(t, 204, conf.Overrides["user2"].Limit2)
+
+	require.Equal(t, 1, testutil.CollectAndCount(overridesManager.configHash, "runtime_config_hash"))
+}
+
+func TestCombinedFilesHash(t *testing.T) {
+	base := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-c": "hash3"}
+
+	// The hash is deterministic and independent of map insertion/iteration order.
+	reordered := map[string]string{"file-c": "hash3", "file-a": "hash1", "file-b": "hash2"}
+	require.Equal(t, combinedFilesHash(base), combinedFilesHash(reordered))
+
+	// Changing any file's content changes the hash.
+	changedContent := map[string]string{"file-a": "hash1", "file-b": "CHANGED", "file-c": "hash3"}
+	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedContent))
+
+	// Renaming a file changes the hash.
+	changedName := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-d": "hash3"}
+	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedName))
+}
+
 func TestOverridesManagerMultipleIncompatibleFiles(t *testing.T) {
 	tempFiles, err := generateRuntimeFiles(t,
 		[]string{

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -330,58 +331,135 @@ func TestOverridesManagerMultipleFilesWithOverrides(t *testing.T) {
 }
 
 func TestOverridesManagerMapLoader(t *testing.T) {
-	tempFiles, err := generateRuntimeFiles(t,
-		[]string{`overrides:
+	t.Run("loads merged config", func(t *testing.T) {
+		tempFiles, err := generateRuntimeFiles(t,
+			[]string{`overrides:
   user1:
     limit1: 101`,
-			`overrides:
+				`overrides:
   user2:
     limit2: 204`})
-	require.NoError(t, err)
+		require.NoError(t, err)
 
-	reg := prometheus.NewPedanticRegistry()
-	cfg := Config{
-		ReloadPeriod: time.Second,
-		LoadPath:     generateLoadPath(tempFiles),
-		Loader: func(io.Reader) (interface{}, error) {
-			return nil, errors.New("Loader should not be called when MapLoader is set")
-		},
-		MapLoader: func(m map[string]interface{}) (interface{}, error) {
-			js, err := json.Marshal(m)
+		reg := prometheus.NewPedanticRegistry()
+		cfg := Config{
+			ReloadPeriod: time.Second,
+			LoadPath:     generateLoadPath(tempFiles),
+			Loader: func(io.Reader) (interface{}, error) {
+				return nil, errors.New("Loader should not be called when MapLoader is set")
+			},
+			MapLoader: func(m map[string]interface{}) (interface{}, error) {
+				js, err := json.Marshal(m)
+				require.NoError(t, err)
+				var o testOverrides
+				err = json.Unmarshal(js, &o)
+				require.NoError(t, err)
+				return &o, nil
+			},
+		}
+
+		overridesManager, err := New(cfg, "overrides", reg, log.NewNopLogger())
+		require.NoError(t, err)
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
+		t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager)) })
+
+		conf := overridesManager.GetConfig().(*testOverrides)
+		require.Equal(t, 101, conf.Overrides["user1"].Limit1)
+		require.Equal(t, 204, conf.Overrides["user2"].Limit2)
+
+		require.Equal(t, 1, testutil.CollectAndCount(overridesManager.configHash, "runtime_config_hash"))
+	})
+
+	t.Run("hash preserves provider order", func(t *testing.T) {
+		tempFiles, err := generateRuntimeFiles(t, []string{
+			"winner: first",
+			"winner: second",
+		})
+		require.NoError(t, err)
+
+		load := func(paths []string) (interface{}, string) {
+			reg := prometheus.NewPedanticRegistry()
+			manager, err := New(Config{
+				LoadPath: paths,
+				MapLoader: func(m map[string]interface{}) (interface{}, error) {
+					return m["winner"], nil
+				},
+			}, "overrides", reg, log.NewNopLogger())
 			require.NoError(t, err)
-			var o testOverrides
-			err = json.Unmarshal(js, &o)
-			require.NoError(t, err)
-			return &o, nil
-		},
+			require.NoError(t, manager.loadConfig(context.Background()))
+			return manager.GetConfig(), runtimeConfigHash(t, reg)
+		}
+
+		paths := generateLoadPath(tempFiles)
+		forwardConfig, forwardHash := load(paths)
+		reversedConfig, reversedHash := load([]string{paths[1], paths[0]})
+
+		require.Equal(t, "second", forwardConfig)
+		require.Equal(t, "first", reversedConfig)
+		require.NotEqual(t, forwardHash, reversedHash)
+	})
+}
+
+func runtimeConfigHash(t *testing.T, reg *prometheus.Registry) string {
+	t.Helper()
+
+	metricFamilies, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range metricFamilies {
+		if family.GetName() != "runtime_config_hash" {
+			continue
+		}
+		require.Len(t, family.Metric, 1)
+		for _, label := range family.Metric[0].Label {
+			if label.GetName() == "sha256" {
+				return label.GetValue()
+			}
+		}
 	}
 
-	overridesManager, err := New(cfg, "overrides", reg, log.NewNopLogger())
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
-	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager)) })
-
-	conf := overridesManager.GetConfig().(*testOverrides)
-	require.Equal(t, 101, conf.Overrides["user1"].Limit1)
-	require.Equal(t, 204, conf.Overrides["user2"].Limit2)
-
-	require.Equal(t, 1, testutil.CollectAndCount(overridesManager.configHash, "runtime_config_hash"))
+	t.Fatal("runtime_config_hash metric has no sha256 label")
+	return ""
 }
 
 func TestCombinedFilesHash(t *testing.T) {
-	base := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-c": "hash3"}
+	digest := func(contents string) [sha256.Size]byte {
+		return sha256.Sum256([]byte(contents))
+	}
+	base := []providerHash{
+		{name: "file-a", digest: digest("contents-a")},
+		{name: "file-b", digest: digest("contents-b")},
+		{name: "file-c", digest: digest("contents-c")},
+	}
 
-	// The hash is deterministic and independent of map insertion/iteration order.
-	reordered := map[string]string{"file-c": "hash3", "file-a": "hash1", "file-b": "hash2"}
-	require.Equal(t, combinedFilesHash(base), combinedFilesHash(reordered))
+	require.Equal(t, combinedFilesHash(base), combinedFilesHash(slices.Clone(base)))
 
-	// Changing any file's content changes the hash.
-	changedContent := map[string]string{"file-a": "hash1", "file-b": "CHANGED", "file-c": "hash3"}
+	reversed := []providerHash{base[2], base[1], base[0]}
+	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(reversed))
+
+	changedContent := slices.Clone(base)
+	changedContent[1].digest = digest("changed")
 	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedContent))
 
-	// Renaming a file changes the hash.
-	changedName := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-d": "hash3"}
+	changedName := slices.Clone(base)
+	changedName[2].name = "file-d"
 	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedName))
+
+	duplicates := []providerHash{
+		{name: "file-a", digest: digest("contents-a")},
+		{name: "file-a", digest: digest("contents-b")},
+	}
+	require.NotEqual(t, combinedFilesHash(duplicates), combinedFilesHash([]providerHash{duplicates[1], duplicates[0]}))
+
+	t.Run("length prefix disambiguates provider sequences", func(t *testing.T) {
+		separateProviders := base[:2]
+		combinedProvider := []providerHash{{
+			// Without the name-length prefix, these sequences produce the same hash input.
+			name:   base[0].name + string(base[0].digest[:]) + base[1].name,
+			digest: base[1].digest,
+		}}
+
+		require.NotEqual(t, combinedFilesHash(separateProviders), combinedFilesHash(combinedProvider))
+	})
 }
 
 func TestOverridesManagerMultipleIncompatibleFiles(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

* Try to unmarshal config files with JSON, if they look like they might be JSON. JSON unmarshaling is quite a bit faster than YAML.
* Add `MapLoader`, which then bypasses re-encoding the merged config as YAML just to have unmarshaled again. We intend to use this in Mimir.

Benchmark, before vs after JSON unmarshaling:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/dskit/runtimeconfig
cpu: Apple M4
                     │ /tmp/old.txt │            /tmp/new.txt             │
                     │    sec/op    │   sec/op     vs base                │
ManagerLoadConfig-10   1425.7m ± 8%   864.7m ± 1%  -39.35% (p=0.000 n=10)

                     │ /tmp/old.txt │            /tmp/new.txt             │
                     │     B/op     │     B/op      vs base               │
ManagerLoadConfig-10   892.7Mi ± 0%   806.4Mi ± 0%  -9.66% (p=0.000 n=10)

                     │ /tmp/old.txt │            /tmp/new.txt             │
                     │  allocs/op   │  allocs/op   vs base                │
ManagerLoadConfig-10    5.909M ± 0%   4.341M ± 0%  -26.54% (p=0.000 n=10)
```

**Which issue(s) this PR fixes**:

—

**Checklist**
- [x] Tests updated
