### PR TITLE
fix(grpcclient): remove DialOption data race

### DIFF
--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -23,6 +23,9 @@ import (
 // grpcWithChainUnaryInterceptor helps to ensure that the requested order of interceptors is preserved.
 var grpcWithChainUnaryInterceptor = grpc.WithChainUnaryInterceptor
 
+// clusterUnaryClientInterceptor lets tests identify the interceptor DialOption appends.
+var clusterUnaryClientInterceptor = middleware.ClusterUnaryClientInterceptor
+
 // Config for a gRPC client.
 type Config struct {
 	MaxRecvMsgSize  int     `yaml:"max_recv_msg_size" category:"advanced"`
@@ -55,9 +58,6 @@ type Config struct {
 	CustomCompressors []string `yaml:"-"`
 
 	ClusterValidation clusterutil.ClusterValidationConfig `yaml:"cluster_validation" category:"experimental"`
-
-	// clusterUnaryClientInterceptor is needed for testing purposes.
-	clusterUnaryClientInterceptor grpc.UnaryClientInterceptor `yaml:"-"`
 }
 
 // RegisterFlags registers flags.
@@ -158,8 +158,8 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 	// to wrap the real call.
 	if cfg.ClusterValidation.Label != "" {
 		// For client side, we use the primary label as our cluster identity
-		cfg.clusterUnaryClientInterceptor = middleware.ClusterUnaryClientInterceptor(cfg.ClusterValidation.Label, invalidClusterValidationReporter)
-		unaryClientInterceptors = append(unaryClientInterceptors, cfg.clusterUnaryClientInterceptor)
+		unaryClientInterceptors = append(unaryClientInterceptors,
+			clusterUnaryClientInterceptor(cfg.ClusterValidation.Label, invalidClusterValidationReporter))
 	}
 
 	if cfg.ConnectTimeout > 0 {

--- a/grpcclient/grpcclient_test.go
+++ b/grpcclient/grpcclient_test.go
@@ -128,16 +128,24 @@ func TestDialOptionWithClusterValidation(t *testing.T) {
 			cfg := Config{}
 			cfg.ClusterValidation = testCase.clusterValidation
 			cfg.RateLimit = testCase.rateLimit
+
+			var appendedClusterInterceptor grpc.UnaryClientInterceptor
+			clusterUnaryClientInterceptor = func(cluster string, reporter middleware.InvalidClusterValidationReporter) grpc.UnaryClientInterceptor {
+				appendedClusterInterceptor = middleware.ClusterUnaryClientInterceptor(cluster, reporter)
+				return appendedClusterInterceptor
+			}
+			t.Cleanup(func() { clusterUnaryClientInterceptor = middleware.ClusterUnaryClientInterceptor })
+
 			withChainUnaryInterceptorCalled := false
 			grpcWithChainUnaryInterceptor = func(unaryInterceptors ...grpc.UnaryClientInterceptor) grpc.DialOption {
 				withChainUnaryInterceptorCalled = true
 				require.Len(t, unaryInterceptors, testCase.expectedUnaryInterceptors)
 				if cfg.ClusterValidation.Label == "" {
-					require.Nil(t, cfg.clusterUnaryClientInterceptor)
+					require.Nil(t, appendedClusterInterceptor)
 				} else {
-					require.NotNil(t, cfg.clusterUnaryClientInterceptor)
+					require.NotNil(t, appendedClusterInterceptor)
 					lastUnaryInterceptor := unaryInterceptors[len(unaryInterceptors)-1]
-					require.Equal(t, fmt.Sprintf("%p", cfg.clusterUnaryClientInterceptor), fmt.Sprintf("%p", lastUnaryInterceptor))
+					require.Equal(t, fmt.Sprintf("%p", appendedClusterInterceptor), fmt.Sprintf("%p", lastUnaryInterceptor))
 				}
 				return grpc.WithChainUnaryInterceptor(unaryInterceptors...)
 			}


### PR DESCRIPTION
**What this PR does**:

`Config.DialOption` wrote the cluster validation interceptor back onto its own receiver, so goroutines sharing a `Config` raced on that field. Store it in a local and drop the field.

- The write only happens when `ClusterValidation.Label` is set, so it stays invisible until a cluster-validated deployment runs under the race detector
- The cached interceptor depended on the per-call `invalidClusterValidationReporter` argument, so keeping it on a shared `Config` was wrong independently of the race
- The field existed only so a test could identify the appended interceptor; a package-level seam alongside the existing `grpcWithChainUnaryInterceptor` does that without shared state

### Context

Mimir's query-scheduler calls `DialOption` per request from `forwardErrorToFrontend`, which runs inside concurrent `QuerierLoop` goroutines against a single `s.cfg.GRPCClientConfig`. An Antithesis run of Mimir caught it: goroutines raced on the same address, the detector reported two races at `grpcclient.go:161`, and the query-scheduler container exited 66.

**Checklist**
- [x] Tests updated
