### PR TITLE
feat(retry): add retry package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ services, including:
  - [Hedging](https://github.com/grafana/dskit/tree/main/hedging), sending extra duplicate requests to improve the chance that one succeeds.
  - A common [key-value](https://github.com/grafana/dskit/tree/main/kv) API, implemented for Consul, Etcd and Memberlist.
  - RPC [middlewares](https://github.com/grafana/dskit/tree/main/middleware), for metrics, logging, etc.
+ - A [retry](https://github.com/grafana/dskit/tree/main/retry) executor, pairing a jittered backoff schedule with per-error retry decisions and metrics.
  - A [services model](https://github.com/grafana/dskit/tree/main/services), to manage start-up and shut-down.
 
 ## Current state

--- a/retry/README.md
+++ b/retry/README.md
@@ -1,0 +1,206 @@
+# retry
+
+Run an operation again until:
+ - it succeeds
+ - the decider gives up on a failure
+ - the attempt budget is spent
+ - the context is done.
+
+The package owns the *mechanism*: an executor, a source of delays, a convention
+for marking errors, and metrics. Deciding what to retry is left to the user.
+
+```go
+err := retry.Retry(ctx, client.Sync, retry.WithPredicate(isTransient))
+```
+
+Runnable examples can be found in [`example_test.go`](example_test.go).
+
+## Deciding what to retry
+
+Every failed attempt is handed to a decider, which says whether another attempt
+has a chance. There are multiple ways to implement that policy, to be chosen by the user.
+
+One way would be to mark the error where it is produced:
+
+```go
+err := retry.Retry(ctx, func(ctx context.Context) error {
+	resp, err := c.send(ctx)
+	if err != nil {
+		return retry.MarkRetryable(err) // retry send errors
+	}
+	// ...
+
+	if resp.StatusCode < 400 {
+		return nil // success
+	}
+
+	statusErr := fmt.Errorf("sync: unexpected status %d", resp.StatusCode)
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return retry.MarkRetryableAfter(statusErr, parseRetryAfter(resp.Header))
+	case resp.StatusCode >= 500:
+		return retry.MarkRetryable(statusErr)
+	default:
+		return statusErr // 4xx: the request itself is wrong: don't retry, leave unmarked
+	}
+})
+```
+
+The knowledge of whether a failure is transient lives at the point of failure.
+
+The default decider is `retry.Marked`, which reports whether an error is marked as
+retryable; unmarked errors are non-retryable, so they get exactly one attempt.
+
+`MarkRetryableAfter` is for the cases where the server sets a lower bound on the next
+delay: the loop then waits `max(backoff delay, after)`. To guard against a very long
+`Retry-After`, use a bounded context.
+
+Another way would be to use a `func(error) bool` that can be wired straight in:
+
+```go
+retry.WithPredicate(isRetryableAPIError)
+retry.WithPredicate(func(error) bool { return true }) // retry everything; the budget and ctx are the bounds
+```
+
+The last and more customizable way is using `WithDecider`. It returns `Decision{Retryable, After}` so
+that policy can also raise the delay before the next attempt, typically a server's
+`Retry-After` (check `ExampleWithDecider`).
+
+The zero `Decision` gives up, so a decider that does not recognize an error
+fails closed. That is the safe choice for work that is not idempotent. Reach for
+a permissive predicate on read paths and start-up loops where not retrying is the
+worse failure mode.
+
+Marks and a call-site decider combine with a plain `if` (`ExampleMarked`), so a
+call site that mixes its own marked errors with errors from a library it does not
+own needs no combinator.
+
+The package ships no built-in decider for HTTP or gRPC for now, but adding them in
+the future could be considered.
+
+## Backoffs and the budget
+
+A `Backoff` says how long to wait after a given attempt; `WithMaxAttempts` says
+how many attempts there are.
+
+```go
+type Backoff func(attempts int) time.Duration
+```
+
+`attempts` starts at `1`, after the first failure. Four backoffs are
+built in, and `Jittered` spreads any of them:
+
+```go
+retry.Exponential(time.Second, 2, time.Minute) // Each attempt increases exponentially
+retry.Linear(time.Second, 1, time.Minute)      // Each attempt increases linearly
+retry.Uniform(0, 500*time.Millisecond)         // [min, max)
+retry.Constant(500 * time.Millisecond)         // Each attempt waits for the same duration
+
+retry.Jittered(retry.Exponential(time.Second, 2, time.Minute), 0.5)
+```
+
+`Jittered` shortens each delay by up to `fraction` of itself, drawn uniformly, so
+that callers that failed together do not retry together:
+
+| `fraction` | delay once the backoff reaches `max` |
+|---|---|
+| `0` | exactly `max` |
+| `0.5` | uniform over `[max/2, max]` |
+| `1` | uniform over `[0, max]` |
+
+The default backoff is
+`Jittered(Exponential(100*time.Millisecond, 2, 10*time.Second), 0.5)`.
+
+The budget is how many attempts an operation gets in total, the first one included:
+
+```go
+retry.WithMaxAttempts(3)      // three attempts in total, initial + 2 retries
+retry.WithUnlimitedAttempts() // until success or ctx error
+```
+
+The default budget is `10`, and no value of `n` turns it off by accident:
+an explicit `WithUnlimitedAttempts` is the only way to do that.
+
+## Reusing a Retrier
+
+`retry.New` binds a set of options once, and the returned `*Retrier` runs any
+number of concurrent operations under them (`ExampleNew`). Prefer it to the
+package-level `retry.Retry(ctx, fn, opts...)` whenever the same options serve more
+than one call: `retry.Retry` is shorthand for `retry.New(opts...).Retry(ctx, fn)`,
+so it rebuilds the options every time.
+
+## Options and defaults
+
+Options apply in order, so a later one overrides an earlier one, and passing `nil` to
+an option restores that option's default. The one worth knowing is `WithBackoff(nil)`:
+it gives you the default jittered exponential backoff rather than no waits at all,
+because retrying with no delay is a hot loop against a dependency that is already
+failing. Ask for that explicitly with `retry.Constant(0)`.
+
+This package registers no flags and reads no YAML for now. Turning the knobs a component
+exposes into `retry.Option`s is that component's job.
+
+## Metrics
+
+By default, metrics are turned off, so passing no `WithMetrics`, or a nil `*Metrics`, records
+nothing. Since Prometheus panics on duplicate registration it is recommended to build them once
+per registry and pass them to every `Retrier` reporting to it:
+
+```go
+metrics := retry.NewMetrics(prometheus.WrapRegistererWithPrefix("mycomponent_", reg))
+retry.Retry(ctx, func(_ context.Context) error { return nil }, retry.WithMetrics(metrics))
+```
+
+Names are unprefixed, so the caller owns the prefix, as above.
+
+| Metric | Type | Labels | Answers |
+|---|---|---|---|
+| `retry_attempts_total` | counter | `operation` | are we retrying more than usual |
+| `retry_duration_seconds` | histogram | `operation`, `outcome` | **is retrying helping**, and what it costs |
+
+Every call reports exactly one `outcome`: `first_attempt`, `after_retry`,
+`terminal`, `exhausted`, `deadline` (the next delay would have outlasted the
+deadline) or `cancelled` (the context ended). Exactly one observation goes in per
+completed operation, so `retry_duration_seconds_count` counts operations by how
+they ended.
+
+That makes the ratio `after_retry / (after_retry + exhausted)` the answer to whether
+retrying is helping or only adding load, and the buckets the answer to what it costs.
+Both are what to read when tuning a backoff or a budget.
+
+The span measured is the whole of the caller's wait on `Retry`.
+
+Weigh the cost before instrumenting a component with many operations: 13
+buckets plus `_sum` and `_count` is 15 series per `outcome`, and `outcome`
+has 6 values, so each operation is on the order of ~90 series.
+
+## Exhaustion and nesting
+
+The context is passed to your function unchanged and bounds the whole loop, waits
+included. A wait that would outlast its deadline is not served out, because no
+attempt could follow it. A context that is already done gets no attempt at all.
+
+When the loop stops for a reason of its own, the returned error wraps two things, why
+it stopped and the last failure, and both are reachable with `errors.Is`. Only a
+terminal decision hands the failure back untouched:
+
+```go
+if errors.Is(err, retry.ErrExhausted) { ... }
+```
+
+| How the loop ended        | Returned error wraps                                            |
+|---------------------------|-----------------------------------------------------------------|
+| a spent budget            | `retry.ErrExhausted`, and the last failure                       |
+| an unfulfillable deadline | `context.DeadlineExceeded`, and the last failure                 |
+| an ended context          | `context.Cause(ctx)`, and the last failure if there was one      |
+| the decider gave up       | nothing: the error comes back as `fn` left it (still `Marked`)    |
+
+The retrier never marks or unmarks an error on its own, so a failure marked retryable
+still reports as retryable once the loop has given up on it. How the loop ended is
+what the table above reports, not the mark.
+
+An outer loop has to look at the returned error before asking for another round.
+
+Nesting is multiplicative: an inner budget of 3 inside an outer
+budget of 5 is up to 15 calls, and the product of the delays. This package does
+not police that.

--- a/retry/backoff.go
+++ b/retry/backoff.go
@@ -1,0 +1,137 @@
+package retry
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// maxDuration is the largest delay a time.Duration can hold. Converting a
+// float64 above it to an integer is undefined in Go, and yields a negative
+// duration on some platforms, which would turn a wait into a hot loop.
+const maxDuration = float64(math.MaxInt64)
+
+// Backoff reports how long to wait after attempts failed attempts. attempts
+// is the number of attempts made so far, so it is 1 after the first failure.
+//
+// A Backoff is a pure function of the attempt count. It holds no state, so
+// one Backoff is safe to share across goroutines and across calls, and it
+// never ends a sequence: the budget is WithMaxAttempts', the waiting and the
+// cancellation are the executor's.
+type Backoff func(attempts int) time.Duration
+
+// Exponential returns a Backoff that waits start after the first failure and
+// multiplies the wait by factor after each one that follows, never exceeding
+// maxDelay. Wrap it in Jittered so that callers that failed together do not
+// retry together.
+//
+// Arguments outside their usable range are clamped: a factor below one, or one
+// that is not a number, to one. A maxDelay of zero or less leaves the growth
+// unbounded, up to what a time.Duration can hold; a start of zero or less waits
+// not at all, whatever the factor.
+func Exponential(start time.Duration, factor float64, maxDelay time.Duration) Backoff {
+	if start <= 0 {
+		return Constant(0)
+	}
+	if math.IsNaN(factor) || factor < 1 {
+		factor = 1
+	}
+
+	return func(attempts int) time.Duration {
+		delay := float64(start) * math.Pow(factor, float64(attempts-1))
+		if maxDelay > 0 && delay > float64(maxDelay) {
+			return maxDelay
+		}
+		if delay >= maxDuration {
+			return math.MaxInt64
+		}
+		return time.Duration(delay)
+	}
+}
+
+// Linear returns a Backoff that waits start after the first failure and adds
+// factor of start after each one that follows, never exceeding maxDelay. It
+// grows by a constant increment where Exponential grows by a constant ratio.
+// Wrap it in Jittered so that callers that failed together do not retry
+// together.
+//
+// A factor of 1 gives start, 2*start, 3*start and so on; a factor of 0 never
+// grows, which is Constant. Arguments outside their usable range are clamped: a
+// factor below zero, or one that is not a number, to zero. A maxDelay of zero or
+// less leaves the growth unbounded, up to what a time.Duration can hold; a start
+// of zero or less waits not at all, whatever the factor.
+func Linear(start time.Duration, factor float64, maxDelay time.Duration) Backoff {
+	if start <= 0 {
+		return Constant(0)
+	}
+	if math.IsNaN(factor) || factor < 0 {
+		factor = 0
+	}
+
+	return func(attempts int) time.Duration {
+		// The increment is added only once there is something to add it to. An
+		// attempt count below the documented minimum would otherwise subtract
+		// from start, and an infinite factor times a zero count is not a number.
+		delay := float64(start)
+		if attempts > 1 {
+			delay += float64(start) * factor * float64(attempts-1)
+		}
+		if maxDelay > 0 && delay > float64(maxDelay) {
+			return maxDelay
+		}
+		if delay >= maxDuration {
+			return math.MaxInt64
+		}
+		return time.Duration(delay)
+	}
+}
+
+// Uniform returns a Backoff that waits a duration drawn uniformly from
+// [minDelay, maxDelay) after every failed attempt, ignoring how many there have
+// been.
+//
+// A minDelay below zero is raised to zero, and a maxDelay at or below minDelay
+// waits exactly minDelay.
+func Uniform(minDelay, maxDelay time.Duration) Backoff {
+	if minDelay < 0 {
+		minDelay = 0
+	}
+	if maxDelay <= minDelay {
+		return Constant(minDelay)
+	}
+	spread := int64(maxDelay - minDelay)
+
+	return func(int) time.Duration {
+		return minDelay + time.Duration(rand.Int64N(spread))
+	}
+}
+
+// Constant returns a Backoff that waits d after every failed attempt.
+func Constant(d time.Duration) Backoff {
+	return func(int) time.Duration { return d }
+}
+
+// Jittered returns a Backoff that shortens each of b's delays by up to
+// fraction of itself, drawn uniformly, so that callers that failed together do
+// not retry together.
+//
+// fraction is a share of the delay, clamped to [0, 1]: 0 returns b untouched,
+// as does a fraction that is not a number; 0.5 shortens each delay by up to a
+// half, and 1 draws from the whole interval below it. Jitter only ever
+// subtracts, so whatever ceiling b has is a true ceiling on the wait.
+func Jittered(b Backoff, fraction float64) Backoff {
+	if math.IsNaN(fraction) || fraction <= 0 {
+		return b
+	}
+	if fraction > 1 {
+		fraction = 1
+	}
+
+	return func(attempts int) time.Duration {
+		delay := b(attempts)
+		if delay <= 0 {
+			return delay
+		}
+		return delay - time.Duration(float64(delay)*fraction*rand.Float64())
+	}
+}

--- a/retry/backoff_test.go
+++ b/retry/backoff_test.go
@@ -1,0 +1,278 @@
+package retry
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstant(t *testing.T) {
+	s := Constant(time.Second)
+	for attempts := 1; attempts <= 5; attempts++ {
+		assert.Equal(t, time.Second, s(attempts))
+	}
+}
+
+func TestUniform_clampsItsArguments(t *testing.T) {
+	for name, tc := range map[string]struct {
+		backoff Backoff
+		want    time.Duration
+	}{
+		"max below min waits exactly min": {Uniform(time.Second, time.Millisecond), time.Second},
+		"an empty interval is constant":   {Uniform(time.Second, time.Second), time.Second},
+		"a negative min is no wait":       {Uniform(-time.Second, 0), 0},
+		// The difference between the bounds is what overflows, so the case to
+		// cover is a max far enough below min to wrap it, not merely below it.
+		"a max below min by more than a Duration holds": {Uniform(time.Nanosecond, math.MinInt64), time.Nanosecond},
+		"both bounds below zero":                        {Uniform(math.MinInt64, math.MinInt64), 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for attempts := 1; attempts <= 5; attempts++ {
+				assert.Equal(t, tc.want, tc.backoff(attempts))
+			}
+		})
+	}
+}
+
+func TestExponential_growsByTheFactor(t *testing.T) {
+	s := Exponential(time.Second, 3, time.Hour)
+
+	assert.Equal(t, time.Second, s(1))
+	assert.Equal(t, 3*time.Second, s(2))
+	assert.Equal(t, 9*time.Second, s(3))
+	assert.Equal(t, 27*time.Second, s(4))
+}
+
+func TestExponential_clampsAtMax(t *testing.T) {
+	s := Exponential(time.Second, 2, 10*time.Second)
+
+	assert.Equal(t, 8*time.Second, s(4))
+	assert.Equal(t, 10*time.Second, s(5))
+	assert.Equal(t, 10*time.Second, s(500), "an attempt count that overflows the growth still clamps")
+}
+
+func TestExponential_zeroMaxLeavesGrowthUnbounded(t *testing.T) {
+	s := Exponential(time.Second, 2, 0)
+	assert.Equal(t, 1024*time.Second, s(11))
+}
+
+func TestExponential_clampsItsArguments(t *testing.T) {
+	assert.Equal(t, time.Second, Exponential(time.Second, 0.5, time.Minute)(5),
+		"a factor below one stops the delay shrinking")
+	assert.Equal(t, time.Second, Exponential(time.Second, math.NaN(), time.Minute)(5),
+		"a factor that is not a number never grows the delay")
+	assert.Equal(t, time.Minute, Exponential(time.Second, math.Inf(1), time.Minute)(2),
+		"an infinite factor reaches the ceiling in one step")
+}
+
+func TestExponential_aStartAtOrBelowZeroNeverWaits(t *testing.T) {
+	for name, s := range map[string]Backoff{
+		"zero":     Exponential(0, 2, time.Minute),
+		"negative": Exponential(-time.Second, 2, time.Minute),
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, attempts := range []int{1, 10, 1_000_000} {
+				assert.Zero(t, s(attempts), "a backoff that starts at zero stays at zero")
+			}
+		})
+	}
+}
+
+func TestLinear_growsByTheIncrement(t *testing.T) {
+	s := Linear(time.Second, 1, time.Hour)
+
+	assert.Equal(t, time.Second, s(1))
+	assert.Equal(t, 2*time.Second, s(2))
+	assert.Equal(t, 3*time.Second, s(3))
+	assert.Equal(t, 4*time.Second, s(4))
+
+	half := Linear(time.Second, 0.5, time.Hour)
+	assert.Equal(t, time.Second, half(1))
+	assert.Equal(t, 1500*time.Millisecond, half(2))
+	assert.Equal(t, 2*time.Second, half(3))
+}
+
+func TestLinear_clampsAtMax(t *testing.T) {
+	s := Linear(time.Second, 1, 3*time.Second)
+
+	assert.Equal(t, 3*time.Second, s(3))
+	assert.Equal(t, 3*time.Second, s(4))
+	assert.Equal(t, 3*time.Second, s(1_000_000))
+}
+
+func TestLinear_clampsItsArguments(t *testing.T) {
+	for name, s := range map[string]Backoff{
+		"a factor of zero never grows":              Linear(time.Second, 0, time.Minute),
+		"a negative factor never grows":             Linear(time.Second, -1, time.Minute),
+		"a factor that is not a number never grows": Linear(time.Second, math.NaN(), time.Minute),
+		"a count below one waits start":             Linear(time.Second, 2, time.Minute),
+		"an infinite factor waits start first":      Linear(time.Second, math.Inf(1), time.Minute),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, time.Second, s(1))
+			assert.Equal(t, time.Second, s(0), "a count below the documented minimum stays positive")
+			assert.Equal(t, time.Second, s(-5))
+		})
+	}
+
+	assert.Equal(t, time.Minute, Linear(time.Second, math.Inf(1), time.Minute)(2),
+		"an infinite factor reaches the ceiling in one step")
+}
+
+func TestLinear_aStartAtOrBelowZeroNeverWaits(t *testing.T) {
+	for name, s := range map[string]Backoff{
+		"zero":     Linear(0, 1, time.Minute),
+		"negative": Linear(-time.Second, 1, time.Minute),
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, attempts := range []int{1, 10, 1_000_000} {
+				assert.Zero(t, s(attempts))
+			}
+		})
+	}
+}
+
+func TestJittered_onlySubtracts(t *testing.T) {
+	const ceiling = 10 * time.Second
+	s := Jittered(Exponential(time.Second, 2, ceiling), 0.5)
+
+	// Attempt 5 and beyond sit on the ceiling, where the jitter has to survive.
+	var low, high time.Duration = ceiling, 0
+	for range 2000 {
+		delay := s(5)
+		require.LessOrEqual(t, delay, ceiling, "jitter must never push a delay above the backoff's max")
+		low, high = min(low, delay), max(high, delay)
+	}
+
+	assert.Less(t, low, 6*time.Second, "the window should reach down to half of max")
+	assert.Greater(t, high, 9*time.Second, "the window should reach up to max")
+}
+
+func TestJittered_fullFractionReachesZero(t *testing.T) {
+	s := Jittered(Constant(time.Second), 1)
+
+	low := time.Second
+	for range 2000 {
+		delay := s(1)
+		require.LessOrEqual(t, delay, time.Second)
+		low = min(low, delay)
+	}
+	assert.Less(t, low, 100*time.Millisecond, "a fraction of 1 draws from the whole interval below the delay")
+}
+
+func TestJittered_clampsItsFraction(t *testing.T) {
+	assert.Equal(t, time.Second, Jittered(Constant(time.Second), 0)(1), "a fraction of zero is no jitter")
+	assert.Equal(t, time.Second, Jittered(Constant(time.Second), -1)(1), "a negative fraction is no jitter")
+	assert.Equal(t, time.Second, Jittered(Constant(time.Second), math.NaN())(1),
+		"a fraction that is not a number is no jitter")
+
+	for name, s := range map[string]Backoff{
+		"above one": Jittered(Constant(time.Second), 5),
+		"infinite":  Jittered(Constant(time.Second), math.Inf(1)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			for range 100 {
+				delay := s(1)
+				assert.GreaterOrEqual(t, delay, time.Duration(0), "a fraction above one cannot go negative")
+				assert.LessOrEqual(t, delay, time.Second)
+			}
+		})
+	}
+}
+
+func TestJittered_leavesANonPositiveDelayAlone(t *testing.T) {
+	assert.Zero(t, Jittered(Constant(0), 1)(1))
+	assert.Equal(t, -time.Second, Jittered(Constant(-time.Second), 1)(1),
+		"a negative delay is passed through rather than jittered towards zero")
+}
+
+func TestJittered_appliesToAnyBackoff(t *testing.T) {
+	s := Jittered(Uniform(time.Second, 2*time.Second), 0.5)
+
+	for range 500 {
+		delay := s(1)
+		require.GreaterOrEqual(t, delay, 500*time.Millisecond, "at most half of the smallest delay is taken")
+		require.Less(t, delay, 2*time.Second)
+	}
+}
+
+// TestBackoff_extremeArgumentsStayInRange sweeps every Backoff over the
+// arithmetic edges of its inputs, where an out-of-range conversion would
+// otherwise yield a negative delay and turn a wait into a hot loop.
+func TestBackoff_extremeArgumentsStayInRange(t *testing.T) {
+	const maxDelay = time.Duration(math.MaxInt64)
+
+	type backoffCase struct {
+		name    string
+		backoff Backoff
+		ceiling time.Duration // zero when the growth is unbounded
+	}
+
+	cases := []backoffCase{
+		{"exponential", Exponential(time.Second, 2, 0), 0},
+		{"exponential capped", Exponential(time.Second, 2, time.Minute), time.Minute},
+		{"exponential from the longest delay", Exponential(maxDelay, 2, 0), 0},
+		{"exponential capped at the longest delay", Exponential(time.Second, 2, maxDelay), maxDelay},
+		{"exponential with a huge factor", Exponential(time.Second, math.MaxFloat64, 0), 0},
+		{"exponential with an infinite factor", Exponential(time.Second, math.Inf(1), 0), 0},
+		{"exponential with an unordered factor", Exponential(time.Second, math.NaN(), 0), 0},
+		{"linear", Linear(time.Hour, 1, 0), 0},
+		{"linear capped", Linear(time.Hour, 1, time.Minute), time.Minute},
+		{"linear from the longest delay", Linear(maxDelay, 1, 0), 0},
+		{"linear with a huge factor", Linear(time.Second, math.MaxFloat64, 0), 0},
+		{"linear with an infinite factor", Linear(time.Second, math.Inf(1), 0), 0},
+		{"linear with an unordered factor", Linear(time.Second, math.NaN(), 0), 0},
+		{"uniform over the whole range", Uniform(0, maxDelay), maxDelay},
+		{"uniform with its bounds reversed", Uniform(maxDelay, math.MinInt64), maxDelay},
+		{"constant at the longest delay", Constant(maxDelay), maxDelay},
+	}
+
+	// Jitter is the last thing applied to a delay, so every shape is swept
+	// through it as well.
+	for _, tc := range cases[:len(cases):len(cases)] {
+		cases = append(cases,
+			backoffCase{"jittered " + tc.name, Jittered(tc.backoff, 1), tc.ceiling},
+			backoffCase{"unordered-jittered " + tc.name, Jittered(tc.backoff, math.NaN()), tc.ceiling},
+		)
+	}
+
+	// Attempt counts a caller could reach under WithUnlimitedAttempts, plus the
+	// ones below the documented minimum of 1. attempts-1 wraps at MinInt64.
+	attempts := []int{math.MinInt64, -5, 0, 1, 2, 63, 64, 65, 1_000_000, math.MaxInt32, math.MaxInt64}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, n := range attempts {
+				for range 10 {
+					delay := tc.backoff(n)
+					require.GreaterOrEqual(t, delay, time.Duration(0),
+						"attempt %d produced a negative delay", n)
+					if tc.ceiling > 0 {
+						require.LessOrEqual(t, delay, tc.ceiling,
+							"attempt %d exceeded the ceiling", n)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBackoff_isSafeForConcurrentUse(t *testing.T) {
+	s := Jittered(Exponential(time.Millisecond, 2, time.Second), 0.5)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for attempts := 1; attempts <= 100; attempts++ {
+				assert.LessOrEqual(t, s(attempts), time.Second)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/retry/decide.go
+++ b/retry/decide.go
@@ -1,0 +1,23 @@
+package retry
+
+import "time"
+
+// Decision is what a Decider reports about one failed attempt.
+type Decision struct {
+	// Retryable says whether another attempt has a chance of succeeding. The
+	// zero Decision gives up, so a decider that does not recognize an error
+	// fails closed by default.
+	Retryable bool
+
+	// After, when non-zero, is a lower bound on the delay before the next
+	// attempt, such as a server-supplied Retry-After. The executor waits
+	// max(backoff delay, After).
+	After time.Duration
+}
+
+// Decider decides whether an error is worth retrying, and may raise the delay
+// before the next attempt.
+//
+// The executor never calls a Decider with a nil error, so implementations need
+// no nil check.
+type Decider func(err error) Decision

--- a/retry/decide_test.go
+++ b/retry/decide_test.go
@@ -1,0 +1,34 @@
+package retry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type statusError struct{ code int }
+
+func (e *statusError) Error() string { return fmt.Sprintf("status %d", e.code) }
+
+func isRetryableStatus(err error) bool {
+	var status *statusError
+	return errors.As(err, &status) && status.code >= 500
+}
+
+func TestDecider_composesWithAnIf(t *testing.T) {
+	decide := func(err error) Decision {
+		if d := Marked(err); d.Retryable {
+			return d
+		}
+		return Decision{Retryable: isRetryableStatus(err)}
+	}
+	var _ Decider = decide
+
+	assert.Equal(t, Decision{Retryable: true}, decide(MarkRetryable(&statusError{code: 404})),
+		"a mark wins over the fallback")
+	assert.Equal(t, Decision{Retryable: true}, decide(&statusError{code: 503}))
+	assert.Equal(t, Decision{}, decide(&statusError{code: 404}))
+	assert.Equal(t, Decision{}, decide(errors.New("boom")))
+}

--- a/retry/example_test.go
+++ b/retry/example_test.go
@@ -1,0 +1,128 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/dskit/retry"
+)
+
+// The default decider retries only what was marked at the point of failure, so
+// an unmarked error gets exactly one attempt.
+func Example() {
+	err := retry.Retry(context.Background(), func(context.Context) error {
+		return errors.New("bad request")
+	}, retry.WithOperation("example"))
+
+	fmt.Println(err)
+	// Output: bad request
+}
+
+func ExampleRetry() {
+	attempts := 0
+	err := retry.Retry(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return retry.MarkRetryable(errors.New("connection refused"))
+		}
+		return nil
+	}, retry.WithBackoff(retry.Constant(time.Millisecond)), retry.WithMaxAttempts(5))
+
+	fmt.Println(attempts, err)
+	// Output: 3 <nil>
+}
+
+// A component that retries the same way every time binds its options once.
+func ExampleNew() {
+	r := retry.New(
+		retry.WithBackoff(retry.Constant(time.Millisecond)),
+		retry.WithMaxAttempts(3),
+		retry.WithOperation("sync"),
+	)
+
+	err := r.Retry(context.Background(), func(context.Context) error {
+		return retry.MarkRetryable(errors.New("unavailable"))
+	})
+
+	fmt.Println(errors.Is(err, retry.ErrExhausted))
+	fmt.Println(err)
+	// Output:
+	// true
+	// retry budget exhausted after 3 attempts: unavailable
+}
+
+// statusError stands in for an error type of your own carrying a status code.
+type statusError struct{ code int }
+
+func (e *statusError) Error() string { return fmt.Sprintf("status %d", e.code) }
+
+func ExampleWithPredicate() {
+	isTransient := func(err error) bool {
+		var status *statusError
+		return errors.As(err, &status) && status.code >= 500
+	}
+
+	attempts := 0
+	err := retry.Retry(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return &statusError{code: 503}
+		}
+		return &statusError{code: 400}
+	}, retry.WithPredicate(isTransient), retry.WithBackoff(retry.Constant(0)))
+
+	fmt.Println(attempts, err)
+	// Output: 3 status 400
+}
+
+// A Decider is the longer form. More customizable.
+func ExampleWithDecider() {
+	decide := func(err error) retry.Decision {
+		var status *statusError
+		if !errors.As(err, &status) {
+			return retry.Decision{}
+		}
+		switch {
+		case status.code == 429:
+			return retry.Decision{Retryable: true, After: time.Millisecond}
+		case status.code >= 500:
+			return retry.Decision{Retryable: true}
+		default:
+			return retry.Decision{}
+		}
+	}
+
+	attempts := 0
+	err := retry.Retry(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return &statusError{code: 429}
+		}
+		return &statusError{code: 400}
+	}, retry.WithDecider(decide), retry.WithBackoff(retry.Constant(0)))
+
+	fmt.Println(attempts, err)
+	// Output: 3 status 400
+}
+
+// Deciders compose with a plain if, so a call site that mixes its own marked
+// errors with errors from a library it does not own needs no combinator.
+func ExampleMarked() {
+	decide := func(err error) retry.Decision {
+		if d := retry.Marked(err); d.Retryable {
+			return d
+		}
+		var status *statusError
+		return retry.Decision{Retryable: errors.As(err, &status) && status.code >= 500}
+	}
+
+	fmt.Println(decide(retry.MarkRetryable(&statusError{code: 404})).Retryable) // the mark wins
+	fmt.Println(decide(&statusError{code: 503}).Retryable)                      // the fallback decides
+	fmt.Println(decide(&statusError{code: 404}).Retryable)
+	// Output:
+	// true
+	// true
+	// false
+}

