### PR TITLE
fix(runtimeconfig): preserve loader compatibility

### DIFF
--- a/runtimeconfig/json.go
+++ b/runtimeconfig/json.go
@@ -1,0 +1,383 @@
+package runtimeconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+func unmarshalYAMLCompatibleJSON(data []byte) (map[string]any, error) {
+	if err := validateYAMLCompatibleJSON(data); err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var config map[string]any
+	if err := dec.Decode(&config); err != nil {
+		return nil, err
+	}
+	if err := requireJSONEOF(dec); err != nil {
+		return nil, err
+	}
+
+	normalized, err := normalizeJSONNumbers(config)
+	if err != nil {
+		return nil, err
+	}
+	return normalized.(map[string]any), nil
+}
+
+const (
+	inlineJSONObjectKeys = 8
+	maxJSONNestingDepth  = 10000
+)
+
+type yamlCompatibleJSONScanner struct {
+	data []byte
+}
+
+type jsonStringPosition struct {
+	end          int
+	contentStart int
+	contentEnd   int
+	hasEscape    bool
+}
+
+type jsonObjectKeys struct {
+	inline   [inlineJSONObjectKeys]string
+	count    int
+	overflow map[string]struct{}
+}
+
+func validateYAMLCompatibleJSON(data []byte) error {
+	// Scalar grammar is left to encoding/json below. This pass only checks the
+	// structure and string semantics needed to decide whether YAML would agree.
+	scanner := yamlCompatibleJSONScanner{data: data}
+	pos := scanner.skipWhitespace(0)
+	if pos >= len(data) || data[pos] != '{' {
+		return fmt.Errorf("JSON configuration must be an object")
+	}
+
+	pos, err := scanner.scanObject(pos, 1)
+	if err != nil {
+		return err
+	}
+	if pos = scanner.skipWhitespace(pos); pos != len(data) {
+		return fmt.Errorf("multiple JSON values")
+	}
+	return nil
+}
+
+func (s yamlCompatibleJSONScanner) scanValue(pos, depth int) (int, error) {
+	pos = s.skipWhitespace(pos)
+	if pos >= len(s.data) {
+		return pos, io.ErrUnexpectedEOF
+	}
+
+	switch s.data[pos] {
+	case '{':
+		return s.scanObject(pos, depth+1)
+	case '[':
+		return s.scanArray(pos, depth+1)
+	case '"':
+		value, err := s.scanString(pos)
+		return value.end, err
+	default:
+		return s.scanScalar(pos)
+	}
+}
+
+func (s yamlCompatibleJSONScanner) scanObject(pos, depth int) (int, error) {
+	if depth > maxJSONNestingDepth {
+		return pos, fmt.Errorf("JSON nesting depth exceeds %d", maxJSONNestingDepth)
+	}
+
+	pos = s.skipWhitespace(pos + 1)
+	if pos < len(s.data) && s.data[pos] == '}' {
+		return pos + 1, nil
+	}
+
+	var keys jsonObjectKeys
+	for {
+		if pos >= len(s.data) || s.data[pos] != '"' {
+			return pos, fmt.Errorf("expected JSON object key")
+		}
+
+		keyPosition, err := s.scanString(pos)
+		if err != nil {
+			return pos, err
+		}
+		key, err := s.decodeKey(pos, keyPosition)
+		if err != nil {
+			return pos, err
+		}
+		if keys.add(key) {
+			return pos, fmt.Errorf("duplicate JSON object key %q", key)
+		}
+
+		pos = s.skipWhitespace(keyPosition.end)
+		if pos >= len(s.data) || s.data[pos] != ':' {
+			return pos, fmt.Errorf("expected colon after JSON object key")
+		}
+		pos, err = s.scanValue(pos+1, depth)
+		if err != nil {
+			return pos, err
+		}
+
+		pos = s.skipWhitespace(pos)
+		if pos >= len(s.data) {
+			return pos, io.ErrUnexpectedEOF
+		}
+		switch s.data[pos] {
+		case '}':
+			return pos + 1, nil
+		case ',':
+			pos = s.skipWhitespace(pos + 1)
+		default:
+			return pos, fmt.Errorf("expected comma or end of JSON object")
+		}
+	}
+}
+
+func (s yamlCompatibleJSONScanner) scanArray(pos, depth int) (int, error) {
+	if depth > maxJSONNestingDepth {
+		return pos, fmt.Errorf("JSON nesting depth exceeds %d", maxJSONNestingDepth)
+	}
+
+	pos = s.skipWhitespace(pos + 1)
+	if pos < len(s.data) && s.data[pos] == ']' {
+		return pos + 1, nil
+	}
+
+	for {
+		var err error
+		pos, err = s.scanValue(pos, depth)
+		if err != nil {
+			return pos, err
+		}
+
+		pos = s.skipWhitespace(pos)
+		if pos >= len(s.data) {
+			return pos, io.ErrUnexpectedEOF
+		}
+		switch s.data[pos] {
+		case ']':
+			return pos + 1, nil
+		case ',':
+			pos = s.skipWhitespace(pos + 1)
+		default:
+			return pos, fmt.Errorf("expected comma or end of JSON array")
+		}
+	}
+}
+
+func (s yamlCompatibleJSONScanner) scanString(pos int) (jsonStringPosition, error) {
+	value := jsonStringPosition{contentStart: pos + 1}
+	for i := pos + 1; i < len(s.data); {
+		switch b := s.data[i]; {
+		case b == '"':
+			value.end = i + 1
+			value.contentEnd = i
+			return value, nil
+
+		case b == '\\':
+			value.hasEscape = true
+			if i+1 >= len(s.data) {
+				return value, io.ErrUnexpectedEOF
+			}
+			switch s.data[i+1] {
+			case '"', '\\', 'b', 'f', 'n', 'r', 't':
+				i += 2
+			case '/':
+				return value, fmt.Errorf("escaped solidus is not accepted by YAML")
+			case 'u':
+				if i+6 > len(s.data) {
+					return value, io.ErrUnexpectedEOF
+				}
+				codePoint, err := strconv.ParseUint(string(s.data[i+2:i+6]), 16, 16)
+				if err != nil {
+					return value, fmt.Errorf("invalid Unicode escape")
+				}
+				if codePoint >= 0xd800 && codePoint <= 0xdfff {
+					return value, fmt.Errorf("UTF-16 surrogate escape is not accepted by YAML")
+				}
+				i += 6
+			default:
+				return value, fmt.Errorf("invalid JSON escape")
+			}
+
+		case b < 0x20:
+			return value, fmt.Errorf("unescaped control character in JSON string")
+
+		case b == 0x7f:
+			return value, fmt.Errorf("raw Unicode character U+007F is not YAML-compatible")
+
+		case b < utf8.RuneSelf:
+			i++
+
+		default:
+			r, size := utf8.DecodeRune(s.data[i:])
+			if r == utf8.RuneError && size == 1 {
+				return value, fmt.Errorf("invalid UTF-8")
+			}
+			if !yamlAllowsRawJSONRune(r) {
+				return value, fmt.Errorf("raw Unicode character U+%04X is not YAML-compatible", r)
+			}
+			i += size
+		}
+	}
+	return value, io.ErrUnexpectedEOF
+}
+
+func (s yamlCompatibleJSONScanner) scanScalar(pos int) (int, error) {
+	start := pos
+	for pos < len(s.data) {
+		switch s.data[pos] {
+		case ' ', '\t', '\r', '\n', ',', '}', ']':
+			if pos == start {
+				return pos, fmt.Errorf("empty JSON value")
+			}
+			return pos, nil
+		default:
+			pos++
+		}
+	}
+	if pos == start {
+		return pos, fmt.Errorf("empty JSON value")
+	}
+	return pos, nil
+}
+
+func (s yamlCompatibleJSONScanner) skipWhitespace(pos int) int {
+	for pos < len(s.data) {
+		switch s.data[pos] {
+		case ' ', '\t', '\r', '\n':
+			pos++
+		default:
+			return pos
+		}
+	}
+	return pos
+}
+
+func (s yamlCompatibleJSONScanner) decodeKey(start int, position jsonStringPosition) (string, error) {
+	if !position.hasEscape {
+		return string(s.data[position.contentStart:position.contentEnd]), nil
+	}
+	return strconv.Unquote(string(s.data[start:position.end]))
+}
+
+func (k *jsonObjectKeys) add(key string) bool {
+	if k.overflow != nil {
+		if _, exists := k.overflow[key]; exists {
+			return true
+		}
+		k.overflow[key] = struct{}{}
+		return false
+	}
+
+	for i := 0; i < k.count; i++ {
+		if k.inline[i] == key {
+			return true
+		}
+	}
+	if k.count < len(k.inline) {
+		k.inline[k.count] = key
+		k.count++
+		return false
+	}
+
+	k.overflow = make(map[string]struct{}, len(k.inline)+1)
+	for _, existing := range k.inline {
+		k.overflow[existing] = struct{}{}
+	}
+	k.overflow[key] = struct{}{}
+	return false
+}
+
+func yamlAllowsRawJSONRune(r rune) bool {
+	// YAML rejects C1 controls and BMP noncharacters, and folds these three
+	// line-break runes. Their escaped forms do not pass through the YAML reader
+	// and can remain on the JSON fast path.
+	switch {
+	case r >= 0x7f && r <= 0x9f:
+		return false
+	case r == '\u2028' || r == '\u2029':
+		return false
+	case r == '\ufffe' || r == '\uffff':
+		return false
+	default:
+		return true
+	}
+}
+
+func requireJSONEOF(dec *json.Decoder) error {
+	if _, err := dec.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func normalizeJSONNumbers(value any) (any, error) {
+	switch value := value.(type) {
+	case json.Number:
+		return yamlCompatibleJSONNumber(value)
+
+	case map[string]any:
+		for key, child := range value {
+			normalized, err := normalizeJSONNumbers(child)
+			if err != nil {
+				return nil, err
+			}
+			value[key] = normalized
+		}
+		return value, nil
+
+	case []any:
+		for i, child := range value {
+			normalized, err := normalizeJSONNumbers(child)
+			if err != nil {
+				return nil, err
+			}
+			value[i] = normalized
+		}
+		return value, nil
+
+	default:
+		return value, nil
+	}
+}
+
+func yamlCompatibleJSONNumber(number json.Number) (any, error) {
+	value := number.String()
+	if strings.ContainsAny(value, ".eE") {
+		number, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return nil, err
+		}
+		return number, nil
+	}
+
+	if number, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if int64(int(number)) == number {
+			return int(number), nil
+		}
+		return number, nil
+	}
+	if number, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return number, nil
+	}
+	if number, err := strconv.ParseFloat(value, 64); err == nil {
+		return number, nil
+	}
+	return nil, fmt.Errorf("cannot decode JSON number %q with YAML semantics", value)
+}

