### PR TITLE
feat(server): add flags for HTTP connection TTL middleware

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -119,6 +119,10 @@ type Config struct {
 	HTTPServerWriteTimeout        time.Duration `yaml:"http_server_write_timeout"`
 	HTTPServerIdleTimeout         time.Duration `yaml:"http_server_idle_timeout"`
 
+	HTTPServerMinConnectionAge             time.Duration `yaml:"http_server_min_connection_age" category:"advanced"`
+	HTTPServerMaxConnectionAge             time.Duration `yaml:"http_server_max_connection_age" category:"advanced"`
+	HTTPServerIdleConnectionCheckFrequency time.Duration `yaml:"http_server_idle_connection_check_frequency" category:"advanced"`
+
 	HTTPLogClosedConnectionsWithoutResponse bool `yaml:"http_log_closed_connections_without_response_enabled"`
 
 	GRPCOptions                   []grpc.ServerOption            `yaml:"-"`
@@ -218,6 +222,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HTTPServerReadHeaderTimeout, "server.http-read-header-timeout", 0, "Read timeout for HTTP request headers. If set to 0, value of -server.http-read-timeout is used.")
 	f.DurationVar(&cfg.HTTPServerWriteTimeout, "server.http-write-timeout", 30*time.Second, "Write timeout for HTTP server")
 	f.DurationVar(&cfg.HTTPServerIdleTimeout, "server.http-idle-timeout", 120*time.Second, "Idle timeout for HTTP server")
+	f.DurationVar(&cfg.HTTPServerMinConnectionAge, "server.http.keepalive.min-connection-age", 0, "The minimum duration for the maximum amount of time an HTTP keepalive connection may exist before the server asks the client to close it. The actual duration is picked randomly per connection between the minimum and maximum, to spread reconnections over time. 0 to disable.")
+	f.DurationVar(&cfg.HTTPServerMaxConnectionAge, "server.http.keepalive.max-connection-age", 0, "The maximum duration for the maximum amount of time an HTTP keepalive connection may exist before the server asks the client to close it. 0 to disable.")
+	f.DurationVar(&cfg.HTTPServerIdleConnectionCheckFrequency, "server.http.keepalive.idle-connection-check-frequency", time.Minute, "How frequently to check for tracked HTTP keepalive connections which have gone idle and can be forgotten. Only applies when -server.http.keepalive.max-connection-age is set.")
 	f.BoolVar(&cfg.HTTPLogClosedConnectionsWithoutResponse, "server.http-log-closed-connections-without-response-enabled", false, "Log closed connections that did not receive any response, most likely because client didn't send any request within timeout.")
 	f.IntVar(&cfg.GRPCServerMaxRecvMsgSize, "server.grpc-max-recv-msg-size-bytes", 4*1024*1024, "Limit on the size of a gRPC message this server can receive (bytes).")
 	f.IntVar(&cfg.GRPCServerMaxSendMsgSize, "server.grpc-max-send-msg-size-bytes", 4*1024*1024, "Limit on the size of a gRPC message this server can send (bytes).")
