### PR TITLE
fix(ring): use proper capacity initialization

### DIFF
--- a/ring/partition_ring_model.go
+++ b/ring/partition_ring_model.go
@@ -442,7 +442,7 @@ func (m *PartitionRingDesc) mergeWithTime(mergeable memberlist.Mergeable, localC
 
 // MergeContent implements memberlist.Mergeable.
 func (m *PartitionRingDesc) MergeContent() []string {
-	result := make([]string, len(m.Partitions)+len(m.Owners))
+	result := make([]string, 0, len(m.Partitions)+len(m.Owners))
 
 	// We're assuming that partition IDs and instance IDs are not colliding (ie. no instance is called "1").
 	for pid := range m.Partitions {

--- a/ring/partition_ring_model_test.go
+++ b/ring/partition_ring_model_test.go
@@ -1192,3 +1192,24 @@ func TestPartitionRingDesc_PartitionOwnersCountUpdatedBefore(t *testing.T) {
 	assert.Equal(t, 1, desc.PartitionOwnersCountUpdatedBefore(1, now.Add(-1*time.Second)))
 	assert.Equal(t, 0, desc.PartitionOwnersCountUpdatedBefore(1, now.Add(-2*time.Second)))
 }
+
+func TestPartitionRingDesc_MergeContent(t *testing.T) {
+	now := time.Now()
+
+	t.Run("empty ring", func(t *testing.T) {
+		require.Empty(t, NewPartitionRingDesc().MergeContent())
+	})
+
+	t.Run("returns exactly the partition and owner IDs", func(t *testing.T) {
+		desc := NewPartitionRingDesc()
+		desc.AddPartition(1, PartitionActive, now)
+		desc.AddPartition(2, PartitionActive, now)
+		desc.AddOrUpdateOwner("ingester-zone-a-0", OwnerActive, 1, now)
+
+		// A make([]string, len(...)) followed by append would prefix this with one
+		// empty string per partition and owner, doubling the content set. That set
+		// is compared pairwise in ringBroadcast.Invalidates, so the padding costs
+		// 4x the comparisons and shows up in the memberlist status page.
+		require.ElementsMatch(t, []string{"1", "2", "ingester-zone-a-0"}, desc.MergeContent())
+	})
+}

--- a/ring/partition_ring_model_test.go
+++ b/ring/partition_ring_model_test.go
@@ -1206,10 +1206,6 @@ func TestPartitionRingDesc_MergeContent(t *testing.T) {
 		desc.AddPartition(2, PartitionActive, now)
 		desc.AddOrUpdateOwner("ingester-zone-a-0", OwnerActive, 1, now)
 
-		// A make([]string, len(...)) followed by append would prefix this with one
-		// empty string per partition and owner, doubling the content set. That set
-		// is compared pairwise in ringBroadcast.Invalidates, so the padding costs
-		// 4x the comparisons and shows up in the memberlist status page.
 		require.ElementsMatch(t, []string{"1", "2", "ingester-zone-a-0"}, desc.MergeContent())
 	})
 }


### PR DESCRIPTION
**What this PR does**:

Fixes a `make([]T, n)` used where `make([]T, 0, n)` was intended. `make([]T, n)`
allocates a slice already *containing* `n` zero values, so the subsequent `append` calls add
the real entries after them. The slice ends up being twice its intended length, half of it blank.

**`ring/partition_ring_model.go` — `PartitionRingDesc.MergeContent()`**

```go
result := make([]string, len(m.Partitions)+len(m.Owners))
for pid := range m.Partitions {
    result = append(result, strconv.Itoa(int(pid)))
}
for id := range m.Owners {
    result = append(result, id)
}
```

Returns `["", "", …, "1", "2", "ingester-zone-a-0"]` instead of just the IDs.

The returned set is consumed by `ringBroadcast.Invalidates` (`kv/memberlist/broadcast.go:18`),
which does a nested-loop subset check between the new and old broadcast content. 

Doubling both sides makes that roughly **4x the string comparisons**, on the gossip path, every time
memberlist evaluates whether a queued broadcast can be dropped.

It is **not** a correctness bug. `""` ends up on both sides of the subset check so it never changes the outcome, and the `len(MergeContent()) == 0` early-outs in `memberlist_client.go` still behave correctly, because a desc with no partitions and no owners still produces a zero-length slice. 

This is just wasted work, noisy output, and potentially unnecessary memory allocation.

The other two `MergeContent` implementations in the repo already do this correctly.