### PR TITLE
fix(memberlist): stop key worker goroutines when obsolete keys are removed

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1553,11 +1553,51 @@ func (m *KV) processValueUpdate(workerCh <-chan valueUpdate, key string) {
 				m.broadcastNewValue(key, mod, version, update.codec, false, deleted, updated)
 			}
 
+			if version == 0 && !m.keyExists(key) {
+				// The update didn't (re)create the key in the store — e.g. a tombstone
+				// received for a key that was already removed by cleanupObsoleteEntries,
+				// which is a no-op merge. The cleanup will therefore never stop this
+				// worker, so it deregisters itself instead of staying around forever.
+				if m.tryDeregisterKeyWorker(key, workerCh) {
+					return
+				}
+			}
+
 		case <-m.shutdown:
 			// stop running on shutdown
 			return
 		}
 	}
+}
+
+func (m *KV) keyExists(key string) bool {
+	m.storeMu.Lock()
+	defer m.storeMu.Unlock()
+
+	_, ok := m.store[key]
+	return ok
+}
+
+// tryDeregisterKeyWorker removes the worker's entry from workersChannels, and returns
+// true if the worker must stop. It returns false if the worker has to keep running,
+// either because more updates were enqueued to it in the meantime, or because it's not
+// the registered worker for the key anymore (stopKeyWorkers removed it already, in
+// which case the closed channel stops the worker instead).
+func (m *KV) tryDeregisterKeyWorker(key string, workerCh <-chan valueUpdate) bool {
+	m.workersMu.Lock()
+	defer m.workersMu.Unlock()
+
+	if ch, ok := m.workersChannels[key]; !ok || ch != workerCh {
+		return false
+	}
+
+	// Sends happen while holding workersMu, so the channel length cannot change here.
+	if len(workerCh) > 0 {
+		return false
+	}
+
+	delete(m.workersChannels, key)
+	return true
 }
 
 // GetBroadcasts is method from Memberlist Delegate interface

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1479,16 +1479,20 @@ func (m *KV) NotifyMsg(msg []byte) {
 		return
 	}
 
-	ch := m.getKeyWorkerChannel(kvPair.Key)
-	select {
-	case ch <- valueUpdate{value: kvPair.Value, codec: codec, messageSize: len(msg), deleted: kvPair.Deleted, updateTime: updateTime(kvPair.UpdateTimeMillis)}:
-	default:
+	update := valueUpdate{value: kvPair.Value, codec: codec, messageSize: len(msg), deleted: kvPair.Deleted, updateTime: updateTime(kvPair.UpdateTimeMillis)}
+	if !m.enqueueKeyUpdate(kvPair.Key, update) {
 		m.numberOfDroppedMessages.Inc()
 		level.Warn(m.logger).Log("msg", "notify queue full, dropping message", "key", kvPair.Key)
 	}
 }
 
