### PR TITLE
kv/memberlist: make max CAS retries configurable

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -162,6 +162,13 @@ type KVConfig struct {
 	AbortIfJoinFails     bool                `yaml:"abort_if_cluster_join_fails"`
 	RejoinInterval       time.Duration       `yaml:"rejoin_interval" category:"advanced"`
 
+	// MaxCasRetries is the maximum number of retries for a CAS (compare-and-swap)
+	// operation on a key before giving up. A CAS retries when it detects the local
+	// value has changed since it was read (e.g. a concurrent update gossiped in from
+	// another node), which happens more often on keys with many concurrent writers
+	// (e.g. a ring with many members). 0 uses the built-in default.
+	MaxCasRetries int `yaml:"max_cas_retries" category:"advanced"`
+
 	// Remove LEFT ingesters from ring after this timeout.
 	LeftIngestersTimeout   time.Duration `yaml:"left_ingesters_timeout" category:"advanced"`
 	ObsoleteEntriesTimeout time.Duration `yaml:"obsolete_entries_timeout" category:"experimental"`
@@ -210,6 +217,7 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.AbortIfFastJoinFails, prefix+"memberlist.abort-if-fast-join-fails", false, "Abort if this node fails the fast memberlist cluster joining procedure at startup. When enabled, it's guaranteed that other services, depending on memberlist, have an updated view over the cluster state when they're started.")
 	f.BoolVar(&cfg.AbortIfJoinFails, prefix+"memberlist.abort-if-join-fails", cfg.AbortIfJoinFails, "Abort if this node fails to join memberlist cluster at startup. When enabled, it's not guaranteed that other services are started only after the cluster state has been successfully updated; use 'abort-if-fast-join-fails' instead.")
 	f.DurationVar(&cfg.RejoinInterval, prefix+"memberlist.rejoin-interval", 0, "If not 0, how often to rejoin the cluster. Occasional rejoin can help to fix the cluster split issue, and is harmless otherwise. For example when using only few components as a seed nodes (via -memberlist.join), then it's recommended to use rejoin. If -memberlist.join points to dynamic service that resolves to all gossiping nodes (eg. Kubernetes headless service), then rejoin is not needed.")
+	f.IntVar(&cfg.MaxCasRetries, prefix+"memberlist.max-cas-retries", maxCasRetries, "Maximum number of retries for a CAS (compare-and-swap) operation on a key before giving up. Raise this for keys with many concurrent writers (e.g. a large ring), where a CAS is more likely to lose the race against a concurrent update before it can commit.")
 	f.DurationVar(&cfg.LeftIngestersTimeout, prefix+"memberlist.left-ingesters-timeout", 5*time.Minute, "How long to keep LEFT ingesters in the ring.")
 	f.DurationVar(&cfg.ObsoleteEntriesTimeout, prefix+"memberlist.obsolete-entries-timeout", mlDefaults.PushPullInterval, "How long to keep obsolete entries in the KV store.")
 	f.DurationVar(&cfg.LeaveTimeout, prefix+"memberlist.leave-timeout", 20*time.Second, "Timeout for leaving memberlist cluster.")
@@ -339,9 +347,10 @@ type KV struct {
 	memberlistMembersCount prometheus.GaugeFunc
 	memberlistHealthScore  prometheus.GaugeFunc
 
-	// make this configurable for tests. Default value is fine for normal usage
-	// where updates are coming from network, but when running tests with many
-	// goroutines using same KV, default can be too low.
+	// maxCasRetries is normally sourced from KVConfig.MaxCasRetries (falling back to
+	// the maxCasRetries constant if unset). Tests that drive many goroutines against
+	// the same KV concurrently can also override it directly, since the default can
+	// be too low for that level of induced contention.
 	maxCasRetries int
 }
 