--- a/retry/marker.go
+++ b/retry/marker.go
@@ -1,0 +1,55 @@
+package retry
+
+import (
+	"errors"
+	"time"
+)
+
+// MarkRetryable marks err as worth retrying, so that Marked reports it as
+// retryable. It returns nil when err is nil.
+func MarkRetryable(err error) error {
+	return mark(err, 0)
+}
+
+// MarkRetryableAfter marks err as worth retrying no sooner than after, which
+// the executor treats as a lower bound on the next delay. It returns nil when
+// err is nil.
+func MarkRetryableAfter(err error, after time.Duration) error {
+	return mark(err, after)
+}
+
+// Marked is the default Decider. It retries what MarkRetryable and
+// MarkRetryableAfter marked. It gives up on everything else, so an unmarked
+// error gets exactly one attempt.
+//
+// Marked is an ordinary function, so it doubles as the read side of the two
+// marking helpers and is useful outside a retry loop. It finds the first mark
+// errors.As finds, so on the ordinary chain of wrapped errors the outermost
+// After wins. For an error holding several others, such as one built by
+// errors.Join, which mark it finds is unspecified: decide an aggregate in your
+// own Decider, or mark the aggregate itself.
+func Marked(err error) Decision {
+	var m *marker
+	if errors.As(err, &m) {
+		return Decision{Retryable: true, After: m.after}
+	}
+	return Decision{}
+}
+
+var _ Decider = Marked
+
+type marker struct {
+	err   error
+	after time.Duration
+}
+
+func mark(err error, after time.Duration) error {
+	if err == nil {
+		return nil
+	}
+	return &marker{err: err, after: after}
+}
+
+func (m *marker) Error() string { return m.err.Error() }
+
+func (m *marker) Unwrap() error { return m.err }