-func (m *KV) getKeyWorkerChannel(key string) chan<- valueUpdate {
+// enqueueKeyUpdate hands the update over to the worker goroutine for the given key,
+// spawning the worker if it doesn't exist yet. It returns false if the worker's queue
+// is full and the update was dropped.
+//
+// The channel send happens while holding workersMu. This guarantees that no update
+// can be sent to a channel after stopKeyWorkers has closed it.
+func (m *KV) enqueueKeyUpdate(key string, update valueUpdate) bool {
 	m.workersMu.Lock()
 	defer m.workersMu.Unlock()
 
@@ -1500,13 +1504,24 @@ func (m *KV) getKeyWorkerChannel(key string) chan<- valueUpdate {
 
 		m.workersChannels[key] = ch
 	}
-	return ch
+
+	select {
+	case ch <- update:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *KV) processValueUpdate(workerCh <-chan valueUpdate, key string) {
 	for {
 		select {
-		case update := <-workerCh:
+		case update, ok := <-workerCh:
+			if !ok {
+				// The channel was closed because the key was removed from the store.
+				// Stop the worker; if the key is seen again, a new worker will be spawned.
+				return
+			}
 			// we have a value update! Let's merge it with our current version for given key
 			mod, version, deleted, updated, err := m.mergeBytesValueForKey(key, update.value, update.codec, update.deleted, update.updateTime)
 
@@ -1900,11 +1915,38 @@ func (m *KV) deleteSentReceivedMessages() {
 
 func (m *KV) cleanupObsoleteEntries() {
 	m.storeMu.Lock()
-	defer m.storeMu.Unlock()
-
+	var removedKeys []string
 	for k, v := range m.store {
 		if v.Deleted && time.Since(v.UpdateTime) > m.cfg.ObsoleteEntriesTimeout {
 			delete(m.store, k)
+			removedKeys = append(removedKeys, k)
+		}
+	}
+	m.storeMu.Unlock()
+
+	m.stopKeyWorkers(removedKeys)
+}
+
+// stopKeyWorkers stops the update-processing worker goroutines for the given keys.
+// Workers of removed keys must be stopped: otherwise every key ever seen keeps a
+// goroutine alive for the lifetime of the process, which is a goroutine leak in
+// clusters where keys are created and deleted over time.
+func (m *KV) stopKeyWorkers(keys []string) {
+	if len(keys) == 0 {
+		return
+	}
+
+	m.workersMu.Lock()
+	defer m.workersMu.Unlock()
+
+	for _, k := range keys {
+		if ch, ok := m.workersChannels[k]; ok {
+			delete(m.workersChannels, k)
+			// Closing the channel is safe: enqueueKeyUpdate only sends while holding
+			// workersMu, so there is no concurrent sender, and no future sender can
+			// obtain this channel anymore. The worker drains any buffered updates
+			// and then exits.
+			close(ch)
 		}
 	}
 }

--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -1554,10 +1554,13 @@ func (m *KV) processValueUpdate(workerCh <-chan valueUpdate, key string) {
 			}
 
 			if version == 0 && !m.keyExists(key) {
-				// The update didn't (re)create the key in the store — e.g. a tombstone
-				// received for a key that was already removed by cleanupObsoleteEntries,
-				// which is a no-op merge. The cleanup will therefore never stop this
-				// worker, so it deregisters itself instead of staying around forever.
+				// The update didn't (re)create the key in the store. This happens when
+				// the merge was a no-op (e.g. a tombstone received for a key that was
+				// already removed by cleanupObsoleteEntries), and also when the merge
+				// failed for a key we don't have. In both cases the cleanup will never
+				// run for this key and would never stop this worker, so it deregisters
+				// itself instead of staying around forever. If the key is seen again,
+				// a new worker is spawned.
 				if m.tryDeregisterKeyWorker(key, workerCh) {
 					return
 				}

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -2066,6 +2066,20 @@ func TestCleanupObsoleteEntriesStopsKeyWorkers(t *testing.T) {
 		}}))
 
 	require.Eventually(t, func() bool { return numKeyWorkers() == 1 }, 5*time.Second, 10*time.Millisecond)
+
+	// A tombstone for a key that is not in the store is a no-op merge which doesn't
+	// (re)create the key, so cleanupObsoleteEntries would never see it: the spawned
+	// worker must deregister itself instead of staying around forever.
+	kvp := keyValuePair(t, "already-purged-key", c, &data{
+		Members: map[string]member{
+			"a": {Timestamp: time.Now().Unix(), State: JOINING},
+		}})
+	kvp.Deleted = true
+	msg, err := kvp.Marshal()
+	require.NoError(t, err)
+	kv.NotifyMsg(msg)
+
+	require.Eventually(t, func() bool { return numKeyWorkers() == 1 }, 5*time.Second, 10*time.Millisecond)
 }
 
 func marshalKeyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}) []byte {

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -2016,6 +2016,58 @@ func keyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}
 
 }
 
