### PR TITLE
fix(memberlist): don't track zone-aware routing skips while joining

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -323,8 +323,9 @@ type KV struct {
 	localBroadcasts  *memberlist.TransmitLimitedQueue // queue for messages generated locally
 	gossipBroadcasts *memberlist.TransmitLimitedQueue // queue for messages that we forward from other nodes
 
-	// Node metadata for zone-aware routing (nil if zone-aware routing is disabled).
-	nodeMeta []byte
+	// Node metadata and node selection delegate for zone-aware routing (nil if it's disabled).
+	nodeMeta            []byte
+	zoneAwareNodeSelect *zoneAwareNodeSelectionDelegate
 
 	// KV Store.
 	storeMu sync.RWMutex
@@ -587,7 +588,8 @@ func (m *KV) configureZoneAwareRouting(mlCfg *memberlist.Config) error {
 	m.nodeMeta = localMeta
 
 	// Set up the node selection delegate.
-	mlCfg.NodeSelection = newZoneAwareNodeSelectionDelegate(role, m.cfg.ZoneAwareRouting.Zone, m.logger, m.registerer)
+	m.zoneAwareNodeSelect = newZoneAwareNodeSelectionDelegate(role, m.cfg.ZoneAwareRouting.Zone, m.logger, m.registerer)
+	mlCfg.NodeSelection = m.zoneAwareNodeSelect
 
 	// The bridge always prefer another bridge as first node. If the bridge only push/pull to 1 node per interval, then
 	// it will only communicate to bridges, potentially leading to network partitioning if the gossiping is not
@@ -666,6 +668,11 @@ func (m *KV) running(ctx context.Context) error {
 	}
 
 	ok := m.joinMembersOnStartup(ctx)
+
+	if m.zoneAwareNodeSelect != nil {
+		m.zoneAwareNodeSelect.markJoined()
+	}
+
 	if !ok && m.cfg.AbortIfJoinFails {
 		return errFailedToJoinCluster
 	}

--- a/kv/memberlist/node_zone_aware_routing.go
+++ b/kv/memberlist/node_zone_aware_routing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/memberlist"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
 )
 
 // NodeRole represents the role of a node in the memberlist cluster.
@@ -90,6 +91,9 @@ type zoneAwareNodeSelectionDelegate struct {
 	localZone string
 	logger    log.Logger
 
+	// Set once the local node has finished its initial cluster join attempt.
+	joined atomic.Bool
+
 	// Metrics
 	selectNodesCalls        prometheus.Counter
 	selectNodesCallsSkipped prometheus.Counter
@@ -112,6 +116,21 @@ func newZoneAwareNodeSelectionDelegate(localRole NodeRole, localZone string, log
 	}
 }
 
+// markJoined is called when the local node has finished its initial cluster join attempt.
+func (d *zoneAwareNodeSelectionDelegate) markJoined() {
+	d.joined.Store(true)
+}
+
+// skipZoneAwareRouting selects all nodes. The skip metric is not increased
+// while the local node is still joining, because until then it's caused by an
+// incomplete view of the cluster.
+func (d *zoneAwareNodeSelectionDelegate) skipZoneAwareRouting(nodes []*memberlist.NodeState) ([]*memberlist.NodeState, *memberlist.NodeState) {
+	if d.joined.Load() {
+		d.selectNodesCallsSkipped.Inc()
+	}
+	return nodes, nil
+}
+
 // SelectNodes implements memberlist.NodeSelectionDelegate.
 // It determines which remote nodes should be selected for gossip operations and which one should be preferred.
 func (d *zoneAwareNodeSelectionDelegate) SelectNodes(nodes []*memberlist.NodeState) (selected []*memberlist.NodeState, preferred *memberlist.NodeState) {
@@ -123,8 +142,7 @@ func (d *zoneAwareNodeSelectionDelegate) SelectNodes(nodes []*memberlist.NodeSta
 
 	// Skip zone-aware routing if local zone is not set.
 	if d.localZone == "" {
-		d.selectNodesCallsSkipped.Inc()
-		return nodes, nil
+		return d.skipZoneAwareRouting(nodes)
 	}
 
 	// Pre-allocate backing arrays on the stack for up to 5 zones (common case).
@@ -176,9 +194,8 @@ func (d *zoneAwareNodeSelectionDelegate) SelectNodes(nodes []*memberlist.NodeSta
 	// This prevents network partitioning when bridges are missing or dead.
 	for _, zone := range zonesWithMembers {
 		if !slices.Contains(zonesWithAliveBridges, zone) {
-			d.selectNodesCallsSkipped.Inc()
 			level.Warn(d.logger).Log("msg", "memberlist zone-aware routing is skipped because a zone has no alive bridge", "zone", zone)
-			return nodes, nil
+			return d.skipZoneAwareRouting(nodes)
 		}
 	}
 

--- a/kv/memberlist/node_zone_aware_routing_test.go
+++ b/kv/memberlist/node_zone_aware_routing_test.go
@@ -129,6 +129,13 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 		}
 	}
 
+	// Helper function to create a delegate which has finished joining the cluster.
+	newJoinedDelegate := func(localRole NodeRole, localZone string, registerer prometheus.Registerer) *zoneAwareNodeSelectionDelegate {
+		delegate := newZoneAwareNodeSelectionDelegate(localRole, localZone, log.NewNopLogger(), registerer)
+		delegate.markJoined()
+		return delegate
+	}
+
 	// Helper function to check if a node is in the selected slice.
 	containsNode := func(nodes []*memberlist.NodeState, name string) bool {
 		for _, n := range nodes {
@@ -141,7 +148,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("local node is member", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "zone-a", reg)
 
 		nodes := []*memberlist.NodeState{
 			createNode(t, "member-zone-a", NodeRoleMember, "zone-a"), // Same zone member: selected, not preferred.
@@ -171,7 +178,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("local node is bridge", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleBridge, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleBridge, "zone-a", reg)
 
 		nodes := []*memberlist.NodeState{
 			createNode(t, "member-zone-a", NodeRoleMember, "zone-a"), // Same zone member: selected, not preferred.
@@ -204,7 +211,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("local node has empty zone", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "", reg)
 
 		nodes := []*memberlist.NodeState{
 			createNode(t, "member-zone-a", NodeRoleMember, "zone-a"), // Selected, not preferred.
@@ -226,7 +233,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("node with empty metadata", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "zone-a", reg)
 
 		// Node with no metadata (empty Meta field).
 		nodes := []*memberlist.NodeState{
@@ -250,7 +257,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("node with invalid metadata", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "zone-a", reg)
 
 		// Node with invalid metadata (too short).
 		nodes := []*memberlist.NodeState{
@@ -275,7 +282,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("empty input", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleBridge, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleBridge, "zone-a", reg)
 
 		selected, preferred := delegate.SelectNodes(nil)
 		assert.Empty(t, selected)
@@ -292,7 +299,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("skip zone-aware routing when zone has no alive bridge", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "zone-a", reg)
 
 		// Zone-b has members but no alive bridge (bridge is dead).
 		nodes := []*memberlist.NodeState{
@@ -316,7 +323,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("skip zone-aware routing when zone has no bridge at all", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "zone-a", reg)
 
 		// Zone-b has members but no bridge.
 		nodes := []*memberlist.NodeState{
@@ -338,7 +345,7 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 
 	t.Run("skip zone-aware routing when bridge is suspect", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "zone-a", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "zone-a", reg)
 
 		// Zone-b has members but bridge is suspect.
 		nodes := []*memberlist.NodeState{
@@ -360,13 +367,40 @@ func TestZoneAwareNodeSelectionDelegate_SelectNodes(t *testing.T) {
 		assert.Equal(t, float64(1), testutil.ToFloat64(delegate.selectNodesCallsSkipped))
 	})
 
+	t.Run("do not track skipped zone-aware routing while the local node is still joining the cluster", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "zone-a", log.NewNopLogger(), reg)
+
+		// Zone-b has been discovered, but not its bridge yet.
+		nodes := []*memberlist.NodeState{
+			createNode(t, "member-zone-a", NodeRoleMember, "zone-a"),
+			createNode(t, "bridge-zone-a", NodeRoleBridge, "zone-a"),
+			createNode(t, "member-zone-b", NodeRoleMember, "zone-b"),
+		}
+
+		selected, preferred := delegate.SelectNodes(nodes)
+
+		// Zone-aware routing is skipped, but not tracked.
+		assert.Len(t, selected, 3)
+		assert.Nil(t, preferred)
+		assert.Equal(t, float64(1), testutil.ToFloat64(delegate.selectNodesCalls))
+		assert.Equal(t, float64(0), testutil.ToFloat64(delegate.selectNodesCallsSkipped))
+
+		// Once joined, the very same call is tracked.
+		delegate.markJoined()
+		delegate.SelectNodes(nodes)
+
+		assert.Equal(t, float64(2), testutil.ToFloat64(delegate.selectNodesCalls))
+		assert.Equal(t, float64(1), testutil.ToFloat64(delegate.selectNodesCallsSkipped))
+	})
+
 	t.Run("zone names ending with digits", func(t *testing.T) {
 		// This test verifies that zone names ending with non-alphabetic characters
 		// (like digits) don't cause a panic in containsZone(). Zone names like
 		// "us-east-1" have a last character ('1') with ASCII value less than 'a',
 		// which could cause a negative index if not handled properly.
 		reg := prometheus.NewRegistry()
-		delegate := newZoneAwareNodeSelectionDelegate(NodeRoleMember, "us-east-1", log.NewNopLogger(), reg)
+		delegate := newJoinedDelegate(NodeRoleMember, "us-east-1", reg)
 
 		nodes := []*memberlist.NodeState{
 			createNode(t, "member-us-east-1", NodeRoleMember, "us-east-1"),
@@ -556,6 +590,7 @@ func BenchmarkZoneAwareNodeSelectionDelegate_SelectNodes(b *testing.B) {
 	// Create a delegate for a bridge node in zone-a.
 	// Pass nil registerer to avoid metric registration overhead in benchmarks.
 	delegate := newZoneAwareNodeSelectionDelegate(NodeRoleBridge, "zone-a", log.NewNopLogger(), nil)
+	delegate.markJoined()
 
 	// Helper function to create a node with metadata.
 	createNode := func(name string, role NodeRole, zone string, state memberlist.NodeStateType) *memberlist.NodeState {


### PR DESCRIPTION
## what
don't increase `memberlist_client_zone_aware_routing_select_nodes_skipped_total` while the local node is still joining the cluster.

## why
a just-started node hasn't discovered every zone's bridge yet, so it skips zone-aware routing for a few seconds. that's expected, but the metric can't tell it apart from a real bridge outage.

during a rollout there's always some node in that state, so `sum(rate(..._skipped_total[...])) > 0` never returns to zero and `MimirMemberlistZoneAwareRoutingAutoFailover` fires for the whole rollout. saw it flap for over an hour on a mimir cell today, with all bridges healthy the entire time.

## notes
the failover behaviour is unchanged, only the metric is gated. the gate opens after the join attempt whether it succeeded or not, so a node that fails to join doesn't hide its failovers forever.