@@ -271,10 +278,11 @@ func (cfg *Config) registererOrDefault() prometheus.Registerer {
 //
 // Servers will be automatically instrumented for Prometheus metrics.
 type Server struct {
-	cfg          Config
-	handler      SignalHandler
-	grpcListener net.Listener
-	httpListener net.Listener
+	cfg                     Config
+	handler                 SignalHandler
+	grpcListener            net.Listener
+	httpListener            net.Listener
+	connectionTTLMiddleware middleware.HTTPConnectionTTLMiddleware
 
 	HTTP       *mux.Router
 	HTTPServer *http.Server
@@ -544,6 +552,15 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		return nil, fmt.Errorf("error building http middleware: %w", err)
 	}
 
+	// The connection TTL middleware owns a background goroutine, so it is built here rather than in
+	// BuildHTTPMiddleware, allowing Shutdown() to stop it. It is the outermost middleware so that the
+	// Connection header is set on every response, including ones short-circuited further in.
+	connectionTTLMiddleware, err := middleware.NewHTTPConnectionTTLMiddleware(cfg.HTTPServerMinConnectionAge, cfg.HTTPServerMaxConnectionAge, cfg.HTTPServerIdleConnectionCheckFrequency, reg)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up HTTP connection TTL middleware: %w", err)
+	}
+	httpMiddleware = append([]middleware.Interface{connectionTTLMiddleware}, httpMiddleware...)
+
 	httpServer := &http.Server{
 		ReadTimeout:       cfg.HTTPServerReadTimeout,
 		ReadHeaderTimeout: cfg.HTTPServerReadHeaderTimeout,
@@ -561,10 +578,11 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	}
 
 	return &Server{
-		cfg:          cfg,
-		httpListener: httpListener,
-		grpcListener: grpcListener,
-		handler:      handler,
+		cfg:                     cfg,
+		httpListener:            httpListener,
+		grpcListener:            grpcListener,
+		handler:                 handler,
+		connectionTTLMiddleware: connectionTTLMiddleware,
 
 		HTTP:       router,
 		HTTPServer: httpServer,
@@ -728,6 +746,7 @@ func (s *Server) Shutdown() {
 
 	_ = s.HTTPServer.Shutdown(ctx)
 	s.GRPC.GracefulStop()
+	s.connectionTTLMiddleware.Stop()
 }
 
 func newProxyProtocolListener(httpListener net.Listener, readHeaderTimeout time.Duration) net.Listener {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1098,3 +1098,89 @@ func httpTarget(srv *Server, path string) string {
 func httpsTarget(srv *Server, path string) string {
 	return fmt.Sprintf("https://%s%s", srv.HTTPListenAddr().String(), path)
 }
+
+func TestHTTPConnectionTTL(t *testing.T) {
+	// The Connection header is hop-by-hop, so the HTTP client consumes it and surfaces it as
+	// Response.Close rather than exposing it in Response.Header.
+	newTestServer := func(t *testing.T, apply func(*Config)) (*Server, chan string) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+		var cfg Config
+		cfg.RegisterFlags(flag.NewFlagSet("", flag.ExitOnError))
+		apply(&cfg)
+		setAutoAssignedPorts(DefaultNetwork, &cfg)
+
+		server, err := New(cfg)
+		require.NoError(t, err)
+		t.Cleanup(server.Shutdown)
+
+		remoteAddrs := make(chan string, 8)
+		server.HTTP.HandleFunc("/test", func(_ http.ResponseWriter, r *http.Request) {
+			remoteAddrs <- r.RemoteAddr
+		})
+
+		go func() {
+			require.NoError(t, server.Run())
+		}()
+
+		return server, remoteAddrs
+	}
+
+	get := func(t *testing.T, client *http.Client, server *Server) *http.Response {
+		res, err := client.Get(httpTarget(server, "/test"))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		_, err = io.Copy(io.Discard, res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+		return res
+	}
+
+	t.Run("disabled by default, the connection is reused", func(t *testing.T) {
+		server, remoteAddrs := newTestServer(t, func(*Config) {})
+		client := &http.Client{}
+
+		require.False(t, get(t, client, server).Close)
+		first := <-remoteAddrs
+
+		require.False(t, get(t, client, server).Close)
+		require.Equal(t, first, <-remoteAddrs, "the connection should have been reused")
+	})
+
+	t.Run("once the max connection age elapses, the server asks the client to close the connection", func(t *testing.T) {
+		// The TTL has millisecond granularity, so it must survive truncation while still
+		// being short enough to elapse between two requests.
+		server, remoteAddrs := newTestServer(t, func(cfg *Config) {
+			cfg.HTTPServerMinConnectionAge = time.Millisecond
+			cfg.HTTPServerMaxConnectionAge = time.Millisecond
+		})
+		client := &http.Client{}
+
+		// The first request registers the connection.
+		require.False(t, get(t, client, server).Close)
+		first := <-remoteAddrs
+
+		time.Sleep(10 * time.Millisecond)
+
+		// The second is served on the same connection, but the server now asks for it to be closed.
+		require.True(t, get(t, client, server).Close)
+		require.Equal(t, first, <-remoteAddrs)
+
+		// So the third has to establish a new one.
+		require.False(t, get(t, client, server).Close)
+		require.NotEqual(t, first, <-remoteAddrs, "a new connection should have been established")
+	})
+
+	t.Run("rejects a minimum connection age greater than the maximum", func(t *testing.T) {
+		prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
+		var cfg Config
+		cfg.RegisterFlags(flag.NewFlagSet("", flag.ExitOnError))
+		cfg.HTTPServerMinConnectionAge = time.Minute
+		cfg.HTTPServerMaxConnectionAge = time.Second
+		setAutoAssignedPorts(DefaultNetwork, &cfg)
+
+		_, err := New(cfg)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
**What this PR does**:

Wires the existing `middleware.HTTPConnectionTTLMiddleware` (#905) into the `server` package behind three new flags, so it can be enabled by configuration rather than by each consumer constructing it and injecting it through `Config.HTTPMiddleware`:

- `-server.http.keepalive.min-connection-age`
- `-server.http.keepalive.max-connection-age`
- `-server.http.keepalive.idle-connection-check-frequency`

Both ages default to `0`, which the middleware already treats as disabled, so behaviour is unchanged unless the flags are set. Naming follows the existing `-server.grpc.keepalive.*` family, since this is the HTTP counterpart of `-server.grpc.keepalive.max-connection-age`.

The motivation is the case described in #1067: behind an L4 load balancer that picks a backend per TCP connection, long-lived HTTP keep-alive connections pin each client to one backend and load stays unevenly spread across replicas. `IdleTimeout` cannot help because a continuously busy connection never goes idle.

A couple of choices worth flagging for review:

- The middleware owns a background goroutine and needs `Stop()`, so it is constructed in `newServer`, stored on `Server`, and stopped from `Shutdown()`. Building it inside `BuildHTTPMiddleware` would have left nothing able to stop it, and that function is exported with a signature returning only the middleware slice — so I left its signature alone.
- It is prepended as the outermost middleware so the `Connection` header is set on responses that are short-circuited by middleware further in.
- The mechanism is effectively HTTP/1.1-only: `Connection` is a hop-by-hop header and is not valid in HTTP/2.

Tests cover the disabled default (connection is reused), the enabled case (the server asks the client to close once the age elapses, and the next request lands on a new connection), and the validation error when the minimum age exceeds the maximum. Note that the HTTP client consumes the hop-by-hop `Connection` header and surfaces it as `Response.Close`, so the tests assert on that rather than on the response header.

**Which issue(s) this PR fixes**:

Fixes #1067

**Checklist**
- [x] Tests updated