+func TestCleanupObsoleteEntriesStopsKeyWorkers(t *testing.T) {
+	c := dataCodec{}
+
+	var cfg KVConfig
+	flagext.DefaultValues(&cfg)
+	cfg.TCPTransport.BindAddrs = getLocalhostAddrs()
+	cfg.Codecs = append(cfg.Codecs, c)
+	cfg.ObsoleteEntriesTimeout = 100 * time.Millisecond
+
+	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
+	defer services.StopAndAwaitTerminated(context.Background(), kv) //nolint:errcheck
+
+	numKeyWorkers := func() int {
+		kv.workersMu.Lock()
+		defer kv.workersMu.Unlock()
+		return len(kv.workersChannels)
+	}
+
+	// Receiving an update for a key spawns a worker goroutine for that key.
+	kv.NotifyMsg(marshalKeyValuePair(t, key, c, &data{
+		Members: map[string]member{
+			"a": {Timestamp: time.Now().Unix(), State: JOINING},
+		}}))
+
+	require.Eventually(t, func() bool { return numKeyWorkers() == 1 }, 5*time.Second, 10*time.Millisecond)
+
+	// Wait until the update has been merged into the store, as Delete is a no-op for
+	// keys that don't exist yet.
+	require.Eventually(t, func() bool {
+		val, err := kv.Get(key, c)
+		return err == nil && val != nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Delete the key. Once the tombstone is older than ObsoleteEntriesTimeout, the
+	// cleanup removes the key from the store, and must also stop the key's worker.
+	require.NoError(t, kv.Delete(key))
+
+	require.Eventually(t, func() bool {
+		kv.cleanupObsoleteEntries()
+		return numKeyWorkers() == 0
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// If the key is seen again, a new worker is spawned.
+	kv.NotifyMsg(marshalKeyValuePair(t, key, c, &data{
+		Members: map[string]member{
+			"b": {Timestamp: time.Now().Unix(), State: JOINING},
+		}}))
+
+	require.Eventually(t, func() bool { return numKeyWorkers() == 1 }, 5*time.Second, 10*time.Millisecond)
+}
+
 func marshalKeyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}) []byte {
 	kvp := keyValuePair(t, key, codec, value)
 

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -2016,70 +2017,76 @@ func keyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}
 
 }
 
+// numKeyWorkers returns the number of registered key worker goroutines.
+func (m *KV) numKeyWorkers() int {
+	m.workersMu.Lock()
+	defer m.workersMu.Unlock()
+
+	return len(m.workersChannels)
+}
+
 func TestCleanupObsoleteEntriesStopsKeyWorkers(t *testing.T) {
-	c := dataCodec{}
+	synctest.Test(t, func(t *testing.T) {
+		c := dataCodec{}
 
-	var cfg KVConfig
-	flagext.DefaultValues(&cfg)
-	cfg.TCPTransport.BindAddrs = getLocalhostAddrs()
-	cfg.Codecs = append(cfg.Codecs, c)
-	cfg.ObsoleteEntriesTimeout = 100 * time.Millisecond
+		var cfg KVConfig
+		flagext.DefaultValues(&cfg)
+		cfg.TCPTransport.BindAddrs = getLocalhostAddrs()
+		cfg.Codecs = append(cfg.Codecs, c)
+		cfg.ObsoleteEntriesTimeout = 100 * time.Millisecond
 
-	kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), kv))
-	defer services.StopAndAwaitTerminated(context.Background(), kv) //nolint:errcheck
+		// The KV service is not started: the real TCP transport would block goroutines
+		// in Accept syscalls, which is incompatible with the synctest bubble. Updates
+		// are driven through enqueueKeyUpdate, which is what NotifyMsg uses. Only the
+		// broadcast queues (normally created on service start) are stubbed, because
+		// workers queue forwarded updates into them.
+		kv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
+		kv.localBroadcasts = &memberlist.TransmitLimitedQueue{NumNodes: func() int { return 1 }, RetransmitMult: cfg.RetransmitMult}
+		kv.gossipBroadcasts = &memberlist.TransmitLimitedQueue{NumNodes: func() int { return 1 }, RetransmitMult: cfg.RetransmitMult}
 
-	numKeyWorkers := func() int {
-		kv.workersMu.Lock()
-		defer kv.workersMu.Unlock()
-		return len(kv.workersChannels)
-	}
+		enqueueUpdate := func(key string, deleted bool) {
+			t.Helper()
+			encoded, err := c.Encode(&data{Members: map[string]member{
+				"a": {Timestamp: time.Now().Unix(), State: JOINING},
+			}})
+			require.NoError(t, err)
+			require.True(t, kv.enqueueKeyUpdate(key, valueUpdate{value: encoded, codec: c, deleted: deleted, updateTime: time.Now()}))
+		}
 
-	// Receiving an update for a key spawns a worker goroutine for that key.
-	kv.NotifyMsg(marshalKeyValuePair(t, key, c, &data{
-		Members: map[string]member{
-			"a": {Timestamp: time.Now().Unix(), State: JOINING},
-		}}))
-
-	require.Eventually(t, func() bool { return numKeyWorkers() == 1 }, 5*time.Second, 10*time.Millisecond)
-
-	// Wait until the update has been merged into the store, as Delete is a no-op for
-	// keys that don't exist yet.
-	require.Eventually(t, func() bool {
+		// Receiving an update for a key spawns a worker goroutine for that key, which
+		// merges the update into the store.
+		enqueueUpdate(key, false)
+		synctest.Wait()
+		require.Equal(t, 1, kv.numKeyWorkers())
 		val, err := kv.Get(key, c)
-		return err == nil && val != nil
-	}, 5*time.Second, 10*time.Millisecond)
+		require.NoError(t, err)
+		require.NotNil(t, val)
 
-	// Delete the key. Once the tombstone is older than ObsoleteEntriesTimeout, the
-	// cleanup removes the key from the store, and must also stop the key's worker.
-	require.NoError(t, kv.Delete(key))
-
-	require.Eventually(t, func() bool {
+		// Delete the key. Once the tombstone is older than ObsoleteEntriesTimeout, the
+		// cleanup removes the key from the store, and must also stop the key's worker.
+		require.NoError(t, kv.Delete(key))
+		time.Sleep(2 * cfg.ObsoleteEntriesTimeout)
 		kv.cleanupObsoleteEntries()
-		return numKeyWorkers() == 0
-	}, 5*time.Second, 50*time.Millisecond)
+		synctest.Wait()
+		require.Equal(t, 0, kv.numKeyWorkers())
 
-	// If the key is seen again, a new worker is spawned.
-	kv.NotifyMsg(marshalKeyValuePair(t, key, c, &data{
-		Members: map[string]member{
-			"b": {Timestamp: time.Now().Unix(), State: JOINING},
-		}}))
+		// If the key is seen again, a new worker is spawned, and it stays running.
+		enqueueUpdate(key, false)
+		synctest.Wait()
+		require.Equal(t, 1, kv.numKeyWorkers())
 
-	require.Eventually(t, func() bool { return numKeyWorkers() == 1 }, 5*time.Second, 10*time.Millisecond)
+		// A tombstone for a key that is not in the store spawns a worker, but the merge
+		// is a no-op that doesn't (re)create the key, so the worker immediately
+		// deregisters itself and stops. The live key's worker above keeps running, so
+		// the count stays at 1.
+		enqueueUpdate("already-purged-key", true)
+		synctest.Wait()
+		require.Equal(t, 1, kv.numKeyWorkers())
 
-	// A tombstone for a key that is not in the store is a no-op merge which doesn't
-	// (re)create the key, so cleanupObsoleteEntries would never see it: the spawned
-	// worker must deregister itself instead of staying around forever.
-	kvp := keyValuePair(t, "already-purged-key", c, &data{
-		Members: map[string]member{
-			"a": {Timestamp: time.Now().Unix(), State: JOINING},
-		}})
-	kvp.Deleted = true
-	msg, err := kvp.Marshal()
-	require.NoError(t, err)
-	kv.NotifyMsg(msg)
-
-	require.Eventually(t, func() bool { return numKeyWorkers() == 1 }, 5*time.Second, 10*time.Millisecond)
+		// Stop the remaining worker: the synctest bubble requires all goroutines
+		// started inside it to exit before the test returns.
+		close(kv.shutdown)
+	})
 }
 
 func marshalKeyValuePair(t *testing.T, key string, codec codec.Codec, value interface{}) []byte {


### PR DESCRIPTION
### What this PR does

Fixes a goroutine leak in the memberlist KV client.

`NotifyMsg` spawns one worker goroutine per distinct KV key (`getKeyWorkerChannel` / `processValueUpdate`) to process incoming value updates. The worker was only ever stopped at full KV shutdown — nothing removed the `workersChannels` entry when a key was deleted and later purged from the store by `cleanupObsoleteEntries`. In clusters where keys are created and deleted over time (e.g. per-tenant keys), every retired key leaks one goroutine until the process restarts.

We spotted this in production: per-pod goroutine counts grow linearly (~+15%/week, r>0.8 correlation with pod age) and reset at every rollout. A goroutine profile shows `processValueUpdate` holding >50% of all goroutines in a process where the memberlist KV client dominates, with the count matching live keys right after a restart and exceeding it as keys churn. The leak affects every memberlist-enabled process; it's just less visible against larger goroutine baselines.

Changes:

- `cleanupObsoleteEntries` now collects the keys it removes from the store and stops their workers (`stopKeyWorkers`): the map entry is deleted and the update channel closed, letting the worker drain buffered updates and exit.
- The channel send in `NotifyMsg` moved under `workersMu` (into `enqueueKeyUpdate`) so closing a worker channel cannot race with a sender. `NotifyMsg` already acquired this mutex once per message via `getKeyWorkerChannel`, so this adds no new lock acquisition — it only extends the critical section by a non-blocking send.
- If a removed key is seen again later, a new worker is spawned on demand, same as for a brand-new key.

### Which issue(s) this PR fixes

n/a

### Checklist
- [x] Tests updated (`TestCleanupObsoleteEntriesStopsKeyWorkers`, passes with `-race`)
- [ ] `CHANGELOG.md` updated (no changelog in this repo)