### PR TITLE
feat(limiter): add RateLimiter.TokensAt to check remaining tokens without consuming them

### DIFF
--- a/limiter/rate_limiter.go
+++ b/limiter/rate_limiter.go
@@ -69,6 +69,19 @@ func (l *RateLimiter) Limit(now time.Time, tenantID string) float64 {
 	return float64(l.getTenantLimiter(now, tenantID).Limit())
 }
 
+// TokensAt returns the number of tokens available for the given tenant at
+// time now, without consuming any of them. It can be used to cheaply check
+// whether a tenant is currently able to afford a request of a known (or
+// estimated) cost before doing any expensive work on their behalf, e.g. to
+// reject over-limit requests before reading and parsing the request body.
+//
+// The returned value can be negative if the tenant has over-consumed via
+// ReserveN, and increases over time up to Burst(tenantID) as tokens are
+// replenished.
+func (l *RateLimiter) TokensAt(now time.Time, tenantID string) float64 {
+	return l.getTenantLimiter(now, tenantID).TokensAt(now)
+}
+
 // Burst returns the currently configured maximum burst size.
 func (l *RateLimiter) Burst(now time.Time, tenantID string) int {
 	return l.getTenantLimiter(now, tenantID).Burst()

--- a/limiter/rate_limiter_test.go
+++ b/limiter/rate_limiter_test.go
@@ -66,6 +66,38 @@ func TestRateLimiter_AllowN(t *testing.T) {
 	assert.Equal(t, true, limiter.AllowN(now.Add(time.Second), "tenant-2", 2))
 }
 
+func TestRateLimiter_TokensAt(t *testing.T) {
+	strategy := &staticLimitStrategy{tenants: map[string]struct {
+		limit float64
+		burst int
+	}{
+		"tenant-1": {limit: 10, burst: 20},
+	}}
+
+	limiter := NewRateLimiter(strategy, 10*time.Second)
+	now := time.Now()
+
+	// A brand new tenant limiter starts fully bursted.
+	assert.Equal(t, float64(20), limiter.TokensAt(now, "tenant-1"))
+
+	// TokensAt does not consume tokens: calling it repeatedly returns the
+	// same value and does not affect subsequent AllowN calls.
+	assert.Equal(t, float64(20), limiter.TokensAt(now, "tenant-1"))
+	assert.True(t, limiter.AllowN(now, "tenant-1", 20))
+
+	// All tokens have been consumed.
+	assert.Equal(t, float64(0), limiter.TokensAt(now, "tenant-1"))
+	assert.False(t, limiter.AllowN(now, "tenant-1", 1))
+
+	// Tokens are replenished over time (limit is 10/s).
+	assert.Equal(t, float64(5), limiter.TokensAt(now.Add(500*time.Millisecond), "tenant-1"))
+
+	// ReserveN can push the token count negative; TokensAt reflects that.
+	r := limiter.ReserveN(now, "tenant-1", 15)
+	assert.True(t, r.OK())
+	assert.Equal(t, float64(-15), limiter.TokensAt(now, "tenant-1"))
+}
+
 func TestRateLimiter_ReserveN(t *testing.T) {
 	strategy := &staticLimitStrategy{tenants: map[string]struct {
 		limit float64


### PR DESCRIPTION
Adds `RateLimiter.TokensAt(now, tenantID)`, which reports how many tokens a tenant currently has available in its per-tenant `rate.Limiter` bucket, without consuming any of them. It is a thin wrapper around the existing `golang.org/x/time/rate.Limiter.TokensAt`, which this package already depends on transitively.

## Why

Callers that want to admission-gate expensive work ahead of the usual `AllowN` charge need a cheap, side-effect-free way to check "can this tenant currently afford a request of roughly this cost?" before doing the work of computing the exact cost.