### PR TITLE
fix(middleware): stop padding the not-added headers span event with empty strings

### DIFF
--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -25,6 +25,10 @@ import (
 
 var tracer = otel.Tracer("dskit/middleware")
 
+// maxHeadersToAddAsSpanAttributes bounds how many request headers are attached to a
+// span, so a client cannot blow up span size by sending unbounded headers.
+const maxHeadersToAddAsSpanAttributes = 100
+
 // Dummy dependency to enforce that we have a nethttp version newer
 // than the one which implements Websockets. (No semver on nethttp)
 var _ = nethttp.MWURLTagFunc
@@ -118,11 +122,9 @@ func (t Tracer) wrapWithOTel(next http.Handler) http.Handler {
 		}
 
 		if t.traceHeaders {
-			const maxHeadersToAddAsSpanAttributes = 100
-
 			var notAddedHeaders []string
 			if len(r.Header) > maxHeadersToAddAsSpanAttributes {
-				notAddedHeaders = make([]string, len(r.Header)-maxHeadersToAddAsSpanAttributes)
+				notAddedHeaders = make([]string, 0, len(r.Header)-maxHeadersToAddAsSpanAttributes)
 			}
 
 			added := 0

--- a/middleware/http_tracing_test.go
+++ b/middleware/http_tracing_test.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestTracer_HeadersNotAddedAsSpanAttributes(t *testing.T) {
+	const headersSent = maxHeadersToAddAsSpanAttributes + 50
+
+	recorder := tracetest.NewSpanRecorder()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)))
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	handler := NewTracer(nil, true, nil, nil).Wrap(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	for i := range headersSent {
+		req.Header.Set(fmt.Sprintf("X-Test-Header-%03d", i), "value")
+	}
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := recorder.Ended()
+	require.NotEmpty(t, spans)
+
+	var reported []string
+	var found bool
+	for _, span := range spans {
+		for _, event := range span.Events() {
+			for _, attr := range event.Attributes {
+				if attr.Key == "headers_not_added_as_span_attributes" {
+					reported = attr.Value.AsStringSlice()
+					found = true
+				}
+			}
+		}
+	}
+	require.True(t, found, "expected a span event listing the headers that were not added")
+	require.Len(t, reported, headersSent-maxHeadersToAddAsSpanAttributes)
+}


### PR DESCRIPTION
**What this PR fixes**

`Tracer.wrapWithOTel` preallocates the list of headers it could not attach to the span using `make([]string, n)` where `make([]string, 0, n)` was intended, then appends to it:

```go
var notAddedHeaders []string
if len(r.Header) > maxHeadersToAddAsSpanAttributes {
    notAddedHeaders = make([]string, len(r.Header)-maxHeadersToAddAsSpanAttributes)
}

added := 0
for header, values := range r.Header {
    if added >= maxHeadersToAddAsSpanAttributes {
        notAddedHeaders = append(notAddedHeaders, header)
        continue
    }
    ...
}
```

It therefore might emit a `Client sent too many headers, some of them were not included in the span attributes` event whose `headers_not_added_as_span_attributes` has twice the intended length. `headers_total` on the same event is computed separately and was always correct.

Included a new test to avoid regressions in the future.