### PR TITLE
perf(ring): skip token comparison in RingCompare for slices sharing storage

### DIFF
--- a/ring/model.go
+++ b/ring/model.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/gogo/protobuf/proto"
 
@@ -700,9 +701,17 @@ func (d *Desc) RingCompare(o *Desc) CompareResult {
 			return Different
 		}
 
-		for ix, t := range ing.Tokens {
-			if oing.Tokens[ix] != t {
-				return Different
+		// Consecutive ring states usually share the token slice storage for instances
+		// whose tokens didn't change: the memberlist KV store only replaces map entries
+		// of changed instances, and Desc clones share the Tokens backing arrays. When
+		// both slices point at the same storage, they are equal without comparing the
+		// elements. This is only a fast path: slices with different storage but equal
+		// content still compare as equal below.
+		if unsafe.SliceData(ing.Tokens) != unsafe.SliceData(oing.Tokens) {
+			for ix, t := range ing.Tokens {
+				if oing.Tokens[ix] != t {
+					return Different
+				}
 			}
 		}
 

--- a/ring/model_test.go
+++ b/ring/model_test.go
@@ -3,6 +3,7 @@ package ring
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -359,6 +360,42 @@ func TestDesc_RingsCompare(t *testing.T) {
 	}
 }
 
+func TestDesc_RingCompare_SharedTokenStorage(t *testing.T) {
+	tokens := []uint32{1, 2, 3}
+	d1 := &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: tokens}}}
+
+	t.Run("clone shares token storage", func(t *testing.T) {
+		d2 := d1.Clone().(*Desc)
+		assert.Equal(t, Equal, d1.RingCompare(d2))
+
+		ing := d2.Ingesters["ing1"]
+		ing.Timestamp++
+		d2.Ingesters["ing1"] = ing
+		assert.Equal(t, EqualButStatesAndTimestamps, d1.RingCompare(d2))
+	})
+
+	t.Run("same backing array, different length", func(t *testing.T) {
+		d2 := &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: tokens[:2]}}}
+		assert.Equal(t, Different, d1.RingCompare(d2))
+	})
+
+	t.Run("equal content, different storage", func(t *testing.T) {
+		d2 := &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: slices.Clone(tokens)}}}
+		assert.Equal(t, Equal, d1.RingCompare(d2))
+	})
+
+	t.Run("shared storage for unchanged instance, different tokens for changed one", func(t *testing.T) {
+		d1 := d1.Clone().(*Desc)
+		d1.Ingesters["ing2"] = InstanceDesc{Addr: "addr2", Tokens: []uint32{4, 5, 6}}
+
+		d2 := d1.Clone().(*Desc)
+		ing2 := d2.Ingesters["ing2"]
+		ing2.Tokens = []uint32{4, 5, 7}
+		d2.Ingesters["ing2"] = ing2
+		assert.Equal(t, Different, d1.RingCompare(d2))
+	})
+}
+
 func TestMergeTokens(t *testing.T) {
 	tests := map[string]struct {
 		input    [][]uint32
@@ -504,30 +541,75 @@ func TestDesc_Clone(t *testing.T) {
 	})
 }
 