@@ -414,6 +423,11 @@ var (
 func NewKV(cfg KVConfig, logger log.Logger, dnsProvider DNSProvider, registerer prometheus.Registerer) *KV {
 	cfg.TCPTransport.MetricsNamespace = cfg.MetricsNamespace
 
+	casRetries := cfg.MaxCasRetries
+	if casRetries <= 0 {
+		casRetries = maxCasRetries
+	}
+
 	mlkv := &KV{
 		cfg:              cfg,
 		logger:           logger,
@@ -426,7 +440,7 @@ func NewKV(cfg KVConfig, logger log.Logger, dnsProvider DNSProvider, registerer 
 		prefixWatchers:   make(map[string][]chan string),
 		workersChannels:  make(map[string]chan valueUpdate),
 		shutdown:         make(chan struct{}),
-		maxCasRetries:    maxCasRetries,
+		maxCasRetries:    casRetries,
 	}
 
 	mlkv.createAndRegisterMetrics()

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -482,6 +482,56 @@ func TestCASFailedBecauseOfVersionChanges(t *testing.T) {
 	})
 }
 
+// TestCASFailedBecauseOfVersionChanges_ConfiguredMaxCasRetries verifies that
+// KVConfig.MaxCasRetries, not just the maxCasRetries constant, governs how many times
+// CAS retries before giving up — the same scenario as
+// TestCASFailedBecauseOfVersionChanges, but with a configured value on both sides of
+// the default.
+func TestCASFailedBecauseOfVersionChanges_ConfiguredMaxCasRetries(t *testing.T) {
+	testCASRetries := func(t *testing.T, configuredRetries, wantRetries int) {
+		c := dataCodec{}
+
+		var cfg KVConfig
+		flagext.DefaultValues(&cfg)
+		cfg.TCPTransport = TCPTransportConfig{BindAddrs: getLocalhostAddrs()}
+		cfg.Codecs = []codec.Codec{c}
+		cfg.MaxCasRetries = configuredRetries
+
+		mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
+		defer services.StopAndAwaitTerminated(context.Background(), mkv) //nolint:errcheck
+
+		kv, err := NewClient(mkv, c)
+		require.NoError(t, err)
+
+		require.NoError(t, cas(kv, key, func(*data) (*data, bool, error) {
+			return &data{Members: map[string]member{"nonempty": {Timestamp: time.Now().Unix()}}}, true, nil
+		}))
+
+		calls := 0
+		err = casWithErr(context.Background(), kv, key, func(d *data) (*data, bool, error) {
+			calls++
+			// An inner CAS that always succeeds makes the outer CAS lose the race every time.
+			require.NoError(t, cas(kv, key, func(d *data) (*data, bool, error) {
+				d.Members[fmt.Sprintf("%d", calls)] = member{Timestamp: time.Now().Unix()}
+				return d, true, nil
+			}))
+			d.Members["world"] = member{Timestamp: time.Now().Unix()}
+			return d, true, nil
+		})
+
+		require.EqualError(t, err, "failed to CAS-update key test: too many retries")
+		require.Equal(t, wantRetries, calls)
+	}
+
+	t.Run("configured value overrides the built-in default", func(t *testing.T) {
+		testCASRetries(t, 3, 3)
+	})
+	t.Run("zero falls back to the built-in default", func(t *testing.T) {
+		testCASRetries(t, 0, maxCasRetries)
+	})
+}
+
 func TestMultipleCAS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds `KVConfig.MaxCasRetries` (flag: `-memberlist.max-cas-retries`, yaml: `max_cas_retries`), making the number of retries a CAS operation attempts before giving up configurable instead of a hardcoded constant (`maxCasRetries = 10`).

## Why

On a memberlist KV key with many concurrent writers (e.g. a ring with hundreds of members, each heartbeating into the same key), a newly-registering member can lose the CAS race repeatedly within milliseconds — well before its local state has converged — and exhaust the fixed retry budget, failing with `too many retries: version mismatch`. This shows up in practice on large dskit-backed rings under load (observed on a ~900-member ring during rollout-restart waves), and this same signature turns up for other dskit consumers too (e.g. Mimir's distributor/store-gateway/querier rings). Making the budget configurable lets an operator size it for their ring's actual scale/churn instead of being stuck with a one-size-fits all default.

## How

- New `KVConfig.MaxCasRetries int` field (`category:"advanced"`), registered via the existing `RegisterFlagsWithPrefix`, defaulting to the current constant (10) — fully backward compatible.
- `NewKV` sources the retry count from config, falling back to the built-in constant if unset/`<=0` — the same shape `kv/consul/client.go` already uses for its own (currently test-only, unexposed) `MaxCasRetries` field.
- No exported function signatures changed; the only API surface change is one new, defaulted struct field — verified no unkeyed `KVConfig{...}` literals exist anywhere in the repo that field insertion could break.

## Testing

- `go build ./...`, `go vet ./kv/...`, `gofmt`, `golangci-lint run ./kv/memberlist/...` all clean.
- `go test ./kv/memberlist/...` (including `-race`) passes, including two new subtests (`TestCASFailedBecauseOfVersionChanges_ConfiguredMaxCasRetries`) proving a configured value overrides the retry count and that `0` correctly falls back to the built-in default.