--- a/retry/marker_test.go
+++ b/retry/marker_test.go
@@ -1,0 +1,72 @@
+package retry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarked(t *testing.T) {
+	sentinel := errors.New("boom")
+
+	for name, tc := range map[string]struct {
+		err  error
+		want Decision
+	}{
+		"nil error": {
+			err: nil,
+		},
+		"unmarked error": {
+			err: sentinel,
+		},
+		"retryable": {
+			err:  MarkRetryable(sentinel),
+			want: Decision{Retryable: true},
+		},
+		"retryable after": {
+			err:  MarkRetryableAfter(sentinel, 3*time.Second),
+			want: Decision{Retryable: true, After: 3 * time.Second},
+		},
+		"mark survives wrapping": {
+			err:  fmt.Errorf("context: %w", MarkRetryable(sentinel)),
+			want: Decision{Retryable: true},
+		},
+		"outermost After wins": {
+			err:  MarkRetryableAfter(fmt.Errorf("context: %w", MarkRetryableAfter(sentinel, time.Hour)), time.Second),
+			want: Decision{Retryable: true, After: time.Second},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, Marked(tc.err))
+		})
+	}
+}
+
+func TestMarked_aggregatesAreDecidedByMarkingThem(t *testing.T) {
+	joined := errors.Join(MarkRetryableAfter(errors.New("slow"), time.Hour), MarkRetryable(errors.New("transient")))
+
+	assert.True(t, Marked(joined).Retryable, "some mark is found, but which one is unspecified")
+	assert.Equal(t, Decision{Retryable: true, After: time.Second}, Marked(MarkRetryableAfter(joined, time.Second)),
+		"marking the aggregate decides for the whole of it")
+}
+
+func TestMarked_nilErrorIsNotMarked(t *testing.T) {
+	assert.NoError(t, MarkRetryable(nil))
+	assert.NoError(t, MarkRetryableAfter(nil, time.Second))
+}
+
+func TestMarked_preservesTheError(t *testing.T) {
+	sentinel := errors.New("boom")
+	marked := MarkRetryable(fmt.Errorf("writing: %w", sentinel))
+
+	require.EqualError(t, marked, "writing: boom")
+	assert.ErrorIs(t, marked, sentinel)
+
+	var target *statusError
+	assert.ErrorAs(t, MarkRetryable(&statusError{code: 404}), &target)
+	assert.Equal(t, 404, target.code)
+}

