### PR TITLE
fix(runtimeconfig): preserve provider order in config hash

### DIFF
--- a/runtimeconfig/manager.go
+++ b/runtimeconfig/manager.go
@@ -5,12 +5,13 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -37,6 +38,11 @@ type Loader func(r io.Reader) (interface{}, error)
 
 // MapLoader loads the configuration from a map.
 type MapLoader func(m map[string]interface{}) (interface{}, error)
+
+type providerHash struct {
+	name   string
+	digest [sha256.Size]byte
+}
 
 // Config holds the config for an Manager instance.
 // It holds config related to loading per-tenant config.
@@ -89,8 +95,8 @@ type Manager struct {
 	configLoadSuccess prometheus.Gauge
 	configHash        *prometheus.GaugeVec
 
-	// Maps provider name to hash. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
-	fileHashes map[string]string
+	// Provider hashes in LoadPath order. Only used by loadConfig in Starting and Running states, so it doesn't need synchronization.
+	fileHashes []providerHash
 
 	providers []provider
 }
@@ -210,7 +216,7 @@ func (om *Manager) loop(ctx context.Context) error {
 // and notifies listeners if successful.
 func (om *Manager) loadConfig(ctx context.Context) error {
 	rawData := make([][]byte, len(om.providers))
-	hashes := map[string]string{}
+	hashes := make([]providerHash, len(om.providers))
 
 	for i, p := range om.providers {
 		buf, err := p.Read(ctx)
@@ -228,19 +234,13 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 		}
 
 		rawData[i] = buf
-		hashes[p.Name()] = fmt.Sprintf("%x", sha256.Sum256(buf))
-	}
-
-	// check if new hashes are the same as before
-	sameHashes := true
-	for name, h := range hashes {
-		if om.fileHashes[name] != h {
-			sameHashes = false
-			break
+		hashes[i] = providerHash{
+			name:   p.Name(),
+			digest: sha256.Sum256(buf),
 		}
 	}
 
-	if sameHashes {
+	if slices.Equal(om.fileHashes, hashes) {
 		// No need to rebuild runtime config.
 		om.configLoadSuccess.Set(1)
 		return nil
@@ -301,19 +301,14 @@ func (om *Manager) loadConfig(ctx context.Context) error {
 	return nil
 }
 
-func combinedFilesHash(hashes map[string]string) [sha256.Size]byte {
-	names := make([]string, 0, len(hashes))
-	for name := range hashes {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
+func combinedFilesHash(hashes []providerHash) [sha256.Size]byte {
 	h := sha256.New()
-	for _, name := range names {
-		_, _ = io.WriteString(h, name)
-		_, _ = io.WriteString(h, "=")
-		_, _ = io.WriteString(h, hashes[name])
-		_, _ = io.WriteString(h, ";")
+	var nameLength [8]byte
+	for _, providerHash := range hashes {
+		binary.BigEndian.PutUint64(nameLength[:], uint64(len(providerHash.name)))
+		_, _ = h.Write(nameLength[:])
+		_, _ = io.WriteString(h, providerHash.name)
+		_, _ = h.Write(providerHash.digest[:])
 	}
 	var out [sha256.Size]byte
 	copy(out[:], h.Sum(nil))

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -449,6 +449,17 @@ func TestCombinedFilesHash(t *testing.T) {
 		{name: "file-a", digest: digest("contents-b")},
 	}
 	require.NotEqual(t, combinedFilesHash(duplicates), combinedFilesHash([]providerHash{duplicates[1], duplicates[0]}))
+
+	t.Run("length prefix disambiguates provider sequences", func(t *testing.T) {
+		separateProviders := base[:2]
+		combinedProvider := []providerHash{{
+			// Without the name-length prefix, these sequences produce the same hash input.
+			name:   base[0].name + string(base[0].digest[:]) + base[1].name,
+			digest: base[1].digest,
+		}}
+
+		require.NotEqual(t, combinedFilesHash(separateProviders), combinedFilesHash(combinedProvider))
+	})
 }
 
 func TestOverridesManagerMultipleIncompatibleFiles(t *testing.T) {

--- a/runtimeconfig/manager_test.go
+++ b/runtimeconfig/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -330,58 +331,124 @@ func TestOverridesManagerMultipleFilesWithOverrides(t *testing.T) {
 }
 
 func TestOverridesManagerMapLoader(t *testing.T) {
-	tempFiles, err := generateRuntimeFiles(t,
-		[]string{`overrides:
+	t.Run("loads merged config", func(t *testing.T) {
+		tempFiles, err := generateRuntimeFiles(t,
+			[]string{`overrides:
   user1:
     limit1: 101`,
-			`overrides:
+				`overrides:
   user2:
     limit2: 204`})
-	require.NoError(t, err)
+		require.NoError(t, err)
 
-	reg := prometheus.NewPedanticRegistry()
-	cfg := Config{
-		ReloadPeriod: time.Second,
-		LoadPath:     generateLoadPath(tempFiles),
-		Loader: func(io.Reader) (interface{}, error) {
-			return nil, errors.New("Loader should not be called when MapLoader is set")
-		},
-		MapLoader: func(m map[string]interface{}) (interface{}, error) {
-			js, err := json.Marshal(m)
+		reg := prometheus.NewPedanticRegistry()
+		cfg := Config{
+			ReloadPeriod: time.Second,
+			LoadPath:     generateLoadPath(tempFiles),
+			Loader: func(io.Reader) (interface{}, error) {
+				return nil, errors.New("Loader should not be called when MapLoader is set")
+			},
+			MapLoader: func(m map[string]interface{}) (interface{}, error) {
+				js, err := json.Marshal(m)
+				require.NoError(t, err)
+				var o testOverrides
+				err = json.Unmarshal(js, &o)
+				require.NoError(t, err)
+				return &o, nil
+			},
+		}
+
+		overridesManager, err := New(cfg, "overrides", reg, log.NewNopLogger())
+		require.NoError(t, err)
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
+		t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager)) })
+
+		conf := overridesManager.GetConfig().(*testOverrides)
+		require.Equal(t, 101, conf.Overrides["user1"].Limit1)
+		require.Equal(t, 204, conf.Overrides["user2"].Limit2)
+
+		require.Equal(t, 1, testutil.CollectAndCount(overridesManager.configHash, "runtime_config_hash"))
+	})
+
+	t.Run("hash preserves provider order", func(t *testing.T) {
+		tempFiles, err := generateRuntimeFiles(t, []string{
+			"winner: first",
+			"winner: second",
+		})
+		require.NoError(t, err)
+
+		load := func(paths []string) (interface{}, string) {
+			reg := prometheus.NewPedanticRegistry()
+			manager, err := New(Config{
+				LoadPath: paths,
+				MapLoader: func(m map[string]interface{}) (interface{}, error) {
+					return m["winner"], nil
+				},
+			}, "overrides", reg, log.NewNopLogger())
 			require.NoError(t, err)
-			var o testOverrides
-			err = json.Unmarshal(js, &o)
-			require.NoError(t, err)
-			return &o, nil
-		},
+			require.NoError(t, manager.loadConfig(context.Background()))
+			return manager.GetConfig(), runtimeConfigHash(t, reg)
+		}
+
+		paths := generateLoadPath(tempFiles)
+		forwardConfig, forwardHash := load(paths)
+		reversedConfig, reversedHash := load([]string{paths[1], paths[0]})
+
+		require.Equal(t, "second", forwardConfig)
+		require.Equal(t, "first", reversedConfig)
+		require.NotEqual(t, forwardHash, reversedHash)
+	})
+}
+
+func runtimeConfigHash(t *testing.T, reg *prometheus.Registry) string {
+	t.Helper()
+
+	metricFamilies, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range metricFamilies {
+		if family.GetName() != "runtime_config_hash" {
+			continue
+		}
+		require.Len(t, family.Metric, 1)
+		for _, label := range family.Metric[0].Label {
+			if label.GetName() == "sha256" {
+				return label.GetValue()
+			}
+		}
 	}
 
-	overridesManager, err := New(cfg, "overrides", reg, log.NewNopLogger())
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
-	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager)) })
-
-	conf := overridesManager.GetConfig().(*testOverrides)
-	require.Equal(t, 101, conf.Overrides["user1"].Limit1)
-	require.Equal(t, 204, conf.Overrides["user2"].Limit2)
-
-	require.Equal(t, 1, testutil.CollectAndCount(overridesManager.configHash, "runtime_config_hash"))
+	t.Fatal("runtime_config_hash metric has no sha256 label")
+	return ""
 }
 
 func TestCombinedFilesHash(t *testing.T) {
-	base := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-c": "hash3"}
+	digest := func(contents string) [sha256.Size]byte {
+		return sha256.Sum256([]byte(contents))
+	}
+	base := []providerHash{
+		{name: "file-a", digest: digest("contents-a")},
+		{name: "file-b", digest: digest("contents-b")},
+		{name: "file-c", digest: digest("contents-c")},
+	}
 
-	// The hash is deterministic and independent of map insertion/iteration order.
-	reordered := map[string]string{"file-c": "hash3", "file-a": "hash1", "file-b": "hash2"}
-	require.Equal(t, combinedFilesHash(base), combinedFilesHash(reordered))
+	require.Equal(t, combinedFilesHash(base), combinedFilesHash(slices.Clone(base)))
 
-	// Changing any file's content changes the hash.
-	changedContent := map[string]string{"file-a": "hash1", "file-b": "CHANGED", "file-c": "hash3"}
+	reversed := []providerHash{base[2], base[1], base[0]}
+	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(reversed))
+
+	changedContent := slices.Clone(base)
+	changedContent[1].digest = digest("changed")
 	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedContent))
 
