### PR TITLE
kv/memberlist: reap per-key workers for keys removed from the store

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -353,7 +353,7 @@ type KV struct {
 
 	// Per-key value update workers
 	workersMu       sync.Mutex
-	workersChannels map[string]chan valueUpdate
+	workersChannels map[string]*kvWorker
 
 	// closed on shutdown
 	shutdown chan struct{}
@@ -379,6 +379,7 @@ type KV struct {
 	casSuccesses                        prometheus.Counter
 	watchPrefixDroppedNotifications     *prometheus.CounterVec
 	numberOfKeyNotifications            prometheus.Gauge
+	numberOfKeyWorkers                  prometheus.GaugeFunc
 
 	storeValuesDesc        *prometheus.Desc
 	storeTombstones        *prometheus.GaugeVec
@@ -443,6 +444,19 @@ type valueUpdate struct {
 	updateTime  time.Time
 }
 
+// kvWorker is a per-key worker goroutine that processes incoming value updates
+// for a single key, one at a time, preserving per-key ordering. The maintenance
+// loop (reapObsoleteWorkers) asks an obsolete worker to retire by sending on
+// retire (buffered, size 1); the worker then removes itself from workersChannels,
+// but only while idle (see retireWorkerIfIdle). It is never removed while applying
+// an update, so there is never more than one worker per key and updates for a key
+// are never processed concurrently or out of order. This keeps goroutines from
+// accumulating for workloads that use many short-lived keys.
+type kvWorker struct {
+	ch     chan valueUpdate
+	retire chan struct{}
+}
+
 func (v ValueDesc) String() string {
 	return fmt.Sprintf("version: %d, codec: %s", v.Version, v.CodecID)
 }
@@ -471,7 +485,7 @@ func NewKV(cfg KVConfig, logger log.Logger, dnsProvider DNSProvider, registerer 
 		watchers:         make(map[string][]chan string),
 		keyNotifications: make(map[string]struct{}),
 		prefixWatchers:   make(map[string][]chan string),
-		workersChannels:  make(map[string]chan valueUpdate),
+		workersChannels:  make(map[string]*kvWorker),
 		shutdown:         make(chan struct{}),
 		maxCasRetries:    maxCasRetries,
 	}
@@ -1479,34 +1493,46 @@ func (m *KV) NotifyMsg(msg []byte) {
 		return
 	}
 
-	ch := m.getKeyWorkerChannel(kvPair.Key)
-	select {
-	case ch <- valueUpdate{value: kvPair.Value, codec: codec, messageSize: len(msg), deleted: kvPair.Deleted, updateTime: updateTime(kvPair.UpdateTimeMillis)}:
-	default:
+	update := valueUpdate{value: kvPair.Value, codec: codec, messageSize: len(msg), deleted: kvPair.Deleted, updateTime: updateTime(kvPair.UpdateTimeMillis)}
+	if !m.enqueueValueUpdate(kvPair.Key, update) {
 		m.numberOfDroppedMessages.Inc()
 		level.Warn(m.logger).Log("msg", "notify queue full, dropping message", "key", kvPair.Key)
 	}
 }
 
-func (m *KV) getKeyWorkerChannel(key string) chan<- valueUpdate {
+// enqueueValueUpdate hands an update to the per-key worker for key, spawning the
+// worker on first use, and reports whether the update was queued. The get-or-create
+// and the (non-blocking) send are done under workersMu so that they are serialized
+// against reapObsoleteWorkers: a worker cannot be reaped between the caller looking
+// it up and sending, which would otherwise drop the update onto an orphaned buffer.
+func (m *KV) enqueueValueUpdate(key string, update valueUpdate) bool {
 	m.workersMu.Lock()
 	defer m.workersMu.Unlock()
 
-	ch := m.workersChannels[key]
-	if ch == nil {
+	w := m.workersChannels[key]
+	if w == nil {
 		// spawn a key associated worker goroutine to process updates in background
-		ch = make(chan valueUpdate, m.cfg.ProcessedMessagesQueueSize)
-		go m.processValueUpdate(ch, key)
+		w = &kvWorker{
+			ch:     make(chan valueUpdate, m.cfg.ProcessedMessagesQueueSize),
+			retire: make(chan struct{}, 1),
+		}
+		go m.processValueUpdate(w, key)
 
-		m.workersChannels[key] = ch
+		m.workersChannels[key] = w
 	}
-	return ch
+
+	select {
+	case w.ch <- update:
+		return true
+	default:
+		return false
+	}
 }
 
-func (m *KV) processValueUpdate(workerCh <-chan valueUpdate, key string) {
+func (m *KV) processValueUpdate(w *kvWorker, key string) {
 	for {
 		select {
-		case update := <-workerCh:
+		case update := <-w.ch:
 			// we have a value update! Let's merge it with our current version for given key
 			mod, version, deleted, updated, err := m.mergeBytesValueForKey(key, update.value, update.codec, update.deleted, update.updateTime)
 
@@ -1538,11 +1564,41 @@ func (m *KV) processValueUpdate(workerCh <-chan valueUpdate, key string) {
 				m.broadcastNewValue(key, mod, version, update.codec, false, deleted, updated)
 			}
 
+		case <-w.retire:
+			// The maintenance loop asked this worker to retire because its key is no
+			// longer in the store. We are at the select here (not applying an update),
+			// so retiring now is safe: retireWorkerIfIdle removes us from
+			// workersChannels under workersMu only if no update is queued, guaranteeing
+			// at most one worker per key. A later update lazily spawns a new worker via
+			// enqueueValueUpdate.
+			if m.retireWorkerIfIdle(key, w) {
+				return
+			}
+
 		case <-m.shutdown:
 			// stop running on shutdown
 			return
 		}
 	}
+}
+
+// retireWorkerIfIdle removes the worker for key from workersChannels and reports
+// whether it did. It only retires an idle worker (no queued update): because both
+// this and enqueueValueUpdate hold workersMu, a send and a retire cannot interleave,
+// so no update handed to enqueueValueUpdate is ever dropped, and the removed worker
+// has nothing left to process.
+func (m *KV) retireWorkerIfIdle(key string, w *kvWorker) bool {
+	m.workersMu.Lock()
+	defer m.workersMu.Unlock()
+
+	if len(w.ch) > 0 {
+		// An update was enqueued after the retire request; keep processing it.
+		return false
+	}
+	if m.workersChannels[key] == w {
+		delete(m.workersChannels, key)
+	}
+	return true
 }
 
 // GetBroadcasts is method from Memberlist Delegate interface
@@ -1900,11 +1956,69 @@ func (m *KV) deleteSentReceivedMessages() {
 
 func (m *KV) cleanupObsoleteEntries() {
 	m.storeMu.Lock()
-	defer m.storeMu.Unlock()
-
 	for k, v := range m.store {
 		if v.Deleted && time.Since(v.UpdateTime) > m.cfg.ObsoleteEntriesTimeout {
 			delete(m.store, k)
+		}
+	}
+	m.storeMu.Unlock()
+
+	// Stop per-key workers whose key has just been removed from the store, so that
+	// workersChannels doesn't grow without bound for high-churn / short-lived keys.
+	m.reapObsoleteWorkers()
+}
+
+// reapObsoleteWorkers asks per-key worker goroutines whose key is no longer present
+// in the store to retire. A per-key worker is created on the first received update
+// for a key (see enqueueValueUpdate) and was otherwise only stopped on shutdown, so
+// workloads that use many short-lived keys would accumulate goroutines without bound.
+// The worker removes itself only while idle (see retireWorkerIfIdle), so a worker
+// that is currently applying an update is never removed and replaced by a second,
+// concurrent worker for the same key.
+//
+// workersMu and storeMu are never held at the same time: doing so would couple
+// ingestion (enqueueValueUpdate takes workersMu on every received message) to the
+// store lock, which LocalState holds for the whole state encode during push/pull.
+// Instead this runs in three phases with each lock taken independently. Because the
+// snapshot can go stale between phases, asking a worker whose key became live again
+// to retire is harmless: it retires only while idle, and a later update respawns it.
+func (m *KV) reapObsoleteWorkers() {
+	// Phase 1: snapshot the current worker keys (workersMu only).
+	m.workersMu.Lock()
+	keys := make([]string, 0, len(m.workersChannels))
+	for key := range m.workersChannels {
+		keys = append(keys, key)
+	}
+	m.workersMu.Unlock()
+
+	if len(keys) == 0 {
+		return
+	}
+
+	// Phase 2: find keys no longer present in the store (storeMu only).
+	m.storeMu.RLock()
+	obsolete := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if _, exists := m.store[key]; !exists {
+			obsolete = append(obsolete, key)
+		}
+	}
+	m.storeMu.RUnlock()
+
+	// Phase 3: ask the obsolete workers to retire (workersMu only). The worker removes
+	// itself while idle rather than being deleted here, so a worker that is currently
+	// applying an update is never removed and replaced by a second concurrent worker.
+	m.workersMu.Lock()
+	defer m.workersMu.Unlock()
+	for _, key := range obsolete {
+		w := m.workersChannels[key]
+		if w == nil {
+			continue
+		}
+		select {
+		case w.retire <- struct{}{}:
+		default:
+			// A retire request is already pending for this worker.
 		}
 	}
 }

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -374,6 +374,79 @@ func TestKV_BuildMemberlistConfig_CompressionAlgorithm(t *testing.T) {
 	}
 }
 
+func newTestKV(t *testing.T) *KV {
+	t.Helper()
+	var cfg KVConfig
+	flagext.DefaultValues(&cfg)
+	cfg.Codecs = []codec.Codec{dataCodec{}}
+	return NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
+}
+
+func newTestWorker() *kvWorker {
+	return &kvWorker{ch: make(chan valueUpdate, 1), retire: make(chan struct{}, 1)}
+}
+
+// TestReapObsoleteWorkers checks that reapObsoleteWorkers asks (only) workers whose
+// key is absent from the store to retire, and does not remove workers itself.
+func TestReapObsoleteWorkers(t *testing.T) {
+	mkv := newTestKV(t)
+
+	// "live": key present in the store -> must not be asked to retire.
+	// "obsolete": no store entry -> must be asked to retire.
+	live := newTestWorker()
+	obsolete := newTestWorker()
+
+	mkv.storeMu.Lock()
+	mkv.store["live"] = ValueDesc{}
+	mkv.storeMu.Unlock()
+
+	mkv.workersMu.Lock()
+	mkv.workersChannels["live"] = live
+	mkv.workersChannels["obsolete"] = obsolete
+	mkv.workersMu.Unlock()
+
+	mkv.reapObsoleteWorkers()
+
+	require.Len(t, obsolete.retire, 1, "worker for a key absent from the store must be asked to retire")
+	require.Len(t, live.retire, 0, "worker for a key still in the store must not be asked to retire")
+
+	// reapObsoleteWorkers does not remove workers itself; the worker retires on its
+	// own only while idle (see retireWorkerIfIdle), so nothing is removed here.
+	mkv.workersMu.Lock()
+	require.Len(t, mkv.workersChannels, 2)
+	mkv.workersMu.Unlock()
+}
+
+// TestRetireWorkerIfIdle checks that a worker removes itself only when it has no
+// queued update, so a worker that is still processing is never removed (which would
+// allow a second, concurrent worker for the same key).
+func TestRetireWorkerIfIdle(t *testing.T) {
+	mkv := newTestKV(t)
+
+	idle := newTestWorker()
+	busy := newTestWorker()
+	busy.ch <- valueUpdate{} // a queued update -> must not retire
+
+	mkv.workersMu.Lock()
+	mkv.workersChannels["idle"] = idle
+	mkv.workersChannels["busy"] = busy
+	mkv.workersMu.Unlock()
+
+	require.True(t, mkv.retireWorkerIfIdle("idle", idle), "idle worker must retire")
+	require.False(t, mkv.retireWorkerIfIdle("busy", busy), "worker with a queued update must not retire")
+
+	mkv.workersMu.Lock()
+	_, idleKept := mkv.workersChannels["idle"]
+	_, busyKept := mkv.workersChannels["busy"]
+	remaining := len(mkv.workersChannels)
+	mkv.workersMu.Unlock()
+
+	require.False(t, idleKept, "retired worker must be removed from workersChannels")
+	require.True(t, busyKept, "worker with a queued update must stay")
+	require.Equal(t, 1, remaining)
+	require.Equal(t, float64(1), testutil.ToFloat64(mkv.numberOfKeyWorkers))
+}
+
 func TestBasicGetAndCas(t *testing.T) {
 	c := dataCodec{}
 

--- a/kv/memberlist/metrics.go
+++ b/kv/memberlist/metrics.go
@@ -196,6 +196,17 @@ func (m *KV) createAndRegisterMetrics() {
 		Help:      "Number of pending notifications in WatchPrefix function",
 	})
 
+	m.numberOfKeyWorkers = promauto.With(m.registerer).NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: m.cfg.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "kv_store_key_workers",
+		Help:      "Number of per-key value-processing worker goroutines currently running. Obsolete workers are reaped after the key is removed from the store.",
+	}, func() float64 {
+		m.workersMu.Lock()
+		defer m.workersMu.Unlock()
+		return float64(len(m.workersChannels))
+	})
+
 	if m.registerer == nil {
 		return
 	}


### PR DESCRIPTION
## What this PR does

The memberlist KV client spawns one worker goroutine per distinct key on the first
received update for that key (`enqueueValueUpdate` → `processValueUpdate`), storing
them in `workersChannels`. Until now a worker was only ever stopped on shutdown, and
`workersChannels` was never pruned.

For workloads that use **many short-lived / high-cardinality keys**, the number of
worker goroutines therefore grows without bound: it tracks the number of *distinct
keys ever seen*, not the number of *live keys*. Even after a key is deleted and its
store entry removed by `cleanupObsoleteEntries` (past `ObsoleteEntriesTimeout`), its
worker goroutine lived on forever.

## Fix

Reap obsolete workers in the periodic maintenance loop. After `cleanupObsoleteEntries`
removes deleted entries from the store, `reapObsoleteWorkers` asks the workers whose
key is no longer present in the store to retire.

Care is taken to preserve the existing invariants:

- **At most one worker per key / no out-of-order updates.** The reaper only *requests*
  retirement (a non-blocking send on a per-worker `retire` channel). A worker removes
  itself from `workersChannels` via `retireWorkerIfIdle`, and only **while idle** — at
  its `select`, never while inside `mergeBytesValueForKey`. So a worker that is applying
  an update is never removed and replaced by a second, concurrent worker for the same
  key.
- **No update is lost.** `retireWorkerIfIdle` retires only when the worker has no queued
  update, and both it and `enqueueValueUpdate` (which does the get-or-create *and* the
  non-blocking send) hold `workersMu`, so a send and a retirement cannot interleave.
- **Ingestion is not coupled to the store lock.** `reapObsoleteWorkers` never holds
  `workersMu` and `storeMu` at the same time — it snapshots worker keys, checks store
  membership, and requests retirement in three separately-locked phases — so a running
  `LocalState` push/pull (which holds `storeMu` for the whole encode) can't block
  `NotifyMsg`/`enqueueValueUpdate`.

Because the snapshot can go stale between phases, a worker whose key becomes live again
may be asked to retire; that is harmless (it retires only while idle, and a later update
respawns it via `enqueueValueUpdate`).

## Observability

Adds a `kv_store_key_workers` gauge exposing the current number of per-key workers, so
operators can confirm the count stays bounded (tracking live keys rather than growing
with churn).

## Tests

- `TestReapObsoleteWorkers`: only workers whose key is absent from the store are asked
  to retire; the reaper doesn't remove workers itself.
- `TestRetireWorkerIfIdle`: a worker removes itself only when it has no queued update.
- Full `kv/memberlist` suite passes, including with `-race`.
