### PR TITLE
fix: use GetFirstAddressOf for fallback advertise address in memberlist

### DIFF
--- a/kv/memberlist/tcp_transport.go
+++ b/kv/memberlist/tcp_transport.go
@@ -36,6 +36,9 @@ const (
 const zeroZeroZeroZero = "0.0.0.0"
 const colonColon = "::"
 
+// getPrivateIP is a variable so that tests can simulate hosts without a private IP address.
+var getPrivateIP = sockaddr.GetPrivateIP
+
 // TCPTransportConfig is a configuration structure for creating new TCPTransport.
 type TCPTransportConfig struct {
 	// BindAddrs is a list of IP addresses to bind to.
@@ -413,12 +416,18 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 			// Otherwise, if we're not bound to a specific IP, let's
 			// use a suitable private IP address.
 			var err error
-			ip, err = sockaddr.GetPrivateIP()
+			ip, err = getPrivateIP()
 			if err != nil {
-				return nil, 0, fmt.Errorf("failed to get interface addresses: %v", err)
+				return nil, 0, fmt.Errorf("failed to get interface addresses: %w", err)
 			}
 			if ip == "" {
-				return nil, 0, fmt.Errorf("no private IP address found, and explicit IP not provided")
+				// No RFC 1918 address on this host (e.g. pods on a non-private
+				// cluster CIDR): fall back to the first non-loopback address,
+				// as the IPv6 case already does.
+				ip, err = netutil.GetFirstAddressOf(nil, t.logger, false)
+				if err != nil {
+					return nil, 0, fmt.Errorf("no private IP address found, and explicit IP not provided: %w", err)
+				}
 			}
 
 			advertiseAddr = net.ParseIP(ip)

--- a/kv/memberlist/tcp_transport_test.go
+++ b/kv/memberlist/tcp_transport_test.go
@@ -1,6 +1,7 @@
 package memberlist
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -18,6 +19,7 @@ import (
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/crypto/tls"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/netutil"
 )
 
 func TestTCPTransport_WriteTo_ShouldNotLogAsWarningExpectedFailures(t *testing.T) {
@@ -188,6 +190,61 @@ func TestFinalAdvertiseAddr(t *testing.T) {
 
 		})
 	}
+}
+
+func TestFinalAdvertiseAddr_BoundToZeroZeroZeroZero(t *testing.T) {
+	newTransport := func(t *testing.T) *TCPTransport {
+		cfg := TCPTransportConfig{}
+		flagext.DefaultValues(&cfg)
+		cfg.BindAddrs = []string{zeroZeroZeroZero}
+		cfg.BindPort = 0
+
+		transport, err := NewTCPTransport(cfg, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, transport.Shutdown()) })
+		return transport
+	}
+
+	overrideGetPrivateIP := func(t *testing.T, fn func() (string, error)) {
+		orig := getPrivateIP
+		getPrivateIP = fn
+		t.Cleanup(func() { getPrivateIP = orig })
+	}
+
+	t.Run("should use the private IP when one is found", func(t *testing.T) {
+		overrideGetPrivateIP(t, func() (string, error) { return "10.1.2.3", nil })
+		transport := newTransport(t)
+
+		ip, port, err := transport.FinalAdvertiseAddr("", 0)
+		require.NoError(t, err)
+		require.Equal(t, "10.1.2.3", ip.String())
+		require.Equal(t, transport.GetAutoBindPort(), port)
+	})
+
+	t.Run("should fall back to the first non-loopback address when no private IP is found", func(t *testing.T) {
+		overrideGetPrivateIP(t, func() (string, error) { return "", nil })
+		transport := newTransport(t)
+
+		expected, err := netutil.GetFirstAddressOf(nil, log.NewNopLogger(), false)
+		require.NoError(t, err)
+
+		ip, port, err := transport.FinalAdvertiseAddr("", 0)
+		require.NoError(t, err)
+		require.NotNil(t, ip)
+		require.False(t, ip.IsLoopback())
+		require.False(t, ip.IsUnspecified())
+		require.Equal(t, expected, ip.String())
+		require.Equal(t, transport.GetAutoBindPort(), port)
+	})
+
+	t.Run("should return the error when looking up the private IP fails", func(t *testing.T) {
+		lookupErr := errors.New("lookup failed")
+		overrideGetPrivateIP(t, func() (string, error) { return "", lookupErr })
+		transport := newTransport(t)
+
+		_, _, err := transport.FinalAdvertiseAddr("", 0)
+		require.ErrorIs(t, err, lookupErr)
+	})
 }
 
 func TestNonIPsAreRejected(t *testing.T) {


### PR DESCRIPTION
## Problem

`memberlist` members that bind to `0.0.0.0` without an explicit advertise address fail to start on hosts whose only IPv4 addresses are outside the RFC 1918 ranges:

```
failed to create memberlist: Failed to get final advertise address: no private IP address found, and explicit IP not provided
```

This happens for example with Kubernetes pods on a cluster CIDR that is not in `10/8`, `172.16/12` or `192.168/16`. Such members currently need an explicit per-member `-memberlist.advertise-addr`, which is awkward to inject into every pod, while the same deployment on a private pod CIDR works out of the box.

## Root cause

`kv/memberlist/tcp_transport.go:416-422` (`FinalAdvertiseAddr`, `0.0.0.0` branch) resolves the advertise address with `sockaddr.GetPrivateIP()`, which only considers RFC 1918 addresses, and returns an error when it finds none. The IPv6 branch right below (`::`) already resolves the address with `netutil.GetFirstAddressOf(nil, t.logger, true)`, so IPv6-only members without a private address work while IPv4 ones do not.

## Fix

In the `0.0.0.0` branch, when `GetPrivateIP()` returns no address, fall back to `netutil.GetFirstAddressOf(nil, t.logger, false)`, i.e. the first non-loopback, non-link-local IPv4 address of the host, like the IPv6 branch does. Behaviour is unchanged when a private IP exists (it is still preferred), when the lookup itself fails (the error is returned, now wrapped with `%w`), and when the transport is bound to a specific address or an advertise address is given.

`sockaddr.GetPrivateIP` is referenced through a package-level `var getPrivateIP` so that tests can simulate a host without a private address.

## How tested

New `TestFinalAdvertiseAddr_BoundToZeroZeroZeroZero` in `kv/memberlist/tcp_transport_test.go`:

- `GetPrivateIP` returns a private IP: that IP is advertised (existing behaviour).
- `GetPrivateIP` returns no address: a non-nil, non-loopback, non-unspecified IP equal to `netutil.GetFirstAddressOf(nil, logger, false)` is advertised, no error.
- `GetPrivateIP` returns an error: the error is returned (`errors.Is` succeeds).

Before the fix, the fallback case fails with `no private IP address found, and explicit IP not provided` (and the error case fails `errors.Is` because the error was formatted with `%v`). After the fix all cases pass, and `go test ./kv/memberlist/...`, `go vet ./kv/memberlist/...` and `gofmt -l kv/memberlist` are clean.

## Links

There is no dskit issue for this. The scenario is memberlist members running on a pod or host network whose addresses are not in the RFC 1918 private ranges, for example Kubernetes clusters whose pod CIDR is a public or otherwise non-private range.

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