--- a/retry/metrics.go
+++ b/retry/metrics.go
@@ -1,0 +1,92 @@
+package retry
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// The values of the outcome label on retry_duration_seconds. Every call to Retry
+// reports exactly one of them.
+const (
+	outcomeFirstAttempt = "first_attempt" // fn succeeded straight away
+	outcomeAfterRetry   = "after_retry"   // fn succeeded, but not on the first attempt
+	outcomeTerminal     = "terminal"      // the decider gave up on a failure
+	outcomeExhausted    = "exhausted"     // the attempt budget ran out
+	outcomeDeadline     = "deadline"      // the next delay would have outlasted the deadline
+	outcomeCancelled    = "cancelled"     // the context ended
+
+	unknownOperation = "unknown"
+)
+
+// durationBuckets spans a retry loop rather than a single request: the bottom
+// bucket is the fast path, where fn succeeded first time and nothing was waited
+// out, and the top is a loop that spent minutes on a dependency that never came
+// back. The default backoff reaches roughly 32s across its ten attempts.
+var durationBuckets = []float64{0.001, 0.01, 0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300}
+
+// Metrics instruments retries. Build it once per registry with NewMetrics,
+// because Prometheus panics on duplicate registration, and pass it to each
+// Retry call with WithMetrics. A nil *Metrics records nothing.
+//
+// Read retry_duration_seconds_count as a count of operations by how they ended:
+// the ratio after_retry / (after_retry + exhausted) answers the question worth
+// asking of any retry loop, which is whether retrying is helping. The buckets
+// answer what it costs, in latency the caller cannot measure for itself.
+type Metrics struct {
+	attempts *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+
+	// now reads the clock the durations are measured against.
+	now func() time.Time
+}
+
+// NewMetrics registers the retry metrics on reg. Metric names are
+// unprefixed, so callers own the prefix via
+// prometheus.WrapRegistererWithPrefix.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	return &Metrics{
+		attempts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "retry_attempts_total",
+			Help: "Total number of attempts made, including the first attempt of each operation.",
+		}, []string{"operation"}),
+		duration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "retry_duration_seconds",
+			Help:    "Time spent on completed operations, waits between attempts included, by final outcome.",
+			Buckets: durationBuckets,
+			// Use defaults recommended by Prometheus for native histograms.
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"operation", "outcome"}),
+		now: time.Now,
+	}
+}
+
+func (m *Metrics) observeAttempt(operation string) {
+	if m == nil {
+		return
+	}
+	m.attempts.WithLabelValues(operation).Inc()
+}
+
+// startTime reads the instant an operation begins, and the zero Time when there
+// is nothing to report it to, so that the clock is not read for nobody.
+func (m *Metrics) startTime() time.Time {
+	if m == nil {
+		return time.Time{}
+	}
+	return m.now()
+}
+
+// observeOutcome records how one operation ended and how long it took, counting
+// from the startTime it began at. Exactly one observation per completed
+// operation, so the histogram's _count is also the number of operations that
+// ended in that outcome.
+func (m *Metrics) observeOutcome(operation, outcome string, startTime time.Time) {
+	if m == nil {
+		return
+	}
+	m.duration.WithLabelValues(operation, outcome).Observe(m.now().Sub(startTime).Seconds())
+}