+func buildBenchmarkDesc(numInstances, tokensPerInstance int) *Desc {
+	d := &Desc{Ingesters: make(map[string]InstanceDesc, numInstances)}
+	for i := 0; i < numInstances; i++ {
+		tokens := make([]uint32, tokensPerInstance)
+		for j := range tokens {
+			tokens[j] = uint32(i*tokensPerInstance + j)
+		}
+		id := fmt.Sprintf("instance-%d", i)
+		d.Ingesters[id] = InstanceDesc{
+			Addr:                fmt.Sprintf("10.0.%d.%d", i/256, i%256),
+			Timestamp:           123456,
+			State:               ACTIVE,
+			Tokens:              tokens,
+			Zone:                fmt.Sprintf("zone-%d", i%3),
+			RegisteredTimestamp: 234567,
+			Id:                  id,
+		}
+	}
+	return d
+}
+
 func BenchmarkDesc_Clone(b *testing.B) {
 	for _, numInstances := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("instances=%d", numInstances), func(b *testing.B) {
-			d := &Desc{Ingesters: make(map[string]InstanceDesc, numInstances)}
-			for i := 0; i < numInstances; i++ {
-				tokens := make([]uint32, 512)
-				for j := range tokens {
-					tokens[j] = uint32(i*512 + j)
-				}
-				id := fmt.Sprintf("instance-%d", i)
-				d.Ingesters[id] = InstanceDesc{
-					Addr:                fmt.Sprintf("10.0.%d.%d", i/256, i%256),
-					Timestamp:           123456,
-					State:               ACTIVE,
-					Tokens:              tokens,
-					Zone:                fmt.Sprintf("zone-%d", i%3),
-					RegisteredTimestamp: 234567,
-					Id:                  id,
-				}
-			}
+			d := buildBenchmarkDesc(numInstances, 512)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = d.Clone()
+			}
+		})
+	}
+}
+
+func BenchmarkDesc_RingCompare(b *testing.B) {
+	for _, numInstances := range []int{100, 1000, 10000} {
+		base := buildBenchmarkDesc(numInstances, 512)
+
+		// The common case for a memberlist watcher notification: the new state is a
+		// clone of the KV store's value where only heartbeat timestamps changed, so
+		// every instance's token slice shares its storage with the previous state.
+		heartbeat := base.Clone().(*Desc)
+		for id, ing := range heartbeat.Ingesters {
+			ing.Timestamp++
+			heartbeat.Ingesters[id] = ing
+		}
+
+		// Worst case: same ring content, but no token slice shares its storage with
+		// the previous state (e.g. states obtained from two independent decodes).
+		unshared := base.Clone().(*Desc)
+		for id, ing := range unshared.Ingesters {
+			ing.Timestamp++
+			ing.Tokens = slices.Clone(ing.Tokens)
+			unshared.Ingesters[id] = ing
+		}
+
+		b.Run(fmt.Sprintf("instances=%d/token storage=shared", numInstances), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if base.RingCompare(heartbeat) != EqualButStatesAndTimestamps {
+					b.Fatal("unexpected compare result")
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("instances=%d/token storage=unshared", numInstances), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if base.RingCompare(unshared) != EqualButStatesAndTimestamps {
+					b.Fatal("unexpected compare result")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`RingCompare` runs on every ring watcher notification and compares all tokens of all instances element-wise (512 × N on typical rings), even for pure heartbeat updates where no tokens changed. On the same profile that motivated #1038 (Mimir store-gateway, thousands of memberlist nodes), it accounted for ~6% of total service CPU. Skip the element-wise comparison when both slices point at the same backing array.

- Consecutive ring states handed to a watcher are clones of the memberlist KV store's value. The store's merge only replaces map entries of changed instances and `Desc.Clone()` shares `Tokens` backing arrays, so for unchanged instances both states reference the same storage — pointer equality (`unsafe.SliceData`) proves token equality without looking at the elements.
- Correctness doesn't depend on the sharing: slices with different storage but equal content still compare equal through the existing element-wise loop. A length mismatch is caught before the pointer check, so prefix-aliased slices are handled.
- The benchmark covers both provenances: `token storage=shared` (heartbeat-style update, the steady-state case for memberlist-backed rings) and `token storage=unshared` (independently decoded states, e.g. consul/etcd backends), which exercises the fallback.

### Benchmarks

512 tokens per instance, Apple M3 Pro (`benchstat`, n=6, interleaved runs):

```
                                                  │  before   │            after                    │
                                                  │  sec/op   │    sec/op     vs base               │
RingCompare/instances=100/token storage=shared      28.194µ ± 29%   3.553µ ± 30%  -87.40% (p=0.002 n=6)
RingCompare/instances=100/token storage=unshared     26.23µ ± 47%   26.98µ ± 24%        ~ (p=0.589 n=6)
RingCompare/instances=1000/token storage=shared     216.42µ ± 10%   31.90µ ± 18%  -85.26% (p=0.002 n=6)
RingCompare/instances=1000/token storage=unshared    200.1µ ± 44%   211.7µ ±  3%        ~ (p=0.065 n=6)
RingCompare/instances=10000/token storage=shared    3552.9µ ±  8%   264.3µ ±  7%  -92.56% (p=0.002 n=6)
RingCompare/instances=10000/token storage=unshared   3.125m ± 12%   3.483m ± 16%        ~ (p=0.180 n=6)
```

Both paths are allocation-free (0 B/op before and after).
