### PR TITLE
feat(memberlist): opt-in exponential backoff between CAS retries

### DIFF
--- a/kv/memberlist/memberlist_client.go
+++ b/kv/memberlist/memberlist_client.go
@@ -188,6 +188,12 @@ type KVConfig struct {
 	// Size of the buffer for key watchers.
 	WatchPrefixBufferSize int `yaml:"watch_prefix_buffer_size" category:"advanced"`
 
+	// CasRetryMinBackoff and CasRetryMaxBackoff add a delay between CAS retries after
+	// a version mismatch. MinBackoff is the on/off toggle: 0 (its default) disables
+	// the delay regardless of MaxBackoff.
+	CasRetryMinBackoff time.Duration `yaml:"cas_retry_min_backoff" category:"experimental"`
+	CasRetryMaxBackoff time.Duration `yaml:"cas_retry_max_backoff" category:"experimental"`
+
 	TCPTransport TCPTransportConfig `yaml:",inline"`
 
 	// Zone-aware routing configuration.
@@ -250,6 +256,8 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.ClusterLabelVerificationDisabled, prefix+"memberlist.cluster-label-verification-disabled", mlDefaults.SkipInboundLabelCheck, "When true, memberlist doesn't verify that inbound packets and gossip streams have the cluster label matching the configured one. This verification should be disabled while rolling out the change to the configured cluster label in a live memberlist cluster.")
 	f.DurationVar(&cfg.BroadcastTimeoutForLocalUpdatesOnShutdown, prefix+"memberlist.broadcast-timeout-for-local-updates-on-shutdown", 10*time.Second, "Timeout for broadcasting all remaining locally-generated updates to other nodes when shutting down. Only used if there are nodes left in the memberlist cluster, and only applies to locally-generated updates, not to broadcast messages that are result of incoming gossip updates. 0 = no timeout, wait until all locally-generated updates are sent.")
 	f.IntVar(&cfg.WatchPrefixBufferSize, prefix+"memberlist.watch-prefix-buffer-size", watchPrefixBufferSize, "Size of the buffered channel for the WatchPrefix function.")
+	f.DurationVar(&cfg.CasRetryMinBackoff, prefix+"memberlist.cas-retry-min-backoff", 0, "Minimum delay between CAS retries after a version mismatch. 0 disables the delay.")
+	f.DurationVar(&cfg.CasRetryMaxBackoff, prefix+"memberlist.cas-retry-max-backoff", 10*time.Second, "Maximum delay between CAS retries after a version mismatch. Only takes effect if cas-retry-min-backoff is also set.")
 
 	cfg.TCPTransport.RegisterFlagsWithPrefix(f, prefix)
 	cfg.ZoneAwareRouting.RegisterFlagsWithPrefix(f, prefix+"memberlist.zone-aware-routing.")
@@ -1305,6 +1313,11 @@ func (m *KV) Delete(key string) error {
 func (m *KV) CAS(ctx context.Context, key string, codec codec.Codec, f func(in interface{}) (out interface{}, retry bool, err error)) error {
 	var lastError error
 
+	var retryBackoff *backoff.Backoff
+	if m.cfg.CasRetryMinBackoff > 0 {
+		retryBackoff = backoff.New(ctx, backoff.Config{MinBackoff: m.cfg.CasRetryMinBackoff, MaxBackoff: m.cfg.CasRetryMaxBackoff})
+	}
+
 outer:
 	for retries := m.maxCasRetries; retries > 0; retries-- {
 		m.casAttempts.Inc()
@@ -1318,6 +1331,12 @@ outer:
 			case <-time.After(noChangeDetectedRetrySleep):
 				// ok
 			case <-ctx.Done():
+				lastError = ctx.Err()
+				break outer
+			}
+		} else if lastError != nil && retryBackoff != nil {
+			retryBackoff.Wait()
+			if ctx.Err() != nil {
 				lastError = ctx.Err()
 				break outer
 			}

--- a/kv/memberlist/memberlist_client_test.go
+++ b/kv/memberlist/memberlist_client_test.go
@@ -592,6 +592,47 @@ func TestCASFailedBecauseOfVersionChanges(t *testing.T) {
 	})
 }
 