--- a/runtimeconfig/json_test.go
+++ b/runtimeconfig/json_test.go
@@ -1,0 +1,196 @@
+package runtimeconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestUnmarshalYAMLCompatibleJSONMatchesYAML(t *testing.T) {
+	data := []byte(`{
+		"small": 42,
+		"large": 9007199254740993,
+		"maxInt64": 9223372036854775807,
+		"aboveMaxInt64": 9223372036854775808,
+		"maxUint64": 18446744073709551615,
+		"fraction": 1.25,
+		"exponent": 1e3,
+		"negativeZero": -0,
+		"nested": [{"value": 7}, null, true, "text"],
+		"escaped": "\u2028"
+	}`)
+
+	var expected map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &expected))
+
+	actual, err := unmarshalYAMLCompatibleJSON(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestUnmarshalJSONOrYAMLPreservesYAMLValidation(t *testing.T) {
+	tests := map[string][]byte{
+		"duplicate key":         []byte(`{"value": 1, "value": 2}`),
+		"escaped duplicate key": []byte(`{"value": 1, "\u0076alue": 2}`),
+		"nested duplicate key":  []byte(`{"values": [{"value": 1, "value": 2}]}`),
+		"invalid UTF-8":         {'{', '"', 'v', '"', ':', '"', 0xff, '"', '}'},
+		"escaped solidus":       []byte(`{"value": "a\/b"}`),
+		"surrogate escape":      []byte(`{"value": "\uD83D\uDE00"}`),
+	}
+
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			var expected map[string]any
+			expectedErr := yaml.Unmarshal(data, &expected)
+			require.Error(t, expectedErr)
+
+			_, err := unmarshalYAMLCompatibleJSON(data)
+			require.Error(t, err)
+
+			_, err = unmarshalJSONOrYAML(data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestUnmarshalJSONOrYAMLPreservesYAMLRawCharacterValidation(t *testing.T) {
+	for name, r := range map[string]rune{
+		"delete":                  '\u007f',
+		"control":                 '\u0080',
+		"application program cmd": '\u009f',
+		"noncharacter U+FFFE":     '\ufffe',
+		"noncharacter U+FFFF":     '\uffff',
+	} {
+		t.Run(name, func(t *testing.T) {
+			data := []byte(`{"value": "before` + string(r) + `after"}`)
+
+			var expected map[string]any
+			require.Error(t, yaml.Unmarshal(data, &expected))
+
+			_, err := unmarshalYAMLCompatibleJSON(data)
+			require.Error(t, err)
+			_, err = unmarshalJSONOrYAML(data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestUnmarshalJSONOrYAMLPreservesYAMLRawLineBreaks(t *testing.T) {
+	for name, r := range map[string]rune{
+		"next line":           '\u0085',
+		"line separator":      '\u2028',
+		"paragraph separator": '\u2029',
+	} {
+		t.Run(name, func(t *testing.T) {
+			data := []byte(`{"value": "before` + string(r) + `  after"}`)
+
+			var expected map[string]any
+			require.NoError(t, yaml.Unmarshal(data, &expected))
+
+			_, err := unmarshalYAMLCompatibleJSON(data)
+			require.Error(t, err)
+
+			actual, err := unmarshalJSONOrYAML(data)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestUnmarshalYAMLCompatibleJSONAcceptsEscapedLineBreaksAndNoncharacters(t *testing.T) {
+	data := []byte(`{
+		"nextLine": "\u0085",
+		"lineSeparator": "\u2028",
+		"paragraphSeparator": "\u2029",
+		"noncharacter": "\uFFFF"
+	}`)
+
+	var expected map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &expected))
+
+	actual, err := unmarshalYAMLCompatibleJSON(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestValidateYAMLCompatibleJSONRejectsExcessiveNesting(t *testing.T) {
+	data := []byte(`{"value":` +
+		strings.Repeat("[", maxJSONNestingDepth) +
+		`0` +
+		strings.Repeat("]", maxJSONNestingDepth) +
+		`}`)
+	require.ErrorContains(t, validateYAMLCompatibleJSON(data), "JSON nesting depth exceeds")
+}
+
+func TestUnmarshalJSONOrYAMLFallsBackToYAML(t *testing.T) {
+	for _, data := range [][]byte{
+		[]byte(`{value: 1e400}`),
+		[]byte(`{"value": 1e400}`),
+		[]byte(`{"value": 1} {"ignored": 2}`),
+	} {
+		var expected map[string]any
+		require.NoError(t, yaml.Unmarshal(data, &expected))
+
+		actual, err := unmarshalJSONOrYAML(data)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
+}
+
+func TestUnmarshalMaybeGzippedJSONMatchesUncompressed(t *testing.T) {
+	data := []byte(`{"limits":{"large":9007199254740993,"fraction":1.25}}`)
+
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, err := writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	manager := &Manager{}
+	uncompressed, err := manager.unmarshalMaybeGzipped("config.json", data)
+	require.NoError(t, err)
+	gzipped, err := manager.unmarshalMaybeGzipped("config.json.gz", compressed.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, uncompressed, gzipped)
+
+	duplicate := []byte(`{"limits":{"value":1,"value":2}}`)
+	compressed.Reset()
+	writer = gzip.NewWriter(&compressed)
+	_, err = writer.Write(duplicate)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	_, plainErr := manager.unmarshalMaybeGzipped("config.json", duplicate)
+	_, gzipErr := manager.unmarshalMaybeGzipped("config.json.gz", compressed.Bytes())
+	require.Error(t, plainErr)
+	require.Error(t, gzipErr)
+
+	rawLineBreak := []byte(`{"limits":{"value":"before` + string('\u2028') + `  after"}}`)
+	compressed.Reset()
+	writer = gzip.NewWriter(&compressed)
+	_, err = writer.Write(rawLineBreak)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	uncompressed, err = manager.unmarshalMaybeGzipped("config.json", rawLineBreak)
+	require.NoError(t, err)
+	gzipped, err = manager.unmarshalMaybeGzipped("config.json.gz", compressed.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, uncompressed, gzipped)
+
+	rawControl := []byte(`{"limits":{"value":"before` + string('\u0080') + `after"}}`)
+	compressed.Reset()
+	writer = gzip.NewWriter(&compressed)
+	_, err = writer.Write(rawControl)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	_, plainErr = manager.unmarshalMaybeGzipped("config.json", rawControl)
+	_, gzipErr = manager.unmarshalMaybeGzipped("config.json.gz", compressed.Bytes())
+	require.Error(t, plainErr)
+	require.Error(t, gzipErr)
+}

--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -5,12 +5,11 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,7 +34,8 @@ type Preprocessor func(b []byte) ([]byte, error)
 // Loader loads the configuration from files.
 type Loader func(r io.Reader) (interface{}, error)
 
-// MapLoader loads the configuration from a map.
+// MapLoader loads the configuration from a recursively string-keyed map.
+// Scalar values retain the types produced by YAML or JSON decoding.
 type MapLoader func(m map[string]interface{}) (interface{}, error)
 
 // Config holds the config for an Manager instance.
@@ -267,8 +267,19 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 		err  error
 	)
 	if om.cfg.MapLoader != nil {
-		hash = combinedFilesHash(hashes)
-		cfg, err = om.cfg.MapLoader(mergedConfig)
+		hash, err = mergedConfigHash(mergedConfig)
+		if err != nil {
+			om.configLoadSuccess.Set(0)
+			return errors.Wrap(err, "marshal file")
+		}
+
+		normalizedConfig, err := normalizeMapLoaderConfig(mergedConfig)
+		if err != nil {
+			om.configLoadSuccess.Set(0)
+			return errors.Wrap(err, "normalize file")
+		}
+
+		cfg, err = om.cfg.MapLoader(normalizedConfig)
 		if err != nil {
 			om.configLoadSuccess.Set(0)
 			return errors.Wrap(err, "load file")
@@ -301,23 +312,137 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 	return nil
 }
 
-func combinedFilesHash(hashes map[string]string) [sha256.Size]byte {
-	names := make([]string, 0, len(hashes))
-	for name := range hashes {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
+func mergedConfigHash(config map[string]any) ([sha256.Size]byte, error) {
 	h := sha256.New()
-	for _, name := range names {
-		_, _ = io.WriteString(h, name)
-		_, _ = io.WriteString(h, "=")
-		_, _ = io.WriteString(h, hashes[name])
-		_, _ = io.WriteString(h, ";")
+	enc := yaml.NewEncoder(h)
+	if err := enc.Encode(config); err != nil {
+		return [sha256.Size]byte{}, err
 	}
+	if err := enc.Close(); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+
 	var out [sha256.Size]byte
 	copy(out[:], h.Sum(nil))
-	return out
+	return out, nil
+}
+
+func normalizeMapLoaderConfig(config map[string]any) (map[string]any, error) {
+	normalized, err := normalizeMapLoaderValue(config, "")
+	if err != nil {
+		return nil, err
+	}
+	return normalized.(map[string]any), nil
+}
+
+func normalizeMapLoaderValue(value any, path string) (any, error) {
+	switch value := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(value))
+		for key, child := range value {
+			normalized, err := normalizeMapLoaderValue(child, configPath(path, key))
+			if err != nil {
+				return nil, err
+			}
+			out[key] = normalized
+		}
+		return out, nil
+
+	case map[any]any:
+		out := make(map[string]any, len(value))
+		for key, child := range value {
+			normalizedKey, err := canonicalYAMLMapKey(key)
+			if err != nil {
+				return nil, errors.Wrapf(err, "map key at %q", path)
+			}
+			if _, exists := out[normalizedKey]; exists {
+				return nil, errors.Errorf("map key collision at %q after normalization to %q", path, normalizedKey)
+			}
+
+			normalized, err := normalizeMapLoaderValue(child, configPath(path, normalizedKey))
+			if err != nil {
+				return nil, err
+			}
+			out[normalizedKey] = normalized
+		}
+		return out, nil
+
+	case []any:
+		out := make([]any, len(value))
+		for i, child := range value {
+			normalized, err := normalizeMapLoaderValue(child, fmt.Sprintf("%s[%d]", path, i))
+			if err != nil {
+				return nil, err
+			}
+			out[i] = normalized
+		}
+		return out, nil
+
+	default:
+		return value, nil
+	}
+}
+
+func canonicalYAMLMapKey(key any) (string, error) {
+	switch key := key.(type) {
+	case nil:
+		return "null", nil
+	case string:
+		return key, nil
+	case bool:
+		return strconv.FormatBool(key), nil
+	case int:
+		return strconv.FormatInt(int64(key), 10), nil
+	case int8:
+		return strconv.FormatInt(int64(key), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(key), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(key), 10), nil
+	case int64:
+		return strconv.FormatInt(key, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(key), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(key), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(key), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(key), 10), nil
+	case uint64:
+		return strconv.FormatUint(key, 10), nil
+	case uintptr:
+		return strconv.FormatUint(uint64(key), 10), nil
+	case float32:
+		return canonicalYAMLFloat(float64(key), 32), nil
+	case float64:
+		return canonicalYAMLFloat(key, 64), nil
+	case time.Time:
+		return key.Format(time.RFC3339Nano), nil
+	default:
+		return "", errors.Errorf("unsupported type %T", key)
+	}
+}
+
+func canonicalYAMLFloat(value float64, bitSize int) string {
+	s := strconv.FormatFloat(value, 'g', -1, bitSize)
+	switch s {
+	case "+Inf":
+		return ".inf"
+	case "-Inf":
+		return "-.inf"
+	case "NaN":
+		return ".nan"
+	default:
+		return s
+	}
+}
+
+func configPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
 }
 
 func (om *Manager) unmarshalMaybeGzipped(filename string, data []byte) (map[string]any, error) {
@@ -348,8 +473,7 @@ func (om *Manager) unmarshalMaybeGzipped(filename string, data []byte) (map[stri
 // encoding/json, which is faster. YAML is used as a fallback
 func unmarshalJSONOrYAML(data []byte) (map[string]any, error) {
 	if looksLikeJSONObject(data) {
-		m := map[string]any{}
-		if err := json.Unmarshal(data, &m); err == nil {
+		if m, err := unmarshalYAMLCompatibleJSON(data); err == nil {
 			return m, nil
 		}
 	}
@@ -370,46 +494,93 @@ func isGzip(data []byte) bool {
 	return len(data) > 2 && data[0] == 0x1f && data[1] == 0x8b
 }
 
-func mergeConfigMaps(a, b map[string]interface{}, path string) (_ map[string]interface{}, err error) {
-	out := make(map[string]interface{}, len(a))
+func mergeConfigMaps(a, b map[string]interface{}, path string) (map[string]interface{}, error) {
+	return mergeStringConfigMaps(a, b, path)
+}
+
+func mergeStringConfigMaps(a, b map[string]any, path string) (map[string]any, error) {
+	out := make(map[string]any, len(a))
 	for k, v := range a {
 		out[k] = v
 	}
 	for k, v := range b {
-		aVal, aHasKey := a[k]
-		bVal, bHasKey := b[k]
-
-		_, aIsMap := a[k].(map[string]interface{})
-		_, bIsMap := b[k].(map[string]interface{})
-
-		if aHasKey && aVal == nil && bIsMap {
-			aIsMap = true
-			out[k] = make(map[string]interface{})
+		aVal, exists := out[k]
+		if !exists {
+			out[k] = v
+			continue
 		}
 
-		if bHasKey && bVal == nil && aIsMap {
-			bIsMap = true
-			v = make(map[string]interface{})
+		merged, err := mergeConfigValues(aVal, v, path+"."+k)
+		if err != nil {
+			return nil, err
 		}
-
-		if aHasKey && aIsMap != bIsMap {
-			return nil, errors.Errorf("conflicting types for %q: %T != %T", path+"."+k, a[k], b[k])
-		}
-
-		if v, ok := v.(map[string]interface{}); ok {
-			if bv, ok := out[k]; ok {
-				if bv, ok := bv.(map[string]interface{}); ok {
-					out[k], err = mergeConfigMaps(bv, v, path+"."+k)
-					if err != nil {
-						return nil, err
-					}
-					continue
-				}
-			}
-		}
-		out[k] = v
+		out[k] = merged
 	}
 	return out, nil
+}
+
+func mergeAnyConfigMaps(a, b map[any]any, path string) (map[any]any, error) {
+	out := make(map[any]any, len(a))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		aVal, exists := out[k]
+		if !exists {
+			out[k] = v
+			continue
+		}
+
+		merged, err := mergeConfigValues(aVal, v, fmt.Sprintf("%s.%v", path, k))
+		if err != nil {
+			return nil, err
+		}
+		out[k] = merged
+	}
+	return out, nil
+}
+
+func mergeConfigValues(a, b any, path string) (any, error) {
+	if a == nil {
+		switch b.(type) {
+		case map[string]any:
+			a = map[string]any{}
+		case map[any]any:
+			a = map[any]any{}
+		}
+	}
+	if b == nil {
+		switch a.(type) {
+		case map[string]any:
+			b = map[string]any{}
+		case map[any]any:
+			b = map[any]any{}
+		}
+	}
+
+	switch a := a.(type) {
+	case map[string]any:
+		bMap, ok := b.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("conflicting types for %q: %T != %T", path, a, b)
+		}
+		return mergeStringConfigMaps(a, bMap, path)
+
+	case map[any]any:
+		bMap, ok := b.(map[any]any)
+		if !ok {
+			return nil, errors.Errorf("conflicting types for %q: %T != %T", path, a, b)
+		}
+		return mergeAnyConfigMaps(a, bMap, path)
+
+	default:
+		switch b.(type) {
+		case map[string]any, map[any]any:
+			return nil, errors.Errorf("conflicting types for %q: %T != %T", path, a, b)
+		default:
+			return b, nil
+		}
+	}
 }
 
 func (om *Manager) setConfig(config interface{}) {

--- a/runtimeconfig/manager_bench_test.go
+++ b/runtimeconfig/manager_bench_test.go
@@ -28,21 +28,33 @@ func BenchmarkManagerLoadConfig(b *testing.B) {
 	require.NoError(b, os.WriteFile(yamlPath, yamlData, 0600))
 	require.NoError(b, os.WriteFile(jsonPath, jsonData, 0600))
 
-	cfg := Config{
-		LoadPath: []string{yamlPath, jsonPath},
-		Loader:   benchLoader,
-	}
-	m, err := New(cfg, "bench", prometheus.NewPedanticRegistry(), log.NewNopLogger())
-	require.NoError(b, err)
+	for _, benchmark := range []struct {
+		name      string
+		loader    Loader
+		mapLoader MapLoader
+	}{
+		{name: "Loader", loader: benchLoader},
+		{name: "MapLoader", mapLoader: benchMapLoader},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			cfg := Config{
+				LoadPath:  []string{yamlPath, jsonPath},
+				Loader:    benchmark.loader,
+				MapLoader: benchmark.mapLoader,
+			}
+			m, err := New(cfg, "bench", prometheus.NewPedanticRegistry(), log.NewNopLogger())
+			require.NoError(b, err)
 
-	ctx := context.Background()
+			ctx := context.Background()
 
-	b.ReportAllocs()
-	for b.Loop() {
-		// Reset the per-file hash cache so every iteration performs a full
-		// reload instead of short-circuiting on unchanged hashes.
-		m.fileHashes = nil
-		require.NoError(b, m.loadConfig(ctx))
+			b.ReportAllocs()
+			for b.Loop() {
+				// Reset the per-file hash cache so every iteration performs a full
+				// reload instead of short-circuiting on unchanged hashes.
+				m.fileHashes = nil
+				require.NoError(b, m.loadConfig(ctx))
+			}
+		})
 	}
 }
 
@@ -88,6 +100,18 @@ func generateOverrides(numTenants int) benchOverrides {
 func benchLoader(r io.Reader) (interface{}, error) {
 	o := &benchOverrides{}
 	if err := yaml.NewDecoder(r).Decode(o); err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+func benchMapLoader(m map[string]interface{}) (interface{}, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	o := &benchOverrides{}
+	if err := json.Unmarshal(data, o); err != nil {
 		return nil, err
 	}
 	return o, nil

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -332,10 +333,9 @@ func TestOverridesManagerMultipleFilesWithOverrides(t *testing.T) {
 func TestOverridesManagerMapLoader(t *testing.T) {
 	tempFiles, err := generateRuntimeFiles(t,
 		[]string{`overrides:
-  user1:
-    limit1: 101`,
-			`overrides:
-  user2:
+  123:
+    limit1: 101
+  456:
     limit2: 204`})
 	require.NoError(t, err)
 
@@ -362,26 +362,218 @@ func TestOverridesManagerMapLoader(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager)) })
 
 	conf := overridesManager.GetConfig().(*testOverrides)
-	require.Equal(t, 101, conf.Overrides["user1"].Limit1)
-	require.Equal(t, 204, conf.Overrides["user2"].Limit2)
+	require.Equal(t, 101, conf.Overrides["123"].Limit1)
+	require.Equal(t, 204, conf.Overrides["456"].Limit2)
 
 	require.Equal(t, 1, testutil.CollectAndCount(overridesManager.configHash, "runtime_config_hash"))
 }
 
-func TestCombinedFilesHash(t *testing.T) {
-	base := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-c": "hash3"}
+func TestOverridesManagerMergesNumericKeysAcrossFiles(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		loader    Loader
+		mapLoader MapLoader
+	}{
+		{name: "Loader", loader: testLoadOverrides},
+		{
+			name: "MapLoader",
+			mapLoader: func(m map[string]interface{}) (interface{}, error) {
+				data, err := json.Marshal(m)
+				if err != nil {
+					return nil, err
+				}
+				var overrides testOverrides
+				if err := json.Unmarshal(data, &overrides); err != nil {
+					return nil, err
+				}
+				return &overrides, nil
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempFiles, err := generateRuntimeFiles(t, []string{
+				`overrides:
+  123:
+    limit1: 101`,
+				`overrides:
+  456:
+    limit2: 204`,
+			})
+			require.NoError(t, err)
 
-	// The hash is deterministic and independent of map insertion/iteration order.
-	reordered := map[string]string{"file-c": "hash3", "file-a": "hash1", "file-b": "hash2"}
-	require.Equal(t, combinedFilesHash(base), combinedFilesHash(reordered))
+			manager, err := New(Config{
+				ReloadPeriod: time.Second,
+				LoadPath:     generateLoadPath(tempFiles),
+				Loader:       test.loader,
+				MapLoader:    test.mapLoader,
+			}, "overrides", prometheus.NewPedanticRegistry(), log.NewNopLogger())
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), manager))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager))
+			})
 
-	// Changing any file's content changes the hash.
-	changedContent := map[string]string{"file-a": "hash1", "file-b": "CHANGED", "file-c": "hash3"}
-	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedContent))
+			config := manager.GetConfig().(*testOverrides)
+			require.Equal(t, 101, config.Overrides["123"].Limit1)
+			require.Equal(t, 204, config.Overrides["456"].Limit2)
+		})
+	}
+}
 
-	// Renaming a file changes the hash.
-	changedName := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-d": "hash3"}
-	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedName))
+func TestMergedConfigHash(t *testing.T) {
+	first := map[string]any{
+		"overrides": map[string]any{
+			"tenant": map[string]any{"limit": 1},
+		},
+	}
+	second := map[string]any{
+		"overrides": map[string]any{
+			"tenant": map[string]any{"limit": 2},
+		},
+	}
+
+	merged, err := mergeConfigMaps(first, second, "")
+	require.NoError(t, err)
+	reversed, err := mergeConfigMaps(second, first, "")
+	require.NoError(t, err)
+
+	hash, err := mergedConfigHash(merged)
+	require.NoError(t, err)
+	reversedHash, err := mergedConfigHash(reversed)
+	require.NoError(t, err)
+	require.NotEqual(t, hash, reversedHash)
+
+	marshaled, err := yaml.Marshal(merged)
+	require.NoError(t, err)
+	require.Equal(t, sha256.Sum256(marshaled), hash)
+
+	equivalent := map[string]any{
+		"overrides": map[string]any{
+			"tenant": map[string]any{"limit": 2},
+		},
+	}
+	equivalentHash, err := mergedConfigHash(equivalent)
+	require.NoError(t, err)
+	require.Equal(t, hash, equivalentHash)
+}
+
+func TestMergedConfigHashWithNumericKeys(t *testing.T) {
+	first := map[string]any{
+		"overrides": map[any]any{
+			123: map[string]any{"limit": 1},
+		},
+	}
+	second := map[string]any{
+		"overrides": map[any]any{
+			456: map[string]any{"limit": 2},
+		},
+	}
+
+	merged, err := mergeConfigMaps(first, second, "")
+	require.NoError(t, err)
+	require.Equal(t, map[any]any{
+		123: map[string]any{"limit": 1},
+		456: map[string]any{"limit": 2},
+	}, merged["overrides"])
+
+	hash, err := mergedConfigHash(merged)
+	require.NoError(t, err)
+	marshaled, err := yaml.Marshal(merged)
+	require.NoError(t, err)
+	require.Equal(t, sha256.Sum256(marshaled), hash)
+
+	changedFirst := map[string]any{
+		"overrides": map[any]any{
+			123: map[string]any{"limit": 3},
+		},
+	}
+	changedMerged, err := mergeConfigMaps(changedFirst, second, "")
+	require.NoError(t, err)
+	changedHash, err := mergedConfigHash(changedMerged)
+	require.NoError(t, err)
+	require.NotEqual(t, hash, changedHash)
+
+	overriddenFirst := map[string]any{
+		"overrides": map[any]any{
+			123: map[string]any{"limit": 99},
+		},
+	}
+	override := map[string]any{
+		"overrides": map[any]any{
+			123: map[string]any{"limit": 1},
+			456: map[string]any{"limit": 2},
+		},
+	}
+	overriddenMerged, err := mergeConfigMaps(overriddenFirst, override, "")
+	require.NoError(t, err)
+	overriddenHash, err := mergedConfigHash(overriddenMerged)
+	require.NoError(t, err)
+	require.Equal(t, hash, overriddenHash)
+}
+
+func TestMergeConfigMapsWithNumericKeysAndNilValues(t *testing.T) {
+	first := map[string]any{
+		"overrides": map[any]any{
+			123: nil,
+			456: map[string]any{"limit": 2},
+		},
+	}
+	second := map[string]any{
+		"overrides": map[any]any{
+			123: map[string]any{"limit": 1},
+			456: nil,
+		},
+	}
+
+	merged, err := mergeConfigMaps(first, second, "")
+	require.NoError(t, err)
+	require.Equal(t, map[any]any{
+		123: map[string]any{"limit": 1},
+		456: map[string]any{"limit": 2},
+	}, merged["overrides"])
+}
+
+func TestNormalizeMapLoaderConfig(t *testing.T) {
+	timestamp := time.Date(2026, time.July, 23, 10, 11, 12, 123, time.UTC)
+	config := map[string]any{
+		"nested": map[any]any{
+			nil:         "nil",
+			true:        "bool",
+			int64(-12):  "int",
+			uint64(13):  "uint",
+			math.Inf(1): "float",
+			timestamp:   "timestamp",
+		},
+		"list": []any{
+			map[any]any{123: "value"},
+		},
+	}
+
+	normalized, err := normalizeMapLoaderConfig(config)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"nested": map[string]any{
+			"null":                           "nil",
+			"true":                           "bool",
+			"-12":                            "int",
+			"13":                             "uint",
+			".inf":                           "float",
+			"2026-07-23T10:11:12.000000123Z": "timestamp",
+		},
+		"list": []any{
+			map[string]any{"123": "value"},
+		},
+	}, normalized)
+
+	_, err = normalizeMapLoaderConfig(map[string]any{
+		"nested": map[any]any{[2]int{1, 2}: "unsupported"},
+	})
+	require.ErrorContains(t, err, `map key at "nested": unsupported type [2]int`)
+
+	_, err = normalizeMapLoaderConfig(map[string]any{
+		"nested": map[any]any{1: "number", "1": "string"},
+	})
+	require.ErrorContains(t, err, `map key collision at "nested" after normalization to "1"`)
 }
 
 func TestOverridesManagerMultipleIncompatibleFiles(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Follow-up to #1033 that preserves existing Loader behavior and hardens the JSON and MapLoader paths:

- validates the JSON fast path against yaml.v3 semantics, including duplicate keys, string escapes, Unicode, nesting limits, and YAML-compatible numeric types;
- deep-merges non-string-keyed YAML maps across providers before converting them to recursively string-keyed maps for MapLoader;
- computes the MapLoader runtime-config hash from the effective merged configuration, matching Loader;
- adds separate Loader and MapLoader benchmarks.

**Benchmarks**:

Command: `go test ./runtimeconfig -run "^$" -bench "^BenchmarkManagerLoadConfig$" -benchmem -count=6`

Environment: Apple M4 Pro, `darwin/arm64`, six samples. The base benchmark name was normalized to `/Loader` for `benchstat`; the workload was unchanged.

Base `a26df7e5` versus head `a8f96815`:

| Metric | Base Loader | Head Loader | Change |
| --- | ---: | ---: | ---: |
| Time | 777.9 ms/op | 769.2 ms/op | statistically unchanged (`p=0.132`) |
| Bytes allocated | 794.5 MiB/op | 812.7 MiB/op | +2.30% |
| Allocations | 4.041M/op | 4.201M/op | +3.96% |

Loader versus MapLoader on the head commit:

| Metric | Loader | MapLoader | Change |
| --- | ---: | ---: | ---: |
| Time | 769.2 ms/op | 285.0 ms/op | -62.95% (`p=0.002`) |
| Bytes allocated | 812.7 MiB/op | 743.0 MiB/op | -8.58% (`p=0.002`) |
| Allocations | 4.201M/op | 2.866M/op | -31.78% (`p=0.002`) |

Direct MapLoader comparison, Toni base versus head:

Command: `go test ./runtimeconfig -run "^$" -bench "^BenchmarkManagerLoadConfig/MapLoader$" -benchtime=5x -benchmem -count=6`

The base commit does not contain the MapLoader sub-benchmark, so the same benchmark-only harness from the head was applied to the base production code.

| Metric | Toni base | Head | Change |
| --- | ---: | ---: | ---: |
| Time | 94.93 ms/op | 279.70 ms/op | +194.63% (`p=0.002`) |
| Bytes allocated | 80.66 MiB/op | 742.95 MiB/op | +821.04% (`p=0.002`) |
| Allocations | 1.341M/op | 2.866M/op | +113.77% (`p=0.002`) |

This shows a material MapLoader regression in the follow-up, despite MapLoader remaining faster than Loader on the head commit.

Validation:

- `go test ./runtimeconfig`
- `go test ./...`
- `go test -race ./runtimeconfig`
- `go vet ./runtimeconfig`
- `golangci-lint run --new-from-rev HEAD^`

**Which issue(s) this PR fixes**:

Follow-up to #1033.

**Checklist**
- [x] Tests updated