### PR TITLE
perf(ring): replace reflection-based proto.Clone in Desc.Clone with maps.Clone

### DIFF
--- a/ring/model.go
+++ b/ring/model.go
@@ -2,6 +2,7 @@ package ring
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"sync"
@@ -469,9 +470,21 @@ func (d *Desc) RemoveTombstones(limit time.Time) (total, removed int) {
 	return
 }
 
-// Clone returns a deep copy of the ring state.
+// Clone returns a copy of the ring state. The returned Desc and its Ingesters map are
+// safe to modify (entries can be added, removed or replaced), but reference-type fields
+// inside InstanceDesc (Tokens, Versions) share their underlying storage with the
+// original, so they must be treated as read-only.
+//
+// It's hand-written instead of using the reflection-based proto.Clone because it runs on
+// the memberlist hot path (once per watcher notification), where reflection is a
+// significant CPU cost on rings with thousands of instances. Sharing Tokens and Versions
+// storage is not a behavior change: gogo's proto.Clone shallow-copies non-nullable map
+// values, so it shared those fields too.
 func (d *Desc) Clone() memberlist.Mergeable {
-	return proto.Clone(d).(*Desc)
+	if d == nil {
+		return (*Desc)(nil)
+	}
+	return &Desc{Ingesters: maps.Clone(d.Ingesters)}
 }
 
 func (d *Desc) getTokensInfo() map[uint32]instanceInfo {

--- a/ring/model_test.go
+++ b/ring/model_test.go
@@ -1,6 +1,8 @@
 package ring
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -440,6 +442,93 @@ func TestMergeTokensByZone(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			assert.Equal(t, testData.expected, MergeTokensByZone(testData.input))
+		})
+	}
+}
+
+func TestDesc_Clone(t *testing.T) {
+	t.Run("nil desc", func(t *testing.T) {
+		var d *Desc
+		assert.Equal(t, (*Desc)(nil), d.Clone())
+	})
+
+	t.Run("empty desc", func(t *testing.T) {
+		assert.Equal(t, &Desc{}, (&Desc{}).Clone())
+	})
+
+	t.Run("populated desc", func(t *testing.T) {
+		orig := &Desc{
+			Ingesters: map[string]InstanceDesc{
+				"ing1": {
+					Addr:                     "addr1",
+					Timestamp:                123456,
+					State:                    LEAVING,
+					Tokens:                   []uint32{1, 2, 3},
+					Zone:                     "zone1",
+					RegisteredTimestamp:      234567,
+					Id:                       "ing1",
+					ReadOnlyUpdatedTimestamp: 345678,
+					ReadOnly:                 true,
+					Versions:                 map[uint64]uint64{1: 2},
+				},
+				"ing2": {
+					Addr:   "addr2",
+					Tokens: []uint32{4, 5, 6},
+				},
+			},
+		}
+
+		// Every InstanceDesc field must be non-zero in "ing1": it guarantees that when a
+		// new field is added in the future, this test fails until the field is set here
+		// and its sharing semantics in Clone() are considered.
+		origVal := reflect.ValueOf(orig.Ingesters["ing1"])
+		for i := 0; i < origVal.NumField(); i++ {
+			assert.False(t, origVal.Field(i).IsZero(), "field %s must be set to a non-zero value in this test", origVal.Type().Field(i).Name)
+		}
+
+		clone := orig.Clone().(*Desc)
+		assert.Equal(t, orig, clone)
+
+		// The Ingesters map itself must not be shared: mutating the clone's map must not
+		// affect the original.
+		clone.Ingesters["ing3"] = InstanceDesc{Addr: "addr3"}
+		delete(clone.Ingesters, "ing2")
+		ing1 := clone.Ingesters["ing1"]
+		ing1.State = ACTIVE
+		clone.Ingesters["ing1"] = ing1
+
+		assert.Len(t, orig.Ingesters, 2)
+		assert.NotContains(t, orig.Ingesters, "ing3")
+		assert.Contains(t, orig.Ingesters, "ing2")
+		assert.Equal(t, LEAVING, orig.Ingesters["ing1"].State)
+	})
+}
+
+func BenchmarkDesc_Clone(b *testing.B) {
+	for _, numInstances := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("instances=%d", numInstances), func(b *testing.B) {
+			d := &Desc{Ingesters: make(map[string]InstanceDesc, numInstances)}
+			for i := 0; i < numInstances; i++ {
+				tokens := make([]uint32, 512)
+				for j := range tokens {
+					tokens[j] = uint32(i*512 + j)
+				}
+				id := fmt.Sprintf("instance-%d", i)
+				d.Ingesters[id] = InstanceDesc{
+					Addr:                fmt.Sprintf("10.0.%d.%d", i/256, i%256),
+					Timestamp:           123456,
+					State:               ACTIVE,
+					Tokens:              tokens,
+					Zone:                fmt.Sprintf("zone-%d", i%3),
+					RegisteredTimestamp: 234567,
+					Id:                  id,
+				}
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = d.Clone()
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`Desc.Clone()` runs on the memberlist hot path (once per watcher notification, via `KV.get`), and its reflection-based `proto.Clone` gets expensive on large rings: in a CPU profile of a Mimir store-gateway in a cluster with thousands of memberlist nodes, this clone alone accounted for ~4.7% of total service CPU. Replace it with a plain `maps.Clone` of the `Ingesters` map, which is 4-8x faster and allocation-free per instance.

- This is not a semantics change: gogo's `proto.Clone` never deep-copied the instance internals. Non-nullable map values (`map[string]InstanceDesc`) fall into the shallow `default` branch of gogo's table-driven merge ([table_merge.go#L591-L624](https://github.com/gogo/protobuf/blob/v1.3.2/proto/table_merge.go#L591-L624)), so `Tokens` and `Versions` were already shared between the clone and the original.
- Document the actual contract on `Clone()` (independent map, read-only `Tokens`/`Versions`) instead of the previous "deep copy" comment, which was inaccurate.
- Pin the behavior with a test that requires every `InstanceDesc` field to be non-zero, so adding a field forces a review of its sharing semantics.

### Benchmarks

512 tokens per instance, Apple M3 Pro (`benchstat`, n=6):

```
                           │  proto.Clone  │              maps.Clone             │
                           │    sec/op     │    sec/op     vs base               │
Desc_Clone/instances=100        17.219µ ± 11%   4.230µ ±  7%  -75.44% (p=0.002 n=6)
Desc_Clone/instances=1000       223.55µ ±  8%   42.57µ ± 30%  -80.96% (p=0.002 n=6)
Desc_Clone/instances=10000      1814.8µ ±  3%   214.4µ ± 19%  -88.19% (p=0.002 n=6)
geomean                          191.2µ         33.80µ        -82.32%

                           │     B/op      │     B/op      vs base               │
Desc_Clone/instances=100         52.25Ki ± 0%   18.09Ki ± 0%  -65.37% (p=0.002 n=6)
Desc_Clone/instances=1000        744.4Ki ± 0%   288.1Ki ± 0%  -61.29% (p=0.002 n=6)
Desc_Clone/instances=10000       6.112Mi ± 0%   2.251Mi ± 0%  -63.18% (p=0.002 n=6)
geomean                          624.4Ki        229.0Ki       -63.32%

                           │   allocs/op   │  allocs/op   vs base                │
Desc_Clone/instances=100         213.000 ± 0%    5.000 ± 0%  -97.65% (p=0.002 n=6)
Desc_Clone/instances=1000       2024.000 ± 0%    7.000 ± 0%  -99.65% (p=0.002 n=6)
Desc_Clone/instances=10000      20083.00 ± 0%   35.00 ± 0%   -99.83% (p=0.002 n=6)
geomean                           2.053k         10.70        -99.48%
```
