### PR TITLE
fix: constrain Renovate Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,19 @@
       "groupName": "go-dependencies"
     },
     {
+      "description": "Respect the go-metrics module rename boundary",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["github.com/armon/go-metrics"],
+      "allowedVersions": "<0.5.0"
+    },
+    {
+      "description": "Only update Go modules compatible with the minimum Go version",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "constraintsFiltering": "strict"
+    },
+    {
       "description": "Don't update replace directives",
       "matchPackageNames": [
         "github.com/hashicorp/memberlist"


### PR DESCRIPTION
## What

- Prevent Renovate from selecting github.com/armon/go-metrics releases after the module was renamed to github.com/hashicorp/go-metrics.
- Limit Go module updates to releases compatible with the Go version declared by each go.mod.

## Why

#1035 updates the old github.com/armon/go-metrics path to v0.6.0, whose module declares the new github.com/hashicorp/go-metrics path. Renovate therefore cannot generate valid module artifacts. The same grouped update also selects Consul and etcd releases requiring Go 1.26 while both dskit modules declare Go 1.25 compatibility.