--- a/retry/metrics_test.go
+++ b/retry/metrics_test.go
@@ -1,0 +1,213 @@
+package retry
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// metricsWithClock builds the metrics against a test clock.
+func metricsWithClock(reg prometheus.Registerer, now func() time.Time) *Metrics {
+	m := NewMetrics(reg)
+	m.now = now
+	return m
+}
+
+// stepClock returns a clock that starts at a fixed instant and advances by step
+// on every read. Retry reads it exactly twice, once at each end of the loop, so
+// every call measures exactly step, however long the test really took. It is
+// safe to share across calls, but only sequential ones: concurrent readers would
+// interleave their pairs and measure multiples of step.
+func stepClock(step time.Duration) func() time.Time {
+	var mu sync.Mutex
+	now := time.Unix(0, 0)
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		read := now
+		now = now.Add(step)
+		return read
+	}
+}
+
+func TestMetrics_outcomes(t *testing.T) {
+	for name, tc := range map[string]struct {
+		failures int
+		err      error
+		opts     []Option
+		attempts int
+		outcome  string
+	}{
+		"first attempt": {
+			failures: 0,
+			attempts: 1,
+			outcome:  outcomeFirstAttempt,
+		},
+		"after retry": {
+			failures: 2,
+			err:      MarkRetryable(errBoom),
+			attempts: 3,
+			outcome:  outcomeAfterRetry,
+		},
+		"terminal": {
+			failures: 1,
+			err:      errBoom,
+			attempts: 1,
+			outcome:  outcomeTerminal,
+		},
+		"exhausted": {
+			failures: 10,
+			err:      MarkRetryable(errBoom),
+			attempts: 3,
+			outcome:  outcomeExhausted,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			fn, _ := failFor(tc.failures, tc.err)
+
+			_ = Retry(context.Background(), fn, append(tc.opts,
+				WithBackoff(Constant(0)), WithMaxAttempts(3),
+				WithMetrics(metricsWithClock(reg, stepClock(time.Second))),
+				WithOperation("sync"),
+			)...)
+
+			assert.Equal(t, float64(tc.attempts), counterValue(t, reg, "retry_attempts_total"))
+
+			duration := single(t, reg, "retry_duration_seconds")
+			assert.Equal(t, map[string]string{"operation": "sync", "outcome": tc.outcome},
+				labelsOf(duration), "every call reports exactly one outcome")
+			assert.Equal(t, uint64(1), duration.GetHistogram().GetSampleCount(),
+				"one observation per completed operation, so _count counts operations")
+			assert.Equal(t, float64(1), duration.GetHistogram().GetSampleSum(),
+				"seconds, and the whole span of the loop")
+		})
+	}
+}
+
+// TestMetrics_durationIsSeconds pins the histogram in full: the unit, which a
+// _sum alone would let drift by a factor of a billion, and the buckets, which
+// callers write alert thresholds against.
+func TestMetrics_durationIsSeconds(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	fn, _ := failFor(0, nil)
+
+	_ = Retry(context.Background(), fn,
+		WithMetrics(metricsWithClock(reg, stepClock(2500*time.Millisecond))),
+		WithOperation("sync"),
+	)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP retry_duration_seconds Time spent on completed operations, waits between attempts included, by final outcome.
+		# TYPE retry_duration_seconds histogram
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="0.001"} 0
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="0.01"} 0
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="0.1"} 0
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="0.5"} 0
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="1"} 0
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="2.5"} 1
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="5"} 1
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="10"} 1
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="30"} 1
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="60"} 1
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="120"} 1
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="300"} 1
+		retry_duration_seconds_bucket{operation="sync",outcome="first_attempt",le="+Inf"} 1
+		retry_duration_seconds_sum{operation="sync",outcome="first_attempt"} 2.5
+		retry_duration_seconds_count{operation="sync",outcome="first_attempt"} 1
+	`), "retry_duration_seconds"))
+}
+
+// TestMetrics_durationCoversTheWaits is the reason the metric exists: the delay
+// between attempts is the caller's latency, and no amount of reading the backoff
+// config recovers it once Jittered and Decision.After have had their say.
+func TestMetrics_durationCoversTheWaits(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	fn, calls := failFor(1, MarkRetryableAfter(errBoom, 20*time.Millisecond))
+
+	// A real clock here, because the wait being measured is a real one.
+	require.NoError(t, Retry(context.Background(), fn,
+		WithBackoff(Constant(0)), WithMaxAttempts(3),
+		WithMetrics(NewMetrics(reg)),
+	))
+	require.Equal(t, 2, *calls)
+
+	assert.GreaterOrEqual(t, single(t, reg, "retry_duration_seconds").GetHistogram().GetSampleSum(), 0.02,
+		"the server-supplied floor was waited out inside the measured span")
+}
+
+func TestMetrics_cancelledOutcome(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_ = Retry(ctx, func(context.Context) error { return nil }, WithMetrics(NewMetrics(reg)))
+
+	duration := single(t, reg, "retry_duration_seconds")
+	assert.Equal(t, map[string]string{"operation": "unknown", "outcome": "cancelled"}, labelsOf(duration))
+	assert.Equal(t, uint64(1), duration.GetHistogram().GetSampleCount(),
+		"a loop that never ran an attempt still reports how it ended")
+}
+
+func TestMetrics_nilIsSilent(t *testing.T) {
+	fn, _ := failFor(1, MarkRetryable(errBoom))
+
+	assert.NoError(t, Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(3), WithMetrics(nil)))
+}
+
+func counterValue(t *testing.T, reg prometheus.Gatherer, name string) float64 {
+	t.Helper()
+	return single(t, reg, name).GetCounter().GetValue()
+}
+
+// outcomeCount is the number of operations that ended in outcome, read off the
+// histogram's _count.
+func outcomeCount(t *testing.T, reg prometheus.Gatherer, operation, outcome string) uint64 {
+	t.Helper()
+
+	for _, metric := range family(t, reg, "retry_duration_seconds").GetMetric() {
+		labels := labelsOf(metric)
+		if labels["operation"] == operation && labels["outcome"] == outcome {
+			return metric.GetHistogram().GetSampleCount()
+		}
+	}
+	return 0
+}
+
+func labelsOf(metric *dto.Metric) map[string]string {
+	labels := make(map[string]string, len(metric.GetLabel()))
+	for _, pair := range metric.GetLabel() {
+		labels[pair.GetName()] = pair.GetValue()
+	}
+	return labels
+}
+
+func single(t *testing.T, reg prometheus.Gatherer, name string) *dto.Metric {
+	t.Helper()
+
+	metrics := family(t, reg, name).GetMetric()
+	require.Len(t, metrics, 1)
+	return metrics[0]
+}
+
+func family(t *testing.T, reg prometheus.Gatherer, name string) *dto.MetricFamily {
+	t.Helper()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	t.Fatalf("metric %s not found", name)
+	return nil
+}

--- a/retry/options.go
+++ b/retry/options.go
@@ -1,0 +1,108 @@
+package retry
+
+import (
+	"time"
+
+	"github.com/go-kit/log"
+)
+
+// Option configures a Retrier. Options are applied in order, so a later one
+// overrides an earlier one, and passing nil to an option restores its default.
+type Option func(*options)
+
+// WithBackoff sets the delays between attempts. The default is a
+// Jittered Exponential, growing from 100ms to 10s with half of each delay
+// available to jitter.
+//
+// A Backoff says how long to wait, never whether to keep going: the budget is
+// WithMaxAttempts'.
+func WithBackoff(b Backoff) Option {
+	return func(o *options) {
+		if b == nil {
+			b = defaultBackoff
+		}
+		o.backoff = b
+	}
+}
+
+// WithDecider sets the decider that says which errors are retried, and may
+// raise the delay before the next attempt. The default retries only errors
+// marked with MarkRetryable or MarkRetryableAfter.
+func WithDecider(d Decider) Option {
+	return func(o *options) {
+		if d == nil {
+			d = Marked
+		}
+		o.decider = d
+	}
+}
+
+// WithPredicate sets a predicate that says which errors are retried, leaving
+// the delay to the Backoff. It is the short form of WithDecider, and a
+// func(error) bool you already have goes straight in.
+func WithPredicate(f func(error) bool) Option {
+	if f == nil {
+		return WithDecider(nil)
+	}
+	return WithDecider(func(err error) Decision {
+		return Decision{Retryable: f(err)}
+	})
+}
+
+// WithMetrics records attempts, outcomes and durations into m. A nil *Metrics
+// records nothing, which is the default.
+func WithMetrics(m *Metrics) Option {
+	return func(o *options) { o.metrics = m }
+}
+
+// WithOperation names the operation being retried. It is the value of the
+// operation label on every metric and appears in log lines.
+func WithOperation(operation string) Option {
+	return func(o *options) { o.operation = operation }
+}
+
+// WithMaxAttempts sets how many attempts an operation gets in total, including
+// the first. The default is 10, and n below 1 is raised to 1, so no argument
+// turns the budget off by accident; WithUnlimitedAttempts spells that out.
+func WithMaxAttempts(n int) Option {
+	return func(o *options) {
+		if n < 1 {
+			n = 1
+		}
+		o.maxAttempts = n
+	}
+}
+
+// WithUnlimitedAttempts retries until the operation succeeds, the decider calls
+// a failure terminal, or the context is done. Nothing else stops the loop, so
+// pair it with a context that ends.
+func WithUnlimitedAttempts() Option {
+	return func(o *options) { o.maxAttempts = 0 }
+}
+
+// WithLogger logs a debug line before each retry, with the operation, the
+// attempt number, the delay and the error being retried. A nil Logger logs
+// nothing, which is the default.
+func WithLogger(l log.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+type options struct {
+	backoff     Backoff
+	decider     Decider
+	metrics     *Metrics
+	operation   string
+	maxAttempts int
+	logger      log.Logger
+}
+
+var defaultBackoff Backoff = Jittered(Exponential(100*time.Millisecond, 2, 10*time.Second), 0.5)
+
+func defaultOptions() options {
+	return options{
+		backoff:     defaultBackoff,
+		decider:     Marked,
+		operation:   unknownOperation,
+		maxAttempts: 10,
+	}
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,203 @@
+// Package retry runs an operation again until it succeeds, until the decider
+// gives up on a failure, until the attempt budget is spent, or until the context
+// is done.
+//
+// The package owns the mechanism: an executor, a source of delays, a convention
+// for marking errors, and metrics. Deciding what is worth retrying is left to
+// the caller. Two pieces are pluggable, and each has a working default:
+//
+//   - a Decider (WithDecider), or the predicate that is its short form
+//     (WithPredicate), says which errors deserve another attempt. The default is
+//     Marked, which retries only what MarkRetryable and MarkRetryableAfter
+//     recorded at the point the error was produced, so an unmarked error gets
+//     exactly one attempt.
+//   - a Backoff (WithBackoff) supplies the delays. The default is jittered
+//     exponential growth. A Backoff says how long to wait, never how long to
+//     keep going: the budget is WithMaxAttempts'.
+//
+// A predicate you already have is enough to get started:
+//
+//	err := retry.Retry(ctx, client.Sync, retry.WithPredicate(isTransient))
+//
+// A component that retries the same way every time builds one Retrier and
+// keeps it, so its options are written once rather than at every call site:
+//
+//	r := retry.New(retry.WithPredicate(isTransient), retry.WithMetrics(m), retry.WithOperation("sync"))
+//	err := r.Retry(ctx, client.Sync)
+//
+// A *Retrier is safe for concurrent use. The metrics are the piece to share
+// rather than rebuild, because Prometheus panics on duplicate registration:
+// build one *Metrics per registry with NewMetrics and pass it to every Retrier
+// reporting there. They answer how often retrying happens, whether it ends in
+// success, and what the waiting costs; see Metrics.
+//
+// The examples in this package are runnable, and README.md carries the longer
+// discussion: how to choose a decider, what each built-in Backoff is for, which
+// questions the metrics answer, and how nesting two loops behaves.
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log/level"
+)
+
+// ErrExhausted is wrapped into the error returned when the attempt budget runs
+// out, so callers can tell a spent budget from a terminal failure with
+// errors.Is.
+var ErrExhausted = errors.New("retry budget exhausted")
+
+// Retrier runs operations under one fixed set of options. It keeps no
+// per-operation state, so one Retrier serves any number of concurrent calls.
+type Retrier struct {
+	options
+}
+
+// New binds opts once, so that the returned Retrier can run any number of
+// operations under them.
+func New(opts ...Option) *Retrier {
+	r := &Retrier{options: defaultOptions()}
+	for _, opt := range opts {
+		opt(&r.options)
+	}
+	return r
+}
+
+// Retry is shorthand for New(opts...).Retry(ctx, fn), so it builds the options
+// again on every call. Prefer New when the same options serve more than one.
+func Retry(ctx context.Context, fn func(context.Context) error, opts ...Option) error {
+	return New(opts...).Retry(ctx, fn)
+}
+
+// Retry calls fn until it succeeds or until retrying stops making sense, and
+// returns the error from the last attempt.
+//
+// ctx is passed to fn unchanged and bounds the whole loop, waits included. A
+// context that is already done gets no attempt at all. Between two attempts the
+// loop waits max(the Backoff's delay, the Decision's After).
+//
+// Retry returns:
+//
+//   - nil, once fn returns nil.
+//   - an error wrapping ErrExhausted and the last failure, when the
+//     WithMaxAttempts budget is spent.
+//   - an error wrapping context.DeadlineExceeded and the last failure, as soon
+//     as the next delay would outlast ctx's deadline. The wait is not served
+//     out, because no attempt could follow it.
+//   - an error wrapping the context's cause, and the last failure if there was
+//     one, when ctx is done.
+//   - the error from fn unchanged, when the decider gives up on it.
+//
+// Every reason but the last comes back with the failure it stopped on, and both
+// are reachable with errors.Is.
+//
+// The loop never marks or unmarks an error of its own accord, so a failure
+// marked retryable still reports so to Marked once the loop has given up on it:
+// how the loop ended is what the wrapped reason says, not the mark. A loop
+// nesting inside another has to read that before asking for one more round.
+func (r *Retrier) Retry(ctx context.Context, fn func(context.Context) error) error {
+	startTime := r.metrics.startTime()
+
+	if ctx.Err() != nil {
+		return r.finish(startTime, outcomeCancelled, stopped(context.Cause(ctx), 0, nil))
+	}
+
+	for attempt := 1; ; attempt++ {
+		r.metrics.observeAttempt(r.operation)
+
+		err := fn(ctx)
+		if err == nil {
+			return r.finish(startTime, success(attempt), nil)
+		}
+
+		// fn may report the cancellation as its own failure, so the cause is
+		// the more useful of the two answers.
+		if ctx.Err() != nil {
+			return r.finish(startTime, outcomeCancelled, stopped(context.Cause(ctx), attempt, err))
+		}
+
+		decision := r.decider(err)
+		if !decision.Retryable {
+			return r.finish(startTime, outcomeTerminal, err)
+		}
+
+		if r.maxAttempts > 0 && attempt >= r.maxAttempts {
+			return r.finish(startTime, outcomeExhausted, stopped(ErrExhausted, attempt, err))
+		}
+
+		delay := max(r.backoff(attempt), decision.After)
+		if remaining, bounded := timeLeft(ctx); bounded && remaining <= delay {
+			return r.finish(startTime, outcomeDeadline, stopped(context.DeadlineExceeded, attempt, err))
+		}
+
+		r.logRetry(attempt, delay, err)
+		if !wait(ctx, delay) {
+			return r.finish(startTime, outcomeCancelled, stopped(context.Cause(ctx), attempt, err))
+		}
+	}
+}
+
+// finish records how the loop ended and how long it took, and returns err, so
+// that every exit from Retry reports an outcome.
+func (r *Retrier) finish(startTime time.Time, outcome string, err error) error {
+	r.metrics.observeOutcome(r.operation, outcome, startTime)
+	return err
+}
+
+func (r *Retrier) logRetry(attempt int, delay time.Duration, err error) {
+	if r.logger == nil {
+		return
+	}
+	level.Debug(r.logger).Log(
+		"msg", "operation failed, retrying",
+		"operation", r.operation,
+		"attempt", attempt,
+		"delay", delay,
+		"err", err,
+	)
+}
+
+func success(attempts int) string {
+	if attempts > 1 {
+		return outcomeAfterRetry
+	}
+	return outcomeFirstAttempt
+}
+
+// stopped builds the error Retry returns when fn never succeeded: the reason
+// the loop gave up, wrapped alongside the last failure so that errors.Is finds
+// either one.
+func stopped(reason error, attempts int, lastErr error) error {
+	if lastErr == nil {
+		return fmt.Errorf("%w after %d attempts", reason, attempts)
+	}
+	return fmt.Errorf("%w after %d attempts: %w", reason, attempts, lastErr)
+}
+
+// wait sleeps for delay, and reports whether it ran to completion rather than
+// being cut short by ctx.
+func wait(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// timeLeft reports how long ctx has to run, and whether it is bounded at all.
+func timeLeft(ctx context.Context) (remaining time.Duration, bounded bool) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0, false
+	}
+	return time.Until(deadline), true
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,426 @@
+package retry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errBoom = errors.New("boom")
+
+// failFor returns a function failing with err for the first n attempts, and a
+// pointer to the number of times it was called.
+func failFor(n int, err error) (func(context.Context) error, *int) {
+	calls := 0
+	return func(context.Context) error {
+		calls++
+		if calls <= n {
+			return err
+		}
+		return nil
+	}, &calls
+}
+
+// alwaysFails returns a function failing with err however many times it is
+// called, and a pointer to the number of times it was. A loop only the context
+// ends has to outlast whatever the loop can count to.
+func alwaysFails(err error) (func(context.Context) error, *int) {
+	calls := 0
+	return func(context.Context) error {
+		calls++
+		return err
+	}, &calls
+}
+
+func TestRetry_succeedsOnFirstAttempt(t *testing.T) {
+	fn, calls := failFor(0, errBoom)
+
+	require.NoError(t, Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(3)))
+	assert.Equal(t, 1, *calls)
+}
+
+func TestRetry_retriesUntilSuccess(t *testing.T) {
+	fn, calls := failFor(2, MarkRetryable(errBoom))
+
+	require.NoError(t, Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(5)))
+	assert.Equal(t, 3, *calls)
+}
+
+func TestRetry_anErrorTheDeciderGivesUpOnIsReturnedUnchanged(t *testing.T) {
+	fn, calls := failFor(5, errBoom)
+
+	err := Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(5))
+	assert.Same(t, errBoom, err, "nothing is added to an error this loop did not retry")
+	assert.Equal(t, 1, *calls, "an unmarked error gets exactly one attempt")
+}
+
+func TestRetry_predicateDecidesWhatIsRetried(t *testing.T) {
+	t.Run("retries what it accepts", func(t *testing.T) {
+		fn, calls := failFor(2, &statusError{code: 503})
+
+		require.NoError(t, Retry(context.Background(), fn,
+			WithBackoff(Constant(0)), WithMaxAttempts(5),
+			WithPredicate(isRetryableStatus),
+		))
+		assert.Equal(t, 3, *calls, "an unmarked error is retried when the predicate says so")
+	})
+
+	t.Run("gives up on what it rejects", func(t *testing.T) {
+		fn, calls := failFor(5, &statusError{code: 404})
+
+		err := Retry(context.Background(), fn,
+			WithBackoff(Constant(0)), WithMaxAttempts(5),
+			WithPredicate(isRetryableStatus),
+		)
+		assert.EqualError(t, err, "status 404")
+		assert.Equal(t, 1, *calls)
+	})
+}
+
+func TestRetry_exhaustionReportsTheBudgetAndTheLastFailure(t *testing.T) {
+	fn, calls := failFor(10, MarkRetryable(errBoom))
+
+	err := Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(3))
+	require.Error(t, err)
+	assert.Equal(t, 3, *calls)
+
+	assert.ErrorIs(t, err, ErrExhausted)
+	assert.ErrorIs(t, err, errBoom)
+}
+
+func TestRetry_deciderSeesTheError(t *testing.T) {
+	var seen []error
+	fn, _ := failFor(1, errBoom)
+
+	require.NoError(t, Retry(context.Background(), fn,
+		WithBackoff(Constant(0)), WithMaxAttempts(3),
+		WithDecider(func(err error) Decision {
+			seen = append(seen, err)
+			return Decision{Retryable: true}
+		}),
+	))
+	assert.Equal(t, []error{errBoom}, seen)
+}
+
+func TestRetry_serverFloorRaisesTheDelay(t *testing.T) {
+	start := time.Now()
+	fn, calls := failFor(1, MarkRetryableAfter(errBoom, 20*time.Millisecond))
+
+	require.NoError(t, Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(3)))
+	assert.Equal(t, 2, *calls)
+	assert.GreaterOrEqual(t, time.Since(start), 20*time.Millisecond,
+		"After is a lower bound on the delay, even when the backoff asks for less")
+}
+
+func TestRetry_contextDoneBeforeFirstAttempt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fn, calls := failFor(0, errBoom)
+
+	assert.ErrorIs(t, Retry(ctx, fn, WithBackoff(Constant(0)), WithMaxAttempts(3)), context.Canceled)
+	assert.Zero(t, *calls)
+}
+
+func TestRetry_contextDoneDuringAttempt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fn, calls := failFor(10, MarkRetryable(errBoom))
+	err := Retry(ctx, func(c context.Context) error {
+		cancel()
+		return fn(c)
+	}, WithBackoff(Constant(time.Hour)), WithMaxAttempts(5))
+
+	require.Error(t, err)
+	assert.Equal(t, 1, *calls)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.ErrorIs(t, err, errBoom, "the last failure is kept alongside the cancellation")
+}
+
+func TestRetry_contextDoneWhileWaiting(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	// No deadline to clip the delay against, so the loop commits to the wait
+	// and is interrupted in it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	fn, calls := failFor(10, MarkRetryable(errBoom))
+	start := time.Now()
+	err := Retry(ctx, fn, WithBackoff(Constant(time.Hour)), WithMaxAttempts(5), WithMetrics(NewMetrics(reg)))
+
+	require.Error(t, err)
+	assert.Equal(t, 1, *calls)
+	assert.Less(t, time.Since(start), time.Minute, "the wait is interrupted rather than slept through")
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.ErrorIs(t, err, errBoom)
+	assert.Equal(t, uint64(1), outcomeCount(t, reg, "unknown", outcomeCancelled))
+}
+
+func TestRetry_doesNotWaitPastTheDeadline(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	fn, calls := failFor(10, MarkRetryable(errBoom))
+	start := time.Now()
+	err := Retry(ctx, fn,
+		WithBackoff(Constant(time.Hour)),
+		WithMaxAttempts(5),
+		WithMetrics(NewMetrics(reg)),
+		WithOperation("sync"),
+	)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, 1, *calls)
+	assert.Less(t, elapsed, time.Second, "a delay that outlasts the deadline is not served out")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.ErrorIs(t, err, errBoom)
+
+	assert.Equal(t, uint64(1), outcomeCount(t, reg, "sync", outcomeDeadline),
+		"giving up early is not the same outcome as an ended context")
+	assert.Zero(t, outcomeCount(t, reg, "sync", outcomeCancelled))
+}
+
+func TestRetry_waitsWhenTheDelayFitsInTheDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	fn, calls := failFor(2, MarkRetryable(errBoom))
+	require.NoError(t, Retry(ctx, fn, WithBackoff(Constant(time.Millisecond)), WithMaxAttempts(5)))
+	assert.Equal(t, 3, *calls)
+}
+
+func TestRetry_deadlineClipRespectsTheServerFloor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// The backoff fits, but the server asked for longer than the deadline.
+	fn, calls := failFor(10, MarkRetryableAfter(errBoom, time.Hour))
+	start := time.Now()
+	err := Retry(ctx, fn, WithBackoff(Constant(time.Millisecond)), WithMaxAttempts(5))
+
+	assert.Equal(t, 1, *calls)
+	assert.Less(t, time.Since(start), time.Second)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRetry_contextCauseIsReported(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(errBoom)
+
+	assert.ErrorIs(t, Retry(ctx, func(context.Context) error { return nil }), errBoom)
+}
+
+func TestRetry_contextIsPassedThroughUnchanged(t *testing.T) {
+	ctx := context.WithValue(context.Background(), testKey{}, "value")
+
+	require.NoError(t, Retry(ctx, func(c context.Context) error {
+		assert.Equal(t, "value", c.Value(testKey{}))
+		_, hasDeadline := c.Deadline()
+		assert.False(t, hasDeadline)
+		return nil
+	}))
+}
+
+type testKey struct{}
+
+func TestRetry_optionsAreAppliedInOrder(t *testing.T) {
+	fn, calls := failFor(10, MarkRetryable(errBoom))
+
+	err := Retry(context.Background(), fn, WithMaxAttempts(9), WithMaxAttempts(2), WithBackoff(Constant(0)))
+	assert.ErrorIs(t, err, ErrExhausted)
+	assert.Equal(t, 2, *calls)
+}
+
+func TestRetry_nilOptionsRestoreTheDefaults(t *testing.T) {
+	t.Run("backoff", func(t *testing.T) {
+		fn, calls := failFor(1, MarkRetryable(errBoom))
+
+		require.NoError(t, Retry(context.Background(), fn, WithBackoff(nil), WithMaxAttempts(2)))
+		assert.Equal(t, 2, *calls, "a nil backoff still retries, and still waits")
+	})
+
+	t.Run("decider", func(t *testing.T) {
+		fn, calls := failFor(1, MarkRetryable(errBoom))
+
+		require.NoError(t, Retry(context.Background(), fn,
+			WithBackoff(Constant(0)), WithMaxAttempts(3), WithDecider(nil)))
+		assert.Equal(t, 2, *calls, "a nil decider still reads the marks")
+	})
+
+	t.Run("predicate", func(t *testing.T) {
+		fn, calls := failFor(1, MarkRetryable(errBoom))
+
+		require.NoError(t, Retry(context.Background(), fn,
+			WithBackoff(Constant(0)), WithMaxAttempts(3), WithPredicate(nil)))
+		assert.Equal(t, 2, *calls, "a nil predicate still reads the marks")
+	})
+
+	t.Run("logger", func(t *testing.T) {
+		fn, calls := failFor(1, MarkRetryable(errBoom))
+
+		require.NoError(t, Retry(context.Background(), fn,
+			WithBackoff(Constant(0)), WithMaxAttempts(3), WithLogger(nil)))
+		assert.Equal(t, 2, *calls)
+	})
+}
+
+func TestRetry_logsEachRetry(t *testing.T) {
+	var buf bytes.Buffer
+	fn, _ := failFor(1, MarkRetryable(errBoom))
+
+	require.NoError(t, Retry(context.Background(), fn,
+		WithBackoff(Constant(0)), WithMaxAttempts(3),
+		WithOperation("sync"),
+		WithLogger(log.NewLogfmtLogger(&buf)),
+	))
+
+	line := buf.String()
+	assert.Equal(t, 1, strings.Count(line, "\n"))
+	assert.Contains(t, line, "operation=sync")
+	assert.Contains(t, line, "attempt=1")
+	assert.Contains(t, line, "err=boom")
+}
+
+func TestRetry_isSafeForConcurrentUseOfOneRetrier(t *testing.T) {
+	r := New(WithBackoff(Constant(0)), WithMaxAttempts(5))
+
+	done := make(chan error, 4)
+	for range cap(done) {
+		go func() {
+			fn, _ := failFor(2, MarkRetryable(errBoom))
+			done <- r.Retry(context.Background(), fn)
+		}()
+	}
+	for range cap(done) {
+		require.NoError(t, <-done)
+	}
+}
+
+func TestRetry_maxAttemptsDefaultsToTen(t *testing.T) {
+	fn, calls := failFor(100, MarkRetryable(errBoom))
+
+	err := Retry(context.Background(), fn, WithBackoff(Constant(0)))
+	assert.ErrorIs(t, err, ErrExhausted)
+	assert.Equal(t, 10, *calls)
+}
+
+func TestRetry_maxAttemptsBelowOneIsASingleAttempt(t *testing.T) {
+	for _, n := range []int{1, 0, -1} {
+		fn, calls := failFor(10, MarkRetryable(errBoom))
+
+		err := Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(n))
+		assert.ErrorIs(t, err, ErrExhausted, "WithMaxAttempts(%d)", n)
+		assert.Equal(t, 1, *calls, "WithMaxAttempts(%d) must not turn the budget off", n)
+	}
+}
+
+func TestRetry_unlimitedAttemptsRunsUntilTheContextEnds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	fn, calls := alwaysFails(MarkRetryable(errBoom))
+	err := Retry(ctx, fn, WithBackoff(Constant(0)), WithUnlimitedAttempts())
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrExhausted)
+	assert.Greater(t, *calls, 10, "the default budget must not apply")
+}
+
+func TestRetrier_isReusable(t *testing.T) {
+	r := New(WithBackoff(Constant(0)), WithMaxAttempts(3))
+
+	for range 3 {
+		fn, calls := failFor(10, MarkRetryable(errBoom))
+		assert.ErrorIs(t, r.Retry(context.Background(), fn), ErrExhausted)
+		assert.Equal(t, 3, *calls, "every call gets the same budget")
+	}
+}
+
+func TestRetry_isNewPlusRetry(t *testing.T) {
+	opts := []Option{WithBackoff(Constant(0)), WithMaxAttempts(4)}
+
+	fn, calls := failFor(10, MarkRetryable(errBoom))
+	viaFunc := Retry(context.Background(), fn, opts...)
+
+	fn2, calls2 := failFor(10, MarkRetryable(errBoom))
+	viaRetrier := New(opts...).Retry(context.Background(), fn2)
+
+	assert.Equal(t, *calls, *calls2)
+	assert.Equal(t, viaFunc.Error(), viaRetrier.Error())
+}
+
+func TestRetry_errorMessages(t *testing.T) {
+	fn, _ := failFor(10, MarkRetryable(errBoom))
+	exhausted := Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(2))
+	assert.EqualError(t, exhausted, "retry budget exhausted after 2 attempts: boom")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.EqualError(t, Retry(ctx, func(context.Context) error { return nil }),
+		"context canceled after 0 attempts")
+
+	deadlined, cancelDeadline := context.WithTimeout(context.Background(), time.Minute)
+	defer cancelDeadline()
+	fn2, _ := failFor(10, MarkRetryable(errBoom))
+	assert.EqualError(t, Retry(deadlined, fn2, WithBackoff(Constant(time.Hour))),
+		"context deadline exceeded after 1 attempts: boom")
+}
+
+// TestRetry_leavesTheMarksOnTheLastFailure pins what a nesting loop works
+// against: how this one stopped is what the wrapped reason says, not the mark.
+func TestRetry_leavesTheMarksOnTheLastFailure(t *testing.T) {
+	// Buried under a caller's own wrapping, where a mark usually is by the time
+	// an outer loop sees it.
+	failure := fmt.Errorf("writing: %w", MarkRetryable(errBoom))
+
+	t.Run("exhausted", func(t *testing.T) {
+		fn, _ := failFor(10, failure)
+		err := Retry(context.Background(), fn, WithBackoff(Constant(0)), WithMaxAttempts(2))
+
+		assert.Equal(t, Decision{Retryable: true}, Marked(err), "the mark is the caller's, and stays")
+		assert.ErrorIs(t, err, ErrExhausted, "a spent budget is what a nested loop checks for")
+		assert.ErrorIs(t, err, errBoom, "the last failure stays reachable")
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+
+		fn, _ := failFor(10, failure)
+		err := Retry(ctx, fn, WithBackoff(Constant(time.Hour)), WithMaxAttempts(5))
+
+		assert.Equal(t, Decision{Retryable: true}, Marked(err))
+		assert.ErrorIs(t, err, context.Canceled, "the ended context is what a nested loop checks for")
+		assert.ErrorIs(t, err, errBoom, "the last failure stays reachable")
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		fn, _ := failFor(10, failure)
+		err := Retry(ctx, fn, WithBackoff(Constant(time.Hour)))
+
+		assert.Equal(t, Decision{Retryable: true}, Marked(err))
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.ErrorIs(t, err, errBoom)
+	})
+}


### PR DESCRIPTION
## What

  Adds a new `retry` package, containing a transport-agnostic retry executor. It is entirely additive, nothing in dskit uses it yet.

  ```go
  err := retry.Retry(ctx, client.Sync, retry.WithPredicate(isTransient))
  ```

  The package owns the executor and leaves the policy to the caller:

  | Piece | Default |
  |---|---|
  | `Decider`: which errors deserve another attempt | `Marked`, so an unmarked error gets exactly one attempt |
  | `Backoff`: how long to wait (`Exponential`, `Linear`, `Uniform`, `Constant`, wrapped in `Jittered`) | `Jittered(Exponential(100ms, 2, 10s), 0.5)` |
  | `WithMaxAttempts`: how many attempts there are | 10, first attempt included |
  | `WithMetrics`: attempts, outcome and duration | off |

  [`retry/README.md`](https://github.com/grafana/dskit/blob/3a3624736a94a01e01399abe054a4ebc1d56f76d/retry/README.md) covers the whole surface; [`example_test.go`](https://github.com/grafana/dskit/blob/3a3624736a94a01e01399abe054a4ebc1d56f76d/retry/example_test.go) has runnable examples.

  ## Why

  It is inspired by [k8s' client-go retry helpers](https://pkg.go.dev/k8s.io/client-go/util/retry), and aims to make the current uses of `dskit/backoff` easier to write.

  Today the caller writes the loop by hand (`for b.Ongoing() { ...; b.Wait() }`), and every call site repeats the same work: instrumenting the loop, deciding whether the error is worth another attempt, handling context cancellation. `backoff.Backoff` also carries per-loop state (`numRetries`, `nextDelayMin/Max`), so it has to be built per operation and reset  
  by hand.

  The aim is to do that once, and to make the simple case a single call, with everything else opt-in through options. A `retry.Backoff` and a `retry.Decider` are plain functions, so they are easy to write and hook into the executor.

  The executor also doesn't care about the transport or the operation itself. The policy lives either in a `Decider` at the call site, or in `MarkRetryable`/`MarkRetryableAfter` at the point the error is produced, so the same executor covers gRPC, HTTP, object storage and plain in-process contention. It ships no HTTP or gRPC decider, which keeps the package   
  free of transport dependencies. `MarkRetryableAfter` is the hook for a server-supplied `Retry-After`, which the loop treats as a lower bound on the next delay.

  ## Future work

  - Improve the support for nested retries, to avoid retry storms. Nesting multiplies today: an inner budget of 3 inside an outer budget of 5 is up to 15 calls. The goal is to make it easier for an outer `Retrier` to decide what to do based on how an inner one ended.
  - Consider adding flags. For now, turning a component's knobs into `retry.Option`s is that component's job.
  - Add built-in transport `Decider`s, perhaps built from a list of HTTP or gRPC status codes.

  ## Checklist
  - [x] Tests updated
