### PR TITLE
feat: gate: add a gate.Gate variant with a timeout

### DIFF
--- a/gate/gate.go
+++ b/gate/gate.go
@@ -12,6 +12,8 @@ import (
 
 var ErrMaxConcurrent = errors.New("max concurrent requests inflight")
 
+var ErrGateTimeout = errors.New("timeout waiting for concurrency gate")
+
 // Gate controls the maximum number of concurrently running and waiting queries.
 //
 // Example of use:
@@ -113,6 +115,45 @@ func (g *instrumentedGate) Start(ctx context.Context) error {
 func (g *instrumentedGate) Done() {
 	g.inflight.Dec()
 	g.gate.Done()
+}
+
+// timeoutGate returns ErrGateTimeout when the timeout is reached while still waiting for the delegate gate.
+type timeoutGate struct {
+	gate    Gate
+	timeout time.Duration
+}
+
+// NewTimeoutGate wraps a Gate implementation with one that sets a timeout on the context passed to the
+// delegated Gate.
+func NewTimeoutGate(timeout time.Duration, gate Gate) Gate {
+	return &timeoutGate{
+		gate:    gate,
+		timeout: timeout,
+	}
+}
+
+func (t *timeoutGate) Start(ctx context.Context) error {
+	if t.timeout == 0 {
+		return t.gate.Start(ctx)
+	}
+
+	// Inject our own error so that we can differentiate between a timeout caused by this gate
+	// or a timeout in the original request timeout.
+	ctx, cancel := context.WithTimeoutCause(ctx, t.timeout, ErrGateTimeout)
+	defer cancel()
+
+	err := t.gate.Start(ctx)
+	// Note that we only return an error for a timeout when the delegate has also returned an
+	// error. This ensures that when we get a slot in the delegate, our caller will call Done()
+	// and release the slot.
+	if err != nil && errors.Is(context.Cause(ctx), ErrGateTimeout) {
+		err = ErrGateTimeout
+	}
+	return err
+}
+
+func (t *timeoutGate) Done() {
+	t.gate.Done()
 }
 
 func NewRejecting(maxConcurrent int) Gate {

--- a/gate/gate_test.go
+++ b/gate/gate_test.go
@@ -98,3 +98,37 @@ func TestInstrumentedGate(t *testing.T) {
 		`), "gate_queries_in_flight"))
 	})
 }
+
+func TestTimeoutGate(t *testing.T) {
+	t.Run("timeout but eventual success", func(t *testing.T) {
+		gate := NewTimeoutGate(time.Nanosecond, &alwaysSuccessfulAfterDelayGate{time.Second})
+		err := gate.Start(context.Background())
+		require.NoError(t, err, "must not return failure if delegated gate returns success even after timeout expires")
+	})
+
+	t.Run("timeout and wrapped gate checks context", func(t *testing.T) {
+		gate := NewTimeoutGate(time.Nanosecond, &blockingInterruptibleGate{})
+		err := gate.Start(context.Background())
+		require.ErrorIs(t, err, ErrGateTimeout, "expected timeout error from delegate gate blocked on context")
+	})
+}
+
+type alwaysSuccessfulAfterDelayGate struct {
+	delay time.Duration
+}
+
+func (a alwaysSuccessfulAfterDelayGate) Start(context.Context) error {
+	<-time.After(a.delay)
+	return nil
+}
+
+func (a alwaysSuccessfulAfterDelayGate) Done() {}
+
+type blockingInterruptibleGate struct{}
+
+func (a blockingInterruptibleGate) Start(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (a blockingInterruptibleGate) Done() {}


### PR DESCRIPTION
**What this PR does**:

Add a new `gate.Gate` implementation that can timeout after waiting for an execution slot. This is a port of the same logic from Mimir.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [X] Tests updated