+func TestCASRetryBackoff(t *testing.T) {
+	c := dataCodec{}
+
+	var cfg KVConfig
+	flagext.DefaultValues(&cfg)
+	cfg.TCPTransport = TCPTransportConfig{BindAddrs: getLocalhostAddrs()}
+	cfg.Codecs = []codec.Codec{c}
+	cfg.CasRetryMinBackoff = 5 * time.Millisecond
+	cfg.CasRetryMaxBackoff = 20 * time.Millisecond
+
+	mkv := NewKV(cfg, log.NewNopLogger(), &staticDNSProviderMock{}, prometheus.NewPedanticRegistry())
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), mkv))
+	defer services.StopAndAwaitTerminated(context.Background(), mkv) //nolint:errcheck
+
+	kv, err := NewClient(mkv, c)
+	require.NoError(t, err)
+
+	require.NoError(t, cas(kv, key, func(*data) (*data, bool, error) {
+		return &data{Members: map[string]member{"nonempty": {Timestamp: time.Now().Unix()}}}, true, nil
+	}))
+
+	calls := 0
+	start := time.Now()
+	err = casWithErr(context.Background(), kv, key, func(d *data) (*data, bool, error) {
+		calls++
+		require.NoError(t, cas(kv, key, func(d *data) (*data, bool, error) {
+			d.Members[fmt.Sprintf("%d", calls)] = member{Timestamp: time.Now().Unix()}
+			return d, true, nil
+		}))
+		d.Members["world"] = member{Timestamp: time.Now().Unix()}
+		return d, true, nil
+	})
+	elapsed := time.Since(start)
+
+	require.EqualError(t, err, "failed to CAS-update key test: too many retries: version mismatch")
+	require.Equal(t, maxCasRetries, calls)
+	// maxCasRetries-1 delays of at least MinBackoff each — a lower bound that only
+	// holds if the delay actually ran (it wouldn't with MinBackoff=0).
+	require.GreaterOrEqual(t, elapsed, time.Duration(maxCasRetries-1)*cfg.CasRetryMinBackoff)
+}
+
 func TestMultipleCAS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds `KVConfig.CasRetryMinBackoff`/`CasRetryMaxBackoff`, letting a caller opt into a delay between CAS retries after a version mismatch, instead of the current immediate retry.

## Why

`CAS()`'s plain version-mismatch retry path (`kv/memberlist/memberlist_client.go`) has no delay between attempts — only the unrelated "no change detected" case sleeps. Right after a node joins, its local copy of a key isn't just missing new writes — it's still absorbing the existing cluster state via catch-up sync, a front-loaded burst of local updates much higher-frequency than the steady-state ambient write rate. Every attempt made during that burst has a high chance of losing the race, not because some other writer happens to be writing at that exact instant, but because the local copy keeps getting rewritten out from under it by its own ongoing convergence. On a key with many members (e.g. a large ring), that burst is enough to exhaust the whole fixed retry budget in well under a second, regardless of the budget's size — a larger retry count alone (see #1065, closed) doesn't help, since it just retries faster within the same narrow, still-converging window. Backing off between retries lets that catch-up finish so the next attempt lands after convergence has caught up, not lucky timing against other writers.

## How

- `CasRetryMinBackoff`/`CasRetryMaxBackoff time.Duration` on `KVConfig`, registered as `-memberlist.cas-retry-min-backoff` (default 0) / `-memberlist.cas-retry-max-backoff` (default 10s).
- `MinBackoff` is the on/off toggle: it defaults to 0, which disables the delay entirely (regardless of `MaxBackoff`) — current behavior is unchanged for every existing caller. `MaxBackoff` gets a real default the same way every other flag in this file does, since it's harmless to a caller who never touches `MinBackoff`.
- Implemented as a `backoff.Backoff` constructed once per `CAS()` call, invoked in place of the previous no-op path for a plain version-mismatch retry (the existing "no change detected" 1s sleep is untouched, a separate mechanism for a separate cause).

## Testing

- `go build ./...`, `go vet ./kv/...`, `gofmt`, `golangci-lint run ./kv/memberlist/...` all clean.
- `go test ./kv/memberlist/...` passes, including a new `TestCASRetryBackoff` that configures both backoff fields, forces repeated version-mismatch retries (same technique as the existing `TestCASFailedBecauseOfVersionChanges`), and asserts both that the retry count is unchanged and that a real delay elapsed.
