### PR TITLE
perf(ring): precompute active partition lookup in PartitionRing

### DIFF
--- a/ring/partition_ring.go
+++ b/ring/partition_ring.go
@@ -34,13 +34,12 @@ type PartitionRing struct {
 	// that registered that token.
 	partitionByToken map[Token]int32
 
-	// ringPartitionIDs is a slice parallel to ringTokens, where ringPartitionIDs[i] is the
-	// partition ID that owns ringTokens[i].
-	ringPartitionIDs []int32
-
-	// ringPartitionActive is a slice parallel to ringTokens, where ringPartitionActive[i]
-	// indicates whether the partition owning ringTokens[i] is active.
-	ringPartitionActive []bool
+	// ringActivePartitionIDs is a slice parallel to ringTokens, where ringActivePartitionIDs[i]
+	// is the ID of the active partition owning keys that map to ringTokens[i], i.e. the partition
+	// owning the first token at or after position i (wrapping around the ring) that belongs to an
+	// active partition. It's precomputed so that ActivePartitionForKey() doesn't have to walk the
+	// ring to skip non-active partitions. Entries are -1 if there are no active partitions.
+	ringActivePartitionIDs []int32
 
 	// ownersByPartition is a map where the key is the partition ID and the value is a list of owner IDs.
 	ownersByPartition map[int32][]string
@@ -87,74 +86,87 @@ func NewPartitionRingWithOptions(desc PartitionRingDesc, opts PartitionRingOptio
 
 	ringTokens := desc.tokens()
 	partitionByToken := desc.partitionByToken()
-	ringPartitionIDs, ringPartitionActive, err := buildRingTokenPartitionLookups(ringTokens, partitionByToken, desc.Partitions)
+	ringActivePartitionIDs, err := buildRingActivePartitionLookup(ringTokens, partitionByToken, desc.Partitions)
 	if err != nil {
 		return nil, err
 	}
 
 	return &PartitionRing{
-		desc:                  desc,
-		ringTokens:            ringTokens,
-		partitionByToken:      partitionByToken,
-		ringPartitionIDs:      ringPartitionIDs,
-		ringPartitionActive:   ringPartitionActive,
-		ownersByPartition:     desc.ownersByPartition(),
-		activePartitionsCount: desc.activePartitionsCount(),
-		maxPartitionID:        desc.maxPartitionID(),
-		shuffleShardCache:     shuffleShardCache,
-		opts:                  opts,
+		desc:                   desc,
+		ringTokens:             ringTokens,
+		partitionByToken:       partitionByToken,
+		ringActivePartitionIDs: ringActivePartitionIDs,
+		ownersByPartition:      desc.ownersByPartition(),
+		activePartitionsCount:  desc.activePartitionsCount(),
+		maxPartitionID:         desc.maxPartitionID(),
+		shuffleShardCache:      shuffleShardCache,
+		opts:                   opts,
 	}, nil
 }
 
-// buildRingTokenPartitionLookups builds two slices parallel to ringTokens:
-// - ringPartitionIDs[i] is the partition ID that owns ringTokens[i]
-// - ringPartitionActive[i] is true if that partition is active
+// buildRingActivePartitionLookup builds a slice parallel to ringTokens, where the i-th entry
+// is the ID of the active partition owning keys that map to ringTokens[i], i.e. the partition
+// owning the first token at or after position i (wrapping around the ring) that belongs to an
+// active partition. Entries are -1 if there's no active partition with tokens in the ring.
+//
+// Precomputing the ring walk here is safe because PartitionRing is immutable, and it keeps
+// ActivePartitionForKey() to a binary search plus a single slice lookup.
 //
 // Returns ErrInconsistentTokensInfo if a token has no matching partition.
-func buildRingTokenPartitionLookups(ringTokens Tokens, partitionByToken map[Token]int32, partitions map[int32]PartitionDesc) ([]int32, []bool, error) {
-	ringPartitionIDs := make([]int32, len(ringTokens))
-	ringPartitionActive := make([]bool, len(ringTokens))
+func buildRingActivePartitionLookup(ringTokens Tokens, partitionByToken map[Token]int32, partitions map[int32]PartitionDesc) ([]int32, error) {
+	lookup := make([]int32, len(ringTokens))
+	active := make([]bool, len(ringTokens))
 
 	for i, token := range ringTokens {
 		partitionID, ok := partitionByToken[Token(token)]
 		if !ok {
-			return nil, nil, ErrInconsistentTokensInfo
+			return nil, ErrInconsistentTokensInfo
 		}
-		ringPartitionIDs[i] = partitionID
 
 		partition, ok := partitions[partitionID]
 		if !ok {
-			return nil, nil, ErrInconsistentTokensInfo
+			return nil, ErrInconsistentTokensInfo
 		}
-		ringPartitionActive[i] = partition.IsActive()
+
+		lookup[i] = partitionID
+		active[i] = partition.IsActive()
 	}
 
-	return ringPartitionIDs, ringPartitionActive, nil
+	// Find the active partition reached when walking past the last token (wrap-around).
+	// If there are no tokens owned by active partitions, every entry resolves to -1.
+	nextActiveID := int32(-1)
+	for i := range lookup {
+		if active[i] {
+			nextActiveID = lookup[i]
+			break
+		}
+	}
+
+	// Walk backwards, resolving each token owned by a non-active partition to the ID of the
+	// next active partition in the ring.
+	for i := len(lookup) - 1; i >= 0; i-- {
+		if active[i] {
+			nextActiveID = lookup[i]
+		} else {
+			lookup[i] = nextActiveID
+		}
+	}
+
+	return lookup, nil
 }
 
 // ActivePartitionForKey returns partition for the given key. Only active partitions are considered.
 // Only one partition is returned: in other terms, the replication factor is always 1.
 func (r *PartitionRing) ActivePartitionForKey(key uint32) (int32, error) {
-	var (
-		start       = searchToken(r.ringTokens, key)
-		iterations  = 0
-		tokensCount = len(r.ringTokens)
-	)
-
-	for i := start; iterations < tokensCount; i++ {
-		iterations++
-
-		if i >= tokensCount {
-			i %= tokensCount
-		}
-
-		// If the partition is not active we'll keep walking the ring.
-		if r.ringPartitionActive[i] {
-			return r.ringPartitionIDs[i], nil
-		}
+	if len(r.ringTokens) == 0 {
+		return 0, ErrNoActivePartitionFound
 	}
 
-	return 0, ErrNoActivePartitionFound
+	partitionID := r.ringActivePartitionIDs[searchToken(r.ringTokens, key)]
+	if partitionID < 0 {
+		return 0, ErrNoActivePartitionFound
+	}
+	return partitionID, nil
 }
 
 // ShuffleShardSize returns number of partitions that would be in the result of ShuffleShard call with the same size.

--- a/ring/partition_ring_test.go
+++ b/ring/partition_ring_test.go
@@ -153,22 +153,65 @@ func TestPartitionRing_ActivePartitionForKey_NoMemoryAllocations(t *testing.T) {
 }
 
 func BenchmarkPartitionRing_ActivePartitionForKey(b *testing.B) {
-	const (
-		numActivePartitions   = 100
-		numInactivePartitions = 10
-	)
+	tests := []struct {
+		numActivePartitions   int
+		numInactivePartitions int
+	}{
+		{numActivePartitions: 100, numInactivePartitions: 0},
+		{numActivePartitions: 100, numInactivePartitions: 10},
+		{numActivePartitions: 100, numInactivePartitions: 100},
+		{numActivePartitions: 1000, numInactivePartitions: 100},
+	}
 
-	ring := createPartitionRingWithPartitions(DefaultPartitionRingOptions(), numActivePartitions, numInactivePartitions, 0)
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for _, testCase := range tests {
+		b.Run(fmt.Sprintf("active=%d,inactive=%d", testCase.numActivePartitions, testCase.numInactivePartitions), func(b *testing.B) {
+			ring := createPartitionRingWithRandomTokens(DefaultPartitionRingOptions(), testCase.numActivePartitions, testCase.numInactivePartitions)
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	b.ResetTimer()
+			b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
-		_, err := ring.ActivePartitionForKey(r.Uint32())
-		if err != nil {
-			b.Fail()
+			for n := 0; n < b.N; n++ {
+				_, err := ring.ActivePartitionForKey(r.Uint32())
+				if err != nil {
+					b.Fail()
+				}
+			}
+		})
+	}
+}
+
+// createPartitionRingWithRandomTokens is like createPartitionRingWithPartitions, but partitions get
+// random tokens instead of spread-minimizing ones. Spread-minimizing token generation is too expensive
+// for benchmarks creating rings with a large number of partitions.
+func createPartitionRingWithRandomTokens(opts PartitionRingOptions, numActive, numInactive int) *PartitionRing {
+	desc := NewPartitionRingDesc()
+	gen := NewRandomTokenGeneratorWithSeed(0)
+	var takenTokens []uint32
+
+	addPartition := func(id int32, state PartitionState) {
+		tokens := gen.GenerateTokens(optimalTokensPerInstance, takenTokens)
+		takenTokens = append(takenTokens, tokens...)
+
+		desc.Partitions[id] = PartitionDesc{
+			Id:             id,
+			Tokens:         tokens,
+			State:          state,
+			StateTimestamp: time.Now().Unix(),
 		}
 	}
+
+	for i := 0; i < numActive; i++ {
+		addPartition(int32(i), PartitionActive)
+	}
+	for i := numActive; i < numActive+numInactive; i++ {
+		addPartition(int32(i), PartitionInactive)
+	}
+
+	ring, err := NewPartitionRingWithOptions(*desc, opts)
+	if err != nil {
+		panic(err)
+	}
+	return ring
 }
 
 func TestPartitionRing_ShuffleShard(t *testing.T) {


### PR DESCRIPTION
## Summary

Speed up `PartitionRing.ActivePartitionForKey()`, which sits on the distributor push path (called once per series via `ActivePartitionBatchRing`). Instead of walking the ring on every call to skip non-active partitions, resolve the walk once at construction time — `PartitionRing` is immutable, so the answer per token never changes.

- Replace the parallel `ringPartitionIDs`/`ringPartitionActive` slices with a single precomputed `ringActivePartitionIDs` slice: entry `i` is the ID of the active partition owning keys that map to `ringTokens[i]`
- `ActivePartitionForKey()` becomes a binary search plus one slice read, making it O(log n) regardless of how many non-active partitions sit between tokens (previously worst case O(n))
- Extend `BenchmarkPartitionRing_ActivePartitionForKey` with inactive-partition ratios and a 1000-partition case, using random tokens for setup since spread-minimizing generation is too slow at that scale

### Context

Found while looking at CPU profiles of Mimir distributors, where `ActivePartitionForKey` shows up for ~1.7% of total CPU. The win is concentrated where the walk actually happens, i.e. rings with a meaningful share of non-active partitions (e.g. during scale-downs):

```
                                                     │   before    │             after                  │
                                                     │   sec/op    │   sec/op     vs base               │
ActivePartitionForKey/active=100,inactive=0-11         70.13n ± 4%   68.04n ± 3%   -2.98% (p=0.041 n=10)
ActivePartitionForKey/active=100,inactive=10-11        72.04n ± 4%   71.17n ± 9%        ~ (p=0.325 n=10)
ActivePartitionForKey/active=100,inactive=100-11       90.45n ± 3%   78.55n ± 8%  -13.16% (p=0.000 n=10)
ActivePartitionForKey/active=1000,inactive=100-11      104.6n ± 4%   102.1n ± 6%        ~ (p=0.218 n=10)
```

The remaining cost is dominated by the token binary search itself. Memory per ring also shrinks slightly (one int32 slice instead of int32 + bool).

Made with [Cursor](https://cursor.com)