-	// Renaming a file changes the hash.
-	changedName := map[string]string{"file-a": "hash1", "file-b": "hash2", "file-d": "hash3"}
+	changedName := slices.Clone(base)
+	changedName[2].name = "file-d"
 	require.NotEqual(t, combinedFilesHash(base), combinedFilesHash(changedName))
+
+	duplicates := []providerHash{
+		{name: "file-a", digest: digest("contents-a")},
+		{name: "file-a", digest: digest("contents-b")},
+	}
+	require.NotEqual(t, combinedFilesHash(duplicates), combinedFilesHash([]providerHash{duplicates[1], duplicates[0]}))
 }
 
 func TestOverridesManagerMultipleIncompatibleFiles(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Follow-up to #1033 that makes the MapLoader runtime-config fingerprint respect provider order.

Runtime-config providers are merged from left to right, so reversing providers can change the effective configuration. The original MapLoader fingerprint stored source hashes in a map and sorted provider names, allowing different effective configurations to expose the same `runtime_config_hash`.

This change:

- keeps provider hashes in `LoadPath` order for reload detection and fingerprinting;
- hashes an unambiguous sequence of length-prefixed provider names and fixed-size content digests, preserving duplicate provider names;
- adds an end-to-end regression test that verifies both merge precedence and the exported hash.

MapLoader continues to receive the merged map directly without YAML re-encoding. There are no public API changes.

**Benchmarks**:

Command for each sample:

```
go test ./runtimeconfig -run '^$' -bench '^BenchmarkManagerLoadConfig/MapLoader$' -benchmem -benchtime=5x
```

Environment: Apple M4 Pro, `darwin/arm64`, six interleaved samples per revision. The same benchmark-only MapLoader harness was applied to base `a26df7e5` and head `c06088d1`; the harness is not part of this PR.

| Metric | Toni base | Head | Change |
| --- | ---: | ---: | ---: |
| Time | 96.85 ms/op | 96.46 ms/op | statistically unchanged (`p=0.818`) |
| Bytes allocated | 80.73 MiB/op | 80.70 MiB/op | statistically unchanged (`p=0.180`) |
| Allocations | 1.341M/op | 1.341M/op | about 18 fewer allocations/op (`p=0.002`) |

Validation:

- `go test ./runtimeconfig`
- `go test -race ./runtimeconfig`
- `go test ./...`
- `go vet ./runtimeconfig`
- `make lint`
- `git diff --check origin/runtimeconfig-optimize-unmarshal...HEAD`

**Which issue(s) this PR fixes**:

Follow-up to #1033.

**Checklist**
- [x] Tests updated
